### PR TITLE
Fixing Quantity + Substance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ install:
   - pip install -r requirements.txt
 
 script:
-  # test the repo as-is
-  # -s flag: do not capture output (avoids killing test after 10 min)
-  - pytest -s
   # generate new Brick ontology (in case this hasn't been run)
   - python generate_brick.py
-  # test again in case this broke anything
+  # -s flag: do not capture output (avoids killing test after 10 min)
   - pytest -s

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -5,6 +5,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <http://schema.org#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa#> .
 @prefix tag: <https://brickschema.org/schema/1.1.0/BrickTag#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -318,13 +319,13 @@ brick:Capacity_Sensor a owl:Class ;
     rdfs:label "Capacity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Capacity ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Capacity ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Capacity ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Centrifugal_Chiller a owl:Class ;
     rdfs:label "Centrifugal Chiller" ;
@@ -1948,13 +1949,13 @@ brick:Frost_Sensor a owl:Class ;
     rdfs:label "Frost Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Frost ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Frost ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frost ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Fuel_Oil a owl:Class,
         brick:Substance ;
@@ -4216,14 +4217,14 @@ brick:PIR_Sensor a owl:Class ;
     rdfs:subClassOf brick:Motion_Sensor,
         brick:Occupancy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:PIR ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Pir ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:PIR ;
                         owl:onProperty brick:hasTag ] ) ] .
 
 brick:PM10_Level a owl:Class,
@@ -4426,18 +4427,18 @@ brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:subClassOf brick:Duration_Sensor,
         brick:Rain_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Rain ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Duration ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ],
         [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Rain ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Duration ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
 brick:Reactive_Power a owl:Class,
@@ -5440,29 +5441,29 @@ brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
     rdfs:subClassOf brick:Direction_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Direction ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Direction ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Direction ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
     rdfs:subClassOf brick:Speed_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Speed ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Speed ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Speed ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Wing a owl:Class ;
     rdfs:label "Wing" ;
@@ -5599,13 +5600,13 @@ brick:Conductivity_Sensor a owl:Class ;
     rdfs:label "Conductivity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Conductivity ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Conductivity ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Conductivity ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Cooling_Command a owl:Class ;
     rdfs:label "Cooling Command" ;
@@ -5654,13 +5655,13 @@ brick:Direction_Sensor a owl:Class ;
     rdfs:label "Direction Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Direction ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Direction ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Direction ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Disable_Command a owl:Class ;
     rdfs:label "Disable Command" ;
@@ -5688,13 +5689,13 @@ brick:Enthalpy_Sensor a owl:Class ;
     rdfs:label "Enthalpy Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Enthalpy ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Enthalpy ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Flow Sensor" ;
@@ -5758,13 +5759,13 @@ brick:Frequency_Sensor a owl:Class ;
     rdfs:label "Frequency Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Frequency ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Frequency ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frequency ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Frost a owl:Class,
         brick:Substance ;
@@ -6187,17 +6188,17 @@ brick:Water_Level_Sensor a owl:Class ;
     rdfs:label "Water Level Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Level ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Water ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Level ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Level ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Water_Valve a owl:Class ;
     rdfs:label "Water Valve" ;
@@ -6793,13 +6794,13 @@ brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Flow ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Flow ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Fluid a owl:Class,
         brick:Substance ;
@@ -7231,7 +7232,9 @@ brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Proportional ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Bandsetpoint ;
+                        owl:hasValue tag:Band ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Parameter ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:PID ;
                         owl:onProperty brick:hasTag ] ) ],
@@ -7246,9 +7249,7 @@ brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Proportional ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Band ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Parameter ;
+                        owl:hasValue tag:Bandsetpoint ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:PID ;
                         owl:onProperty brick:hasTag ] ) ] .
@@ -7574,7 +7575,8 @@ brick:Luminance a owl:Class,
                         owl:hasValue tag:Luminance ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Measurable a owl:Class .
+brick:Measurable a owl:Class ;
+    rdfs:subClassOf sosa:ObservableProperty .
 
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
@@ -7625,13 +7627,13 @@ brick:Pressure_Sensor a owl:Class ;
     rdfs:label "Pressure Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Pressure_Setpoint a owl:Class ;
     rdfs:label "Pressure Setpoint" ;
@@ -7677,13 +7679,13 @@ brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Valve a owl:Class ;
     rdfs:label "Valve" ;
@@ -8192,17 +8194,17 @@ brick:Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Air Humidity Sensor" ;
     rdfs:subClassOf brick:Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Humidity ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Humidity ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
@@ -8234,17 +8236,17 @@ brick:Air_Flow_Sensor a owl:Class ;
     rdfs:label "Air Flow Sensor" ;
     rdfs:subClassOf brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Flow ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Flow ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Demand_Setpoint a owl:Class ;
     rdfs:label "Demand Setpoint" ;

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -23,7 +23,8 @@ brick:Absorption_Chiller a owl:Class ;
     rdfs:label "Absorption Chiller" ;
     rdfs:subClassOf brick:Chiller .
 
-brick:Active_Power a owl:Class ;
+brick:Active_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Active Power" ;
     rdfs:subClassOf brick:Electric_Power ;
     owl:equivalentClass brick:Real_Power .
@@ -71,16 +72,19 @@ brick:Air_Temperature_Step_Parameter a owl:Class ;
                         owl:hasValue tag:PID ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Alternating_Current_Frequency a owl:Class ;
+brick:Alternating_Current_Frequency a owl:Class,
+        brick:Quantity ;
     rdfs:label "Alternating Current Frequency" ;
     rdfs:subClassOf brick:Electric_Current,
         brick:Frequency .
 
-brick:Apparent_Power a owl:Class ;
+brick:Apparent_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Apparent Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
-brick:Atmospheric_Pressure a owl:Class ;
+brick:Atmospheric_Pressure a owl:Class,
+        brick:Quantity ;
     rdfs:label "Atmospheric Pressure" ;
     rdfs:subClassOf brick:Pressure .
 
@@ -168,7 +172,8 @@ brick:Battery_Voltage_Sensor a owl:Class ;
                         owl:hasValue tag:Battery ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Blowdown_Water a owl:Class ;
+brick:Blowdown_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Blowdown Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -241,11 +246,6 @@ brick:Building_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Building Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Building ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Static ;
@@ -253,7 +253,12 @@ brick:Building_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Pressure ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Building_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Building Static Pressure Setpoint" ;
@@ -292,7 +297,8 @@ brick:CO2_Differential_Sensor a owl:Class ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:CO2_Level a owl:Class ;
+brick:CO2_Level a owl:Class,
+        brick:Quantity ;
     rdfs:label "CO2 Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
@@ -324,7 +330,8 @@ brick:Centrifugal_Chiller a owl:Class ;
     rdfs:label "Centrifugal Chiller" ;
     rdfs:subClassOf brick:Chiller .
 
-brick:Chilled_Water a owl:Class ;
+brick:Chilled_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Chilled Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -653,7 +660,8 @@ brick:City a owl:Class ;
                         owl:hasValue tag:Location ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Cloudage a owl:Class ;
+brick:Cloudage a owl:Class,
+        brick:Quantity ;
     rdfs:label "Cloudage" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -661,7 +669,8 @@ brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
     rdfs:subClassOf brick:Laboratory .
 
-brick:Complex_Power a owl:Class ;
+brick:Complex_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Complex Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
@@ -679,7 +688,8 @@ brick:Condenser_Heat_Exchanger a owl:Class ;
     rdfs:label "Condenser Heat Exchanger" ;
     rdfs:subClassOf brick:Heat_Exchanger .
 
-brick:Condenser_Water a owl:Class ;
+brick:Condenser_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Condenser Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -915,19 +925,23 @@ brick:Cooling_Tower_Fan a owl:Class ;
     rdfs:label "Cooling Tower Fan" ;
     rdfs:subClassOf brick:Fan .
 
-brick:Current_Angle a owl:Class ;
+brick:Current_Angle a owl:Class,
+        brick:Quantity ;
     rdfs:label "Current Angle" ;
     rdfs:subClassOf brick:Electric_Current .
 
-brick:Current_Imbalance a owl:Class ;
+brick:Current_Imbalance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Current Imbalance" ;
     rdfs:subClassOf brick:Electric_Current .
 
-brick:Current_Magnitude a owl:Class ;
+brick:Current_Magnitude a owl:Class,
+        brick:Quantity ;
     rdfs:label "Current Magnitude" ;
     rdfs:subClassOf brick:Electric_Current .
 
-brick:Current_Total_Harmonic_Distortion a owl:Class ;
+brick:Current_Total_Harmonic_Distortion a owl:Class,
+        brick:Quantity ;
     rdfs:label "Current Total Harmonic Distortion" ;
     rdfs:subClassOf brick:Electric_Current .
 
@@ -988,7 +1002,8 @@ brick:Damper_Position_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Daytime a owl:Class ;
+brick:Daytime a owl:Class,
+        brick:Quantity ;
     rdfs:label "Daytime" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -1171,6 +1186,11 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -1180,12 +1200,7 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Discharge ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Discharge_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Setpoint" ;
@@ -1385,7 +1400,8 @@ brick:Domestic_Hot_Water_Valve a owl:Class ;
                         owl:hasValue tag:Equipment ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Domestic_Water a owl:Class ;
+brick:Domestic_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Domestic Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -1408,7 +1424,8 @@ brick:Drive_Ready_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Dry_Bulb_Temperature a owl:Class ;
+brick:Dry_Bulb_Temperature a owl:Class,
+        brick:Quantity ;
     rdfs:label "Dry Bulb Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -1467,7 +1484,8 @@ brick:Effective_Air_Temperature_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Electric_Energy a owl:Class ;
+brick:Electric_Energy a owl:Class,
+        brick:Quantity ;
     rdfs:label "Electric Energy" ;
     rdfs:subClassOf brick:Energy .
 
@@ -1596,7 +1614,8 @@ brick:Even_Month_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Exhaust_Air a owl:Class ;
+brick:Exhaust_Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Exhaust Air" ;
     rdfs:subClassOf brick:Air ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -1937,7 +1956,8 @@ brick:Frost_Sensor a owl:Class ;
                         owl:hasValue brick:Frost ;
                         owl:onProperty brick:measures ] ) ] .
 
-brick:Fuel_Oil a owl:Class ;
+brick:Fuel_Oil a owl:Class,
+        brick:Substance ;
     rdfs:label "Fuel Oil" ;
     rdfs:subClassOf brick:Oil ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -1973,7 +1993,8 @@ brick:Furniture a owl:Class ;
     rdfs:label "Furniture" ;
     rdfs:subClassOf brick:Equipment .
 
-brick:Gasoline a owl:Class ;
+brick:Gasoline a owl:Class,
+        brick:Substance ;
     rdfs:label "Gasoline" ;
     rdfs:subClassOf brick:Liquid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -1998,13 +2019,13 @@ brick:Hail_Sensor a owl:Class ;
     rdfs:label "Hail Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Hail ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Hail ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Hail ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Hand_Auto_Status a owl:Class ;
     rdfs:label "Hand Auto Status" ;
@@ -2407,7 +2428,8 @@ brick:Hot_Box a owl:Class ;
     rdfs:label "Hot Box" ;
     rdfs:subClassOf brick:Laboratory .
 
-brick:Hot_Water a owl:Class ;
+brick:Hot_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Hot Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -2638,7 +2660,8 @@ brick:Humidifier_Fault_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Ice a owl:Class ;
+brick:Ice a owl:Class,
+        brick:Substance ;
     rdfs:label "Ice" ;
     rdfs:subClassOf brick:Solid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -2682,7 +2705,8 @@ brick:Ice_Tank_Leaving_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Illuminance a owl:Class ;
+brick:Illuminance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Illuminance" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -2875,11 +2899,13 @@ brick:Luminance_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Luminous_Flux a owl:Class ;
+brick:Luminous_Flux a owl:Class,
+        brick:Quantity ;
     rdfs:label "Luminous Flux" ;
     rdfs:subClassOf brick:Luminance .
 
-brick:Luminous_Intensity a owl:Class ;
+brick:Luminous_Intensity a owl:Class,
+        brick:Quantity ;
     rdfs:label "Luminous Intensity" ;
     rdfs:subClassOf brick:Luminance .
 
@@ -2887,7 +2913,8 @@ brick:Maintenance_Mode_Command a owl:Class ;
     rdfs:label "Maintenance Mode Command" ;
     rdfs:subClassOf brick:Mode_Command .
 
-brick:Makeup_Water a owl:Class ;
+brick:Makeup_Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Makeup Water" ;
     rdfs:subClassOf brick:Water ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3730,7 +3757,8 @@ brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
                         owl:hasValue tag:Limit ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Mixed_Air a owl:Class ;
+brick:Mixed_Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Mixed Air" ;
     rdfs:subClassOf brick:Air ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3831,7 +3859,8 @@ brick:Motor_Torque_Sensor a owl:Class ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Natural_Gas a owl:Class ;
+brick:Natural_Gas a owl:Class,
+        brick:Substance ;
     rdfs:label "Natural Gas" ;
     rdfs:subClassOf brick:Gas ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3981,7 +4010,8 @@ brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Operative_Temperature a owl:Class ;
+brick:Operative_Temperature a owl:Class,
+        brick:Quantity ;
     rdfs:label "Operative Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -4016,7 +4046,8 @@ brick:Outside a owl:Class ;
                         owl:hasValue tag:Location ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Outside_Air a owl:Class ;
+brick:Outside_Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Outside Air" ;
     rdfs:subClassOf brick:Air ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -4195,12 +4226,14 @@ brick:PIR_Sensor a owl:Class ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:PM10_Level a owl:Class ;
+brick:PM10_Level a owl:Class,
+        brick:Quantity ;
     rdfs:label "PM10 Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
 
-brick:PM25_Level a owl:Class ;
+brick:PM25_Level a owl:Class,
+        brick:Quantity ;
     rdfs:label "PM25 Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
@@ -4250,7 +4283,8 @@ brick:PlugStrip a owl:Class ;
                         owl:hasValue tag:Equipment ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Power_Factor a owl:Class ;
+brick:Power_Factor a owl:Class,
+        brick:Quantity ;
     rdfs:label "Power Factor" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -4308,7 +4342,8 @@ brick:Pre_Filter_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Precipitation a owl:Class ;
+brick:Precipitation a owl:Class,
+        brick:Quantity ;
     rdfs:label "Precipitation" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -4381,7 +4416,8 @@ brick:Pump_Start_Stop_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Radiant_Temperature a owl:Class ;
+brick:Radiant_Temperature a owl:Class,
+        brick:Quantity ;
     rdfs:label "Radiant Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -4390,21 +4426,22 @@ brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:subClassOf brick:Duration_Sensor,
         brick:Rain_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Rain ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Duration ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ],
         [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Rain ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Duration ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Reactive_Power a owl:Class ;
+brick:Reactive_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Reactive Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
@@ -4478,7 +4515,8 @@ brick:Reset_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Return_Air a owl:Class ;
+brick:Return_Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Return Air" ;
     rdfs:subClassOf brick:Air ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -4806,7 +4844,8 @@ brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Solar_Irradiance a owl:Class ;
+brick:Solar_Irradiance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Solar Irradiance" ;
     rdfs:subClassOf brick:Irradiance .
 
@@ -4922,7 +4961,8 @@ brick:Standby_Unit_On_Off_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Static_Pressure a owl:Class ;
+brick:Static_Pressure a owl:Class,
+        brick:Quantity ;
     rdfs:label "Static Pressure" ;
     rdfs:subClassOf brick:Pressure .
 
@@ -4941,7 +4981,8 @@ brick:Static_Pressure_Dead_Band_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Steam a owl:Class ;
+brick:Steam a owl:Class,
+        brick:Substance ;
     rdfs:label "Steam" ;
     rdfs:subClassOf brick:Gas ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -5210,7 +5251,8 @@ brick:System_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:TVOC_Level a owl:Class ;
+brick:TVOC_Level a owl:Class,
+        brick:Quantity ;
     rdfs:label "TVOC Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
@@ -5226,7 +5268,8 @@ brick:Temporary_Occupancy_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Thermal_Energy a owl:Class ;
+brick:Thermal_Energy a owl:Class,
+        brick:Quantity ;
     rdfs:label "Thermal Energy" ;
     rdfs:subClassOf brick:Energy .
 
@@ -5255,7 +5298,8 @@ brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Dead_Band_Setpoi
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Thermal_Power a owl:Class ;
+brick:Thermal_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Thermal Power" ;
     rdfs:subClassOf brick:Power .
 
@@ -5360,15 +5404,18 @@ brick:Vent_Operating_Mode_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Voltage_Angle a owl:Class ;
+brick:Voltage_Angle a owl:Class,
+        brick:Quantity ;
     rdfs:label "Voltage Angle" ;
     rdfs:subClassOf brick:Electric_Voltage .
 
-brick:Voltage_Imbalance a owl:Class ;
+brick:Voltage_Imbalance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Voltage Imbalance" ;
     rdfs:subClassOf brick:Electric_Voltage .
 
-brick:Voltage_Magnitude a owl:Class ;
+brick:Voltage_Magnitude a owl:Class,
+        brick:Quantity ;
     rdfs:label "Voltage Magnitude" ;
     rdfs:subClassOf brick:Electric_Voltage .
 
@@ -5379,11 +5426,13 @@ brick:Weather a owl:Class ;
                         owl:hasValue tag:Weather ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Weather_Condition a owl:Class ;
+brick:Weather_Condition a owl:Class,
+        brick:Quantity ;
     rdfs:label "Weather Condition" ;
     rdfs:subClassOf brick:Quantity .
 
-brick:Wet_Bulb_Temperature a owl:Class ;
+brick:Wet_Bulb_Temperature a owl:Class,
+        brick:Quantity ;
     rdfs:label "Wet Bulb Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -5405,15 +5454,15 @@ brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
     rdfs:subClassOf brick:Speed_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Speed ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Speed ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Speed ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Wing a owl:Class ;
     rdfs:label "Wing" ;
@@ -5530,7 +5579,8 @@ brick:CRAC a owl:Class ;
     rdfs:subClassOf brick:HVAC ;
     owl:equivalentClass brick:Computer_Room_Air_Conditioning .
 
-brick:Capacity a owl:Class ;
+brick:Capacity a owl:Class,
+        brick:Quantity ;
     rdfs:label "Capacity" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5540,7 +5590,8 @@ brick:Computer_Room_Air_Conditioning a owl:Class ;
     owl:equivalentClass brick:CRAC ;
     skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " .
 
-brick:Conductivity a owl:Class ;
+brick:Conductivity a owl:Class,
+        brick:Quantity ;
     rdfs:label "Conductivity" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5548,13 +5599,13 @@ brick:Conductivity_Sensor a owl:Class ;
     rdfs:label "Conductivity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Conductivity ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Conductivity ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Conductivity ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Cooling_Command a owl:Class ;
     rdfs:label "Cooling Command" ;
@@ -5565,7 +5616,8 @@ brick:Cooling_Command a owl:Class ;
                         owl:hasValue tag:Command ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Current a owl:Class ;
+brick:Current a owl:Class,
+        brick:Quantity ;
     rdfs:label "Current" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5578,7 +5630,8 @@ brick:Damper_Command a owl:Class ;
                         owl:hasValue tag:Command ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Dewpoint a owl:Class ;
+brick:Dewpoint a owl:Class,
+        brick:Quantity ;
     rdfs:label "Dewpoint" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5705,15 +5758,16 @@ brick:Frequency_Sensor a owl:Class ;
     rdfs:label "Frequency Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frequency ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Frequency ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Frequency ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
-brick:Frost a owl:Class ;
+brick:Frost a owl:Class,
+        brick:Substance ;
     rdfs:label "Frost" ;
     rdfs:subClassOf brick:Solid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -5722,11 +5776,13 @@ brick:Frost a owl:Class ;
                         owl:hasValue tag:Frost ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Grains a owl:Class ;
+brick:Grains a owl:Class,
+        brick:Quantity ;
     rdfs:label "Grains" ;
     rdfs:subClassOf brick:Quantity .
 
-brick:Hail a owl:Class ;
+brick:Hail a owl:Class,
+        brick:Substance ;
     rdfs:label "Hail" ;
     rdfs:subClassOf brick:Solid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -5744,11 +5800,6 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Sensor" ;
     rdfs:subClassOf brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -5758,7 +5809,12 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Water ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Hot ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Hot Water System Enable Command" ;
@@ -5779,13 +5835,13 @@ brick:Humidity_Sensor a owl:Class ;
     rdfs:label "Humidity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Humidity ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Humidity ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Integral Gain Parameter" ;
@@ -5800,7 +5856,8 @@ brick:Integral_Gain_Parameter a owl:Class ;
                         owl:hasValue tag:Integral ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Irradiance a owl:Class ;
+brick:Irradiance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Irradiance" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5828,13 +5885,13 @@ brick:Luminance_Sensor a owl:Class ;
     rdfs:label "Luminance Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Luminance ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Luminance ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Luminance ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Meter a owl:Class ;
     rdfs:label "Meter" ;
@@ -5872,7 +5929,8 @@ brick:Occupancy_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Oil a owl:Class ;
+brick:Oil a owl:Class,
+        brick:Substance ;
     rdfs:label "Oil" ;
     rdfs:subClassOf brick:Liquid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -5999,7 +6057,8 @@ brick:Static_Pressure_Step_Parameter a owl:Class ;
                         owl:hasValue tag:PID ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Supply_Air a owl:Class ;
+brick:Supply_Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Supply Air" ;
     rdfs:subClassOf brick:Air ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -6151,11 +6210,13 @@ brick:Water_Valve a owl:Class ;
                         owl:hasValue tag:Equipment ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Wind_Direction a owl:Class ;
+brick:Wind_Direction a owl:Class,
+        brick:Quantity ;
     rdfs:label "Wind Direction" ;
     rdfs:subClassOf brick:Direction .
 
-brick:Wind_Speed a owl:Class ;
+brick:Wind_Speed a owl:Class,
+        brick:Quantity ;
     rdfs:label "Wind Speed" ;
     rdfs:subClassOf brick:Speed .
 
@@ -6551,17 +6612,17 @@ brick:Air_Grains_Sensor a owl:Class ;
     rdfs:label "Air Grains Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Grains ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Grains ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
@@ -6612,13 +6673,13 @@ brick:Dewpoint_Sensor a owl:Class ;
     rdfs:label "Dewpoint Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Dewpoint ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Dewpoint ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Differential_Pressure_Dead_Band_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Dead Band Setpoint" ;
@@ -6646,7 +6707,8 @@ brick:Differential_Speed_Sensor a owl:Class ;
                         owl:hasValue tag:Differential ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Direction a owl:Class ;
+brick:Direction a owl:Class,
+        brick:Quantity ;
     rdfs:label "Direction" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6698,7 +6760,8 @@ brick:Enable_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Enthalpy a owl:Class ;
+brick:Enthalpy a owl:Class,
+        brick:Quantity ;
     rdfs:label "Enthalpy" ;
     rdfs:subClassOf brick:Quantity ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -6710,11 +6773,6 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Sensor" ;
     rdfs:subClassOf brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -6724,7 +6782,12 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Exhaust ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
@@ -6738,14 +6801,16 @@ brick:Flow_Sensor a owl:Class ;
                         owl:hasValue brick:Flow ;
                         owl:onProperty brick:measures ] ) ] .
 
