### PR TITLE
Reworking `Water_System` Hierarchy

### DIFF
--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -42,11 +42,9 @@ equipment_subclasses = {
                 "subclasses": {
                     "Water_Meter": {
                         "tags": [TAG.Meter, TAG.Equipment, TAG.Water],
-                        "parents": [BRICK.Water_System],
                         "subclasses": {
                             "Chilled_Water_Meter": {
                                 "tags": [TAG.Meter, TAG.Equipment, TAG.Water, TAG.Chilled],
-                                "parents": [BRICK.Chilled_Water_System],
                             },
                         },
                     },
@@ -333,11 +331,11 @@ valve_subclasses = {
             },
             "Domestic_Hot_Water_Valve": {
                 "tags": [TAG.Domestic, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
-                "parents": [BRICK.Domestic_Hot_Water_System, BRICK.Water_Valve],
+                "parents": [BRICK.Water_Valve],
             },
             "Preheat_Hot_Water_Valve": {
                 "tags": [TAG.Preheat, TAG.Water, TAG.Hot, TAG.Valve, TAG.Heat, TAG.Equipment],
-                "parents": [BRICK.Hot_Water_System, BRICK.Water_Valve],
+                "parents": [BRICK.Water_Valve],
             },
         },
     },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -75,18 +75,18 @@ equipment_subclasses = {
         },
     },
     "Water_System": {
-        "tags": [TAG.Water, TAG.Equipment],
+        "tags": [TAG.Water, TAG.Equipment, TAG.System],
         "subclasses": {
             "Chilled_Water_System": {
                 OWL.equivalentClass: "CWS",
-                "tags": [TAG.Water, TAG.Chilled, TAG.Equipment],
+                "tags": [TAG.Water, TAG.Chilled, TAG.Equipment, TAG.System],
             },
             "Hot_Water_System": {
                 OWL.equivalentClass: "HWS",
-                "tags": [TAG.Water, TAG.Hot, TAG.Equipment],
+                "tags": [TAG.Water, TAG.Hot, TAG.Equipment, TAG.System],
                 "subclasses": {
                     "Domestic_Hot_Water_System": {
-                        "tags": [TAG.Domestic, TAG.Water, TAG.Hot, TAG.Equipment],
+                        "tags": [TAG.Domestic, TAG.Water, TAG.Hot, TAG.Equipment, TAG.System],
                     },
                 },
             },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -349,7 +349,7 @@ valve_subclasses = {
         "subclasses": {
             "Chilled_Water_Valve": {
                 "tags": [TAG.Chilled, TAG.Valve, TAG.Water, TAG.Equipment],
-                "parents": [BRICK.Chilled_Water_System],
+                "parents": [BRICK.Water_Valve],
             },
         },
     },


### PR DESCRIPTION
The current model has `Water_System` as a general type of any equipment related to water. However, `Water_System` commonly refers to a collection of devices for water control as Brick 1.0 modeled. I am reverting the current definition to Brick 1.0's in this PR.

For that, I made changes as:
- Add `System` tag to `Water_Systems`.
- Remove `Water_System` as a parent of `Pumps`.