### PR TITLE
Add a new test script to check if the tags inference is correct in the hierarchy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  # test the repo as-is
+  - pytest
+  # generate new Brick ontology (in case this hasn't been run)
+  - python generate_brick.py
+  # test again in case this broke anything
+  - pytest

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -285,7 +285,7 @@ brick:CO2_Differential_Sensor a owl:Class ;
     rdfs:label "CO2 Differential Sensor" ;
     rdfs:subClassOf brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Co2 ;
+                        owl:hasValue tag:CO2 ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Differential ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
@@ -301,7 +301,7 @@ brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
     rdfs:subClassOf brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Co2 ;
+                        owl:hasValue tag:CO2 ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Level ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
@@ -1171,6 +1171,11 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -1180,12 +1185,7 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Discharge ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Discharge_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Setpoint" ;
@@ -4038,7 +4038,7 @@ brick:Outside_Air_CO2_Sensor a owl:Class ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Co2 ;
+                        owl:hasValue tag:CO2 ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
@@ -4185,14 +4185,14 @@ brick:PIR_Sensor a owl:Class ;
     rdfs:subClassOf brick:Motion_Sensor,
         brick:Occupancy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:PIR ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Pir ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:PIR ;
                         owl:onProperty brick:hasTag ] ) ] .
 
 brick:PM10_Level a owl:Class ;
@@ -4500,7 +4500,7 @@ brick:Return_Air_CO2_Sensor a owl:Class ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Co2 ;
+                        owl:hasValue tag:CO2 ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
@@ -5093,11 +5093,6 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Supply Air Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -5107,7 +5102,12 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Supply ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Supply Air Static Pressure Setpoint" ;
@@ -5404,15 +5404,15 @@ brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
     rdfs:subClassOf brick:Direction_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Direction ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Direction ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Direction ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
@@ -5614,13 +5614,13 @@ brick:Direction_Sensor a owl:Class ;
     rdfs:label "Direction Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Direction ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Direction ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Direction ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Disable_Command a owl:Class ;
     rdfs:label "Disable Command" ;
@@ -5635,13 +5635,13 @@ brick:Enthalpy_Sensor a owl:Class ;
     rdfs:label "Enthalpy Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Enthalpy ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Enthalpy ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Flow Sensor" ;
@@ -5705,13 +5705,13 @@ brick:Frequency_Sensor a owl:Class ;
     rdfs:label "Frequency Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Frequency ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Frequency ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frequency ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Frost a owl:Class ;
     rdfs:label "Frost" ;
@@ -5744,6 +5744,11 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Sensor" ;
     rdfs:subClassOf brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -5753,12 +5758,7 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Water ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Hot ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Hot Water System Enable Command" ;
@@ -5779,13 +5779,13 @@ brick:Humidity_Sensor a owl:Class ;
     rdfs:label "Humidity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Humidity ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Humidity ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Integral Gain Parameter" ;
@@ -6099,17 +6099,17 @@ brick:Water_Flow_Sensor a owl:Class ;
     rdfs:label "Water Flow Sensor" ;
     rdfs:subClassOf brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Flow ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Flow ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Water ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Water_Level_Sensor a owl:Class ;
     rdfs:label "Water Level Sensor" ;
@@ -6538,17 +6538,17 @@ brick:Air_Grains_Sensor a owl:Class ;
     rdfs:label "Air Grains Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Grains ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Grains ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
@@ -6599,13 +6599,13 @@ brick:Dewpoint_Sensor a owl:Class ;
     rdfs:label "Dewpoint Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Dewpoint ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Dewpoint ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Differential_Pressure_Dead_Band_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Dead Band Setpoint" ;
@@ -6710,11 +6710,6 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -6724,7 +6719,12 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Exhaust ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
@@ -7391,6 +7391,11 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Air Temperature Sensor" ;
     rdfs:subClassOf brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
@@ -7399,11 +7404,6 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Discharge ;
                         owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Supply_Air ;
-                        owl:onProperty brick:measures ] ) ],
         brick:Supply_Air_Temperature_Sensor .
 
 brick:Duration_Sensor a owl:Class ;
@@ -7918,12 +7918,6 @@ brick:Voltage_Sensor a owl:Class ;
 tag:Average a brick:Tag ;
     rdfs:label "Average" .
 
-tag:CO2 a brick:Tag ;
-    rdfs:label "CO2" .
-
-tag:Co2 a brick:Tag ;
-    rdfs:label "Co2" .
-
 tag:Current a brick:Tag ;
     rdfs:label "Current" .
 
