### PR TITLE
Fix Meter hierarchy

### DIFF
--- a/Brick.ttl
+++ b/Brick.ttl
@@ -8577,7 +8577,7 @@ brick:Load_Shed_Status a owl:Class ;
 brick:Meter a owl:Class ;
     rdfs:label "Meter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment ) ],
-        brick:Electrical_System ;
+        brick:Equipment ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Meter .
 
@@ -9399,6 +9399,13 @@ brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
+brick:Electrical_System a owl:Class ;
+    rdfs:label "Electrical System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:System .
+
 brick:Enthalpy a owl:Class,
         brick:Enthalpy ;
     rdfs:label "Enthalpy" ;
@@ -9576,13 +9583,6 @@ brick:Electric_Power a owl:Class,
         brick:Electric_Power ;
     rdfs:label "Electric Power" ;
     rdfs:subClassOf brick:Power .
-
-brick:Electrical_System a owl:Class ;
-    rdfs:label "Electrical System" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
-        brick:Equipment ;
-    brick:hasAssociatedTag tag:Electrical,
-        tag:System .
 
 brick:Exhaust_Air a owl:Class,
         brick:Exhaust_Air ;
@@ -9970,12 +9970,6 @@ tag:Emergency a brick:Tag ;
 tag:Medium a brick:Tag ;
     rdfs:label "Medium" .
 
-brick:Equipment a owl:Class ;
-    rdfs:label "Equipment" ;
-    rdfs:subClassOf _:has_Equipment,
-        brick:Class ;
-    brick:hasAssociatedTag tag:Equipment .
-
 brick:Temperature_Parameter a owl:Class ;
     rdfs:label "Temperature Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Parameter ) ],
@@ -9992,6 +9986,12 @@ tag:System a brick:Tag ;
 
 tag:Valve a brick:Tag ;
     rdfs:label "Valve" .
+
+brick:Equipment a owl:Class ;
+    rdfs:label "Equipment" ;
+    rdfs:subClassOf _:has_Equipment,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Equipment .
 
 brick:Flow a owl:Class,
         brick:Flow ;

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -42,20 +42,56 @@ equipment_subclasses = {
     "Meter": {
         "tags": [TAG.Meter, TAG.Equipment],
         "subclasses": {
+            "Electrical_Meter": {
+                "tags": [TAG.Electrical, TAG.Meter, TAG.Equipment],
+                "subclasses": {
+                    "Building_Electrical_Meter": {
+                        "tags": [TAG.Building, TAG.Electrical, TAG.Meter, TAG.Equipment],
+                        "parents": [BRICK.Building_Meter],
+                    }
+                }
+            },
+            "Gas_Meter": {
+                "tags": [TAG.Meter, TAG.Equipment, TAG.Gas],
+                "subclasses": {
+                    "Building_Gas_Meter": {
+                        "tags": [TAG.Building, TAG.Gas, TAG.Meter, TAG.Equipment],
+                        "parents": [BRICK.Building_Meter],
+                    }
+                }
+            },
             "Water_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Water],
                 "parents": [BRICK.Water_System],
                 "subclasses": {
+                    "Building_Water_Meter": {
+                        "tags": [TAG.Building, TAG.Water, TAG.Meter, TAG.Equipment],
+                        "parents": [BRICK.Building_Meter],
+                    },
                     "Chilled_Water_Meter": {
                         "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Chilled],
                         "parents": [BRICK.Chilled_Water_System],
+                        "subclasses": {
+                            "Building_Chilled_Water_Meter": {
+                                "tags": [TAG.Building, TAG.Chilled, TAG.Water, TAG.Meter, TAG.Equipment],
+                                "parents": [BRICK.Building_Meter],
+                            },
+                        },
+                    },
+                    "Hot_Water_Meter": {
+                        "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Hot],
+                        "parents": [BRICK.Chilled_Water_System],
+                        "subclasses": {
+                            "Building_Hot_Water_Meter": {
+                                "tags": [TAG.Building, TAG.Hot, TAG.Water, TAG.Meter, TAG.Equipment],
+                                "parents": [BRICK.Building_Meter],
+                            },
+                        },
                     },
                 },
             },
             "Building_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Building],
-                "subclasses": {
-                }
             },
         },
     },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -52,9 +52,9 @@ equipment_subclasses = {
                     "Chilled_Water_Meter": {
                         "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Chilled],
                         "parents": [BRICK.Chilled_Water_System],
-                        },
                     },
                 },
+            },
             "Power_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Power],
                 "parents": [BRICK.Power_System],
