### PR TITLE
SHACL Shapes for Brick (proof of concept)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,6 +30,14 @@ To validate a graph, use [pySHACL](https://github.com/RDFLib/pySHACL):
 pyshacl -s shacl_test.ttl -m -e Brick.ttl -f human sample_graph.ttl
 ```
 
+You may want to expand a graph before validating it. In that case, run
+
+```bash
+python expand_graph.py sample_graph.ttl
+```
+
+which will drop the expanded graph into `output.ttl` in the same directory.
+
 ## Brick SHACL shapes
 
 Going through what the SHACL shapes would look for for different tests. The examples below declare shapes in the `bsh` ("brickshape") namespace for clarity

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,117 @@
+# SHACL for Brick
+
+The SHACL Shapes Constraint Language validates RDF graphs against conditions (called "shapes"), which are expressed themselves as an RDF graph. This document discusses the application of SHACL to Brick. In this document we are specifically looking at writing SHACL shapes for validating Brick *models* (instances of buildings). Using SHACL to validate the Brick ontology deserves its own investigation.
+
+SHACL shapes for Brick should validate the following:
+
+- validating endpoints of Brick relationships (properties):
+  - check type of subject/object: are the `rdfs:range`, `rdfs:domain` properties respected?
+  - cardinality checks: with varying severity
+    - floors without rooms
+    - equipment missing certain points (e.g. thermostat should have a temperature sensor, at least one setpoint)
+    - all named individuals should have `rdf:type`
+- compatibility checking:
+  - all objects of `rdf:type` should be Brick classes (subclassof, etc)
+  - check for deprecated classes, relationships
+- idioms, semantic checks:
+  - these may be optional; users can "opt-in" to check for certain idioms
+  - equipment along a chain of `brick:feeds` should all operate on the same substance
+  - proper relationships exist between equipment: e.g. thermostat should have `controls` relationship to RTU
+
+
+## Brick SHACL shapes
+
+Going through what the SHACL shapes would look for for different tests. The examples below declare shapes in the `bsh` ("brickshape") namespace for clarity
+
+### Property Constraints
+
+Property definitions (from the `bricksrc/properties.py` file) define inverses, domains/ranges of properties and subproperties. The shape graph would contain one shape for each Brick property that encodes constraints on the domain and/or range of the property.
+
+For example, the definitions of `brick:isLocationOf` and `brick:hasLocation` are
+
+```python
+{
+  "isLocationOf": {
+    A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+    OWL.inverseOf: "hasLocation",
+    RDFS.domain: BRICK.Location,
+    SKOS.definition: Literal("Subject is the physical location encapsulating the object"),
+  }
+  "hasLocation": {
+    A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+    OWL.inverseOf: "isLocationOf",
+    RDFS.range: BRICK.Location,
+    SKOS.definition: Literal("Subject is physically located in the location given by the object"),
+  },
+}
+```
+
+This definition informs the following Shapes
+
+```ttl
+bsh:IsLocationOfShape
+    a   sh:NodeShape ;
+    sh:targetSubjectsOf brick:isLocationOf ;
+    sh:property [
+        sh:class    brick:Location ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:closed false .
+
+bsh:HasLocationShape
+    a   sh:NodeShape ;
+    sh:targetObjectsOf brick:hasLocation ;
+    sh:property [
+        sh:class    brick:Location ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:closed false .
+```
+
+For properties with both a domain and a range, we will need both a "domain" Shape and a "range" Shape:
+
+```ttl
+bsh:isMeasuredByDomainShape a sh:NodeShape ;
+    sh:property [ sh:class brick:Measurable ;
+            sh:nodeKind sh:IRI ] ;
+    sh:targetSubjectsOf brick:isMeasuredBy .
+
+bsh:isMeasuredByRangeShape a sh:NodeShape ;
+    sh:property [ sh:class brick:Point ;
+            sh:nodeKind sh:IRI ] ;
+    sh:targetObjectsOf brick:isMeasuredBy .
+```
+
+### Special Property Constraints
+
+We will also want to define special shapes for certain properties that have additional semantics. For example, the `feedsAir` subproperty should require that all equipment on its endpoints should have the `brick:regulates brick:Air` property.
+
+We can model this by requiring that all subjects *and* objects of the `brick:feedsAir` property have the `brick:Air` value for either a `brick:requlates` or `brick:measures` property.
+
+```ttl
+bsh:FeedsAirSubjectShape a sh:NodeShape ;
+    sh:targetSubjectsOf brick:feedsAir ;
+    sh:or (
+        sh:property [
+            sh:path brick:regulates ;
+            sh:class brick:Air ;
+        ]
+        sh:property [
+            sh:path brick:measures ;
+            sh:class brick:Air ;
+        ]
+    ) .
+
+bsh:FeedsAirObjectShape a sh:NodeShape ;
+    sh:targetObjectsOf brick:feedsAir ;
+    sh:or (
+        sh:property [
+            sh:path brick:regulates ;
+            sh:class brick:Air ;
+        ]
+        sh:property [
+            sh:path brick:measures ;
+            sh:class brick:Air ;
+        ]
+    ) .
+```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,6 +18,17 @@ SHACL shapes for Brick should validate the following:
   - equipment along a chain of `brick:feeds` should all operate on the same substance
   - proper relationships exist between equipment: e.g. thermostat should have `controls` relationship to RTU
 
+## Getting Started
+
+Install `pyshacl` from pip.
+
+`generate_shacl.py` uses `bricksrc/` to generate a Shapes graph that is serialized to `shacl_test.ttl`.
+
+To validate a graph, use [pySHACL](https://github.com/RDFLib/pySHACL):
+
+```bash
+pyshacl -s shacl_test.ttl -m -e Brick.ttl -f human sample_graph.ttl
+```
 
 ## Brick SHACL shapes
 
@@ -27,16 +38,12 @@ Going through what the SHACL shapes would look for for different tests. The exam
 
 Property definitions (from the `bricksrc/properties.py` file) define inverses, domains/ranges of properties and subproperties. The shape graph would contain one shape for each Brick property that encodes constraints on the domain and/or range of the property.
 
-For example, the definitions of `brick:isLocationOf` and `brick:hasLocation` are
+**TODO**: so far, I'm only sure how to encode the `rdfs:range` property
+
+For example, the definition of `brick:hasLocation` is
 
 ```python
 {
-  "isLocationOf": {
-    A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-    OWL.inverseOf: "hasLocation",
-    RDFS.domain: BRICK.Location,
-    SKOS.definition: Literal("Subject is the physical location encapsulating the object"),
-  }
   "hasLocation": {
     A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
     OWL.inverseOf: "isLocationOf",
@@ -46,41 +53,20 @@ For example, the definitions of `brick:isLocationOf` and `brick:hasLocation` are
 }
 ```
 
-This definition informs the following Shapes
+This definition informs the following Shape for the `rdfs:range` property
 
 ```ttl
-bsh:IsLocationOfShape
-    a   sh:NodeShape ;
-    sh:targetSubjectsOf brick:isLocationOf ;
-    sh:property [
-        sh:class    brick:Location ;
-        sh:nodeKind sh:IRI ;
-    ] ;
-    sh:closed false .
-
-bsh:HasLocationShape
+bsh:HasLocationRangeShape
     a   sh:NodeShape ;
     sh:targetObjectsOf brick:hasLocation ;
     sh:property [
         sh:class    brick:Location ;
+        sh:path     brick:hasLocation ;
         sh:nodeKind sh:IRI ;
-    ] ;
-    sh:closed false .
+    ] .
 ```
 
-For properties with both a domain and a range, we will need both a "domain" Shape and a "range" Shape:
-
-```ttl
-bsh:isMeasuredByDomainShape a sh:NodeShape ;
-    sh:property [ sh:class brick:Measurable ;
-            sh:nodeKind sh:IRI ] ;
-    sh:targetSubjectsOf brick:isMeasuredBy .
-
-bsh:isMeasuredByRangeShape a sh:NodeShape ;
-    sh:property [ sh:class brick:Point ;
-            sh:nodeKind sh:IRI ] ;
-    sh:targetObjectsOf brick:isMeasuredBy .
-```
+For properties with both a domain and a range, we will need both a "domain" Shape and a "range" Shape; however, at this time I'm not sure how to encode constraints for `rdfs:domain`.
 
 ### Special Property Constraints
 

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -4,6 +4,8 @@ BRICK_VERSION = '1.1.0'
 
 BRICK = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/Brick#")
 TAG = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/BrickTag#")
+BSH = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/BrickShape#")
+SH = Namespace(f"http://www.w3.org/ns/shacl#")
 #BLDG = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/ExampleBuilding#")
 OWL = Namespace("http://www.w3.org/2002/07/owl#")
 RDF = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
@@ -22,5 +24,7 @@ def bind_prefixes(g):
     g.bind('rdfs', RDFS)
     g.bind('skos', SKOS)
     g.bind('sosa', SOSA)
+    g.bind('sh', SH)
     g.bind('brick', BRICK)
     g.bind('tag', TAG)
+    g.bind('bsh', BSH)

--- a/expand_graph.py
+++ b/expand_graph.py
@@ -1,0 +1,16 @@
+from rdflib import Graph, Namespace
+from bricksrc.namespaces import BRICK, RDF, OWL, DCTERMS, SDO, RDFS, SKOS, BRICK, TAG, SOSA, BSH, SH
+from bricksrc.namespaces import bind_prefixes
+from tests.util.reasoner import reason_brick
+import sys
+
+G = Graph()
+bind_prefixes(G)
+A = RDF.type
+G.parse(sys.argv[1], format='ttl')
+#G.parse('Brick.ttl', format='ttl')
+
+reason_brick(G)
+
+with open('output.ttl', 'wb') as f:
+    f.write(G.serialize(format='ttl'))

--- a/generate_shacl.py
+++ b/generate_shacl.py
@@ -1,16 +1,15 @@
-from rdflib import Graph, Literal, BNode, Namespace, RDF, URIRef, RDFS, OWL
-from rdflib.namespace import XSD
+from rdflib import Graph, Literal, BNode
 from rdflib.collection import Collection
-
-from bricksrc.namespaces import BRICK, RDF, OWL, DCTERMS, SDO, RDFS, SKOS, BRICK, TAG, SOSA, BSH, SH
+from bricksrc.namespaces import RDF, RDFS, BRICK, BSH, SH
 from bricksrc.namespaces import bind_prefixes
+# add SHACL shapes from properties
+from bricksrc.properties import properties as property_definitions
 
 G = Graph()
 bind_prefixes(G)
 A = RDF.type
-
-# add SHACL shapes from properties
-from bricksrc.properties import properties as property_definitions
+rootclasses = ["Equipment", "Location", "Point",
+               "Substance", "Quantity"]
 
 for name, properties in property_definitions.items():
 
@@ -21,33 +20,49 @@ for name, properties in property_definitions.items():
 
         if pred == RDFS.range:
             shapename = f"{name}RangeShape"
-            G.add( (BSH[shapename], SH['property'], sh_prop) )
-            G.add( (BSH[shapename], A, SH.NodeShape) )
+            G.add((BSH[shapename], SH['property'], sh_prop))
+            G.add((BSH[shapename], A, SH.NodeShape))
 
-            G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
-            G.add( (sh_prop, SH['path'], BRICK[name]) )
-            G.add( (sh_prop, SH['class'], obj) )
-            qualifier = SH.targetObjectsOf
-            G.add( (BSH[shapename], qualifier, BRICK[name]) )
+            G.add((sh_prop, SH['nodeKind'], SH.IRI))
+            G.add((sh_prop, SH['path'], BRICK[name]))
+            G.add((sh_prop, SH['class'], obj))
+            G.add((BSH[shapename], SH.targetSubjectsOf, BRICK[name]))
+            G.add((sh_prop, SH['message'],
+                   Literal(f"Property {name} has object with incorrect type")))
 
-            G.add( (sh_prop, SH['message'], Literal(f"Property {name} has object with incorrect type")) )
 
         # TODO: broken SHACL for rdfs.domain
         #if pred == RDFS.domain:
         #    shapename = f"{name}DomainShape"
-        #    G.add( (BSH[shapename], SH['property'], sh_prop) )
-        #    G.add( (BSH[shapename], A, SH.NodeShape) )
+        #    G.add( (BSH[shapename], SH['property'], sh_prop))
+        #    G.add( (BSH[shapename], A, SH.NodeShape))
 
-        #    G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
-        #    G.add( (sh_prop, SH['path'], BRICK[name]) )
+        #    G.add( (sh_prop, SH['nodeKind'], SH.IRI))
+        #    G.add( (sh_prop, SH['path'], BRICK[name]))
         #    qualifier = SH.targetClass
-        #    G.add( (BSH[shapename], qualifier, obj) )
+        #    G.add( (BSH[shapename], qualifier, obj))
 
-        #    G.add( (sh_prop, SH['message'], Literal(f"Property {name} has subject with incorrect type")) )
+        #    G.add( (sh_prop, SH['message'], Literal(f"Property {name} has subject with incorrect type")))
+
+# make sure that root classes are disjoint, even if inference has generated
+# some invalid properties (e.g. a subject of hasLocation will be inferred
+# as a Location even if it is already an Equipment).
+for rootclass1 in rootclasses:
+    for rootclass2 in rootclasses:
+        if rootclass1 == rootclass2:
+            continue
+        sh_prop = BNode()
+        shapename = f"{rootclass1}CanNotBe{rootclass2}Shape"
+        G.add((BSH[shapename], A, SH.NodeShape))
+        G.add((BSH[shapename], SH.targetClass, BRICK[rootclass1]))
+        G.add((BSH[shapename], SH["not"], sh_prop))
+        G.add((sh_prop, SH["class"], BRICK[rootclass2]))
+        G.add((sh_prop, SH["message"], Literal(f"Node cannot be both a \
+               {BRICK[rootclass1]} and a {BRICK[rootclass2]}. Check the \
+               properties it has")))
 
 # subproperties
 # TODO: explicitly coded for now, but we should generalize
-
 substance_subproperties = {
     'feedsAir':  {
         'substance': BRICK.Air,
@@ -65,9 +80,9 @@ for subprop, desc in substance_subproperties.items():
     for prop in desc['properties']:
         constraint = BNode()
         definition = BNode()
-        G.add( (constraint, SH['property'], definition) )
-        G.add( (definition, SH['path'], prop) )
-        G.add( (definition, SH['class'], desc['substance']) )
+        G.add( (constraint, SH['property'], definition))
+        G.add( (definition, SH['path'], prop))
+        G.add( (definition, SH['class'], desc['substance']))
         constraints.append(constraint)
 
     c = Collection(G, constraintlist, constraints)

--- a/generate_shacl.py
+++ b/generate_shacl.py
@@ -1,0 +1,47 @@
+from rdflib import Graph, Literal, BNode, Namespace, RDF, URIRef, RDFS, OWL
+from rdflib.namespace import XSD
+from rdflib.collection import Collection
+
+from bricksrc.namespaces import BRICK, RDF, OWL, DCTERMS, SDO, RDFS, SKOS, BRICK, TAG, SOSA, BSH, SH
+from bricksrc.namespaces import bind_prefixes
+
+G = Graph()
+bind_prefixes(G)
+A = RDF.type
+
+# add SHACL shapes from properties
+from bricksrc.properties import properties as property_definitions
+
+for name, properties in property_definitions.items():
+
+    for pred, obj in properties.items():
+        sh_prop = BNode()
+
+        # TODO: currently just for rdfs:{domain, range}
+
+        if pred == RDFS.range:
+            shapename = f"{name}RangeShape"
+            G.add( (BSH[shapename], SH['property'], sh_prop) )
+            G.add( (BSH[shapename], A, SH.NodeShape) )
+
+            G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
+            G.add( (sh_prop, SH['class'], obj) )
+            qualifier = SH.targetObjectsOf
+            G.add( (BSH[shapename], qualifier, name) )
+
+            G.add( (sh_prop, SH['message'], Literal("Property has object with incorrect type")) )
+
+        if pred == RDFS.domain:
+            shapename = f"{name}DomainShape"
+            G.add( (BSH[shapename], SH['property'], sh_prop) )
+            G.add( (BSH[shapename], A, SH.NodeShape) )
+
+            G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
+            G.add( (sh_prop, SH['class'], obj) )
+            qualifier = SH.targetSubjectsOf
+            G.add( (BSH[shapename], qualifier, name) )
+
+            G.add( (sh_prop, SH['message'], Literal("Property has subject with incorrect type")) )
+
+with open('shacl_test.ttl', 'wb') as f:
+    f.write(G.serialize(format='ttl'))

--- a/generate_shacl.py
+++ b/generate_shacl.py
@@ -25,23 +25,52 @@ for name, properties in property_definitions.items():
             G.add( (BSH[shapename], A, SH.NodeShape) )
 
             G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
+            G.add( (sh_prop, SH['path'], BRICK[name]) )
             G.add( (sh_prop, SH['class'], obj) )
             qualifier = SH.targetObjectsOf
-            G.add( (BSH[shapename], qualifier, name) )
+            G.add( (BSH[shapename], qualifier, BRICK[name]) )
 
-            G.add( (sh_prop, SH['message'], Literal("Property has object with incorrect type")) )
+            G.add( (sh_prop, SH['message'], Literal(f"Property {name} has object with incorrect type")) )
 
-        if pred == RDFS.domain:
-            shapename = f"{name}DomainShape"
-            G.add( (BSH[shapename], SH['property'], sh_prop) )
-            G.add( (BSH[shapename], A, SH.NodeShape) )
+        # TODO: broken SHACL for rdfs.domain
+        #if pred == RDFS.domain:
+        #    shapename = f"{name}DomainShape"
+        #    G.add( (BSH[shapename], SH['property'], sh_prop) )
+        #    G.add( (BSH[shapename], A, SH.NodeShape) )
 
-            G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
-            G.add( (sh_prop, SH['class'], obj) )
-            qualifier = SH.targetSubjectsOf
-            G.add( (BSH[shapename], qualifier, name) )
+        #    G.add( (sh_prop, SH['nodeKind'], SH.IRI) )
+        #    G.add( (sh_prop, SH['path'], BRICK[name]) )
+        #    qualifier = SH.targetClass
+        #    G.add( (BSH[shapename], qualifier, obj) )
 
-            G.add( (sh_prop, SH['message'], Literal("Property has subject with incorrect type")) )
+        #    G.add( (sh_prop, SH['message'], Literal(f"Property {name} has subject with incorrect type")) )
+
+# subproperties
+# TODO: explicitly coded for now, but we should generalize
+
+substance_subproperties = {
+    'feedsAir':  {
+        'substance': BRICK.Air,
+        'properties': [BRICK.regulates, BRICK.measures]
+    },
+}
+
+for subprop, desc in substance_subproperties.items():
+    shape = BSH[f"{subprop}SubstanceShape"]
+    constraintlist = BNode()
+    G.add((shape, A, SH.NodeShape))
+    G.add((shape, SH['or'], constraintlist))
+
+    constraints = []
+    for prop in desc['properties']:
+        constraint = BNode()
+        definition = BNode()
+        G.add( (constraint, SH['property'], definition) )
+        G.add( (definition, SH['path'], prop) )
+        G.add( (definition, SH['class'], desc['substance']) )
+        constraints.append(constraint)
+
+    c = Collection(G, constraintlist, constraints)
 
 with open('shacl_test.ttl', 'wb') as f:
     f.write(G.serialize(format='ttl'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ six==1.12.0
 owlready2
 pytest
 tqdm
+pyshacl

--- a/sample_graph.ttl
+++ b/sample_graph.ttl
@@ -1,0 +1,41 @@
+@prefix bldg: <http://example.com/mybuilding#> .
+@prefix brick: <https://brickschema.org/schema/1.1.0/Brick#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bldg:AHU1A a brick:Air_Handler_Unit ;
+    brick:feeds bldg:VAV2-4,
+        bldg:VAV2_3 .
+
+bldg:VAV2-3 a brick:Variable_Air_Volume_Box ;
+    brick:feeds bldg:VAV2-3Zone .
+
+bldg:VAV2-4.ZN_T a brick:Supply_Air_Temperature_Sensor .
+
+bldg:Room-410 a brick:Room .
+
+bldg:Room-411 a brick:Room .
+
+bldg:Room-412 a brick:Room .
+
+bldg:VAV2-3Zone a brick:HVAC_Zone ;
+    brick:hasPart bldg:Room-410,
+        bldg:Room-411,
+        bldg:Room-412 .
+
+bldg:VAV2-4 a brick:Variable_Air_Volume_Box ;
+    brick:hasPart bldg:VAV2-4.DPR ;
+    brick:hasPoint bldg:VAV2-4.SUPFLOW,
+        bldg:VAV2-4.SUPFLSP .
+
+bldg:VAV2-4.DPR a brick:Damper ;
+    brick:hasPoint bldg:VAV2-4.DPRPOS .
+
+bldg:VAV2-4.DPRPOS a brick:Damper_Position_Setpoint .
+
+bldg:VAV2-4.SUPFLOW a brick:Supply_Air_Flow_Sensor .
+
+bldg:VAV2-4.SUPFLSP a brick:Supply_Air_Flow_Setpoint .
+


### PR DESCRIPTION
**Do not merge this branch yet!**

This PR is a forum for discussing the integration of SHACL into Brick. The existing implementation is very spare and incomplete, and I expect it to change over time. Below is the content of `DESIGN.md` from the branch:

---

# SHACL for Brick

The SHACL Shapes Constraint Language validates RDF graphs against conditions (called "shapes"), which are expressed themselves as an RDF graph. This document discusses the application of SHACL to Brick. In this document we are specifically looking at writing SHACL shapes for validating Brick *models* (instances of buildings). Using SHACL to validate the Brick ontology deserves its own investigation.

SHACL shapes for Brick should validate the following:

- validating endpoints of Brick relationships (properties):
  - check type of subject/object: are the `rdfs:range`, `rdfs:domain` properties respected?
  - cardinality checks: with varying severity
    - floors without rooms
    - equipment missing certain points (e.g. thermostat should have a temperature sensor, at least one setpoint)
    - all named individuals should have `rdf:type`
- compatibility checking:
  - all objects of `rdf:type` should be Brick classes (subclassof, etc)
  - check for deprecated classes, relationships
- idioms, semantic checks:
  - these may be optional; users can "opt-in" to check for certain idioms
  - equipment along a chain of `brick:feeds` should all operate on the same substance
  - proper relationships exist between equipment: e.g. thermostat should have `controls` relationship to RTU

## Getting Started

Install `pyshacl` from pip.

`generate_shacl.py` uses `bricksrc/` to generate a Shapes graph that is serialized to `shacl_test.ttl`.

To validate a graph, use [pySHACL](https://github.com/RDFLib/pySHACL):

```bash
pyshacl -s shacl_test.ttl -m -e Brick.ttl -f human sample_graph.ttl
```

You may want to expand a graph before validating it. In that case, run

```bash
python expand_graph.py sample_graph.ttl
```

which will drop the expanded graph into `output.ttl` in the same directory.

## Brick SHACL shapes

Going through what the SHACL shapes would look for for different tests. The examples below declare shapes in the `bsh` ("brickshape") namespace for clarity

### Property Constraints

Property definitions (from the `bricksrc/properties.py` file) define inverses, domains/ranges of properties and subproperties. The shape graph would contain one shape for each Brick property that encodes constraints on the domain and/or range of the property.

**TODO**: so far, I'm only sure how to encode the `rdfs:range` property

For example, the definition of `brick:hasLocation` is

```python
{
  "hasLocation": {
    A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
    OWL.inverseOf: "isLocationOf",
    RDFS.range: BRICK.Location,
    SKOS.definition: Literal("Subject is physically located in the location given by the object"),
  },
}
```

This definition informs the following Shape for the `rdfs:range` property

```ttl
bsh:HasLocationRangeShape
    a   sh:NodeShape ;
    sh:targetObjectsOf brick:hasLocation ;
    sh:property [
        sh:class    brick:Location ;
        sh:path     brick:hasLocation ;
        sh:nodeKind sh:IRI ;
    ] .
```

For properties with both a domain and a range, we will need both a "domain" Shape and a "range" Shape; however, at this time I'm not sure how to encode constraints for `rdfs:domain`.

### Special Property Constraints

We will also want to define special shapes for certain properties that have additional semantics. For example, the `feedsAir` subproperty should require that all equipment on its endpoints should have the `brick:regulates brick:Air` property.

We can model this by requiring that all subjects *and* objects of the `brick:feedsAir` property have the `brick:Air` value for either a `brick:requlates` or `brick:measures` property.

```ttl
bsh:FeedsAirSubjectShape a sh:NodeShape ;
    sh:targetSubjectsOf brick:feedsAir ;
    sh:or (
        sh:property [
            sh:path brick:regulates ;
            sh:class brick:Air ;
        ]
        sh:property [
            sh:path brick:measures ;
            sh:class brick:Air ;
        ]
    ) .

bsh:FeedsAirObjectShape a sh:NodeShape ;
    sh:targetObjectsOf brick:feedsAir ;
    sh:or (
        sh:property [
            sh:path brick:regulates ;
            sh:class brick:Air ;
        ]
        sh:property [
            sh:path brick:measures ;
            sh:class brick:Air ;
        ]
    ) .
```