@@ -8036,17 +8030,17 @@ brick:Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Air Temperature Sensor" ;
     rdfs:subClassOf brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Air Temperature Setpoint" ;
@@ -8158,17 +8152,17 @@ brick:Air_Flow_Sensor a owl:Class ;
     rdfs:label "Air Flow Sensor" ;
     rdfs:subClassOf brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Flow ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Flow ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Demand_Setpoint a owl:Class ;
     rdfs:label "Demand Setpoint" ;
@@ -8203,6 +8197,9 @@ brick:Substance a owl:Class ;
 brick:Temperature a owl:Class ;
     rdfs:label "Temperature" ;
     rdfs:subClassOf brick:Quantity .
+
+tag:CO2 a brick:Tag ;
+    rdfs:label "CO2" .
 
 tag:Position a brick:Tag ;
     rdfs:label "Position" .

--- a/README.md
+++ b/README.md
@@ -220,3 +220,9 @@ define_subclasses(definitions, BRICK.Equipment)
 ```
 
 For now, the code is the documentation. Look at `equipment.py`, `point.py`, etc for examples and how to add to each of the class hierarchies.
+
+
+## How to Test?
+1. ``python tests/test_inference.py``: A basic test if Classes can be inferred from associated Tags.
+2. ``python tests/test_hierarchy_inference.py``: It tests whether all the instances associated with the right tags are correctly inferred through the hierarchy. For example, an instance with Tags of ``tag:Temperature`` and ``tag:Sensor`` should be inferred as ``brick:Temperature_Sensor``, ``brick:Sensor``, and ``brick:Point``.
+    - This test involves a time-consuming reasoning process, which took 4.5 hours in my desktop. In case you have the result graph at ``tests/test_hierarchy_inference.ttl``, you can reuse the file with an option like ``python tests/test_hierarchy_inference.py --reuse-inference``.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Brick
 
+[![Build Status](https://travis-ci.org/BrickSchema/Brick.svg?branch=master)](https://travis-ci.org/BrickSchema/Brick)
+
 Brick is an open-source, BSD-licensed development effort to create a uniform schema for representing metadata in buildings. Brick has three components:
 
 * An RDF class hierarchy describing the various building subsystems and the entities and equipment therein

--- a/README.md
+++ b/README.md
@@ -220,9 +220,3 @@ define_subclasses(definitions, BRICK.Equipment)
 ```
 
 For now, the code is the documentation. Look at `equipment.py`, `point.py`, etc for examples and how to add to each of the class hierarchies.