@@ -64,19 +64,19 @@ equipment_subclasses = {
                         "subclasses": {
                             "Cooling_Thermal_Power_Meter": {
                                 "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Cooling],
-                                },
+                            },
                             "Heating_Thermal_Power_Meter": {
                                 "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Heating],
-                                },
                             },
                         },
                     },
                 },
+            },
             "Building_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Building],
-                },
             },
         },
+    },
     "Water_System": {
         "tags": [TAG.Water, TAG.Equipment],
         "subclasses": {

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -52,24 +52,10 @@ equipment_subclasses = {
                     },
                 },
             },
-            "Power_Meter": {
-                "tags": [TAG.Meter, TAG.Equipment, TAG.Power],
-                "subclasses": {
-                    "Thermal_Power_Meter": {
-                        "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal],
-                        "subclasses": {
-                            "Cooling_Thermal_Power_Meter": {
-                                "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Cooling],
-                            },
-                            "Heating_Thermal_Power_Meter": {
-                                "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Heating],
-                            },
-                        },
-                    },
-                },
-            },
             "Building_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Building],
+                "subclasses": {
+                }
             },
         },
     },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -40,43 +40,43 @@ equipment_subclasses = {
             "PlugStrip": {
                 "tags": [TAG.PlugStrip, TAG.Equipment],
             },
-            "Meter": {
-                "tags": [TAG.Meter, TAG.Equipment],
+        },
+    },
+    "Meter": {
+        "tags": [TAG.Meter, TAG.Equipment],
+        "subclasses": {
+            "Water_Meter": {
+                "tags": [TAG.Meter, TAG.Equipment, TAG.Water],
+                "parents": [BRICK.Water_System],
                 "subclasses": {
-                    "Water_Meter": {
-                        "tags": [TAG.Meter, TAG.Equipment, TAG.Water],
-                        "parents": [BRICK.Water_System],
-                        "subclasses": {
-                            "Chilled_Water_Meter": {
-                                "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Chilled],
-                                "parents": [BRICK.Chilled_Water_System],
-                            },
+                    "Chilled_Water_Meter": {
+                        "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Chilled],
+                        "parents": [BRICK.Chilled_Water_System],
                         },
                     },
-                    "Power_Meter": {
-                        "tags": [TAG.Meter, TAG.Equipment, TAG.Power],
-                        "parents": [BRICK.Power_System],
+                },
+            "Power_Meter": {
+                "tags": [TAG.Meter, TAG.Equipment, TAG.Power],
+                "parents": [BRICK.Power_System],
+                "subclasses": {
+                    "Thermal_Power_Meter": {
+                        "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal],
                         "subclasses": {
-                            "Thermal_Power_Meter": {
-                                "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal],
-                                "subclasses": {
-                                    "Cooling_Thermal_Power_Meter": {
-                                        "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Cooling],
-                                    },
-                                    "Heating_Thermal_Power_Meter": {
-                                        "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Heating],
-                                    },
+                            "Cooling_Thermal_Power_Meter": {
+                                "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Cooling],
+                                },
+                            "Heating_Thermal_Power_Meter": {
+                                "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal, TAG.Heating],
                                 },
                             },
                         },
                     },
-                    "Building_Meter": {
-                        "tags": [TAG.Meter, TAG.Equipment, TAG.Building],
-                    },
+                },
+            "Building_Meter": {
+                "tags": [TAG.Meter, TAG.Equipment, TAG.Building],
                 },
             },
         },
-    },
     "Water_System": {
         "tags": [TAG.Water, TAG.Equipment],
         "subclasses": {

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -34,9 +34,6 @@ equipment_subclasses = {
             "Inverter": {
                 "tags": [TAG.Inverter, TAG.Equipment],
             },
-            "Power_System": {
-                "tags": [TAG.Power, TAG.Equipment],
-            },
             "PlugStrip": {
                 "tags": [TAG.PlugStrip, TAG.Equipment],
             },
@@ -57,7 +54,6 @@ equipment_subclasses = {
             },
             "Power_Meter": {
                 "tags": [TAG.Meter, TAG.Equipment, TAG.Power],
-                "parents": [BRICK.Power_System],
                 "subclasses": {
                     "Thermal_Power_Meter": {
                         "tags": [TAG.Meter, TAG.Equipment, TAG.Power, TAG.Thermal],


### PR DESCRIPTION
`Meter` is not a subclass of `Electrical_System` but devices for a collection of points related to metering. Moving it as a top class of `Equipment`.