-brick:Fluid a owl:Class ;
+brick:Fluid a owl:Class,
+        brick:Substance ;
     rdfs:label "Fluid" ;
     rdfs:subClassOf brick:Substance ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Fluid ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Frequency a owl:Class ;
+brick:Frequency a owl:Class,
+        brick:Quantity ;
     rdfs:label "Frequency" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6754,7 +6819,8 @@ brick:Heat_Exchanger a owl:Class ;
     rdfs:subClassOf brick:HVAC ;
     owl:equivalentClass brick:HX .
 
-brick:Humidity a owl:Class ;
+brick:Humidity a owl:Class,
+        brick:Quantity ;
     rdfs:label "Humidity" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7104,7 +7170,8 @@ brick:Room a owl:Class ;
     rdfs:label "Room" ;
     rdfs:subClassOf brick:Location .
 
-brick:Speed a owl:Class ;
+brick:Speed a owl:Class,
+        brick:Quantity ;
     rdfs:label "Speed" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7237,7 +7304,8 @@ brick:Terminal_Unit a owl:Class ;
     rdfs:subClassOf brick:HVAC ;
     skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium." .
 
-brick:Voltage a owl:Class ;
+brick:Voltage a owl:Class,
+        brick:Quantity ;
     rdfs:label "Voltage" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7391,11 +7459,6 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Air Temperature Sensor" ;
     rdfs:subClassOf brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Supply_Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
@@ -7404,6 +7467,11 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Discharge ;
                         owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
         brick:Supply_Air_Temperature_Sensor .
 
 brick:Duration_Sensor a owl:Class ;
@@ -7415,11 +7483,13 @@ brick:Duration_Sensor a owl:Class ;
                         owl:hasValue tag:Duration ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Electric_Voltage a owl:Class ;
+brick:Electric_Voltage a owl:Class,
+        brick:Quantity ;
     rdfs:label "Electric Voltage" ;
     rdfs:subClassOf brick:Voltage .
 
-brick:Energy a owl:Class ;
+brick:Energy a owl:Class,
+        brick:Quantity ;
     rdfs:label "Energy" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7436,7 +7506,8 @@ brick:Entering_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue tag:Entering ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Flow a owl:Class ;
+brick:Flow a owl:Class,
+        brick:Quantity ;
     rdfs:label "Flow" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7451,7 +7522,8 @@ brick:Gain_Parameter a owl:Class ;
                         owl:hasValue tag:Gain ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Gas a owl:Class ;
+brick:Gas a owl:Class,
+        brick:Substance ;
     rdfs:label "Gas" ;
     rdfs:subClassOf brick:Fluid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -7486,14 +7558,16 @@ brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
                         owl:hasValue tag:Supply ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Liquid a owl:Class ;
+brick:Liquid a owl:Class,
+        brick:Substance ;
     rdfs:label "Liquid" ;
     rdfs:subClassOf brick:Fluid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Liquid ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Luminance a owl:Class ;
+brick:Luminance a owl:Class,
+        brick:Quantity ;
     rdfs:label "Luminance" ;
     rdfs:subClassOf brick:Quantity ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -7540,7 +7614,8 @@ brick:Outside_Air_Temperature_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Power a owl:Class ;
+brick:Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Power" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7548,13 +7623,13 @@ brick:Pressure_Sensor a owl:Class ;
     rdfs:label "Pressure Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Pressure_Setpoint a owl:Class ;
     rdfs:label "Pressure Setpoint" ;
@@ -7565,7 +7640,8 @@ brick:Pressure_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Solid a owl:Class ;
+brick:Solid a owl:Class,
+        brick:Substance ;
     rdfs:label "Solid" ;
     rdfs:subClassOf brick:Substance ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -7599,13 +7675,13 @@ brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Valve a owl:Class ;
     rdfs:label "Valve" ;
@@ -7711,7 +7787,8 @@ tag:Stack a brick:Tag ;
 tag:Standby a brick:Tag ;
     rdfs:label "Standby" .
 
-brick:Air_Quality a owl:Class ;
+brick:Air_Quality a owl:Class,
+        brick:Quantity ;
     rdfs:label "Air Quality" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7719,15 +7796,15 @@ brick:CO2_Sensor a owl:Class ;
     rdfs:label "CO2 Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:CO2 ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Air ;
                         owl:onProperty brick:measures ] [ a owl:Restriction ;
                         owl:hasValue brick:CO2 ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sensor ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:CO2 ;
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Damper a owl:Class ;
     rdfs:label "Damper" ;
@@ -7775,7 +7852,8 @@ brick:Differential_Pressure_Setpoint_Limit a owl:Class ;
                         owl:hasValue tag:Limit ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Electric_Power a owl:Class ;
+brick:Electric_Power a owl:Class,
+        brick:Quantity ;
     rdfs:label "Electric Power" ;
     rdfs:subClassOf brick:Power .
 
@@ -7959,11 +8037,13 @@ tag:Wheel a brick:Tag ;
 
 brick:Class a owl:Class .
 
-brick:Electric_Current a owl:Class ;
+brick:Electric_Current a owl:Class,
+        brick:Quantity ;
     rdfs:label "Electric Current" ;
     rdfs:subClassOf brick:Current .
 
-brick:Level a owl:Class ;
+brick:Level a owl:Class,
+        brick:Quantity ;
     rdfs:label "Level" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -8191,10 +8271,8 @@ brick:Min_Limit a owl:Class ;
                         owl:hasValue tag:Limit ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Substance a owl:Class ;
-    rdfs:subClassOf brick:Class .
-
-brick:Temperature a owl:Class ;
+brick:Temperature a owl:Class,
+        brick:Quantity ;
     rdfs:label "Temperature" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -8221,7 +8299,8 @@ brick:On_Off_Status a owl:Class ;
                         owl:hasValue tag:Status ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Pressure a owl:Class ;
+brick:Pressure a owl:Class,
+        brick:Quantity ;
     rdfs:label "Pressure" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -8254,7 +8333,8 @@ brick:Dead_Band_Setpoint a owl:Class ;
                         owl:hasValue tag:Setpoint ;
                         owl:onProperty brick:hasTag ] ) ] .
 
-brick:Water a owl:Class ;
+brick:Water a owl:Class,
+        brick:Substance ;
     rdfs:label "Water" ;
     rdfs:subClassOf brick:Liquid ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -8303,7 +8383,8 @@ tag:Heat a brick:Tag ;
 tag:Load a brick:Tag ;
     rdfs:label "Load" .
 
-brick:Air a owl:Class ;
+brick:Air a owl:Class,
+        brick:Substance ;
     rdfs:label "Air" ;
     rdfs:subClassOf brick:Gas ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -8392,11 +8473,6 @@ tag:Chilled a brick:Tag ;
 tag:Heating a brick:Tag ;
     rdfs:label "Heating" .
 
-brick:Quantity a owl:Class ;
-    rdfs:label "Quantity" ;
-    rdfs:subClassOf brick:Class,
-        brick:Quantity .
-
 tag:Command a brick:Tag ;
     rdfs:label "Command" .
 
@@ -8418,6 +8494,9 @@ brick:Sensor a owl:Class ;
 
 tag:Max a brick:Tag ;
     rdfs:label "Max" .
+
+brick:Substance a owl:Class ;
+    rdfs:subClassOf brick:Class .
 
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
@@ -8448,7 +8527,6 @@ brick:measures a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Point ;
-    rdfs:range brick:Substance ;
     owl:inverseOf brick:isMeasuredBy ;
     skos:definition "The subject measures a quantity or substance given by the object" .
 
@@ -8472,6 +8550,9 @@ tag:Water a brick:Tag ;
 
 tag:Temperature a brick:Tag ;
     rdfs:label "Temperature" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf brick:Class .
 
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -446,11 +446,6 @@ brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Sensor" ;
     rdfs:subClassOf brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -460,7 +455,12 @@ brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Water ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Chilled ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Setpoint" ;
@@ -1561,13 +1561,13 @@ brick:Energy_Sensor a owl:Class ;
     rdfs:label "Energy Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Energy ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Energy ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Energy ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Energy_Storage a owl:Class ;
     rdfs:label "Energy Storage" ;
@@ -1948,13 +1948,13 @@ brick:Frost_Sensor a owl:Class ;
     rdfs:label "Frost Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frost ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Frost ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Frost ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Fuel_Oil a owl:Class,
         brick:Substance ;
@@ -2019,13 +2019,13 @@ brick:Hail_Sensor a owl:Class ;
     rdfs:label "Hail Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Hail ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Hail ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Hail ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Hand_Auto_Status a owl:Class ;
     rdfs:label "Hand Auto Status" ;
@@ -5440,29 +5440,29 @@ brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
     rdfs:subClassOf brick:Direction_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Direction ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Direction ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Direction ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
     rdfs:subClassOf brick:Speed_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Speed ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Speed ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Wind ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Wind_Speed ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Wing a owl:Class ;
     rdfs:label "Wing" ;
@@ -5688,13 +5688,13 @@ brick:Enthalpy_Sensor a owl:Class ;
     rdfs:label "Enthalpy Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Enthalpy ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Enthalpy ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Flow Sensor" ;
@@ -5800,6 +5800,11 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Sensor" ;
     rdfs:subClassOf brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
@@ -5809,12 +5814,7 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:hasValue tag:Water ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Hot ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Hot Water System Enable Command" ;
@@ -5835,13 +5835,13 @@ brick:Humidity_Sensor a owl:Class ;
     rdfs:label "Humidity Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Humidity ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Humidity ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Integral Gain Parameter" ;
@@ -5885,13 +5885,13 @@ brick:Luminance_Sensor a owl:Class ;
     rdfs:label "Luminance Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Luminance ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Luminance ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Luminance ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Meter a owl:Class ;
     rdfs:label "Meter" ;
@@ -6560,17 +6560,17 @@ brick:Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Air Enthalpy Sensor" ;
     rdfs:subClassOf brick:Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Enthalpy ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Enthalpy ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 brick:Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Air Flow Demand Setpoint" ;
@@ -6612,17 +6612,17 @@ brick:Air_Grains_Sensor a owl:Class ;
     rdfs:label "Air Grains Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Grains ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Grains ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
@@ -7459,6 +7459,11 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Air Temperature Sensor" ;
     rdfs:subClassOf brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
@@ -7467,11 +7472,6 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Discharge ;
                         owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Supply_Air ;
-                        owl:onProperty brick:measures ] ) ],
         brick:Supply_Air_Temperature_Sensor .
 
 brick:Duration_Sensor a owl:Class ;
@@ -7574,6 +7574,8 @@ brick:Luminance a owl:Class,
                         owl:hasValue tag:Luminance ;
                         owl:onProperty brick:hasTag ] ) ] .
 
+brick:Measurable a owl:Class .
+
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
     rdfs:subClassOf brick:Command ;
@@ -7623,13 +7625,13 @@ brick:Pressure_Sensor a owl:Class ;
     rdfs:label "Pressure Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Pressure ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Pressure ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Pressure_Setpoint a owl:Class ;
     rdfs:label "Pressure Setpoint" ;
@@ -7652,13 +7654,13 @@ brick:Speed_Sensor a owl:Class ;
     rdfs:label "Speed Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Speed ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Speed ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Speed ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Step_Parameter a owl:Class ;
     rdfs:label "Step Parameter" ;
@@ -7675,13 +7677,13 @@ brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Valve a owl:Class ;
     rdfs:label "Valve" ;
@@ -7796,15 +7798,15 @@ brick:CO2_Sensor a owl:Class ;
     rdfs:label "CO2 Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:CO2 ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:CO2 ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO2 ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Damper a owl:Class ;
     rdfs:label "Damper" ;
@@ -7985,13 +7987,13 @@ brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
     rdfs:subClassOf brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Voltage ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Voltage ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Voltage ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 tag:Average a brick:Tag ;
     rdfs:label "Average" .
@@ -8162,17 +8164,17 @@ brick:Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Water Temperature Sensor" ;
     rdfs:subClassOf brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Temperature ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Water ;
-                        owl:onProperty brick:hasTag ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Temperature ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Water ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ] .
 
 tag:Direction a brick:Tag ;
     rdfs:label "Direction" .
@@ -8190,17 +8192,17 @@ brick:Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Air Humidity Sensor" ;
     rdfs:subClassOf brick:Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Humidity ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Humidity ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
@@ -8232,17 +8234,17 @@ brick:Air_Flow_Sensor a owl:Class ;
     rdfs:label "Air Flow Sensor" ;
     rdfs:subClassOf brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue brick:Flow ;
-                        owl:onProperty brick:measures ] [ a owl:Restriction ;
-                        owl:hasValue brick:Air ;
-                        owl:onProperty brick:measures ] ) ],
-        [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue tag:Sensor ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Flow ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Air ;
-                        owl:onProperty brick:hasTag ] ) ] .
+                        owl:onProperty brick:hasTag ] ) ],
+        [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] .
 
 brick:Demand_Setpoint a owl:Class ;
     rdfs:label "Demand Setpoint" ;
@@ -8496,7 +8498,8 @@ tag:Max a brick:Tag ;
     rdfs:label "Max" .
 
 brick:Substance a owl:Class ;
-    rdfs:subClassOf brick:Class .
+    rdfs:subClassOf brick:Class,
+        brick:Measurable .
 
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
@@ -8527,6 +8530,7 @@ brick:measures a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Point ;
+    rdfs:range brick:Measurable ;
     owl:inverseOf brick:isMeasuredBy ;
     skos:definition "The subject measures a quantity or substance given by the object" .
 
@@ -8552,7 +8556,8 @@ tag:Temperature a brick:Tag ;
     rdfs:label "Temperature" .
 
 brick:Quantity a owl:Class ;
-    rdfs:subClassOf brick:Class .
+    rdfs:subClassOf brick:Class,
+        brick:Measurable .
 
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ Class names should be alpha-numeric strings consisting of capitalized words sepa
 The class property dictionary can have the following keys:
 
 - `tags`: a list of Brick tags; an entity who has all of these tags will be inferred as an instance of the class
+- `parents`: a list of Brick *classes* that are parent classes of the current class; this lets us form the class lattice with less duplication
 - `subclasses`: a dictionary whose keys+values are class names and definitions; this recursively follows the same structure
 - `substances`: a nested list of Brick Substance classes. Each list item should be of the form `[BRICK.measures, BRICK.<substance name>]` where `<substance name>` is replaced with the substance that is measured. Substances are defined in `substances.py`
 - `SKOS.definition`: contains the definition of the class. The value must use the `Literal` constructor from RDFlib:

--- a/command.py
+++ b/command.py
@@ -118,10 +118,9 @@ command_definitions = {
             },
             "On_Off_Command": {
                 "tags": [TAG.OnOff, TAG.Command],
-                OWL.equivalentClass: BRICK.Start_Stop_Command,
                 "subclasses": {
                     "Steam_On_Off_Command": {},
-                    "Booster_Fan_Start_Stop_Command": {},
+                    "Start_Stop_Command": {},
                 },
             },
             "Override_Command": {

--- a/equipment.py
+++ b/equipment.py
@@ -10,7 +10,6 @@ Set up subclasses of the equipment superclass
 equipment_subclasses = {
     "HVAC": {
         OWL.equivalentClass: "Heating_Ventilation_Air_Conditioning_System",
-        "tags": [TAG.HVAC],
     },
     "Heating_Ventilation_Air_Conditioning_System": {
         OWL.equivalentClass: "HVAC",
@@ -216,21 +215,13 @@ hvac_subclasses = {
     },
     "Coil": {
         SKOS.definition: Literal("Exchanger that transfers heat from an exhaust airstream to a separated supply airstream."),
-        "tagvalues": [
-            [ BRICK.hasTag, TAG.Coil ],
-        ],
+                "tags": [TAG.Equipment, TAG.Coil],
         "subclasses": {
             "Cooling_Coil": {
-                "tagvalues": [
-                    [ BRICK.hasTag, TAG.Coil ],
-                    [ BRICK.hasTag, TAG.Cool ],
-                ]
+                "tags": [TAG.Equipment, TAG.Coil, TAG.Cool],
             },
             "Heating_Coil": {
-                "tagvalues": [
-                    [ BRICK.hasTag, TAG.Coil ],
-                    [ BRICK.hasTag, TAG.Heat ],
-                ]
+                "tags": [TAG.Equipment, TAG.Coil, TAG.Heat],
             },
         },
     },
@@ -271,9 +262,11 @@ valve_subclasses = {
             },
             "Domestic_Hot_Water_Valve": {
                 "tags": [TAG.Domestic, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
+                "parents": [BRICK.Hot_Water_System],
             },
             "Preheat_Hot_Water_Valve": {
                 "tags": [TAG.Preheat, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
+                "parents": [BRICK.Hot_Water_System],
             },
         },
         # OWL.equivalentClass: Restriction(BRICK.hasTag, graph=G, allValuesFrom=BRICK.Valve)

--- a/equipment.py
+++ b/equipment.py
@@ -262,11 +262,11 @@ valve_subclasses = {
             },
             "Domestic_Hot_Water_Valve": {
                 "tags": [TAG.Domestic, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
-                "parents": [BRICK.Hot_Water_System],
+                "parents": [BRICK.Hot_Water_System, BRICK.Water_Valve],
             },
             "Preheat_Hot_Water_Valve": {
                 "tags": [TAG.Preheat, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
-                "parents": [BRICK.Hot_Water_System],
+                "parents": [BRICK.Hot_Water_System, BRICK.Water_Valve],
             },
         },
         # OWL.equivalentClass: Restriction(BRICK.hasTag, graph=G, allValuesFrom=BRICK.Valve)
@@ -276,6 +276,7 @@ valve_subclasses = {
         "subclasses": {
             "Chilled_Water_Valve": {
                 "tags": [TAG.Chilled, TAG.Valve, TAG.Water, TAG.Equipment],
+                "parents": [BRICK.Chilled_Water_System],
             },
         },
     },

--- a/equipment.py
+++ b/equipment.py
@@ -8,9 +8,7 @@ from namespaces import *
 Set up subclasses of the equipment superclass
 """
 equipment_subclasses = {
-    "HVAC": {
-        OWL.equivalentClass: "Heating_Ventilation_Air_Conditioning_System",
-    },
+    "HVAC": {},
     "Heating_Ventilation_Air_Conditioning_System": {
         OWL.equivalentClass: "HVAC",
     },
@@ -95,7 +93,6 @@ hvac_subclasses = {
         # subclasses defined in 'valve_subclasses'
     },
     "VFD": {
-        OWL.equivalentClass: "VFD",
         "subclasses": {
             "Heat_Wheel_VFD": {},
             "Preheat_Valve_VFD": {},
@@ -110,14 +107,17 @@ hvac_subclasses = {
             "Fan_Coil_Unit": {
                 OWL.equivalentClass: "FCU",
             },
+            "FCU": {},
             "Variable_Air_Volume_Box": {
                 OWL.equivalentClass: "VAV",
                 "subclasses": {
                     "Variable_Air_Volume_Box_With_Reheat": {
                         OWL.equivalentClass: "RVAV",
                     },
+                    "RVAV": {},
                 },
             },
+            "VAV": {},
         },
     },
     "Space_Heater": {
@@ -142,6 +142,7 @@ hvac_subclasses = {
             "Condenser_Heat_Exchanger": {},
         },
     },
+    "HX": {},
     "Fume_Hood": {
         SKOS.definition: Literal("A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed."),
     },
@@ -239,13 +240,13 @@ hvac_subclasses = {
         OWL.equivalentClass: "AHU",
     },
     "AHU": {
-        OWL.equivalentClass: "Air_Handler_Unit",
         "tags": [ TAG.Equipment, TAG.AHU],
         "subclasses": {
             "Rooftop_Unit": {
                 OWL.equivalentClass: "RTU",
                 "tags": [TAG.Equipment, TAG.Rooftop, TAG.AHU],
             },
+            "RTU": {},
         },
     },
 }
@@ -269,7 +270,6 @@ valve_subclasses = {
                 "parents": [BRICK.Hot_Water_System, BRICK.Water_Valve],
             },
         },
-        # OWL.equivalentClass: Restriction(BRICK.hasTag, graph=G, allValuesFrom=BRICK.Valve)
     },
     "Water_Valve": {
         "tags": [TAG.Valve, TAG.Water, TAG.Equipment],

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -221,9 +221,9 @@ define_subclasses(quantity_definitions, BRICK.Quantity)
 #
 # In the above example, brick:Air and brick:Temperature are both instances.
 G.update("""INSERT { ?sc rdf:type brick:Substance }
-            WHERE { ?sc rdfs:subClassOf* brick:Substance }""")
+            WHERE { ?sc rdfs:subClassOf+ brick:Substance }""")
 G.update("""INSERT { ?qc rdf:type brick:Quantity }
-            WHERE { ?qc rdfs:subClassOf* brick:Quantity }""")
+            WHERE { ?qc rdfs:subClassOf+ brick:Quantity }""")
 
 from properties import properties
 define_properties(properties)

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -199,6 +199,7 @@ from quantities import quantity_definitions
 define_subclasses(quantity_definitions, BRICK.Quantity)
 
 G.add((BRICK.Measurable, A, OWL.Class))
+G.add((BRICK.Measurable, RDFS.subClassOf, SOSA.ObservableProperty))
 G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Quantity, RDFS.subClassOf, BRICK.Measurable))
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -211,6 +211,20 @@ define_subclasses(substances, BRICK.Substance)
 from quantities import quantity_definitions
 define_subclasses(quantity_definitions, BRICK.Quantity)
 
+# We make the punning explicit here. Any subclass of brick:Substance
+# or brick:Quantity is itself a substance or quantity. There is one canonical
+# instance of each class, which is indicated by referencing the class itself.
+#
+#    bldg:tmp1      a           brick:Air_Temperature_Sensor;
+#               brick:measures  brick:Air ,
+#                               brick:Temperature .
+#
+# In the above example, brick:Air and brick:Temperature are both instances.
+G.update("""INSERT { ?sc rdf:type brick:Substance }
+            WHERE { ?sc rdfs:subClassOf* brick:Substance }""")
+G.update("""INSERT { ?qc rdf:type brick:Quantity }
+            WHERE { ?qc rdfs:subClassOf* brick:Quantity }""")
+
 from properties import properties
 define_properties(properties)
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -211,6 +211,10 @@ define_subclasses(substances, BRICK.Substance)
 from quantities import quantity_definitions
 define_subclasses(quantity_definitions, BRICK.Quantity)
 
+G.add((BRICK.Measurable, A, OWL.Class))
+G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
+G.add((BRICK.Quantity, RDFS.subClassOf, BRICK.Measurable))
+
 # We make the punning explicit here. Any subclass of brick:Substance
 # or brick:Quantity is itself a substance or quantity. There is one canonical
 # instance of each class, which is indicated by referencing the class itself.

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -199,7 +199,8 @@ from quantities import quantity_definitions
 define_subclasses(quantity_definitions, BRICK.Quantity)
 
 G.add((BRICK.Measurable, A, OWL.Class))
-G.add((BRICK.Measurable, RDFS.subClassOf, SOSA.ObservableProperty))
+G.add((BRICK.Quantity, RDFS.subClassOf, SOSA.ObservableProperty))
+G.add((BRICK.Substance, RDFS.subClassOf, SOSA.FeatureOfInterest))
 G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Quantity, RDFS.subClassOf, BRICK.Measurable))
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -32,12 +32,12 @@ def add_restriction(klass, definition):
 # sets tags that only belong to a certain subclass?
 
 tag_subclasses = {
-    (TAG.Setpoint, TAG.Limit): BRICK.Parameter,    
-    (TAG.Setpoint, TAG.Deadband): BRICK.Deadband_Setpoint,    
-    (TAG.Status, TAG.Load, TAG.Shed): BRICK.Load_Shed_Status,
+    #(TAG.Setpoint, TAG.Limit): BRICK.Parameter,    
+    #(TAG.Setpoint, TAG.Deadband): BRICK.Deadband_Setpoint,    
+    #(TAG.Status, TAG.Load, TAG.Shed): BRICK.Load_Shed_Status,
     #(TAG.Setpoint, TAG.Load, TAG.Shed): BRICK.Load_Shed_Status,
-    (TAG.Valve, TAG.Equipment): BRICK.Valve,
-    (TAG.Status, TAG.On, TAG.Off): BRICK.On_Off_Status,
+    ##(TAG.Valve, TAG.Equipment): BRICK.Valve,
+    #(TAG.Status, TAG.On, TAG.Off): BRICK.On_Off_Status,
 }
 
 def has_tags(tagset, definition):
@@ -53,12 +53,12 @@ def add_tags(klass, definition, distinct):
 
     # if 'distinct' is true, then using the tags requires the additional class statement
     # to disambiguate what is meant.
-    if distinct:
-        restriction = BNode()
-        l.append(restriction)
-        G.add( (restriction, A, OWL.Restriction) )
-        G.add( (restriction, OWL.onProperty, RDF.type) )
-        G.add( (restriction, OWL.hasValue, BRICK[klass]) )
+    #if distinct:
+    #    restriction = BNode()
+    #    l.append(restriction)
+    #    G.add( (restriction, A, OWL.Restriction) )
+    #    G.add( (restriction, OWL.onProperty, RDF.type) )
+    #    G.add( (restriction, OWL.hasValue, BRICK[klass]) )
 
 
     #is_limit = TAG.Setpoint in definition and TAG.Limit in definition
@@ -76,18 +76,6 @@ def add_tags(klass, definition, distinct):
         G.add( (restriction, A, OWL.Restriction) )
         G.add( (restriction, OWL.onProperty, RDF.type) )
         G.add( (restriction, OWL.hasValue, c) )
-    #if is_limit:
-    #    restriction = BNode()
-    #    l.append(restriction)
-    #    G.add( (restriction, A, OWL.Restriction) )
-    #    G.add( (restriction, OWL.onProperty, RDF.type) )
-    #    G.add( (restriction, OWL.hasValue, BRICK.Parameter) )
-    # cardinality
-    #restriction = BNode()
-    #l.append(restriction)
-    #G.add( (restriction, A, OWL.Restriction) )
-    #G.add( (restriction, OWL.onProperty, BRICK.hasTag) )
-    #G.add( (restriction, OWL.cardinality, Literal(len(definition))) )
 
     # tag index
     tagset = tuple(sorted([item.split('#')[-1] for item in definition]))
@@ -252,8 +240,6 @@ G.add((BRICK.Quantity, RDFS.subClassOf, SOSA.ObservableProperty))
 G.add((BRICK.Substance, RDFS.subClassOf, SOSA.FeatureOfInterest))
 G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Quantity, RDFS.subClassOf, BRICK.Measurable))
-
-G.add((BRICK.Parameter, OWL.disjointWith, BRICK.Setpoint))
 
 # We make the punning explicit here. Any subclass of brick:Substance
 # or brick:Quantity is itself a substance or quantity. There is one canonical

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -28,11 +28,40 @@ def add_restriction(klass, definition):
     G.add( (equivalent_class, OWL.intersectionOf, list_name) )
     c = Collection(G, list_name, l)
 
-def add_tags(klass, definition):
+# mapping of subsets of tags that imply a class;
+# sets tags that only belong to a certain subclass?
+
+tag_subclasses = {
+    (TAG.Setpoint, TAG.Limit): BRICK.Parameter,    
+    (TAG.Setpoint, TAG.Deadband): BRICK.Deadband_Setpoint,    
+    (TAG.Status, TAG.Load, TAG.Shed): BRICK.Load_Shed_Status,
+    #(TAG.Setpoint, TAG.Load, TAG.Shed): BRICK.Load_Shed_Status,
+    (TAG.Valve, TAG.Equipment): BRICK.Valve,
+    (TAG.Status, TAG.On, TAG.Off): BRICK.On_Off_Status,
+}
+
+def has_tags(tagset, definition):
+    return all([t in definition for t in tagset])
+
+def add_tags(klass, definition, distinct):
     l = []
     equivalent_class = BNode()
     list_name = BNode()
-    is_limit = TAG.Setpoint in definition and TAG.Limit in definition
+
+    additional_tag_restriction_classes = [c for tagset, c in tag_subclasses.items() 
+                                            if has_tags(tagset, definition)]
+
+    # if 'distinct' is true, then using the tags requires the additional class statement
+    # to disambiguate what is meant.
+    if distinct:
+        restriction = BNode()
+        l.append(restriction)
+        G.add( (restriction, A, OWL.Restriction) )
+        G.add( (restriction, OWL.onProperty, RDF.type) )
+        G.add( (restriction, OWL.hasValue, BRICK[klass]) )
+
+
+    #is_limit = TAG.Setpoint in definition and TAG.Limit in definition
     for idnum, item in enumerate(definition):
         restriction = BNode()
         l.append(restriction)
@@ -41,12 +70,18 @@ def add_tags(klass, definition):
         G.add( (restriction, OWL.hasValue, item) )
         G.add( (item, A, BRICK.Tag) ) # make sure the tag is declared as such
         G.add( (item, RDFS.label, Literal(item.split('#')[-1])) ) # make sure the tag is declared as such
-    if is_limit:
+    for c in additional_tag_restriction_classes:
         restriction = BNode()
         l.append(restriction)
         G.add( (restriction, A, OWL.Restriction) )
         G.add( (restriction, OWL.onProperty, RDF.type) )
-        G.add( (restriction, OWL.hasValue, BRICK.Parameter) )
+        G.add( (restriction, OWL.hasValue, c) )
+    #if is_limit:
+    #    restriction = BNode()
+    #    l.append(restriction)
+    #    G.add( (restriction, A, OWL.Restriction) )
+    #    G.add( (restriction, OWL.onProperty, RDF.type) )
+    #    G.add( (restriction, OWL.hasValue, BRICK.Parameter) )
     # cardinality
     #restriction = BNode()
     #l.append(restriction)
@@ -87,11 +122,15 @@ def define_subclasses(definitions, superclass):
         G.add( (BRICK[subclass], A, OWL.Class) )
         G.add( (BRICK[subclass], RDFS.label, Literal(subclass.replace("_"," "))) )
         G.add( (BRICK[subclass], RDFS.subClassOf, superclass) )
+        distinct = 'distinct' in properties and properties.pop('distinct')
         for k, v in properties.items():
             if isinstance(v, list) and k == "tagvalues":
                 add_restriction(subclass, v)
             elif isinstance(v, list) and k == "tags":
-                add_tags(subclass, v)
+                add_tags(subclass, v, distinct)
+            elif isinstance(v, list) and k == "parents":
+                for parent in v:
+                    G.add( (BRICK[subclass], RDFS.subClassOf, parent) )
             elif isinstance(v, list) and k == "substances":
                 add_restriction(subclass, v)
             elif not apply_prop(subclass, k, v):
@@ -104,11 +143,14 @@ def define_rootclasses(definitions):
     for rootclass, properties in definitions.items():
         G.add( (BRICK[rootclass], A, OWL.Class) )
         G.add( (BRICK[rootclass], RDFS.subClassOf, BRICK.Class) )
+
+        distinct = 'distinct' in properties and properties.pop('distinct')
+
         for k, v in properties.items():
             if isinstance(v, list) and k == "tagvalues":
                 add_restriction(rootclass, v)
             elif isinstance(v, list) and k == "tags":
-                add_tags(rootclass, v)
+                add_tags(rootclass, v, distinct)
             elif isinstance(v, list) and k == "substances":
                 add_class_restriction(subclass, v)
             elif not apply_prop(rootclass, k, v):
@@ -210,6 +252,8 @@ G.add((BRICK.Quantity, RDFS.subClassOf, SOSA.ObservableProperty))
 G.add((BRICK.Substance, RDFS.subClassOf, SOSA.FeatureOfInterest))
 G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Quantity, RDFS.subClassOf, BRICK.Measurable))
+
+G.add((BRICK.Parameter, OWL.disjointWith, BRICK.Setpoint))
 
 # We make the punning explicit here. Any subclass of brick:Substance
 # or brick:Quantity is itself a substance or quantity. There is one canonical

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -3,24 +3,11 @@ from rdflib.namespace import XSD
 from rdflib.collection import Collection
 from rdflib.extras.infixowl import Restriction
 
-BRICK_VERSION = '1.1.0'
-
-BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
-TAG = Namespace("https://brickschema.org/schema/{0}/BrickTag#".format(BRICK_VERSION))
-SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
-DCTERMS = Namespace("http://purl.org/dc/terms#")
-SDO = Namespace("http://schema.org#")
+from namespaces import BRICK, RDF, OWL, DCTERMS, SDO, RDFS, SKOS, BRICK, TAG, SOSA
+from namespaces import bind_prefixes
 
 G = Graph()
-G.bind('rdf', RDF)
-G.bind('owl', OWL)
-G.bind('dcterms', DCTERMS)
-G.bind('sdo', SDO)
-G.bind('rdfs', RDFS)
-G.bind('skos', SKOS)
-G.bind('brick', BRICK)
-G.bind('tag', TAG)
-
+bind_prefixes(G)
 A = RDF.type
 
 from collections import defaultdict

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -32,6 +32,7 @@ def add_tags(klass, definition):
     l = []
     equivalent_class = BNode()
     list_name = BNode()
+    is_limit = TAG.Setpoint in definition and TAG.Limit in definition
     for idnum, item in enumerate(definition):
         restriction = BNode()
         l.append(restriction)
@@ -40,6 +41,12 @@ def add_tags(klass, definition):
         G.add( (restriction, OWL.hasValue, item) )
         G.add( (item, A, BRICK.Tag) ) # make sure the tag is declared as such
         G.add( (item, RDFS.label, Literal(item.split('#')[-1])) ) # make sure the tag is declared as such
+    if is_limit:
+        restriction = BNode()
+        l.append(restriction)
+        G.add( (restriction, A, OWL.Restriction) )
+        G.add( (restriction, OWL.onProperty, RDF.type) )
+        G.add( (restriction, OWL.hasValue, BRICK.Parameter) )
     # cardinality
     #restriction = BNode()
     #l.append(restriction)

--- a/namespaces.py
+++ b/namespaces.py
@@ -1,12 +1,26 @@
 from rdflib import Graph, Literal, BNode, Namespace, RDF, URIRef
 
-BRICK = Namespace("https://brickschema.org/schema/1.1.0/Brick#")
-TAG = Namespace("https://brickschema.org/schema/1.1.0/BrickTag#")
-BLDG = Namespace("https://brickschema.org/schema/1.1.0/ExampleBuilding#")
+BRICK_VERSION = '1.1.0'
+
+BRICK = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/Brick#")
+TAG = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/BrickTag#")
+#BLDG = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/ExampleBuilding#")
 OWL = Namespace("http://www.w3.org/2002/07/owl#")
 RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
 SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 DCTERMS = Namespace("http://purl.org/dc/terms#")
 SDO = Namespace("http://schema.org#")
+SOSA = Namespace("http://www.w3.org/ns/sosa#")
 A = RDF.type
+
+def bind_prefixes(g):
+    g.bind('rdf', RDF)
+    g.bind('owl', OWL)
+    g.bind('dcterms', DCTERMS)
+    g.bind('sdo', SDO)
+    g.bind('rdfs', RDFS)
+    g.bind('skos', SKOS)
+    g.bind('sosa', SOSA)
+    g.bind('brick', BRICK)
+    g.bind('tag', TAG)

--- a/parameter.py
+++ b/parameter.py
@@ -208,26 +208,26 @@ parameter_definitions = {
                 "tags": [TAG.Parameter, TAG.Limit],
                 "subclasses": {
                     "Speed_Setpoint_Limit": {
-                        "tags": [TAG.Speed, TAG.Setpoint, TAG.Limit],
+                        "tags": [TAG.Speed, TAG.Limit],
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Speed, TAG.Limit],
                                 "parents": [BRICK.Max_Limit],
                             },
                             "Min_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Speed, TAG.Limit],
                                 "parents": [BRICK.Min_Limit],
                             },
                         },
                     },
                     "Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                        "tags": [TAG.Air, TAG.Flow, TAG.Limit],
                         "subclasses": {
                             "Max_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Limit],
                             },
                             "Min_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Limit],
                             },
                         },
                     },
@@ -235,118 +235,123 @@ parameter_definitions = {
                         "tags": [TAG.Damper, TAG.Position, TAG.Limit],
                         "subclasses": {
                             "Max_Damper_Position_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Limit],
                             },
                             "Min_Damper_Position_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Limit],
                             },
                         },
                     },
                     "Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                        "tags": [TAG.Differential, TAG.Pressure, TAG.Limit],
                         "subclasses": {
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                         },
                     },
                     "Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                        "tags": [TAG.Static, TAG.Pressure, TAG.Limit],
                         "subclasses": {
                             "Min_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit],
                             },
                         },
+                        "parents": [BRICK.Static_Pressure_Setpoint],
                     },
                     "Max_Limit": {
                         "tags": [TAG.Max, TAG.Limit],
                         "distinct": True,
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Speed, TAG.Limit],
                             },
                             "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                             },
                             "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
+                            },
+                            "High_Static_Pressure_Cutout_Setpoint_Limit": {
+                                "tags": [ TAG.High, TAG.Static, TAG.Pressure, TAG.Cutout, TAG.Limit, TAG.Setpoint ],
+                                "parents": [BRICK.Static_Pressure_Setpoint_Limit],
                             },
                             "Max_Damper_Position_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Limit],
                             },
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit],
                                 "subclasses": {
                                     "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                                     },
                                     "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                                     },
                                 },
                             },
                             "Max_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Limit],
                                 "subclasses": {
                                     "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
@@ -359,81 +364,81 @@ parameter_definitions = {
                         "distinct": True,
                         "subclasses": {
                             "Min_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Speed, TAG.Limit],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Damper_Position_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Limit],
                             },
                             "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                             },
                             "Min_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit],
                                 "subclasses": {
                                     "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                                     },
                                     "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit],
                                     },
                                 },
                             },
                             "Min_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Limit],
                                 "subclasses": {
                                     "Min_Outside_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Limit],
                                     },
                                     "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },
                                     "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "tags": [TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                         "subclasses": {
                                             "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                             "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit],
                                             },
                                         },
                                     },

--- a/parameter.py
+++ b/parameter.py
@@ -12,415 +12,430 @@ SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 A = RDF.type
 
 parameter_definitions = {
-    "PID_Parameter":{
-        "tags": [TAG.Parameter, TAG.PID],
+    "Parameter": {
+        "tags": [TAG.Parameter],
         "subclasses": {
-            "Gain_Parameter": {
-                "tags": [TAG.Parameter, TAG.PID, TAG.Gain],
+            "PID_Parameter":{
+                "tags": [TAG.Parameter, TAG.PID],
                 "subclasses": {
-                    "Integral_Gain_Parameter": {
-                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Integral],
+                    "Gain_Parameter": {
+                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain],
                         "subclasses": {
-                            "Supply_Air_Integral_Gain_Parameter": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Integral, TAG.Gain, TAG.Parameter, TAG.PID],
-                            }
-                        }
-                    },
-                    "Proportional_Gain_Parameter": {
-                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional],
-                        "subclasses": {
-                            "Supply_Air_Proportional_Gain_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional, TAG.Supply, TAG.Air],
+                            "Integral_Gain_Parameter": {
+                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Integral],
+                                "subclasses": {
+                                    "Supply_Air_Integral_Gain_Parameter": {
+                                        "tags": [TAG.Supply, TAG.Air, TAG.Integral, TAG.Gain, TAG.Parameter, TAG.PID],
+                                    }
+                                }
+                            },
+                            "Proportional_Gain_Parameter": {
+                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional],
+                                "subclasses": {
+                                    "Supply_Air_Proportional_Gain_Parameter": {
+                                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional, TAG.Supply, TAG.Air],
+                                    },
+                                }
+                            },
+                            "Derivative_Gain_Parameter": {
+                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Derivative],
                             },
                         }
                     },
-                    "Derivative_Gain_Parameter": {
-                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Derivative],
+                    "Step_Parameter": {
+                        "tags": [TAG.Parameter, TAG.PID, TAG.Step],
+                        "subclasses": {
+                            "Differential_Pressure_Step_Parameter": {
+                                "subclasses": {
+                                    "Chilled_Water_Differential_Pressure_Step_Parameter": {
+                                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
+                                    }
+                                },
+                                "tags": [ TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
+                            },
+                            "Static_Pressure_Step_Parameter": {
+                                "subclasses": {
+                                    "Air_Static_Pressure_Step_Parameter": {
+                                        "tags": [ TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
+                                    }
+                                },
+                                "tags": [ TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
+                            },
+                            "Temperature_Step_Parameter": {
+                                "subclasses": {
+                                    "Air_Temperature_Step_Parameter": {
+                                        "tags": [ TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter, TAG.PID  ],
+                                    }
+                                },
+                                "tags": [ TAG.Temperature, TAG.Step, TAG.Parameter , TAG.PID ],
+                            }
+                        },
+                    },
+                    "Time_Parameter":{
+                        "Integral_Time_Parameter": {
+                            "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
+                            "subclasses": {
+                                "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                    "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID ],
+                                },
+                                "Cooling_Discharge_Air_Temperature_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Cooling_Supply_Air_Temperature_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Differential_Pressure_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID ],
+                                    "subclasses": {
+                                        "Hot_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                            "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
+                                        },
+                                        "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                            "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                        }
+                                    },
+                                },
+                                "Discharge_Air_Static_Pressure_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Exhaust_Air_Flow_Integral_Time_Parameter": {
+                                    "subclasses": {
+                                        "Exhaust_Air_Stack_Flow_Integral_Time_Parameter": {
+                                            "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                        }
+                                    },
+                                    "tags": [ TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Heating_Discharge_Air_Temperature_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Heating_Supply_Air_Temperature_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Static_Pressure_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
+                                },
+                                "Supply_Air_Static_Pressure_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
+                                },
+                                "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
+                                },
+                                "Supply_Water_Temperature_Integral_Time_Parameter": {
+                                    "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
+                                }
+                            },
+                        },
+                        "Derivative_Time_Parameter": {
+                            "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Derivative],
+                        },
+                    },
+                    "Proportional_Band_Parameter": {
+                        "tags": [TAG.Parameter, TAG.PID, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
+                        "subclasses": {
+                            "Differential_Pressure_Proportional_Band": {
+                                "tags": [ TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band , TAG.PID ],
+                                "subclasses": {
+                                    "Hot_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                    "Chilled_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                    "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                        "subclasses": {
+                                            "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                            },
+                                            "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                                "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Bandsetpoint , TAG.PID ],
+                                            }
+                                        },
+                                        "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                }
+                            },
+                            "Discharge_Air_Temperature_Proportional_Band_Parameter": {
+                                "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                "subclasses": {
+                                    "Heating_Discharge_Air_Temperature_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                    "Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                },
+                            },
+                            "Supply_Air_Temperature_Proportional_Band_Parameter": {
+                                "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                "subclasses": {
+                                    "Cooling_Supply_Air_Temperature_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID  ],
+                                    },
+                                    "Heating_Supply_Air_Temperature_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                }
+                            },
+                            "Exhaust_Air_Flow_Proportional_Band_Parameter": {
+                                "tags": [ TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                            },
+                            "Static_Pressure_Proportional_Band_Parameter": {
+                                "subclasses": {
+                                    "Discharge_Air_Static_Pressure_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                    "Exhaust_Air_Static_Pressure_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID  ],
+                                    },
+                                    "Supply_Air_Static_Pressure_Proportional_Band_Parameter": {
+                                        "tags": [ TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                                    },
+                                },
+                                "tags": [ TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                            },
+                            "Supply_Water_Temperature_Proportional_Band_Parameter": {
+                                "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
+                            },
+                            "Discharge_Water_Temperature_Proportional_Band_Parameter": {
+                                "tags": [TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
+                            },
+                        },
                     },
                 }
             },
-            "Step_Parameter": {
-                "tags": [TAG.Parameter, TAG.PID, TAG.Step],
+            "Limit": {
+                "tags": [TAG.Parameter, TAG.Limit],
                 "subclasses": {
-                    "Differential_Pressure_Step_Parameter": {
+                    "Speed_Setpoint_Limit": {
+                        "tags": [TAG.Speed, TAG.Setpoint, TAG.Limit],
                         "subclasses": {
-                            "Chilled_Water_Differential_Pressure_Step_Parameter": {
-                                "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
-                            }
-                        },
-                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
-                    },
-                    "Static_Pressure_Step_Parameter": {
-                        "subclasses": {
-                            "Air_Static_Pressure_Step_Parameter": {
-                                "tags": [ TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
-                            }
-                        },
-                        "tags": [ TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter , TAG.PID ],
-                    },
-                    "Temperature_Step_Parameter": {
-                        "subclasses": {
-                            "Air_Temperature_Step_Parameter": {
-                                "tags": [ TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter, TAG.PID  ],
-                            }
-                        },
-                        "tags": [ TAG.Temperature, TAG.Step, TAG.Parameter , TAG.PID ],
-                    }
-                },
-            },
-            "Time_Parameter":{
-                "Integral_Time_Parameter": {
-                    "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
-                    "subclasses": {
-                        "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {
-                            "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID ],
-                        },
-                        "Cooling_Discharge_Air_Temperature_Integral_Time_Parameter": {
-                            "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Cooling_Supply_Air_Temperature_Integral_Time_Parameter": {
-                            "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Differential_Pressure_Integral_Time_Parameter": {
-                            "tags": [ TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID ],
-                            "subclasses": {
-                                "Hot_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                    "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
-                                },
-                                "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                    "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                                }
+                            "Max_Speed_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "parents": [BRICK.Max_Limit],
+                            },
+                            "Min_Speed_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                                "parents": [BRICK.Min_Limit],
                             },
                         },
-                        "Discharge_Air_Static_Pressure_Integral_Time_Parameter": {
-                            "tags": [ TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Exhaust_Air_Flow_Integral_Time_Parameter": {
-                            "subclasses": {
-                                "Exhaust_Air_Stack_Flow_Integral_Time_Parameter": {
-                                    "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                                }
+                    },
+                    "Air_Flow_Setpoint_Limit": {
+                        "tags": [TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                        "subclasses": {
+                            "Max_Air_Flow_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
                             },
-                            "tags": [ TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Heating_Discharge_Air_Temperature_Integral_Time_Parameter": {
-                            "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Heating_Supply_Air_Temperature_Integral_Time_Parameter": {
-                            "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Static_Pressure_Integral_Time_Parameter": {
-                            "tags": [ TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID  ],
-                        },
-                        "Supply_Air_Static_Pressure_Integral_Time_Parameter": {
-                            "tags": [ TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
-                        },
-                        "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
-                            "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
-                        },
-                        "Supply_Water_Temperature_Integral_Time_Parameter": {
-                            "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter , TAG.PID ],
-                        }
-                    },
-                },
-                "Derivative_Time_Parameter": {
-                    "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Derivative],
-                },
-            },
-            "Proportional_Band_Parameter": {
-                "tags": [TAG.Parameter, TAG.PID, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
-                "subclasses": {
-                    "Chilled_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Cooling_Supply_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID  ],
-                    },
-                    "Differential_Pressure_Proportional_Band": {
-                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band , TAG.PID ],
-                    },
-                    "Hot_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Discharge_Air_Static_Pressure_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Supply_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Exhaust_Air_Flow_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Heating_Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Heating_Supply_Air_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Static_Pressure_Proportional_Band_Parameter": {
-                        "subclasses": {
-                            "Exhaust_Air_Static_Pressure_Proportional_Band_Parameter": {
-                                "tags": [ TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID  ],
-                            }
-                        },
-                        "tags": [ TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Supply_Air_Static_Pressure_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
-                    },
-                    "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                        "subclasses": {
-                            "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
+                            "Min_Air_Flow_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
                             },
-                            "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Bandsetpoint , TAG.PID ],
-                            }
                         },
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter , TAG.PID ],
                     },
-                    "Supply_Water_Temperature_Proportional_Band_Parameter": {
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
-                    },
-                    "Discharge_Water_Temperature_Proportional_Band_Parameter": {
-                        "tags": [TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID ],
-                    },
-                },
-            },
-        }
-    },
-    "Limit": {
-        "tags": [TAG.Parameter, TAG.Limit],
-        "subclasses": {
-            "Speed_Setpoint_Limit": {
-                "tags": [TAG.Speed, TAG.Setpoint, TAG.Limit],
-                "subclasses": {
-                    "Max_Speed_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Speed_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
-                    },
-                },
-            },
-            "Air_Flow_Setpoint_Limit": {
-                "tags": [TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                "subclasses": {
-                    "Max_Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                    },
-                },
-            },
-            "Damper_Position_Limit": {
-                "tags": [TAG.Damper, TAG.Position, TAG.Limit],
-                "subclasses": {
-                    "Max_Damper_Position_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Damper_Position_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
-                    },
-                },
-            },
-            "Differential_Pressure_Setpoint_Limit": {
-                "tags": [TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                "subclasses": {
-                    "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                },
-            },
-            "Static_Pressure_Setpoint_Limit": {
-                "tags": [TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                "subclasses": {
-                    "Min_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                },
-            },
-            "Max_Limit": {
-                "tags": [TAG.Max, TAG.Limit],
-                "subclasses": {
-                    "Max_Speed_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Damper_Position_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Max_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                    "Damper_Position_Limit": {
+                        "tags": [TAG.Damper, TAG.Position, TAG.Limit],
                         "subclasses": {
+                            "Max_Damper_Position_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Min_Damper_Position_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                            },
+                        },
+                    },
+                    "Differential_Pressure_Setpoint_Limit": {
+                        "tags": [TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                        "subclasses": {
+                            "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                        },
+                    },
+                    "Static_Pressure_Setpoint_Limit": {
+                        "tags": [TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                        "subclasses": {
+                            "Min_Static_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Max_Static_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                        },
+                    },
+                    "Max_Limit": {
+                        "tags": [TAG.Max, TAG.Limit],
+                        "distinct": True,
+                        "subclasses": {
+                            "Max_Speed_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Speed, TAG.Setpoint, TAG.Limit],
+                            },
                             "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
                                 "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
                             "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
                                 "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
+                            "Max_Damper_Position_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                            },
+                            "Max_Static_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                "subclasses": {
+                                    "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                    },
+                                    "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
+                                    },
+                                },
+                            },
+                            "Max_Air_Flow_Setpoint_Limit": {
+                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                "subclasses": {
+                                    "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
+                                    },
+                                    "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
+                                    },
+                                    "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
+                                    },
+                                    "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
                         },
                     },
-                    "Max_Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                    "Min_Limit": {
+                        "tags": [TAG.Min, TAG.Limit],
+                        "distinct": True,
                         "subclasses": {
-                            "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                    "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                },
+                            "Min_Speed_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
                             },
-                            "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                    "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                },
+                            "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
-                            "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                    "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                },
+                            "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
-                            "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                    "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                },
+                            "Min_Damper_Position_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
                             },
-                        },
-                    },
-                },
-            },
-            "Min_Limit": {
-                "tags": [TAG.Min, TAG.Limit],
-                "subclasses": {
-                    "Min_Speed_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Speed, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Damper_Position_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Damper, TAG.Position, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                    },
-                    "Min_Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
-                        "subclasses": {
                             "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
                                 "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
                             "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
                                 "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                             },
-                        },
-                    },
-                    "Min_Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                        "subclasses": {
-                            "Min_Outside_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                            },
-                            "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                            "Min_Static_Pressure_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                                 "subclasses": {
-                                    "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                                     },
-                                    "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint, TAG.Limit],
                                     },
                                 },
                             },
-                            "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                            "Min_Air_Flow_Setpoint_Limit": {
+                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
                                 "subclasses": {
-                                    "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Outside_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
                                     },
-                                    "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
                                     },
-                                },
-                            },
-                            "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
                                     },
-                                    "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
                                     },
-                                },
-                            },
-                            "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                "subclasses": {
-                                    "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
-                                    },
-                                    "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                    "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                        "tags": [TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                        "subclasses": {
+                                            "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                            "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
+                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint, TAG.Limit],
+                                            },
+                                        },
                                     },
                                 },
                             },
@@ -428,6 +443,6 @@ parameter_definitions = {
                     },
                 },
             },
-        },
-    },
+        }
+    }
 }

--- a/parameter.py
+++ b/parameter.py
@@ -15,6 +15,14 @@ parameter_definitions = {
     "Parameter": {
         "tags": [TAG.Parameter],
         "subclasses": {
+            "Load_Parameter": {
+                "tags": [ TAG.Load, TAG.Parameter ],
+                "subclasses": {
+                    "Max_Load_Setpoint": {
+                        "tags": [ TAG.Max, TAG.Load, TAG.Parameter ],
+                    },
+                },
+            },
             "PID_Parameter":{
                 "tags": [TAG.Parameter, TAG.PID],
                 "subclasses": {

--- a/parameter.py
+++ b/parameter.py
@@ -273,7 +273,6 @@ parameter_definitions = {
                     },
                     "Max_Limit": {
                         "tags": [TAG.Max, TAG.Limit],
-                        "distinct": True,
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
                                 "tags": [TAG.Max, TAG.Speed, TAG.Limit],
@@ -361,7 +360,6 @@ parameter_definitions = {
                     },
                     "Min_Limit": {
                         "tags": [TAG.Min, TAG.Limit],
-                        "distinct": True,
                         "subclasses": {
                             "Min_Speed_Setpoint_Limit": {
                                 "tags": [TAG.Min, TAG.Speed, TAG.Limit],

--- a/properties.py
+++ b/properties.py
@@ -109,7 +109,7 @@ properties = {
     },
     "isMeasuredBy": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        RDFS.domain: BRICK.Substance,
+        RDFS.domain: BRICK.Measurable,
         RDFS.range: BRICK.Point,
     },
     "regulates": {

--- a/properties.py
+++ b/properties.py
@@ -99,6 +99,10 @@ properties = {
         SKOS.definition: Literal("The subject has the given tag"),
         RDFS.range: BRICK.Tag,
     },
+    "isTagOf": {
+        A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        RDFS.domain: BRICK.Tag,
+    },
 
     "measures": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],

--- a/properties.py
+++ b/properties.py
@@ -106,7 +106,7 @@ properties = {
         SKOS.definition: Literal("The subject measures a quantity or substance given by the object"),
         RDFS.domain: BRICK.Point,
         # TODO: make a union class 'measurable' that is both quantities and substances
-        RDFS.range: BRICK.Substance,
+        #RDFS.range: BRICK.Substance,
     },
     "isMeasuredBy": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],

--- a/properties.py
+++ b/properties.py
@@ -105,8 +105,7 @@ properties = {
         OWL.inverseOf: "isMeasuredBy",
         SKOS.definition: Literal("The subject measures a quantity or substance given by the object"),
         RDFS.domain: BRICK.Point,
-        # TODO: make a union class 'measurable' that is both quantities and substances
-        #RDFS.range: BRICK.Substance,
+        RDFS.range: BRICK.Measurable,
     },
     "isMeasuredBy": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],

--- a/quantities.py
+++ b/quantities.py
@@ -33,6 +33,9 @@ quantity_definitions = {
                     "Complex_Power": {},
                 },
             },
+            "Peak_Power": {
+                SKOS.definition: Literal("Tracks the highest (peak) observed power in some interval"),
+            },
             "Thermal_Power": {}
         },
     },
@@ -80,7 +83,11 @@ quantity_definitions = {
             "Alternating_Current_Frequency": {},
         },
     },
-    "Humidity": {},
+    "Humidity": {
+        "subclasses": {
+            "Relative_Humidity": {},
+        },
+    },
     "Illuminance": {},
     "Irradiance": {
         "subclasses": {

--- a/quantities.py
+++ b/quantities.py
@@ -6,127 +6,123 @@ from namespaces import *
 
 
 quantity_definitions = {
-    "Quantity": {
+    "Air_Quality": {
         "subclasses": {
-            "Air_Quality": {
+            "CO2_Level": {},
+            "PM10_Level": {},
+            "PM25_Level": {},
+            "TVOC_Level": {},
+        },
+    },
+    "Conductivity": {},
+    "Capacity": {},
+    "Enthalpy": {
+        "tags": [TAG.Enthalpy],
+        SKOS.definition: Literal("(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"),
+    },
+    "Grains": {},
+    "Power": {
+        "subclasses": {
+            "Electric_Power": {
                 "subclasses": {
-                    "CO2_Level": {},
-                    "PM10_Level": {},
-                    "PM25_Level": {},
-                    "TVOC_Level": {},
-                },
-            },
-            "Conductivity": {},
-            "Capacity": {},
-            "Enthalpy": {
-                "tags": [TAG.Enthalpy],
-                SKOS.definition: Literal("(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"),
-            },
-            "Grains": {},
-            "Power": {
-                "subclasses": {
-                    "Electric_Power": {
-                        "subclasses": {
-                            "Apparent_Power": {},
-                            "Active_Power": {
-                                OWL.equivalentClass: "Real_Power",
-                            },
-                            "Reactive_Power": {},
-                            "Complex_Power": {},
-                        },
+                    "Apparent_Power": {},
+                    "Active_Power": {
+                        OWL.equivalentClass: "Real_Power",
                     },
-                    "Thermal_Power": {}
+                    "Reactive_Power": {},
+                    "Complex_Power": {},
                 },
             },
-            "Cloudage": {},
-            "Current": {
+            "Thermal_Power": {}
+        },
+    },
+    "Cloudage": {},
+    "Current": {
+        "subclasses": {
+            "Electric_Current": {
                 "subclasses": {
-                    "Electric_Current": {
-                        "subclasses": {
-                            "Current_Angle": {},
-                            "Current_Magnitude": {},
-                            "Current_Imbalance": {},
-                            "Current_Total_Harmonic_Distortion": {},
-                            "Alternating_Current_Frequency": {},
-                        },
-                    },
-                },
-            },
-            "Voltage": {
-                "subclasses": {
-                    "Electric_Voltage": {
-                        "subclasses": {
-                            "Voltage_Magnitude": {},
-                            "Voltage_Angle": {},
-                            "Voltage_Imbalance": {},
-                        },
-                    },
-                },
-            },
-            "Daytime": {},
-            "Dewpoint": {},
-            "Direction": {
-                "subclasses": {
-                    "Wind_Direction": {},
-                },
-            },
-            "Energy": {
-                "subclasses": {
-                    "Electric_Energy": {},
-                    "Thermal_Energy": {},
-                },
-            },
-            "Flow": {},
-            "Frequency": {
-                "subclasses": {
+                    "Current_Angle": {},
+                    "Current_Magnitude": {},
+                    "Current_Imbalance": {},
+                    "Current_Total_Harmonic_Distortion": {},
                     "Alternating_Current_Frequency": {},
                 },
             },
-            "Humidity": {},
-            "Illuminance": {},
-            "Irradiance": {
+        },
+    },
+    "Voltage": {
+        "subclasses": {
+            "Electric_Voltage": {
                 "subclasses": {
-                    "Solar_Irradiance": {},
+                    "Voltage_Magnitude": {},
+                    "Voltage_Angle": {},
+                    "Voltage_Imbalance": {},
                 },
-            },
-            "Level": {
-                "subclasses": {
-                    "CO2_Level": {},
-                    "PM10_Level": {},
-                    "PM25_Level": {},
-                    "TVOC_Level": {},
-                },
-            },
-            "Luminance": {
-                "tags": [TAG.Luminance],
-                "subclasses": {
-                    "Luminous_Flux": {},
-                    "Luminous_Intensity": {},
-                },
-            },
-            "Power_Factor": {},
-            "Precipitation": {},
-            "Pressure": {
-                "subclasses": {
-                    "Atmospheric_Pressure": {},
-                    "Static_Pressure": {},
-                },
-            },
-            "Speed": {
-                "subclasses": {
-                    "Wind_Speed": {},
-                },
-            },
-            "Temperature": {
-                "subclasses": {
-                    "Operative_Temperature": {},
-                    "Radiant_Temperature": {},
-                    "Dry_Bulb_Temperature": {},
-                    "Wet_Bulb_Temperature": {},
-                },
-            },
-            "Weather_Condition": {
             },
         },
+    },
+    "Daytime": {},
+    "Dewpoint": {},
+    "Direction": {
+        "subclasses": {
+            "Wind_Direction": {},
+        },
+    },
+    "Energy": {
+        "subclasses": {
+            "Electric_Energy": {},
+            "Thermal_Energy": {},
+        },
+    },
+    "Flow": {},
+    "Frequency": {
+        "subclasses": {
+            "Alternating_Current_Frequency": {},
+        },
+    },
+    "Humidity": {},
+    "Illuminance": {},
+    "Irradiance": {
+        "subclasses": {
+            "Solar_Irradiance": {},
+        },
+    },
+    "Level": {
+        "subclasses": {
+            "CO2_Level": {},
+            "PM10_Level": {},
+            "PM25_Level": {},
+            "TVOC_Level": {},
+        },
+    },
+    "Luminance": {
+        "tags": [TAG.Luminance],
+        "subclasses": {
+            "Luminous_Flux": {},
+            "Luminous_Intensity": {},
+        },
+    },
+    "Power_Factor": {},
+    "Precipitation": {},
+    "Pressure": {
+        "subclasses": {
+            "Atmospheric_Pressure": {},
+            "Static_Pressure": {},
+        },
+    },
+    "Speed": {
+        "subclasses": {
+            "Wind_Speed": {},
+        },
+    },
+    "Temperature": {
+        "subclasses": {
+            "Operative_Temperature": {},
+            "Radiant_Temperature": {},
+            "Dry_Bulb_Temperature": {},
+            "Wet_Bulb_Temperature": {},
+        },
+    },
+    "Weather_Condition": {
     },
 }

--- a/quantities.py
+++ b/quantities.py
@@ -103,10 +103,15 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        "tags": [TAG.Luminance],
         "subclasses": {
             "Luminous_Flux": {},
             "Luminous_Intensity": {},
+        },
+    },
+    "Occupancy": {
+        "subclasses": {
+            "Occupancy_Count": {},
+            "Occupancy_Percentage": {},
         },
     },
     "Power_Factor": {},
@@ -115,6 +120,12 @@ quantity_definitions = {
         "subclasses": {
             "Atmospheric_Pressure": {},
             "Static_Pressure": {},
+            "Velocity_Pressure": {},
+        },
+    },
+    "Radiance": {
+        "subclasses": {
+            "Solar_Radiance": {},
         },
     },
     "Speed": {
@@ -130,6 +141,7 @@ quantity_definitions = {
             "Wet_Bulb_Temperature": {},
         },
     },
+    "Torque": {},
     "Weather_Condition": {
     },
 }

--- a/quantities.py
+++ b/quantities.py
@@ -28,6 +28,7 @@ quantity_definitions = {
                     "Active_Power": {
                         OWL.equivalentClass: "Real_Power",
                     },
+                    "Real_Power": {},
                     "Reactive_Power": {},
                     "Complex_Power": {},
                 },

--- a/quantities.py
+++ b/quantities.py
@@ -14,6 +14,8 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
+    "Angle": {
+    },
     "Conductivity": {},
     "Capacity": {},
     "Enthalpy": {
@@ -114,6 +116,7 @@ quantity_definitions = {
             "Occupancy_Percentage": {},
         },
     },
+    "Position": {},
     "Power_Factor": {},
     "Precipitation": {},
     "Pressure": {

--- a/quantities.py
+++ b/quantities.py
@@ -17,7 +17,6 @@ quantity_definitions = {
     "Conductivity": {},
     "Capacity": {},
     "Enthalpy": {
-        "tags": [TAG.Enthalpy],
         SKOS.definition: Literal("(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"),
     },
     "Grains": {},

--- a/sensor.py
+++ b/sensor.py
@@ -194,15 +194,19 @@ sensor_definitions = {
                                     },
                                     "Discharge_Fan_Air_Flow_Sensor": {
                                         "tags": [ TAG.Discharge, TAG.Fan, TAG.Air, TAG.Flow, TAG.Sensor ],
+                                        "parents": [BRICK.Discharge_Air_Flow_Sensor],
                                     },
                                     "Return_Fan_Air_Flow_Sensor": {
+                                        "parents": [BRICK.Return_Air_Flow_Sensor],
                                         "tags": [ TAG.Return, TAG.Fan, TAG.Air, TAG.Flow, TAG.Sensor ],
                                     },
                                     "Supply_Fan_Air_Flow_Sensor": {
+                                        "parents": [BRICK.Supply_Air_Flow_Sensor],
                                         "tags": [ TAG.Supply, TAG.Fan, TAG.Air, TAG.Flow, TAG.Sensor ],
                                     }
                                 },
                                 "tags": [ TAG.Fan, TAG.Air, TAG.Flow, TAG.Sensor ],
+                                "distinct": True,
                             },
                             "Fume_Hood_Air_Flow_Sensor": {
                                 "tags": [ TAG.Fume, TAG.Hood, TAG.Air, TAG.Flow, TAG.Sensor ],
@@ -354,11 +358,6 @@ sensor_definitions = {
                             "Hot_Water_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot ],
                                 "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Hot_Water ], ],
-                                "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {
-                                        "tags": [ TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Sensor ],
-                                    }
-                                }
                             }
                         }
                     },
@@ -503,8 +502,7 @@ sensor_definitions = {
                         "subclasses": {
                             "Discharge_Air_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Discharge ],
-                                OWL.equivalentClass: "Supply_Air_Temperature_Sensor",
-                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Supply_Air ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Discharge_Air ], ],
                                 "subclasses": {
                                     "Cooling_Coil_Discharge_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Cooling, TAG.Coil, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor ],
@@ -514,6 +512,21 @@ sensor_definitions = {
                                     },
                                     "Preheat_Discharge_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Preheat, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor ],
+                                    }
+                                }
+                            },
+                            "Supply_Air_Temperature_Sensor": {
+                                "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Supply ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Supply_Air ], ],
+                                "subclasses": {
+                                    "Cooling_Coil_Supply_Air_Temperature_Sensor": {
+                                        "tags": [ TAG.Cooling, TAG.Coil, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
+                                    },
+                                    "Heat_Wheel_Supply_Air_Temperature_Sensor": {
+                                        "tags": [ TAG.Heat, TAG.Wheel, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
+                                    },
+                                    "Preheat_Supply_Air_Temperature_Sensor": {
+                                        "tags": [ TAG.Preheat, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
                                     }
                                 }
                             },
@@ -562,6 +575,12 @@ sensor_definitions = {
                                         "tags": [ TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor ],
                                     }
                                 }
+                            },
+                            "PreHeat_Coil_Leaving_Air_Temperature_Sensor": {
+                                "tags": [ TAG.Preheat, TAG.Coil, TAG.Leaving, TAG.Air, TAG.Temperature, TAG.Sensor ],
+                            },
+                            "PreHeat_Coil_Entering_Air_Temperature_Sensor": {
+                                "tags": [ TAG.Preheat, TAG.Coil, TAG.Entering, TAG.Air, TAG.Temperature, TAG.Sensor ],
                             }
                         }
                     },
@@ -610,9 +629,6 @@ sensor_definitions = {
                                     "Ice_Tank_Entering_Water_Temperature_Sensor": {
                                         "tags": [ TAG.Ice, TAG.Tank, TAG.Entering, TAG.Water, TAG.Temperature, TAG.Sensor ],
                                     },
-                                    "PreHeat_Coil_Entering_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Preheat, TAG.Coil, TAG.Entering, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    }
                                 }
                             },
                             "Leaving_Water_Temperature_Sensor": {
@@ -622,9 +638,6 @@ sensor_definitions = {
                                     "Ice_Tank_Leaving_Water_Temperature_Sensor": {
                                         "tags": [ TAG.Ice, TAG.Tank, TAG.Leaving, TAG.Water, TAG.Temperature, TAG.Sensor ],
                                     },
-                                    "PreHeat_Coil_Leaving_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Preheat, TAG.Coil, TAG.Leaving, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    }
                                 }
                             },
                             "Return_Water_Temperature_Sensor": {
@@ -636,6 +649,7 @@ sensor_definitions = {
                                     },
                                     "Chilled_Water_Return_Temperature_Sensor": {
                                         "tags": [ TAG.Chilled, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor ],
+                                        "parents": [BRICK.Chilled_Water_Temperature_Sensor],
                                     }
                                 }
                             }

--- a/sensor.py
+++ b/sensor.py
@@ -351,9 +351,6 @@ sensor_definitions = {
                             "Filter_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Filter ],
                             },
-                            "Heat_Wheel_Differential_Pressure_Sensor": {
-                                "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Wheel, TAG.Heat ],
-                            },
                             "Hot_Water_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot ],
                                 "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Hot_Water ], ],
@@ -503,12 +500,6 @@ sensor_definitions = {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Discharge ],
                                 "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Discharge_Air ], ],
                                 "subclasses": {
-                                    "Cooling_Coil_Discharge_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Cooling, TAG.Coil, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    },
-                                    "Heat_Wheel_Discharge_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Heat, TAG.Wheel, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    },
                                     "Preheat_Discharge_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Preheat, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor ],
                                     }
@@ -518,12 +509,6 @@ sensor_definitions = {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Supply ],
                                 "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Supply_Air ], ],
                                 "subclasses": {
-                                    "Cooling_Coil_Supply_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Cooling, TAG.Coil, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    },
-                                    "Heat_Wheel_Supply_Air_Temperature_Sensor": {
-                                        "tags": [ TAG.Heat, TAG.Wheel, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                                    },
                                     "Preheat_Supply_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Preheat, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor ],
                                     }
@@ -575,12 +560,6 @@ sensor_definitions = {
                                     }
                                 }
                             },
-                            "PreHeat_Coil_Leaving_Air_Temperature_Sensor": {
-                                "tags": [ TAG.Preheat, TAG.Coil, TAG.Leaving, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                            },
-                            "PreHeat_Coil_Entering_Air_Temperature_Sensor": {
-                                "tags": [ TAG.Preheat, TAG.Coil, TAG.Entering, TAG.Air, TAG.Temperature, TAG.Sensor ],
-                            }
                         }
                     },
                     "Water_Temperature_Sensor": {
@@ -621,14 +600,6 @@ sensor_definitions = {
                             "Entering_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Entering ],
                                 "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Entering_Water ], ],
-                                "subclasses": {
-                                    "Hot_Water_Coil_Entering_Temperature_Sensor": {
-                                        "tags": [ TAG.Hot, TAG.Water, TAG.Coil, TAG.Entering, TAG.Temperature, TAG.Sensor ],
-                                    },
-                                    "Ice_Tank_Entering_Water_Temperature_Sensor": {
-                                        "tags": [ TAG.Ice, TAG.Tank, TAG.Entering, TAG.Water, TAG.Temperature, TAG.Sensor ],
-                                    },
-                                }
                             },
                             "Leaving_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Leaving ],

--- a/sensor.py
+++ b/sensor.py
@@ -25,6 +25,7 @@ sensor_definitions = {
             },
             "Angle_Sensor": {
                 #TODO substances
+                "substances": [[BRICK.measures, BRICK.Angle]],
                 "subclasses": {
                     "Solar_Azimuth_Angle_Sensor": {
                         "tags": [ TAG.Solar, TAG.Azimuth, TAG.Angle, TAG.Sensor ],
@@ -86,6 +87,7 @@ sensor_definitions = {
                 }
             },
             "Damper_Position_Sensor": {
+                "substances": [[BRICK.measures, BRICK.Position]],
                 "tags": [ TAG.Damper, TAG.Position, TAG.Sensor ],
             },
             "Demand_Sensor": {

--- a/sensor.py
+++ b/sensor.py
@@ -206,7 +206,6 @@ sensor_definitions = {
                                     }
                                 },
                                 "tags": [ TAG.Fan, TAG.Air, TAG.Flow, TAG.Sensor ],
-                                "distinct": True,
                             },
                             "Fume_Hood_Air_Flow_Sensor": {
                                 "tags": [ TAG.Fume, TAG.Hood, TAG.Air, TAG.Flow, TAG.Sensor ],

--- a/sensor.py
+++ b/sensor.py
@@ -15,13 +15,16 @@ sensor_definitions = {
                 "subclasses": {
                     "Outside_Air_Grains_Sensor": {
                         "tags": [ TAG.Outside, TAG.Air, TAG.Grains, TAG.Sensor ],
+                        "substances": [ [ BRICK.measures, BRICK.Outside_Air ], [ BRICK.measures, BRICK.Grains ], ],
                     },
                     "Return_Air_Grains_Sensor": {
                         "tags": [ TAG.Return, TAG.Air, TAG.Grains, TAG.Sensor ],
+                        "substances": [ [ BRICK.measures, BRICK.Return_Air ], [ BRICK.measures, BRICK.Grains ], ],
                     }
                 }
             },
             "Angle_Sensor": {
+                #TODO substances
                 "subclasses": {
                     "Solar_Azimuth_Angle_Sensor": {
                         "tags": [ TAG.Solar, TAG.Azimuth, TAG.Angle, TAG.Sensor ],
@@ -44,9 +47,11 @@ sensor_definitions = {
                     },
                     "Outside_Air_CO2_Sensor": {
                         "tags": [ TAG.Outside, TAG.Air, TAG.CO2, TAG.Sensor ],
+                        "substances": [ [ BRICK.measures, BRICK.Outside_Air ], [ BRICK.measures, BRICK.CO2 ], ],
                     },
                     "Return_Air_CO2_Sensor": {
                         "tags": [ TAG.Return, TAG.Air, TAG.CO2, TAG.Sensor ],
+                        "substances": [ [ BRICK.measures, BRICK.Retur_Air ], [ BRICK.measures, BRICK.CO2 ], ],
                     }
                 }
             },
@@ -59,11 +64,13 @@ sensor_definitions = {
                 "subclasses": {
                     "Deionised_Water_Conductivity_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Conductivity, TAG.Water, TAG.Deionised ],
+                        "substances": [ [ BRICK.measures, BRICK.Conductivity ], [ BRICK.measures, BRICK.Deionized_Water] ],
                     }
                 }
             },
             "Current_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Current ],
+                "substances": [ [ BRICK.measures, BRICK.Current ], ],
                 "subclasses": {
                     "Load_Current_Sensor": {
                         "tags": [ TAG.Load, TAG.Current, TAG.Sensor ],
@@ -86,15 +93,19 @@ sensor_definitions = {
                 "subclasses": {
                     "Active_Power_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Power, TAG.Active ],
+                        "substances": [ [BRICK.measures, BRICK.Active_Power] ],
                     },
                     "Reactive_Power_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Power, TAG.Reactive ],
+                        "substances": [ [BRICK.measures, BRICK.Reactive_Power] ],
                     },
                     "Real_Power_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Power, TAG.Real ],
+                        "substances": [ [BRICK.measures, BRICK.Real_Power] ],
                     },
                     "Peak_Power_Demand_Sensor": {
                         "tags": [ TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor ],
+                        "substances": [ [BRICK.measures, BRICK.Peak_Power] ],
                     }
                 }
             },
@@ -104,9 +115,11 @@ sensor_definitions = {
                 "subclasses": {
                     "Outside_Air_Dewpoint_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Outside ],
+                        "substances": [ [ BRICK.measures, BRICK.Dewpoint ], [BRICK.measures, BRICK.Outside_Air] ],
                     },
                     "Return_Air_Dewpoint_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Return ],
+                        "substances": [ [ BRICK.measures, BRICK.Dewpoint ], [BRICK.measures, BRICK.Return_Air] ],
                     }
                 }
             },
@@ -133,9 +146,11 @@ sensor_definitions = {
                         "subclasses": {
                             "Outside_Air_Enthalpy_Sensor": {
                                 "tags": [ TAG.Outside, TAG.Air, TAG.Enthalpy, TAG.Sensor ],
+                                "substances": [ [ BRICK.measures, BRICK.Enthalpy ], [ BRICK.measures, BRICK.Outside_Air ], ],
                             },
                             "Return_Air_Enthalpy_Sensor": {
                                 "tags": [ TAG.Return, TAG.Air, TAG.Enthalpy, TAG.Sensor ],
+                                "substances": [ [ BRICK.measures, BRICK.Enthalpy ], [ BRICK.measures, BRICK.Return_Air ], ],
                             }
                         },
                         "tags": [ TAG.Air, TAG.Enthalpy, TAG.Sensor ],
@@ -147,14 +162,16 @@ sensor_definitions = {
                 "substances": [ [ BRICK.measures, BRICK.Flow ], ],
                 "subclasses": {
                     "Air_Flow_Sensor": {
-                        "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Air ], ],
                         "tags": [ TAG.Sensor, TAG.Flow, TAG.Air ],
+                        "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Air ], ],
                         "subclasses": {
                             "Bypass_Air_Flow_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Bypass ],
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Bypass_Air ], ],
                             },
                             "Discharge_Air_Flow_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Discharge ],
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Discharge_Air ], ],
                                 "subclasses": {
                                     "Average_Discharge_Air_Flow_Sensor": {
                                         "tags": [ TAG.Average, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Sensor ],
@@ -163,6 +180,7 @@ sensor_definitions = {
                             },
                             "Exhaust_Air_Flow_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Exhaust ],
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Exhaust_Air ], ],
                                 "subclasses": {
                                     "Exhaust_Air_Stack_Flow_Sensor": {
                                         "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Sensor ],
@@ -190,13 +208,16 @@ sensor_definitions = {
                                 "tags": [ TAG.Fume, TAG.Hood, TAG.Air, TAG.Flow, TAG.Sensor ],
                             },
                             "Outside_Air_Flow_Sensor": {
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Outside_Air ], ],
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Outside ],
                             },
                             "Return_Air_Flow_Sensor": {
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Return_Air ], ],
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Return ],
                             },
                             "Supply_Air_Flow_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Air, TAG.Supply ],
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Supply_Air ], ],
                                 "subclasses": {
                                     "Average_Supply_Air_Flow_Sensor": {
                                         "tags": [ TAG.Average, TAG.Supply, TAG.Air, TAG.Flow, TAG.Sensor ],
@@ -211,12 +232,15 @@ sensor_definitions = {
                         "subclasses": {
                             "Supply_Water_Flow_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply ],
+                                "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Supply_Water ], ],
                                 "subclasses": {
                                     "Chilled_Water_Discharge_Flow_Sensor": {
                                         "tags": [ TAG.Sensor, TAG.Flow, TAG.Water, TAG.Discharge, TAG.Chilled ],
+                                        "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Discharge_Chilled_Water ], ],
                                     },
                                     "Chilled_Water_Supply_Flow_Sensor": {
                                         "tags": [ TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply, TAG.Chilled ],
+                                        "substances": [ [ BRICK.measures, BRICK.Flow ], [ BRICK.measures, BRICK.Supply_Chilled_Water ], ],
                                     }
                                 }
                             }
@@ -251,21 +275,27 @@ sensor_definitions = {
                         "subclasses": {
                             "Discharge_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Discharge ],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Discharge_Air ], ],
                             },
                             "Exhaust_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Exhaust ],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Exhaust_Air ], ],
                             },
                             "Outside_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Outside ],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Outside_Air ], ],
                             },
                             "Relative_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Relative ],
+                                "substances": [ [ BRICK.measures, BRICK.Relative_Humidity ], [ BRICK.measures, BRICK.Air ], ],
                             },
                             "Return_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Return ],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Return_Air ], ],
                             },
                             "Supply_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Supply ],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Supply_Air ], ],
                             },
                             "Zone_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Zone ],

--- a/sensor.py
+++ b/sensor.py
@@ -299,6 +299,7 @@ sensor_definitions = {
                             },
                             "Zone_Air_Humidity_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Zone],
+                                "substances": [ [ BRICK.measures, BRICK.Humidity ], [ BRICK.measures, BRICK.Zone_Air ], ],
                             }
                         }
                     }

--- a/sensor.py
+++ b/sensor.py
@@ -324,6 +324,7 @@ sensor_definitions = {
             },
             "Occupancy_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Occupancy ],
+                "substances": [ [BRICK.measures, BRICK.Occupancy] ],
                 "subclasses": {
                     "PIR_Sensor": {
                         "tags": [ TAG.Pir, TAG.Sensor ],
@@ -342,7 +343,7 @@ sensor_definitions = {
                         "subclasses": {
                             "Chilled_Water_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Chilled ],
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Water ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Chilled_Water ], ],
                             },
                             "Filter_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Filter ],
@@ -352,7 +353,7 @@ sensor_definitions = {
                             },
                             "Hot_Water_Differential_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot ],
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Water ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Hot_Water ], ],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {
                                         "tags": [ TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Sensor ],
@@ -392,15 +393,19 @@ sensor_definitions = {
                     },
                     "Velocity_Pressure_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Pressure, TAG.Velocity ],
+                        "substances": [ [BRICK.measures, BRICK.Velocity_Pressure] ],
                         "subclasses": {
                             "Discharge_Air_Velocity_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Discharge, TAG.Air ],
+                                "substances": [ [BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Discharge_Air] ],
                             },
                             "Exhaust_Air_Velocity_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Exhaust, TAG.Air ],
+                                "substances": [ [BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Exhaust_Air] ],
                             },
                             "Supply_Air_Velocity_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Supply, TAG.Air ],
+                                "substances": [ [BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Supply_Air] ],
                             }
                         }
                     }
@@ -408,6 +413,7 @@ sensor_definitions = {
             },
             "Rain_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Rain ],
+                #TODO: substances
                 "subclasses": {
                     "Rain_Duration_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Rain, TAG.Duration ],
@@ -416,6 +422,7 @@ sensor_definitions = {
             },
             "Duration_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Duration ],
+                #TODO: substances
                 "subclasses": {
                     "Rain_Duration_Sensor": {
                         "tags": [ TAG.Rain, TAG.Duration, TAG.Sensor ],
@@ -430,6 +437,7 @@ sensor_definitions = {
             },
             "Solar_Radiance_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Radiance, TAG.Solar ],
+                "substances": [ [BRICK.measures, BRICK.Solar_Radiance] ],
             },
             "Speed_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Speed ],
@@ -437,14 +445,6 @@ sensor_definitions = {
                 "subclasses": {
                     "Differential_Speed_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Speed, TAG.Differential ],
-                        "subclasses": {
-                            "Heat_Wheel_Speed_Sensor": {
-                                "tags": [ TAG.Sensor, TAG.Speed, TAG.Heat, TAG.Wheel ],
-                            },
-                            "Return_Fan_Differential_Speed_Sensor": {
-                                "tags": [ TAG.Return, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Sensor ],
-                            }
-                        }
                     },
                     "Motor_Speed_Sensor": {
                         "tags": [ TAG.Motor, TAG.Speed, TAG.Sensor ],
@@ -457,6 +457,7 @@ sensor_definitions = {
             },
             "Torque_Sensor": {
                 "tags": [ TAG.Sensor, TAG.Torque ],
+                "substances": [ [BRICK.measures, BRICK.Torque] ],
                 "subclasses": {
                     "Motor_Torque_Sensor": {
                         "tags": [ TAG.Motor, TAG.Torque, TAG.Sensor ],
@@ -464,6 +465,7 @@ sensor_definitions = {
                 }
             },
             "Trace_Heat_Sensor": {
+                #TODO: substance
                 "tags": [ TAG.Trace, TAG.Heat, TAG.Sensor ],
             },
             "Voltage_Sensor": {
@@ -476,9 +478,6 @@ sensor_definitions = {
                     "DC_Bus_Voltage_Sensor": {
                         "tags": [ TAG.Dc, TAG.Bus, TAG.Voltage, TAG.Sensor ],
                     },
-                    "Heat_Wheel_Voltage_Sensor": {
-                        "tags": [ TAG.Heat, TAG.Wheel, TAG.Voltage, TAG.Sensor ],
-                    },
                     "Output_Voltage_Sensor": {
                         "tags": [ TAG.Output, TAG.Voltage, TAG.Sensor ],
                     }
@@ -490,7 +489,7 @@ sensor_definitions = {
                 "subclasses": {
                     "Deionised_Water_Level_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Water, TAG.Level, TAG.Deionised ],
-                        OWL.equivalentClass: "DI_Water_Level_Sensor"
+                        "substances": [ [ BRICK.measures, BRICK.Deionized_Water ], [ BRICK.measures, BRICK.Level ], ],
                     }
                 }
             },
@@ -520,6 +519,7 @@ sensor_definitions = {
                             },
                             "Zone_Air_Temperature_Sensor": {
                                 "tags": [ TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Zone_Air ], ],
                                 "subclasses": {
                                     "Average_Zone_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Average, TAG.Air],
@@ -535,16 +535,20 @@ sensor_definitions = {
                                 }
                             },
                             "Exhaust_Air_Temperature_Sensor": {
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Exhaust_Air ], ],
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Exhaust ],
                             },
                             "Mixed_Air_Temperature_Sensor": {
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Mixed_Air ], ],
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Mixed ],
                             },
                             "Return_Air_Temperature_Sensor": {
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Return_Air ], ],
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Return ],
                             },
                             "Outside_Air_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Outside ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Outside_Air ], ],
                                 "subclasses": {
                                     "Outside_Air_Lockout_Temperature_Differential_Sensor": {
                                         "subclasses": {
@@ -570,6 +574,7 @@ sensor_definitions = {
                             },
                             "Hot_Water_Supply_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Hot, TAG.Supply ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Supply_Hot_Water ], ],
                                 "subclasses": {
                                     "Domestic_Hot_Water_Supply_Temperature_Sensor": {
                                         "tags": [ TAG.Domestic, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor ],
@@ -584,18 +589,20 @@ sensor_definitions = {
                             },
                             "Chilled_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Chilled_Water ], ],
                                 "subclasses": {
                                     "Chilled_Water_Differential_Temperature_Sensor": {
                                         "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Temperature, TAG.Sensor ],
                                     },
                                     "Chilled_Water_Supply_Temperature_Sensor": {
                                         "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled, TAG.Supply ],
-                                        OWL.equivalentClass: "Chilled_Water_Discharge_Temperature_Sensor"
+                                        "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Supply_Chilled_Water ], ],
                                     }
                                 }
                             },
                             "Entering_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Entering ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Entering_Water ], ],
                                 "subclasses": {
                                     "Hot_Water_Coil_Entering_Temperature_Sensor": {
                                         "tags": [ TAG.Hot, TAG.Water, TAG.Coil, TAG.Entering, TAG.Temperature, TAG.Sensor ],
@@ -610,6 +617,7 @@ sensor_definitions = {
                             },
                             "Leaving_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Leaving ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Leaving_Water ], ],
                                 "subclasses": {
                                     "Ice_Tank_Leaving_Water_Temperature_Sensor": {
                                         "tags": [ TAG.Ice, TAG.Tank, TAG.Leaving, TAG.Water, TAG.Temperature, TAG.Sensor ],
@@ -621,6 +629,7 @@ sensor_definitions = {
                             },
                             "Return_Water_Temperature_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Return ],
+                                "substances": [ [ BRICK.measures, BRICK.Temperature ], [ BRICK.measures, BRICK.Return_Water ], ],
                                 "subclasses": {
                                     "Hot_Water_Return_Temperature_Sensor": {
                                         "tags": [ TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor ],

--- a/sensor.py
+++ b/sensor.py
@@ -366,20 +366,20 @@ sensor_definitions = {
                         "tags": [ TAG.Sensor, TAG.Pressure, TAG.Static ],
                         "subclasses": {
                             "Building_Air_Static_Pressure_Sensor": {
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Air ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Static_Pressure ], [ BRICK.measures, BRICK.Building_Air ], ],
                                 "tags": [ TAG.Building, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor ],
                             },
                             "Discharge_Air_Static_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Discharge ],
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Air ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Static_Pressure ], [ BRICK.measures, BRICK.Discharge_Air ], ],
                             },
                             "Supply_Air_Static_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Supply ],
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Air ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Static_Pressure ], [ BRICK.measures, BRICK.Supply_Air ], ],
                             },
                             "Exhaust_Air_Static_Pressure_Sensor": {
                                 "tags": [ TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Exhaust ],
-                                "substances": [ [ BRICK.measures, BRICK.Pressure ], [ BRICK.measures, BRICK.Air ], ],
+                                "substances": [ [ BRICK.measures, BRICK.Static_Pressure ], [ BRICK.measures, BRICK.Exhaust_Air ], ],
                                 "subclasses": {
                                     "Average_Exhaust_Air_Static_Pressure_Sensor": {
                                         "tags": [ TAG.Average, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor ],

--- a/sensor.py
+++ b/sensor.py
@@ -51,7 +51,7 @@ sensor_definitions = {
                     },
                     "Return_Air_CO2_Sensor": {
                         "tags": [ TAG.Return, TAG.Air, TAG.CO2, TAG.Sensor ],
-                        "substances": [ [ BRICK.measures, BRICK.Retur_Air ], [ BRICK.measures, BRICK.CO2 ], ],
+                        "substances": [ [ BRICK.measures, BRICK.Return_Air ], [ BRICK.measures, BRICK.CO2 ], ],
                     }
                 }
             },
@@ -99,9 +99,9 @@ sensor_definitions = {
                         "tags": [ TAG.Sensor, TAG.Power, TAG.Reactive ],
                         "substances": [ [BRICK.measures, BRICK.Reactive_Power] ],
                     },
-                    "Real_Power_Sensor": {
+                    "Active_Power_Sensor": {
                         "tags": [ TAG.Sensor, TAG.Power, TAG.Real ],
-                        "substances": [ [BRICK.measures, BRICK.Real_Power] ],
+                        "substances": [ [BRICK.measures, BRICK.Active_Power] ],
                     },
                     "Peak_Power_Demand_Sensor": {
                         "tags": [ TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor ],

--- a/sensor.py
+++ b/sensor.py
@@ -81,7 +81,8 @@ sensor_definitions = {
                     "Photovoltaic_Current_Output_Sensor": {
                         OWL.equivalentClass: "PV_Current_Output_Sensor",
                         "tags": [ TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor ],
-                    }
+                    },
+                    "PV_Current_Output_Sensor": {},
                 }
             },
             "Damper_Position_Sensor": {
@@ -528,7 +529,9 @@ sensor_definitions = {
                                     "Lowest_Zone_Air_Temperature_Sensor": {
                                         "tags": [ TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Lowest, TAG.Air],
                                         OWL.equivalentClass: "Coldest_Zone_Air_Temperature_Sensor"
-                                    }
+                                    },
+                                    "Coldest_Zone_Air_Temperature_Sensor": {},
+                                    "Warmest_Zone_Air_Temperature_Sensor": {},
                                 }
                             },
                             "Exhaust_Air_Temperature_Sensor": {

--- a/setpoint.py
+++ b/setpoint.py
@@ -238,9 +238,6 @@ setpoint_definitions = {
             },
             "Load_Setpoint": {
                 "subclasses": {
-                    "Max_Load_Setpoint": {
-                        "tags": [ TAG.Max, TAG.Load, TAG.Setpoint ],
-                    },
                     "Load_Shed_Setpoint": {
                         "tags": [ TAG.Shed, TAG.Load, TAG.Setpoint ],
                     }

--- a/setpoint.py
+++ b/setpoint.py
@@ -386,6 +386,8 @@ setpoint_definitions = {
                                         OWL.equivalentClass: "Minimum_Discharge_Air_Temperature_Setpoint",
                                         "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint ],
                                     },
+                                    "Minimum_Discharge_Air_Temperature_Setpoint": {},
+                                    "Maximum_Discharge_Air_Temperature_Setpoint": {},
                                     "Discharge_Air_Temperature_Cooling_Setpoint": {
                                         OWL.equivalentClass: "Maximum_Discharge_Air_Temperature_Setpoint",
                                         "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Cooling, TAG.Setpoint ],

--- a/setpoint.py
+++ b/setpoint.py
@@ -23,6 +23,7 @@ setpoint_definitions = {
                     },
                     "Cooling_Request_Percent_Setpoint": {
                         "tags": [ TAG.Cooling, TAG.Request, TAG.Percent, TAG.Setpoint ],
+                        "parents": [BRICK.Cooling_Request_Setpoint],
                     },
                     "Cooling_Request_Setpoint": {
                         "tags": [ TAG.Cooling, TAG.Request, TAG.Setpoint ],
@@ -30,11 +31,13 @@ setpoint_definitions = {
                     "Heating_Demand_Setpoint": {
                         "tags": [ TAG.Heating, TAG.Demand, TAG.Setpoint ],
                     },
-                    "Heating_Request_Percent_Setpoint": {
-                        "tags": [ TAG.Heating, TAG.Request, TAG.Percent, TAG.Setpoint ],
-                    },
                     "Heating_Request_Setpoint": {
                         "tags": [ TAG.Heating, TAG.Request, TAG.Setpoint ],
+                        "subclasses": {
+                            "Heating_Request_Percent_Setpoint": {
+                                "tags": [ TAG.Heating, TAG.Request, TAG.Percent, TAG.Setpoint ],
+                            },
+                        }
                     },
                     "Preheat_Demand_Setpoint": {
                         "tags": [ TAG.Preheat, TAG.Demand, TAG.Setpoint ],
@@ -55,90 +58,91 @@ setpoint_definitions = {
             "Damper_Position_Setpoint": {
                 "tags": [ TAG.Damper, TAG.Position, TAG.Setpoint ],
             },
-            "Dead_Band_Setpoint": {
+            "Deadband_Setpoint": {
                 "subclasses": {
-                    "Chilled_Water_Differential_Pressure_Dead_Band_Setpoint": {
-                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                    "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
+                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Cooling_Discharge_Air_Temperature_Dead_Band_Setpoint": {
-                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                    "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
+                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Cooling_Supply_Air_Temperature_Dead_Band_Setpoint": {
-                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                    "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
+                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Differential_Pressure_Dead_Band_Setpoint": {
+                    "Differential_Pressure_Deadband_Setpoint": {
                         "subclasses": {
-                            "Chilled_Water_Pump_Differential_Pressure_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint": {
+                                "tags": [ TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                             },
-                            "Hot_Water_Differential_Pressure_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
+                                "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Discharge_Air_Temperature_Dead_Band_Setpoint": {
+                    "Discharge_Air_Temperature_Deadband_Setpoint": {
                         "subclasses": {
-                            "Heating_Discharge_Air_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             },
-                            "Cooling_Discharge_Air_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Supply_Air_Temperature_Dead_Band_Setpoint": {
+                    "Supply_Air_Temperature_Deadband_Setpoint": {
                         "subclasses": {
-                            "Heating_Supply_Air_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Heating_Supply_Air_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             },
-                            "Cooling_Supply_Air_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Temperature_Dead_Band_Setpoint": {
+                    "Temperature_Deadband_Setpoint": {
                         "subclasses": {
-                            "Occupied_Cooling_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Occupied, TAG.Cooling, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Occupied_Cooling_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Occupied, TAG.Cooling, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             },
-                            "Occupied_Heating_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Occupied, TAG.Heating, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Occupied_Heating_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Occupied, TAG.Heating, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Air_Flow_Dead_Band_Setpoint": {
+                    "Air_Flow_Deadband_Setpoint": {
                         "subclasses": {
-                            "Exhaust_Air_Stack_Flow_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {
+                                "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Air, TAG.Flow, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Air, TAG.Flow, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Static_Pressure_Dead_Band_Setpoint": {
-                        "tags": [ TAG.Static, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                    "Static_Pressure_Deadband_Setpoint": {
+                        "tags": [ TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Supply_Water_Differential_Pressure_Dead_Band_Setpoint": {
+                    "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
                         "subclasses": {
-                            "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint": {
+                                "tags": [ TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
                     },
-                    "Supply_Water_Temperature_Dead_Band_Setpoint": {
+                    "Supply_Water_Temperature_Deadband_Setpoint": {
                         "subclasses": {
-                            "Heat_Exchanger_Supply_Water_Temperature_Dead_Band_Setpoint": {
-                                "tags": [ TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                            "Heat_Exchanger_Supply_Water_Temperature_Deadband_Setpoint": {
+                                "tags": [ TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                             }
                         },
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Dead, TAG.Band, TAG.Setpoint ],
+                        "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
                     }
                 },
-                "tags": [ TAG.Dead, TAG.Band, TAG.Setpoint ],
+                "tags": [ TAG.Deadband, TAG.Setpoint ],
+                "distinct": True,
             },
             "Flow_Setpoint": {
                 "tags": [TAG.Flow, TAG.Setpoint],
@@ -186,9 +190,11 @@ setpoint_definitions = {
                                         "subclasses": {
                                             "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
                                                 "tags": [ TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint ],
+                                                "parents": [BRICK.Cooling_Supply_Air_Flow_Setpoint],
                                             },
                                             "Occupied_Heating_Supply_Air_Flow_Setpoint": {
                                                 "tags": [ TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint ],
+                                                "parents": [BRICK.Heating_Supply_Air_Flow_Setpoint],
                                             }
                                         },
                                         "tags": [ TAG.Occupied, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint ],
@@ -223,6 +229,10 @@ setpoint_definitions = {
                 "subclasses": {
                     "Max_Load_Setpoint": {
                         "tags": [ TAG.Max, TAG.Load, TAG.Setpoint ],
+                    },
+                    "Load_Shed_Setpoint": {
+                        "tags": [ TAG.Shed, TAG.Load, TAG.Setpoint ],
+                        "distinct": True,
                     }
                 },
                 "tags": [ TAG.Load, TAG.Setpoint ],
@@ -255,13 +265,12 @@ setpoint_definitions = {
                                 "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint ],
                             },
                             "Load_Shed_Differential_Pressure_Setpoint": {
+                                "parents": [BRICK.Load_Shed_Setpoint],
                                 "subclasses": {
                                     "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {
                                         "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Setpoint ],
+                                        "parents": [BRICK.Chilled_Water_Differential_Pressure_Setpoint],
                                     },
-                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                        "tags": [ TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Setpoint ],
-                                    }
                                 },
                                 "tags": [ TAG.Load, TAG.Shed, TAG.Differential, TAG.Pressure, TAG.Setpoint ],
                             }
@@ -345,14 +354,14 @@ setpoint_definitions = {
                 "subclasses": {
                     "Differential_Speed_Setpoint": {
                         "subclasses": {
-                            "Return_Discharge_Fan_Differential_Speed_Setpoint": {
-                                "tags": [ TAG.Return, TAG.Discharge, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint ],
+                            "Return_Fan_Differential_Speed_Setpoint": {
+                                "tags": [ TAG.Discharge, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint ],
                             },
                             "Return_Fan_Differential_Speed_Setpoint": {
                                 "tags": [ TAG.Return, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint ],
                             },
-                            "Return_Supply_Fan_Differential_Speed_Setpoint": {
-                                "tags": [ TAG.Return, TAG.Supply, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint ],
+                            "Supply_Fan_Differential_Speed_Setpoint": {
+                                "tags": [ TAG.Supply, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint ],
                             }
                         },
                         "tags": [ TAG.Differential, TAG.Speed, TAG.Setpoint ],
@@ -415,7 +424,7 @@ setpoint_definitions = {
                                 "tags": [ TAG.Entering, TAG.Water, TAG.Temperature, TAG.Setpoint ],
                             },
                             "Leaving_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Entering, TAG.Setpoint, TAG.Temperature, TAG.Water],
+                                "tags": [TAG.Leaving, TAG.Setpoint, TAG.Temperature, TAG.Water],
                             }
                         },
                         "tags": [ TAG.Water, TAG.Temperature, TAG.Setpoint ],

--- a/setpoint.py
+++ b/setpoint.py
@@ -154,7 +154,6 @@ setpoint_definitions = {
                     },
                 },
                 "tags": [ TAG.Deadband, TAG.Setpoint ],
-                "distinct": True,
             },
             "Flow_Setpoint": {
                 "tags": [TAG.Flow, TAG.Setpoint],
@@ -244,7 +243,6 @@ setpoint_definitions = {
                     },
                     "Load_Shed_Setpoint": {
                         "tags": [ TAG.Shed, TAG.Load, TAG.Setpoint ],
-                        "distinct": True,
                     }
                 },
                 "tags": [ TAG.Load, TAG.Setpoint ],

--- a/setpoint.py
+++ b/setpoint.py
@@ -60,47 +60,36 @@ setpoint_definitions = {
             },
             "Deadband_Setpoint": {
                 "subclasses": {
-                    "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
-                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                    },
-                    "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
-                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                    },
-                    "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
-                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                    },
                     "Differential_Pressure_Deadband_Setpoint": {
                         "subclasses": {
-                            "Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint": {
-                                "tags": [ TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                            },
                             "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
                                 "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                            }
-                        },
-                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                    },
-                    "Discharge_Air_Temperature_Deadband_Setpoint": {
-                        "subclasses": {
-                            "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {
-                                "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Hot_Water_Differential_Pressure_Setpoint],
+                            },
+                            "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
+                                "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Chilled_Water_Differential_Pressure_Setpoint],
+                                "subclasses": {
+                                    "Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint": {
+                                        "tags": [ TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                                    },
+                                },
                             },
                             "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
                                 "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                            }
-                        },
-                        "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                    },
-                    "Supply_Air_Temperature_Deadband_Setpoint": {
-                        "subclasses": {
-                            "Heating_Supply_Air_Temperature_Deadband_Setpoint": {
-                                "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Discharge_Air_Temperature_Cooling_Setpoint],
                             },
-                            "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
-                                "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                            }
+                            "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
+                                "subclasses": {
+                                    "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint": {
+                                        "tags": [ TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                                    }
+                                },
+                                "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                            },
                         },
-                        "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                        "tags": [ TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                        "parents": [BRICK.Differential_Pressure_Setpoint],
                     },
                     "Temperature_Deadband_Setpoint": {
                         "subclasses": {
@@ -109,37 +98,60 @@ setpoint_definitions = {
                             },
                             "Occupied_Heating_Temperature_Deadband_Setpoint": {
                                 "tags": [ TAG.Occupied, TAG.Heating, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                            },
+                            "Discharge_Air_Temperature_Deadband_Setpoint": {
+                                "subclasses": {
+                                    "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {
+                                        "tags": [ TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                        "parents": [BRICK.Discharge_Air_Temperature_Heating_Setpoint],
+                                    },
+                                    "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
+                                        "tags": [ TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                        "parents": [BRICK.Discharge_Air_Temperature_Cooling_Setpoint],
+                                    }
+                                },
+                                "tags": [ TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Discharge_Air_Temperature_Setpoint],
+                            },
+                            "Supply_Air_Temperature_Deadband_Setpoint": {
+                                "subclasses": {
+                                    "Heating_Supply_Air_Temperature_Deadband_Setpoint": {
+                                        "tags": [ TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                    },
+                                    "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
+                                        "tags": [ TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                    }
+                                },
+                                "tags": [ TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Air_Temperature_Setpoint],
+                            },
+                            "Supply_Water_Temperature_Deadband_Setpoint": {
+                                "subclasses": {
+                                    "Heat_Exchanger_Supply_Water_Temperature_Deadband_Setpoint": {
+                                        "tags": [ TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                    }
+                                },
+                                "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Water_Temperature_Setpoint],
                             }
                         },
                         "tags": [ TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
+                        "parents": [BRICK.Temperature_Setpoint],
                     },
                     "Air_Flow_Deadband_Setpoint": {
                         "subclasses": {
                             "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {
                                 "tags": [ TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Deadband, TAG.Setpoint ],
+                                "parents": [BRICK.Exhaust_Air_Stack_Flow_Setpoint],
                             }
                         },
                         "tags": [ TAG.Air, TAG.Flow, TAG.Deadband, TAG.Setpoint ],
+                        "parents": [BRICK.Air_Flow_Setpoint],
                     },
                     "Static_Pressure_Deadband_Setpoint": {
                         "tags": [ TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
+                        "parents": [BRICK.Static_Pressure_Setpoint],
                     },
-                    "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                        "subclasses": {
-                            "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                                "tags": [ TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                            }
-                        },
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint ],
-                    },
-                    "Supply_Water_Temperature_Deadband_Setpoint": {
-                        "subclasses": {
-                            "Heat_Exchanger_Supply_Water_Temperature_Deadband_Setpoint": {
-                                "tags": [ TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                            }
-                        },
-                        "tags": [ TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint ],
-                    }
                 },
                 "tags": [ TAG.Deadband, TAG.Setpoint ],
                 "distinct": True,
@@ -290,9 +302,6 @@ setpoint_definitions = {
                             },
                             "Exhaust_Air_Static_Pressure_Setpoint": {
                                 "tags": [ TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint ],
-                            },
-                            "High_Static_Pressure_Cutout_Limit_Setpoint": {
-                                "tags": [ TAG.High, TAG.Static, TAG.Pressure, TAG.Cutout, TAG.Limit, TAG.Setpoint ],
                             },
                             "Hot_Water_Static_Pressure_Setpoint": {
                                 "tags": [ TAG.Hot, TAG.Water, TAG.Static, TAG.Pressure, TAG.Setpoint ],

--- a/status.py
+++ b/status.py
@@ -31,6 +31,7 @@ status_definitions = {
             },
             "Emergency_Power_Off_Status": {
                 "tags": [ TAG.Emergency, TAG.Power, TAG.Off, TAG.Status ],
+                "parents": [BRICK.Off_Status],
                 "subclasses": {
                     "Emergency_Power_Off_Activated_By_High_Temperature_Status": {},
                     "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {},
@@ -49,6 +50,7 @@ status_definitions = {
                     },
                     "Run_Enable_Status": {
                         "tags": [ TAG.Run, TAG.Enable, TAG.Status ],
+                        "parents": [BRICK.Run_Status],
                     }
                 },
                 "tags": [ TAG.Enable, TAG.Status ],
@@ -185,14 +187,18 @@ status_definitions = {
                     "Off_Status": {
                         "tags": [ TAG.Off, TAG.Status ],
                         "subclasses": {
-                            "Emergency_Power_Off_Status": {}, # defined elsewhere
-                            "Turn_Off_Status": {
-                                "tags": [ TAG.Turn, TAG.Off, TAG.Status ],
-                            },
+                            "Turn_Off_Status": {},
+                        }
+                    },
+                    "On_Status": {
+                        "tags": [ TAG.On, TAG.Status ],
+                        "subclasses": {
+                            "Turn_On_Status": {},
                         }
                     },
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
+                "parents": [BRICK.Off_Status, BRICK.On_Status],
             },
             "Overridden_Status": {
                 "subclasses": {
@@ -238,9 +244,6 @@ status_definitions = {
                     },
                     "Run_Status": {
                         "tags": [ TAG.Run, TAG.Status ],
-                        "subclasses": {
-                            "Run_Enable_Status": {}, # defined elsewhere
-                        }
                     }
                 },
                 "tags": [ TAG.Start, TAG.Stop, TAG.Status ],

--- a/status.py
+++ b/status.py
@@ -16,7 +16,6 @@ status_definitions = {
                     },
                 },
                 "tags": [ TAG.Direction, TAG.Status ],
-                "distinct": True,
             },
             "Disable_Status": {
                 "tags": [ TAG.Disable, TAG.Status ],
@@ -195,7 +194,6 @@ status_definitions = {
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
                 "parents": [BRICK.On_Status, BRICK.Off_Status],
-                "distinct": True,
             },
             "Overridden_Status": {
                 "subclasses": {

--- a/status.py
+++ b/status.py
@@ -14,9 +14,6 @@ status_definitions = {
                     "Motor_Direction_Status": {
                         "tags": [ TAG.Motor, TAG.Direction, TAG.Status ],
                     },
-                    "Run_Direction_Status": {
-                        "tags": [ TAG.Run, TAG.Direction, TAG.Status ],
-                    }
                 },
                 "tags": [ TAG.Direction, TAG.Status ],
                 "distinct": True,
@@ -226,6 +223,7 @@ status_definitions = {
                 "subclasses": {
                     "Fan_Start_Stop_Status": {
                         "tags": [ TAG.Fan, TAG.Start, TAG.Stop, TAG.Status ],
+                        "parents": [BRICK.Fan_Status],
                     },
                     "Motor_Start_Stop_Status": {
                         "tags": [ TAG.Motor, TAG.Start, TAG.Stop, TAG.Status ],

--- a/status.py
+++ b/status.py
@@ -19,6 +19,7 @@ status_definitions = {
                     }
                 },
                 "tags": [ TAG.Direction, TAG.Status ],
+                "distinct": True,
             },
             "Disable_Status": {
                 "tags": [ TAG.Disable, TAG.Status ],
@@ -37,9 +38,7 @@ status_definitions = {
                 "subclasses": {
                     "Emergency_Power_Off_Activated_By_High_Temperature_Status": {},
                     "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {},
-                    "Emergency_Power_Off_Enable_Status": {
-                        "tags": [ TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status ],
-                    },
+                    "Emergency_Power_Off_Enable_Status": {},
                     "Emergency_Power_Off_System_Enable_Status": {}
                 },
             },
@@ -50,6 +49,7 @@ status_definitions = {
                 "subclasses": {
                     "Heat_Exchanger_System_Enable_Status": {
                         "tags": [ TAG.Heat, TAG.Exchanger, TAG.System, TAG.Enable, TAG.Status ],
+                        "parents": [BRICK.System_Status],
                     },
                     "Run_Enable_Status": {
                         "tags": [ TAG.Run, TAG.Enable, TAG.Status ],
@@ -63,14 +63,15 @@ status_definitions = {
             "Fan_Status": {
                 "tags": [ TAG.Fan, TAG.Status ],
             },
-            "Fault_Indicator_Status": {
-                "tags": [ TAG.Fault, TAG.Indicator, TAG.Status ],
-            },
             "Fault_Status": {
+                OWL.equivalentClass: "Fault_Indicator_Status",
                 "subclasses": {
                     "Humidifier_Fault_Status": {
                         "tags": [ TAG.Humidifier, TAG.Fault, TAG.Status ],
-                    }
+                    },
+                    "Last_Fault_Code_Status": {
+                        "tags": [ TAG.Last, TAG.Fault, TAG.Code, TAG.Status ],
+                    },
                 },
                 "tags": [ TAG.Fault, TAG.Status ],
             },
@@ -90,9 +91,6 @@ status_definitions = {
             },
             "Hold_Status": {
                 "tags": [ TAG.Hold, TAG.Status ],
-            },
-            "Last_Fault_Code_Status": {
-                "tags": [ TAG.Last, TAG.Fault, TAG.Code, TAG.Status ],
             },
             "Load_Shed_Status": {
                 "subclasses": {
@@ -128,6 +126,7 @@ status_definitions = {
                     },
                     "System_Mode_Status": {
                         "tags": [ TAG.System, TAG.Mode, TAG.Status ],
+                        "parents": [BRICK.System_Status],
                     },
                     "Operating_Mode_Status": {
                         "subclasses": {
@@ -150,6 +149,12 @@ status_definitions = {
             },
             "Off_Status": {
                 "tags": [ TAG.Off, TAG.Status ],
+                "subclasses": {
+                    "Emergency_Power_Off_Status": {}, # defined elsewhere
+                    "Turn_Off_Status": {
+                        "tags": [ TAG.Turn, TAG.Off, TAG.Status ],
+                    },
+                }
             },
             "On_Status": {
                 "tags": [ TAG.On, TAG.Status ],
@@ -185,14 +190,17 @@ status_definitions = {
                     }
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
+                "distinct": True,
             },
             "Overridden_Status": {
                 "subclasses": {
                     "Overridden_Off_Status": {
                         "tags": [ TAG.Overridden, TAG.Off, TAG.Status ],
+                        "parents": [BRICK.Off_Status],
                     },
                     "Overridden_On_Status": {
                         "tags": [ TAG.Overridden, TAG.On, TAG.Status ],
+                        "parents": [BRICK.On_Status],
                     }
                 },
                 "tags": [ TAG.Overridden, TAG.Status ],
@@ -227,18 +235,19 @@ status_definitions = {
                     },
                     "Run_Status": {
                         "tags": [ TAG.Run, TAG.Status ],
+                        "subclasses": {
+                            "Run_Enable_Status": {}, # defined elsewhere
+                        }
                     }
                 },
                 "tags": [ TAG.Start, TAG.Stop, TAG.Status ],
             },
             "System_Shutdown_Status": {
                 "tags": [ TAG.System, TAG.Shutdown, TAG.Status ],
+                "parents": [BRICK.System_Status],
             },
             "System_Status": {
                 "tags": [ TAG.System, TAG.Status ],
-            },
-            "Turn_Off_Status": {
-                "tags": [ TAG.Turn, TAG.Off, TAG.Status ],
             },
             "Speed_Status": {
                 "tags": [ TAG.Speed, TAG.Status ],

--- a/status.py
+++ b/status.py
@@ -93,22 +93,30 @@ status_definitions = {
                 "subclasses": {
                     "Differential_Pressure_Load_Shed_Status": {
                         "subclasses": {
-                            "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status": {
-                                "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status ],
-                            },
                             "Chilled_Water_Differential_Pressure_Load_Shed_Status": {
-                                "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status ] },
-                            "Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {
-                                "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status ],
+                                "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status ],
+                                "subclasses": {
+                                    "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status": {
+                                        "tags": [ TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status ],
+                                    },
+                                }
                             },
                             "Hot_Water_Differential_Pressure_Load_Shed_Status": {
-                                "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status ] },
+                                "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status ] ,
+                                # TODO: conflicts with Pressure Status
+                                "subclasses": {
+                                    "Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {
+                                        "tags": [ TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status ],
+                                    },
+                                }
+                            },
                             "Hot_Water_Discharge_Temperature_Load_Shed_Status": {
                                 "tags": [ TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status ] },
                             "Hot_Water_Supply_Temperature_Load_Shed_Status": {
                                 "tags": [ TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status ] }
                         },
                         "tags": [ TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status ],
+                        "parents": [BRICK.Pressure_Status],
                     }
                 },
                 "tags": [ TAG.Load, TAG.Shed, TAG.Status ],
@@ -153,9 +161,6 @@ status_definitions = {
                     },
                 }
             },
-            "On_Status": {
-                "tags": [ TAG.On, TAG.Status ],
-            },
             "On_Off_Status": {
                 "subclasses": {
                     "Cooling_On_Off_Status": {
@@ -179,14 +184,17 @@ status_definitions = {
                     "Remotely_On_Off_Status": {
                         "tags": [ TAG.Remotely, TAG.On, TAG.Off, TAG.Status ],
                     },
-                    "Standby_Glycool_Unit_On_Off_Status": {
-                        "tags": [ TAG.Standby, TAG.Glycool, TAG.Unit, TAG.On, TAG.Off, TAG.Status ],
-                    },
                     "Standby_Unit_On_Off_Status": {
                         "tags": [ TAG.Standby, TAG.Unit, TAG.On, TAG.Off, TAG.Status ],
+                        "subclasses": {
+                            "Standby_Glycool_Unit_On_Off_Status": {
+                                "tags": [ TAG.Standby, TAG.Glycool, TAG.Unit, TAG.On, TAG.Off, TAG.Status ],
+                            },
+                        },
                     }
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
+                "parents": [BRICK.On_Status, BRICK.Off_Status],
                 "distinct": True,
             },
             "Overridden_Status": {

--- a/status.py
+++ b/status.py
@@ -151,15 +151,6 @@ status_definitions = {
                 },
                 "tags": [ TAG.Occupancy, TAG.Status ],
             },
-            "Off_Status": {
-                "tags": [ TAG.Off, TAG.Status ],
-                "subclasses": {
-                    "Emergency_Power_Off_Status": {}, # defined elsewhere
-                    "Turn_Off_Status": {
-                        "tags": [ TAG.Turn, TAG.Off, TAG.Status ],
-                    },
-                }
-            },
             "On_Off_Status": {
                 "subclasses": {
                     "Cooling_On_Off_Status": {
@@ -190,7 +181,16 @@ status_definitions = {
                                 "tags": [ TAG.Standby, TAG.Glycool, TAG.Unit, TAG.On, TAG.Off, TAG.Status ],
                             },
                         },
-                    }
+                    },
+                    "Off_Status": {
+                        "tags": [ TAG.Off, TAG.Status ],
+                        "subclasses": {
+                            "Emergency_Power_Off_Status": {}, # defined elsewhere
+                            "Turn_Off_Status": {
+                                "tags": [ TAG.Turn, TAG.Off, TAG.Status ],
+                            },
+                        }
+                    },
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
             },

--- a/status.py
+++ b/status.py
@@ -193,7 +193,6 @@ status_definitions = {
                     }
                 },
                 "tags": [ TAG.On, TAG.Off, TAG.Status ],
-                "parents": [BRICK.On_Status, BRICK.Off_Status],
             },
             "Overridden_Status": {
                 "subclasses": {

--- a/substances.py
+++ b/substances.py
@@ -22,6 +22,10 @@ substances = {
                     "Air": {
                         "tags": [TAG.Fluid, TAG.Gas, TAG.Air],
                         "subclasses": {
+                            "Bypass_Air": {
+                                "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Bypass],
+                                SKOS.definition: Literal("air in a bypass duct, used to relieve static pressure"),
+                             },
                             "Outside_Air": {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Outside],
                                 SKOS.definition: Literal("air external to a defined zone (e.g., corridors)."),
@@ -42,7 +46,14 @@ substances = {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Supply],
                                 SKOS.definition: Literal("(1) air delivered by mechanical or natural ventilation to a space, composed of any combination of outdoor air, recirculated air, or transfer air. (2) air entering a space from an air-conditioning, heating, or ventilating apparatus for the purpose of comfort conditioning. Supply air is generally filtered, fan forced, and either heated, cooled, humidified, or dehumidified as necessary to maintain specified conditions. Only the quantity of outdoor air within the supply airflow may be used as replacement air."),
                             },
+                            "Discharge_Air": {
+                                "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Discharge],
+                            },
                         },
+                    },
+                    "CO2": {
+                        "tags": [TAG.Fluid, TAG.Gas, TAG.CO2],
+                        SKOS.definition: Literal("Carbon Dioxide in the vapor phase"),
                     },
                     "Steam": {
                         "tags": [TAG.Fluid, TAG.Gas, TAG.Steam],
@@ -61,6 +72,10 @@ substances = {
                         "tags": [TAG.Liquid, TAG.Gasoline],
                         SKOS.definition: Literal("Petroleum derived liquid used as a fuel source"),
                     },
+                    "Liquid_CO2": {
+                        "tags": [TAG.Liquid, TAG.Gas, TAG.CO2],
+                        SKOS.definition: Literal("Carbon Dioxide in the liquid phase"),
+                    },
                     "Oil": {
                         "tags": [TAG.Liquid, TAG.Oil],
                         "subclasses": {
@@ -74,9 +89,21 @@ substances = {
                         "tags": [TAG.Liquid, TAG.Water],
                         SKOS.definition: Literal("transparent, odorless, tasteless liquid; a compound of hydrogen and oxygen (H2O), containing 11.188% hydrogen and 88.812% oxygen by mass; freezing at 32°F (0°C); boiling near 212°F (100°C)."),
                         "subclasses": {
+                            "Deionized_Water": {
+                                "tags": [TAG.Deionized, TAG.Water],
+                                SKOS.definition: Literal("Water which has been purified by removing its ions (constituting the majority of non-particulate contaminants)"),
+                            },
                             "Chilled_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Chilled],
                                 SKOS.definition: Literal( "water used as a cooling medium (particularly in air-conditioning systems or in processes) at below ambient temperature."),
+                                "subclasses": {
+                                    "Discharge_Chilled_Water": {
+                                        "tags": [TAG.Liquid, TAG.Water, TAG.Chilled, TAG.Discharge],
+                                    },
+                                    "Supply_Chilled_Water": {
+                                        "tags": [TAG.Liquid, TAG.Water, TAG.Chilled, TAG.Supply],
+                                    }
+                                },
                             },
                             "Blowdown_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Blowdown],
@@ -89,6 +116,14 @@ substances = {
                             "Domestic_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Domestic],
                                 SKOS.definition: Literal("Tap water for drinking, washing, cooking, and flushing of toliets"),
+                            },
+                            "Supply_Water": {
+                                "tags": [TAG.Liquid, TAG.Water, TAG.Supply],
+                                "subclasses": {
+                                    "Supply_Chilled_Water": {
+                                        "tags": [TAG.Liquid, TAG.Water, TAG.Chilled, TAG.Supply],
+                                    }
+                                },
                             },
                             "Hot_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Hot],

--- a/substances.py
+++ b/substances.py
@@ -30,6 +30,10 @@ substances = {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Outside],
                                 SKOS.definition: Literal("air external to a defined zone (e.g., corridors)."),
                              },
+                            "Zone_Air": {
+                                "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Zone],
+                                SKOS.definition: Literal("air inside a defined zone (e.g., corridors)."),
+                             },
                             "Mixed_Air": {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Mixed],
                                 SKOS.definition: Literal("(1) air that contains two or more streams of air. (2) combined outdoor air and recirculated air."),

--- a/substances.py
+++ b/substances.py
@@ -131,6 +131,7 @@ substances = {
                             "Leaving_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Leaving],
                             },
+                            "Return_Water": {},
                             "Supply_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Supply],
                                 "subclasses": {

--- a/substances.py
+++ b/substances.py
@@ -34,6 +34,10 @@ substances = {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Zone],
                                 SKOS.definition: Literal("air inside a defined zone (e.g., corridors)."),
                              },
+                            "Building_Air": {
+                                "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Building],
+                                SKOS.definition: Literal("air contained within a building"),
+                             },
                             "Mixed_Air": {
                                 "tags": [TAG.Fluid, TAG.Gas, TAG.Air, TAG.Mixed],
                                 SKOS.definition: Literal("(1) air that contains two or more streams of air. (2) combined outdoor air and recirculated air."),

--- a/substances.py
+++ b/substances.py
@@ -131,7 +131,9 @@ substances = {
                             "Leaving_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Leaving],
                             },
-                            "Return_Water": {},
+                            "Return_Water": {
+                                "tags": [TAG.Liquid, TAG.Water, TAG.Return],
+                            },
                             "Supply_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Supply],
                                 "subclasses": {

--- a/substances.py
+++ b/substances.py
@@ -121,17 +121,31 @@ substances = {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Domestic],
                                 SKOS.definition: Literal("Tap water for drinking, washing, cooking, and flushing of toliets"),
                             },
+                            "Entering_Water": {
+                                "tags": [TAG.Liquid, TAG.Water, TAG.Entering],
+                            },
+                            "Leaving_Water": {
+                                "tags": [TAG.Liquid, TAG.Water, TAG.Leaving],
+                            },
                             "Supply_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Supply],
                                 "subclasses": {
                                     "Supply_Chilled_Water": {
                                         "tags": [TAG.Liquid, TAG.Water, TAG.Chilled, TAG.Supply],
+                                    },
+                                    "Supply_Hot_Water": {
+                                        "tags": [TAG.Liquid, TAG.Water, TAG.Hot, TAG.Supply],
                                     }
                                 },
                             },
                             "Hot_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Hot],
                                 SKOS.definition: Literal("Hot water used for HVAC heating or supply to hot taps"),
+                                "subclasses": {
+                                    "Supply_Hot_Water": {
+                                        "tags": [TAG.Liquid, TAG.Water, TAG.Hot, TAG.Supply],
+                                    }
+                                }
                             },
                             "Makeup_Water": {
                                 "tags": [TAG.Liquid, TAG.Water, TAG.Makeup],

--- a/tests/test_class_structure.py
+++ b/tests/test_class_structure.py
@@ -1,0 +1,35 @@
+import rdflib
+from rdflib import RDF, OWL, RDFS, Namespace
+from util.reasoner import reason_brick, make_readable
+
+BRICK_VERSION = '1.1.0'
+BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
+TAG = Namespace("https://brickschema.org/schema/{0}/BrickTag#".format(BRICK_VERSION))
+BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
+SOSA = Namespace("http://www.w3.org/ns/sosa#")
+
+g = rdflib.Graph()
+g.parse('Brick.ttl', format='turtle')
+
+reason_brick(g)
+
+g.bind('rdf', RDF)
+g.bind('owl', OWL)
+g.bind('rdfs', RDFS)
+g.bind('brick', BRICK)
+g.bind('tag', TAG)
+g.bind('bldg', BLDG)
+
+def test_subclasses():
+    subclasses1 = g.query("SELECT ?parent ?child WHERE { ?child rdfs:subClassOf ?parent }")
+    subclasses2 = g.query("SELECT ?parent ?child WHERE { ?child rdfs:subClassOf ?parent . ?child a owl:Class . ?parent a owl:Class }")
+    sc1 = [x[0] for x in subclasses1]
+    sc2 = [x[0] for x in subclasses2]
+    diff = set(sc1).difference(set(sc2))
+
+    # there should only be these two SOSA properties outside of Brick *at this point in time*
+    expected = set([
+        SOSA.FeatureOfInterest,
+        SOSA.ObservableProperty
+    ])
+    assert expected == diff, f"Got extra classes that may not be defined: {diff.difference(expected)}"

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -55,7 +55,7 @@ def test_hierarchyinference():
 
     # Get all the Classes with their restrictions.
     qstr = q_prefix + """
-    select ?class ?p ?o where {
+    select ?class ?p ?o ?restrictions where {
       ?class rdfs:subClassOf+ brick:Class.
       ?class owl:equivalentClass ?restrictions.
       ?restrictions owl:intersectionOf ?inter.
@@ -76,13 +76,15 @@ def test_hierarchyinference():
         klass = row[0]
         entity = klass + entity_postfix  # Define an entity for the class
         g.add((entity, row[1], row[2]))  # Associate the entity with restrictions (i.e., Tags)
+        print(row[3],row[1],row[2])
     end_time = time.time()
     print('Instantiation took {0} seconds'.format(int(end_time-start_time)))
 
     # Infer classes of the entities.
     # Apply reasoner
-    from util.reasoner import reason_brick
-    reason_brick(g)
+    from util.reasoner import reason_brick, reason_owlrl
+    #reason_brick(g)
+    reason_owlrl(g)
     g.serialize(inference_file, format='turtle')  # Store the inferred graph.
 
 

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -81,7 +81,7 @@ def test_hierarchyinference():
 
     # Infer classes of the entities.
     # Apply reasoner
-    from util.reasoner import reason_brick, reason_owlrl
+    from util.reasoner import reason_brick, reason_owlrl, make_readable
     reason_brick(g)
     #reason_owlrl(g)
     g.serialize(inference_file, format='turtle')  # Store the inferred graph.
@@ -125,10 +125,15 @@ def test_hierarchyinference():
         }
         if inferred_parents > true_parents:
             over_inferences[entity] = serialized
+            diff = set(inferred_parents).difference(set(true_parents))
+            print(f"Tags for {true_class.split('#')[-1]} imply extra classes: {make_readable([diff])}")
         elif inferred_parents < true_parents:
             under_inferences[entity] = serialized
+            diff = set(true_parents).difference(set(inferred_parents))
+            print(f"Tags for {true_class.split('#')[-1]} do not imply classes, but should: {make_readable([diff])}")
         elif inferred_parents != true_parents:
             wrong_inferences[entity] = serialized
+
 
     with open('tests/test_hierarchy_inference.json', 'w') as fp:
         json.dump({

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -76,15 +76,14 @@ def test_hierarchyinference():
         klass = row[0]
         entity = klass + entity_postfix  # Define an entity for the class
         g.add((entity, row[1], row[2]))  # Associate the entity with restrictions (i.e., Tags)
-        print(row[3],row[1],row[2])
     end_time = time.time()
     print('Instantiation took {0} seconds'.format(int(end_time-start_time)))
 
     # Infer classes of the entities.
     # Apply reasoner
     from util.reasoner import reason_brick, reason_owlrl
-    #reason_brick(g)
-    reason_owlrl(g)
+    reason_brick(g)
+    #reason_owlrl(g)
     g.serialize(inference_file, format='turtle')  # Store the inferred graph.
 
 

--- a/tests/test_measures_inference.py
+++ b/tests/test_measures_inference.py
@@ -1,0 +1,90 @@
+import time
+import sys
+import rdflib
+import json
+from collections import defaultdict
+from rdflib import RDF, RDFS, OWL, Namespace, URIRef
+
+BRICK_VERSION = '1.1.0'
+
+BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
+TAG = Namespace("https://brickschema.org/schema/{0}/BrickTag#".format(BRICK_VERSION))
+BLDG = Namespace("https://brickschema.org/schema/{0}/ExampleBuilding#".format(BRICK_VERSION))
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
+DCTERMS = Namespace("http://purl.org/dc/terms#")
+SDO = Namespace("http://schema.org#")
+A = RDF.type
+
+g = rdflib.Graph()
+g.parse('Brick.ttl', format='turtle')
+
+def test_measures_infers():
+    qstr = """select ?class ?o where {
+      ?class rdfs:subClassOf+ brick:Class.
+      ?class owl:equivalentClass ?restrictions.
+      ?restrictions owl:intersectionOf ?inter.
+      ?inter rdf:rest*/rdf:first ?node.
+      ?node owl:onProperty brick:measures .
+      ?node owl:hasValue ?o.
+    }
+    """
+    for row in g.query(qstr):
+        klass = row[0]
+        entity = klass + '_entity'  # Define an entity for the class
+        g.add((entity, BRICK.measures, row[1]))  # Associate the entity with measurement restrictions
+
+    # Infer classes of the entities.
+    # Apply reasoner
+    from util.reasoner import reason_brick
+    reason_brick(g)
+
+    qstr = """select ?instance ?class where {
+        ?instance a ?class.
+        ?class rdfs:subClassOf* brick:Class.
+    }
+    """
+    inferred_klasses = defaultdict(set)
+    for row in g.query(qstr):
+        entity = row[0]
+        klass = row[1]
+        if BRICK in klass: # Filter out non-Brick classes such as Restrictions
+            inferred_klasses[entity].add(klass)
+
+    over_inferences = {}  # Inferred Classes that are not supposed to be inferred.
+    under_inferences = {}  # Classes that should have been inferred but not actually inferred.
+    wrong_inferences = {}  # Other wrongly inferred Classes.
+    for entity, inferred_parents in inferred_klasses.items():
+        if entity[-7:] != '_entity':
+            continue
+        true_class = URIRef(entity[0:-7])  # This is based on how the entity name is defined above.
+
+        # Find the original classes through the hierarchy from the original graph.
+        qstr = """select ?parent where {{
+            <{0}> rdfs:subClassOf* ?parent.
+            ?parent rdfs:subClassOf* brick:Class.
+        }}
+        """.format(true_class)
+        res = g.query(qstr)
+        true_parents = [row[0] for row in res]
+        true_parents = set(filter(lambda parent: BRICK in parent, true_parents))
+        serialized = {
+            'inferred_parents': list(inferred_parents),
+            'true_parents': list(true_parents),
+        }
+        if inferred_parents > true_parents:
+            over_inferences[entity] = serialized
+        elif inferred_parents < true_parents:
+            under_inferences[entity] = serialized
+        elif inferred_parents != true_parents:
+            wrong_inferences[entity] = serialized
+
+    with open('tests/test_measures_inference.json', 'w') as fp:
+        json.dump({
+            'over_inferences': over_inferences,
+            'under_inferences': under_inferences,
+            'wrong_inferencers': wrong_inferences,
+        }, fp, indent=2)
+
+    assert not over_inferences, 'There are {0} classes that are over-inferred'.format(len(over_inferences))
+    assert not under_inferences, 'There are {0} classes that are under-inferred'.format(len(under_inferences))
+    assert not wrong_inferences, 'There are {0} classes that are inferred incorrectly in other ways'.format(len(wrong_inferences))

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -1,0 +1,49 @@
+import rdflib
+from rdflib import RDF, OWL, RDFS, Namespace
+from util.reasoner import reason_brick, make_readable
+
+BRICK_VERSION = '1.1.0'
+BRICK = Namespace("https://brickschema.org/schema/{0}/Brick#".format(BRICK_VERSION))
+TAG = Namespace("https://brickschema.org/schema/{0}/BrickTag#".format(BRICK_VERSION))
+BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
+
+g = rdflib.Graph()
+g.parse('Brick.ttl', format='turtle')
+
+
+g.add((BLDG.Tmp1, RDF.type, BRICK.Air_Temperature_Sensor))
+
+reason_brick(g)
+
+g.bind('rdf', RDF)
+g.bind('owl', OWL)
+g.bind('rdfs', RDFS)
+g.bind('brick', BRICK)
+g.bind('tag', TAG)
+g.bind('bldg', BLDG)
+
+def test_quantity_instances():
+    quantities = make_readable(g.query("SELECT ?q WHERE { ?q a brick:Quantity}"))
+    quantity_classes = make_readable(g.query("SELECT ?q WHERE { ?q rdfs:subClassOf+ brick:Quantity}"))
+    assert(sorted(quantities) == sorted(quantity_classes))
+
+
+def test_substance_instances():
+    substances = make_readable(g.query("SELECT ?q WHERE { ?q a brick:Substance}"))
+    substance_classes = make_readable(g.query("SELECT ?q WHERE { ?q rdfs:subClassOf+ brick:Substance}"))
+    assert(sorted(substances) == sorted(substance_classes))
+
+def test_measurables_defined():
+    # test to make sure all objects of the brick:measures relationship are a Measurable
+    measurable = make_readable(g.query("SELECT ?m WHERE { ?m a brick:Measurable }"))
+
+    measured = make_readable(g.query("""SELECT ?m WHERE {
+        ?class rdfs:subClassOf brick:Class .
+        ?class owl:equivalentClass ?restrictions .
+        ?restrictions owl:intersectionOf ?inter .
+        ?inter rdf:rest*/rdf:first ?node .
+        ?node owl:onProperty brick:measures .
+        ?node owl:hasValue ?m
+        }"""))
+    for m in measured:
+        assert m in measurable

--- a/tests/util/reasoner.py
+++ b/tests/util/reasoner.py
@@ -104,7 +104,7 @@ def reason_brick(g):
         elif prop == BRICK.measures:
             measures_properties[classname].append(obj)
 
-        print(classname,groupname,prop,obj)
+        #print(classname,groupname,prop,obj)
         grouped_properties[(classname,groupname)].append( (prop, obj) )
 
     # add properties based on classes

--- a/tests/util/reasoner.py
+++ b/tests/util/reasoner.py
@@ -118,19 +118,17 @@ def reason_brick(g):
             [f"\t ?inst rdf:type <{classname}> ."]
         )
         q += "\n}"
-        #print(classname, q)
         g.update(q)
 
     # add properties based on classes
     for (classname, groupname), props in grouped_properties.items():
         q = f"""INSERT {{
-        ?inst rdf:type <{classname}> 
-        }} WHERE {{ """
+        ?inst rdf:type <{classname}>
+        }} WHERE {{ \n"""
         q += '\n'.join(
             [f"\t ?inst <{prop}> <{obj}> ." for prop,obj in props]
         )
-        q += "\n}"
-        #print(classname, q)
+        q += "}\n"
         g.update(q)
 
 

--- a/tests/util/reasoner.py
+++ b/tests/util/reasoner.py
@@ -75,7 +75,7 @@ def reason_brick(g):
 
     # handle tags
     res = g.query("""
-    select ?class ?p ?o where {
+    select ?class ?p ?o ?restrictions where {
       ?class rdfs:subClassOf+ brick:Class.
       ?class owl:equivalentClass ?restrictions.
       ?restrictions owl:intersectionOf ?inter.
@@ -96,22 +96,52 @@ def reason_brick(g):
     }""")
     tag_properties = defaultdict(list)
     measures_properties = defaultdict(list)
-    for (classname, prop, obj) in tqdm(res):
+    grouped_properties = defaultdict(list)
+
+    for (classname, prop, obj, groupname) in tqdm(res):
         if prop == BRICK.hasTag:
             tag_properties[classname].append(obj)
         elif prop == BRICK.measures:
             measures_properties[classname].append(obj)
 
+        grouped_properties[(classname,groupname)].append( (prop, obj) )
+
+    # add classes based on properties
+    for (classname, groupname), props in grouped_properties.items():
+        q = "INSERT {\n"
+        q += '\n'.join(
+            [f"\t ?inst <{prop}> <{obj}> ." for prop,obj in props]
+        )
+        q += "\n} WHERE {\n"
+        q += '\n'.join(
+            [f"\t ?inst rdf:type <{classname}> ."]
+        )
+        q += "\n}"
+        g.update(q)
+
+    # add properties based on classes
+    #for (classname, groupname), props in grouped_properties.items():
+    #    q = f"""INSERT {{
+    #    ?inst rdf:type <{classname}> 
+    #    }} WHERE {{ """
+
+    #    q += '\n'.join(
+    #        [f"\t ?inst <{prop}> <{obj}> ." for prop,obj in props]
+    #    )
+    #    q += "\n}"
+    #    g.update(q)
+
+
     # tag inference
     for classname, tags in tag_properties.items():
-        # find entities with tags and instantiate the class
-        qstr = "select ?inst where {\n"
-        for tag in tags:
-            qstr += f"  ?inst brick:hasTag <{tag}> .\n"
-        qstr +="}"
-        for row in g.query(qstr):
-            inst = row[0]
-            g.add((inst, RDF.type, classname))
+        ## find entities with tags and instantiate the class
+        #qstr = "select ?inst where {\n"
+        #for tag in tags:
+        #    qstr += f"  ?inst brick:hasTag <{tag}> .\n"
+        #qstr +="}"
+        #for row in g.query(qstr):
+        #    inst = row[0]
+        #    g.add((inst, RDF.type, classname))
 
         # find entities of the class and add the tags
         qstr = f"select ?inst where {{ ?inst rdf:type/rdfs:subClassOf* <{classname}> }}"
@@ -119,8 +149,8 @@ def reason_brick(g):
             inst = row[0]
             for tag in tags:
                 g.add((inst, BRICK.hasTag, tag))
-
-    # measures inference
+#
+#    # measures inference
     for classname, substances in measures_properties.items():
         # find entities with substances and instantiate the class
         qstr = "select ?inst where {\n"

--- a/tests/util/reasoner.py
+++ b/tests/util/reasoner.py
@@ -88,6 +88,10 @@ def reason_brick(g):
           BIND (brick:measures as ?p)
           ?node owl:onProperty ?p.
           ?node owl:hasValue ?o.
+      } UNION {
+          BIND (rdf:type as ?p)
+          ?node owl:onProperty ?p.
+          ?node owl:hasValue ?o.
       }
     }""")
     tag_properties = defaultdict(list)

--- a/tests/util/reasoner.py
+++ b/tests/util/reasoner.py
@@ -104,9 +104,10 @@ def reason_brick(g):
         elif prop == BRICK.measures:
             measures_properties[classname].append(obj)
 
+        print(classname,groupname,prop,obj)
         grouped_properties[(classname,groupname)].append( (prop, obj) )
 
-    # add classes based on properties
+    # add properties based on classes
     for (classname, groupname), props in grouped_properties.items():
         q = "INSERT {\n"
         q += '\n'.join(
@@ -117,19 +118,20 @@ def reason_brick(g):
             [f"\t ?inst rdf:type <{classname}> ."]
         )
         q += "\n}"
+        #print(classname, q)
         g.update(q)
 
     # add properties based on classes
-    #for (classname, groupname), props in grouped_properties.items():
-    #    q = f"""INSERT {{
-    #    ?inst rdf:type <{classname}> 
-    #    }} WHERE {{ """
-
-    #    q += '\n'.join(
-    #        [f"\t ?inst <{prop}> <{obj}> ." for prop,obj in props]
-    #    )
-    #    q += "\n}"
-    #    g.update(q)
+    for (classname, groupname), props in grouped_properties.items():
+        q = f"""INSERT {{
+        ?inst rdf:type <{classname}> 
+        }} WHERE {{ """
+        q += '\n'.join(
+            [f"\t ?inst <{prop}> <{obj}> ." for prop,obj in props]
+        )
+        q += "\n}"
+        #print(classname, q)
+        g.update(q)
 
 
     # tag inference


### PR DESCRIPTION
~~**In progress**~~

Rectifying some of the issues we have uncovered in the modeling of quantities and substances

- quantities + substance classes are instantiated/punned as part of the Brick ontology generation script
- added a test file to verify this is done correctly
- changed the `rdfs:range` property on `brick:measures` because this was improperly inferring some quantities as substances. It now references a new `brick:Measurable` class which groups the Substance and Quantity subclasses
- aligned `brick:Quantity` with `sosa:ObservableProperty` using a subclass relationship
- aligned `brick:Substance` with `sosa:FeatureOfInterest` using subclass relationship
- improve the coverage of `brick:measures` relationships in `sensor` hierarchy
- add tests to verify that all objects of `brick:measures` are defined `Measurable`s

---

**09/24/2019: More major changes**: in the process of performing the above changes, I found an opportunity to help clear up some other issues with Brick while I was at it. These changes are:

- adding a "parent" component to the Python framework to enable "up-pointers" in the class lattice. This helps avoid duplication in the specification
- **important**: removed the `TAG.Setpoint` tag from all `Parameter` classes. Even though `Setpoint` is part of terms like `Max Air Flow Setpoint Limit`, the constraints of open-world set-based formalisms like OWL mean that it is difficult to enforce a class-based separation between setpoints and parameters *without introducing other constraints*. I will get around to writing up those tradeoffs at some later point, but in the mean time this is -- I believe -- an acceptable compromise.