-
-
-## How to Test?
-1. ``python tests/test_inference.py``: A basic test if Classes can be inferred from associated Tags.
-2. ``python tests/test_hierarchy_inference.py``: It tests whether all the instances associated with the right tags are correctly inferred through the hierarchy. For example, an instance with Tags of ``tag:Temperature`` and ``tag:Sensor`` should be inferred as ``brick:Temperature_Sensor``, ``brick:Sensor``, and ``brick:Point``.
-    - This test involves a time-consuming reasoning process, which took 4.5 hours in my desktop. In case you have the result graph at ``tests/test_hierarchy_inference.ttl``, you can reuse the file with an option like ``python tests/test_hierarchy_inference.py --reuse-inference``.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ If you have an issue with Brick's coverage, utility or usability, or any other B
 
 See [CONTRIBUTING.md](https://github.com/BrickSchema/Brick/blob/master/CONTRIBUTING.md)
 
+## Tests
+
+Tests go in the `tests/` directory and should be implemented using [pytest](https://pytest.readthedocs.io/en/latest/getting-started.html#getstarted).
+[`tests/test_inference.py`](https://github.com/BrickSchema/Brick/blob/master/tests/test_inference.py) is a good example.
+
+Run tests by executing `pytest` in the top-level directory of this repository.
+
 ## Ontology Implementation
 
 ### Complexity

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ rdflib-jsonld==0.4.0
 six==1.12.0
 owlready2
 pytest
-arrow
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ rdflib==4.2.2
 rdflib-jsonld==0.4.0
 six==1.12.0
 owlready2
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 isodate==0.6.0
-owlrl==5.2.0
+#owlrl==5.2.0
+git+https://github.com/RDFLib/OWL-RL.git@471d1dfe8f6 # because of issue https://github.com/RDFLib/OWL-RL/issues/29, use git directly until it's released.
 pyparsing==2.3.1
 rdflib==4.2.2
 rdflib-jsonld==0.4.0
 six==1.12.0
 owlready2
 pytest
+arrow
+tqdm

--- a/sensor.py
+++ b/sensor.py
@@ -37,16 +37,16 @@ sensor_definitions = {
                 "substances": [ [ BRICK.measures, BRICK.Air ], [ BRICK.measures, BRICK.CO2 ], ],
                 "subclasses": {
                     "CO2_Differential_Sensor": {
-                        "tags": [ TAG.Co2, TAG.Differential, TAG.Sensor ],
+                        "tags": [ TAG.CO2, TAG.Differential, TAG.Sensor ],
                     },
                     "CO2_Level_Sensor": {
-                        "tags": [ TAG.Co2, TAG.Level, TAG.Sensor ],
+                        "tags": [ TAG.CO2, TAG.Level, TAG.Sensor ],
                     },
                     "Outside_Air_CO2_Sensor": {
-                        "tags": [ TAG.Outside, TAG.Air, TAG.Co2, TAG.Sensor ],
+                        "tags": [ TAG.Outside, TAG.Air, TAG.CO2, TAG.Sensor ],
                     },
                     "Return_Air_CO2_Sensor": {
-                        "tags": [ TAG.Return, TAG.Air, TAG.Co2, TAG.Sensor ],
+                        "tags": [ TAG.Return, TAG.Air, TAG.CO2, TAG.Sensor ],
                     }
                 }
             },

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -51,7 +51,6 @@ prefix brick: <https://brickschema.org/schema/1.1.0/Brick#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 """
 
-<<<<<<< HEAD
 def test_hierarchyinference():
 
     # Load the schema

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -118,7 +118,7 @@ for entity, parents in inferred_klasses.items():
     elif parents != true_parents:
         wrong_inferences[entity] = serialized
 
-with open('test_hierarchy_inference.json', 'w') as fp:
+with open('tests/test_hierarchy_inference.json', 'w') as fp:
     json.dump({
         'over_inferences': over_inferences,
         'under_inferences': under_inferences,

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -8,22 +8,37 @@ import arrow
 import owlrl
 from rdflib import RDF, OWL, RDFS, Namespace, URIRef, Graph
 
+"""
+This script does the following:
+(1) Create entities that are supposed to be instances of Classes. (Class == ``brick:Class``)
+(2) Associate the entities with Tags defined for each Class.
+(3) Infer each entity's classes (throughout the hierarchy) based only on its Tags.
+
+If the schema is correctly designe, the following properties should be met
+[1] Each of the entities should be an instance of the target Class defined in (2).
+[2] Each of the entities should be instances of all the parent Classes of the target Class but nothing else. This is basically a super set of [1].
+
+This test is a superset of ``test_inference.py``.
+"""
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--reuse-inference',
                     action='store_const',
-                    default=False,
+                    default=True,
                     const=True,
                     dest='reuse_inference',
+                    help='`True` forces the script to reuse previously inferred schema at `tests/test_hierarchy_inference.ttl`.',
                     )
 args = parser.parse_args()
 inference_file = 'tests/test_hierarchy_inference.ttl'
 
-def rereason_owlrl(G, dummy=None):
+def owlrl_reason(g):
     start_time = arrow.get()
-    owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(G)
+    owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(deepcopy(g))
     end_time = arrow.get()
     print('{0} took for owlrl reasoning'.format(end_time - start_time))
-    return G
+    return g
 
 BRICK_VERSION = '1.1.0'
 BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
@@ -36,95 +51,98 @@ prefix brick: <https://brickschema.org/schema/1.1.0/Brick#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 """
 
-g = Graph()
-g.parse('Brick.ttl', format='turtle')
+def test_hierarchyinference():
 
-qstr = q_prefix + """
-select ?class where {
-    ?class rdfs:subClassOf+ brick:Class.
-}
-"""
+    # Load the schema
+    g = Graph()
+    g.parse('Brick.ttl', format='turtle')
 
-if args.reuse_inference:
-    expanded_g = Graph()
-    expanded_g.parse(inference_file, format='turtle')
-else:
-    # create instances and associate them with related Tags.
+    if args.reuse_inference:  # Reuse previously inferred file if the flag is set.
+        expanded_g = Graph()
+        expanded_g.parse(inference_file, format='turtle')
+    else:  # create instances and associate them with related Tags.
+
+        # Get all the Classes with their restrictions.
+        qstr = q_prefix + """
+        select ?class ?p ?o where {
+          ?class rdfs:subClassOf+ brick:Class.
+          ?class owl:equivalentClass ?restrictions.
+          ?restrictions owl:intersectionOf ?inter.
+          ?inter rdf:rest*/rdf:first ?node.
+          {
+              BIND (brick:hasTag as ?p)
+              ?node owl:onProperty ?p.
+              ?node owl:hasValue ?o.
+          } UNION {
+              BIND (brick:measures as ?p)
+              ?node owl:onProperty ?p.
+              ?node owl:hasValue ?o.
+          }
+        }
+        """
+        start_time = arrow.get()
+        for row in tqdm(g.query(qstr)):
+            klass = row[0]
+            entity = klass + entity_postfix  # Define an entity for the class
+            g.add((entity, row[1], row[2]))  # Associate the entity with restrictions (i.e., Tags)
+        end_time = arrow.get()
+        print('Instantiation took {0} seconds'.format(end_time - start_time))
+
+        # Infer classes of the entities.
+        expanded_g = owlrl_reason(g)
+        expanded_g.serialize(inference_file, format='turtle')  # Store the inferred graph.
+
+
+    # Find all instances and their parents from the inferred graph.
     qstr = q_prefix + """
-    select ?class ?p ?o where {
-      ?class rdfs:subClassOf+ brick:Class.
-      ?class owl:equivalentClass ?restrictions.
-      ?restrictions owl:intersectionOf ?inter.
-      ?inter rdf:rest*/rdf:first ?node.
-      {
-          BIND (brick:hasTag as ?p)
-          ?node owl:onProperty ?p.
-          ?node owl:hasValue ?o.
-      } UNION {
-          BIND (brick:measures as ?p)
-          ?node owl:onProperty ?p.
-          ?node owl:hasValue ?o.
-      }
+    select ?instance ?class where {
+        ?instance a ?class.
+        ?class rdfs:subClassOf* brick:Class.
     }
     """
-    start_time = arrow.get()
-    for row in tqdm(g.query(qstr)):
-        klass = row[0]
-        entity = klass + entity_postfix
-        g.add((entity, row[1], row[2]))
-    end_time = arrow.get()
-    print('{0} seconds taken'.format(end_time - start_time))
-    expanded_g = rereason_owlrl(g, 'tests/test_hierarchy_inference.n3')
-    expanded_g.serialize('tests/test_hierarchy_inference.ttl', format='turtle')
+    inferred_klasses = defaultdict(set)
+    for row in tqdm(expanded_g.query(qstr)):
+        entity = row[0]
+        klass = row[1]
+        if BRICK in klass: # Filter out non-Brick classes such as Restrictions
+            inferred_klasses[entity].add(klass)
 
+    over_inferences = {}  # Inferred Classes that are not supposed to be inferred.
+    under_inferences = {}  # Classes that should have been inferred but not actually inferred.
+    wrong_inferences = {}  # Other wrongly inferred Classes.
+    for entity, inferred_parents in inferred_klasses.items():
+        if entity[-2:] != entity_postfix:
+            continue
+        true_class = URIRef(entity[0:-2])  # This is based on how the entity name is defined above.
 
-# Find all instances and their parents from the inferred graph.
-qstr = q_prefix + """
-select ?instance ?class where {
-    ?instance a ?class.
-    ?class rdfs:subClassOf* brick:Class.
-}
-"""
-inferred_klasses = defaultdict(set)
-for row in tqdm(expanded_g.query(qstr)):
-    klass = row[1]
-    if BRICK in klass: # Filter out non-Brick classes such as Restrictions
-        inferred_klasses[row[0]].add(row[1])
+        # Find the original classes through the hierarchy from the original graph.
+        qstr = q_prefix + """
+        select ?parent where {{
+            <{0}> rdfs:subClassOf* ?parent.
+            ?parent rdfs:subClassOf* brick:Class.
+        }}
+        """.format(true_class)
+        res = g.query(qstr)
+        true_parents = [row[0] for row in res]
+        true_parents = set(filter(lambda parent: BRICK in parent, true_parents))
+        serialized = {
+            'inferred_parents': list(inferred_parents),
+            'true_parents': list(true_parents),
+        }
+        if inferred_parents > true_parents:
+            over_inferences[entity] = serialized
+        elif inferred_parents < true_parents:
+            under_inferences[entity] = serialized
+        elif inferred_parents != true_parents:
+            wrong_inferences[entity] = serialized
 
-over_inferences = {}
-under_inferences = {}
-wrong_inferences = {}
-for entity, parents in inferred_klasses.items():
-    if entity[-2:] != entity_postfix:
-        continue
-    true_class = URIRef(entity[0:-2])
-    qstr = q_prefix + """
-    select ?parent where {{
-        <{0}> rdfs:subClassOf* ?parent.
-        ?parent rdfs:subClassOf* brick:Class.
-    }}
-    """.format(true_class)
-    res = g.query(qstr)
-    true_parents = [row[0] for row in res]
-    true_parents = set(filter(lambda parent: BRICK in parent, true_parents))
-    serialized = {
-        'inferred_parents': list(parents),
-        'true_parents': list(true_parents),
-    }
-    if parents > true_parents:
-        over_inferences[entity] = serialized
-    elif parents < true_parents:
-        under_inferences[entity] = serialized
-    elif parents != true_parents:
-        wrong_inferences[entity] = serialized
+    with open('tests/test_hierarchy_inference.json', 'w') as fp:
+        json.dump({
+            'over_inferences': over_inferences,
+            'under_inferences': under_inferences,
+            'wrong_inferencers': wrong_inferences,
+        }, fp, indent=2)
 
-with open('tests/test_hierarchy_inference.json', 'w') as fp:
-    json.dump({
-        'over_inferences': over_inferences,
-        'under_inferences': under_inferences,
-        'wrong_inferencers': wrong_inferences,
-    }, fp, indent=2)
-
-assert not over_inferences, 'There are {0} classes that are over-inferred'.format(len(over_inferences))
-assert not under_inferences, 'There are {0} classes that are under-inferred'.format(len(under_inferences))
-assert not wrong_inferences, 'There are {0} classes that are inferred incorrectly in other ways'.format(len(wrong_inferences))
+    assert not over_inferences, 'There are {0} classes that are over-inferred'.format(len(over_inferences))
+    assert not under_inferences, 'There are {0} classes that are under-inferred'.format(len(under_inferences))
+    assert not wrong_inferences, 'There are {0} classes that are inferred incorrectly in other ways'.format(len(wrong_inferences))

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -2,6 +2,7 @@ import argparse
 import json
 from copy import deepcopy
 from collections import defaultdict
+import time
 
 from tqdm import tqdm
 import owlrl

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -25,7 +25,7 @@ This test is a superset of ``test_inference.py``.
 parser = argparse.ArgumentParser()
 parser.add_argument('--reuse-inference',
                     action='store_const',
-                    default=True,
+                    default=False,
                     const=True,
                     dest='reuse_inference',
                     help='`True` forces the script to reuse previously inferred schema at `tests/test_hierarchy_inference.ttl`.',
@@ -37,7 +37,7 @@ def owlrl_reason(g):
     start_time = arrow.get()
     owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(deepcopy(g))
     end_time = arrow.get()
-    print('{0} took for owlrl reasoning'.format(end_time - start_time))
+    print('owlrl reasoning took {0} seconds.'.format(end_time - start_time))
     return g
 
 BRICK_VERSION = '1.1.0'
@@ -51,6 +51,7 @@ prefix brick: <https://brickschema.org/schema/1.1.0/Brick#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 """
 
+<<<<<<< HEAD
 def test_hierarchyinference():
 
     # Load the schema

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 from collections import defaultdict
 
 from tqdm import tqdm
-import arrow
 import owlrl
 from rdflib import RDF, OWL, RDFS, Namespace, URIRef, Graph
 
@@ -34,10 +33,10 @@ args = parser.parse_args()
 inference_file = 'tests/test_hierarchy_inference.ttl'
 
 def owlrl_reason(g):
-    start_time = arrow.get()
+    start_time = time.time()
     owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(deepcopy(g))
-    end_time = arrow.get()
-    print('owlrl reasoning took {0} seconds.'.format(end_time - start_time))
+    end_time = time.time()
+    print('owlrl reasoning took {0} seconds.'.format(int(end_time - start_time)))
     return g
 
 BRICK_VERSION = '1.1.0'
@@ -80,13 +79,13 @@ def test_hierarchyinference():
           }
         }
         """
-        start_time = arrow.get()
+        start_time = time.time()
         for row in tqdm(g.query(qstr)):
             klass = row[0]
             entity = klass + entity_postfix  # Define an entity for the class
             g.add((entity, row[1], row[2]))  # Associate the entity with restrictions (i.e., Tags)
-        end_time = arrow.get()
-        print('Instantiation took {0} seconds'.format(end_time - start_time))
+        end_time = time.get()
+        print('Instantiation took {0} seconds'.format(int(end_time-start_time)))
 
         # Infer classes of the entities.
         expanded_g = owlrl_reason(g)

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 import time
 
 from tqdm import tqdm
-import owlready2
 import owlrl
 from rdflib import RDF, OWL, RDFS, Namespace, URIRef, Graph
 
@@ -40,16 +39,6 @@ def owlrl_reason(g):
     end_time = time.time()
     print('owlrl reasoning took {0} seconds.'.format(int(end_time - start_time)))
     return g
-
-def owlready2_reason(g):
-    filename = 'buffer.n3'
-    world = owlready2.World()
-    with open(filename, 'wb') as f:
-        f.write(g.serialize(format='ntriples'))
-    on = world.get_ontology(f"file://./{filename}").load()
-    owlready2.sync_reasoner(world, infer_property_values =True)
-    G = world.as_rdflib_graph()
-    return G
 
 BRICK_VERSION = '1.1.0'
 BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
@@ -96,11 +85,11 @@ def test_hierarchyinference():
             klass = row[0]
             entity = klass + entity_postfix  # Define an entity for the class
             g.add((entity, row[1], row[2]))  # Associate the entity with restrictions (i.e., Tags)
-        end_time = time.time()
+        end_time = time.get()
         print('Instantiation took {0} seconds'.format(int(end_time-start_time)))
 
         # Infer classes of the entities.
-        expanded_g = owlready2_reason(g)
+        expanded_g = owlrl_reason(g)
         expanded_g.serialize(inference_file, format='turtle')  # Store the inferred graph.
 
 
@@ -117,7 +106,6 @@ def test_hierarchyinference():
         klass = row[1]
         if BRICK in klass: # Filter out non-Brick classes such as Restrictions
             inferred_klasses[entity].add(klass)
-    pdb.set_trace()
 
     over_inferences = {}  # Inferred Classes that are not supposed to be inferred.
     under_inferences = {}  # Classes that should have been inferred but not actually inferred.
@@ -158,6 +146,3 @@ def test_hierarchyinference():
     assert not over_inferences, 'There are {0} classes that are over-inferred'.format(len(over_inferences))
     assert not under_inferences, 'There are {0} classes that are under-inferred'.format(len(under_inferences))
     assert not wrong_inferences, 'There are {0} classes that are inferred incorrectly in other ways'.format(len(wrong_inferences))
-
-if __name__ == '__main__':
-    test_hierarchyinference()

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -1,0 +1,130 @@
+import argparse
+import json
+from copy import deepcopy
+from collections import defaultdict
+
+from tqdm import tqdm
+import arrow
+import owlrl
+from rdflib import RDF, OWL, RDFS, Namespace, URIRef, Graph
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--reuse-inference',
+                    action='store_const',
+                    default=False,
+                    const=True,
+                    dest='reuse_inference',
+                    )
+args = parser.parse_args()
+inference_file = 'tests/test_hierarchy_inference.ttl'
+
+def rereason_owlrl(G, dummy=None):
+    start_time = arrow.get()
+    owlrl.DeductiveClosure(owlrl.OWLRL_Semantics).expand(G)
+    end_time = arrow.get()
+    print('{0} took for owlrl reasoning'.format(end_time - start_time))
+    return G
+
+BRICK_VERSION = '1.1.0'
+BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
+TAG = Namespace("https://brickschema.org/schema/{0}/BrickTag#".format(BRICK_VERSION))
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+entity_postfix = '_0'
+
+q_prefix = """
+prefix brick: <https://brickschema.org/schema/1.1.0/Brick#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+"""
+
+g = Graph()
+g.parse('Brick.ttl', format='turtle')
+
+qstr = q_prefix + """
+select ?class where {
+    ?class rdfs:subClassOf+ brick:Class.
+}
+"""
+
+if args.reuse_inference:
+    expanded_g = Graph()
+    expanded_g.parse(inference_file, format='turtle')
+else:
+    # create instances and associate them with related Tags.
+    qstr = q_prefix + """
+    select ?class ?p ?o where {
+      ?class rdfs:subClassOf+ brick:Class.
+      ?class owl:equivalentClass ?restrictions.
+      ?restrictions owl:intersectionOf ?inter.
+      ?inter rdf:rest*/rdf:first ?node.
+      {
+          BIND (brick:hasTag as ?p)
+          ?node owl:onProperty ?p.
+          ?node owl:hasValue ?o.
+      } UNION {
+          BIND (brick:measures as ?p)
+          ?node owl:onProperty ?p.
+          ?node owl:hasValue ?o.
+      }
+    }
+    """
+    start_time = arrow.get()
+    for row in tqdm(g.query(qstr)):
+        klass = row[0]
+        entity = klass + entity_postfix
+        g.add((entity, row[1], row[2]))
+    end_time = arrow.get()
+    print('{0} seconds taken'.format(end_time - start_time))
+    expanded_g = rereason_owlrl(g, 'tests/test_hierarchy_inference.n3')
+    expanded_g.serialize('tests/test_hierarchy_inference.ttl', format='turtle')
+
+
+# Find all instances and their parents from the inferred graph.
+qstr = q_prefix + """
+select ?instance ?class where {
+    ?instance a ?class.
+    ?class rdfs:subClassOf* brick:Class.
+}
+"""
+inferred_klasses = defaultdict(set)
+for row in tqdm(expanded_g.query(qstr)):
+    klass = row[1]
+    if BRICK in klass: # Filter out non-Brick classes such as Restrictions
+        inferred_klasses[row[0]].add(row[1])
+
+over_inferences = {}
+under_inferences = {}
+wrong_inferences = {}
+for entity, parents in inferred_klasses.items():
+    if entity[-2:] != entity_postfix:
+        continue
+    true_class = URIRef(entity[0:-2])
+    qstr = q_prefix + """
+    select ?parent where {{
+        <{0}> rdfs:subClassOf* ?parent.
+        ?parent rdfs:subClassOf* brick:Class.
+    }}
+    """.format(true_class)
+    res = g.query(qstr)
+    true_parents = [row[0] for row in res]
+    true_parents = set(filter(lambda parent: BRICK in parent, true_parents))
+    serialized = {
+        'inferred_parents': list(parents),
+        'true_parents': list(true_parents),
+    }
+    if parents > true_parents:
+        over_inferences[entity] = serialized
+    elif parents < true_parents:
+        under_inferences[entity] = serialized
+    elif parents != true_parents:
+        wrong_inferences[entity] = serialized
+
+with open('test_hierarchy_inference.json', 'w') as fp:
+    json.dump({
+        'over_inferences': over_inferences,
+        'under_inferences': under_inferences,
+        'wrong_inferencers': wrong_inferences,
+    }, fp, indent=2)
+
+assert not over_inferences, 'There are {0} classes that are over-inferred'.format(len(over_inferences))
+assert not under_inferences, 'There are {0} classes that are under-inferred'.format(len(under_inferences))
+assert not wrong_inferences, 'There are {0} classes that are inferred incorrectly in other ways'.format(len(wrong_inferences))


### PR DESCRIPTION
This tests whether all the classes tagging rules are correctly defined or not. If there is any entity associated with Tags associated for a Class, the reasoner should be able to identify the entity is an instance of all the superclasses of the Class too but nothing else.

### The basic logic
To do that, I [instantiate entities](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L73) (named as class_name + ``_0``) and [associate them with the Tags](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L74) [defined as restrictions for the classes](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L54). Then, I run [owlrl reasoner](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L77) and query what classes are inferred for the instances. [A naive query to get all the superclasses](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L102) are used to extract "true parents', which [are compared to](https://github.com/jbkoh/Brick/blob/new-hierarchytest/tests/test_hierarchy_inference.py#L114) the inferred parents.
### An example:
- Inference result: https://drive.google.com/open?id=1lrBiCQS3O8RnoGaaVI8Spzbq3_wgDEGs
- Test result: https://drive.google.com/open?id=18Wi-eYnBM51DCs4u793CK8RbLpCnfddZ

As described in the README, reasoning takes a long time and you may reuse an inferred result as explained there. In the above example, one has to copy paste Inference result into the right location as in README.

This shows an interesting result, for which I will create a separate issue, but please take a look at the code in this PR.