### PR TITLE
Refactoring Brick generation script

### DIFF
--- a/Brick.ttl
+++ b/Brick.ttl
@@ -35,6 +35,20 @@ brick:Acceleration_Time_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Time .
 
+brick:Active_Power_Sensor a owl:Class ;
+    rdfs:label "Active Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Real ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Active_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Power,
+        tag:Real,
+        tag:Sensor .
+
 brick:Air_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Air Differential Pressure Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
@@ -773,13 +787,6 @@ brick:Deionized_Water_Alarm a owl:Class ;
         tag:Deionized,
         tag:Water .
 
-brick:Demand_Sensor a owl:Class ;
-    rdfs:label "Demand Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Demand ) ],
-        brick:Sensor ;
-    brick:hasAssociatedTag tag:Demand,
-        tag:Sensor .
-
 brick:Derivative_Gain_Parameter a owl:Class ;
     rdfs:label "Derivative Gain Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
@@ -1229,16 +1236,6 @@ brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
         tag:Heating,
         tag:Setpoint,
         tag:Temperature .
-
-brick:Electrical_Power_Sensor a owl:Class ;
-    rdfs:label "Electrical Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
-                        owl:hasValue tag:Electrical ;
-                        owl:onProperty brick:hasTag ] ) ],
-        brick:Power_Sensor ;
-    brick:hasAssociatedTag tag:Electrical,
-        tag:Power,
-        tag:Sensor .
 
 brick:Elevator a owl:Class ;
     rdfs:label "Elevator" ;
@@ -3355,6 +3352,22 @@ brick:PIR_Sensor a owl:Class ;
         tag:Pir,
         tag:Sensor .
 
+brick:Peak_Power_Demand_Sensor a owl:Class ;
+    rdfs:label "Peak Power Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Peak ;
+                        owl:onProperty brick:hasTag ] _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
+        brick:Demand_Sensor,
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Peak_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Electrical,
+        tag:Peak,
+        tag:Power,
+        tag:Sensor .
+
 brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     rdfs:label "Photovoltaic Current Output Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3474,6 +3487,20 @@ brick:Rated_Speed_Setpoint a owl:Class ;
     brick:hasAssociatedTag tag:Rated,
         tag:Setpoint,
         tag:Speed .
+
+brick:Reactive_Power_Sensor a owl:Class ;
+    rdfs:label "Reactive Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Reactive ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Reactive_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Power,
+        tag:Reactive,
+        tag:Sensor .
 
 brick:Reheat_Valve a owl:Class ;
     rdfs:label "Reheat Valve" ;
@@ -4430,17 +4457,9 @@ brick:regulates a owl:AsymmetricProperty,
     skos:definition "The subject contributes to or performs the regulation of the substance given by the object" .
 
 brick:Acceleration_Time a owl:Class,
-        brick:Acceleration_Time,
-        brick:Time ;
+        brick:Acceleration_Time ;
     rdfs:label "Acceleration Time" ;
     rdfs:subClassOf brick:Time .
-
-brick:Active_Power a owl:Class,
-        brick:Active_Power,
-        brick:Electric_Power ;
-    rdfs:label "Active Power" ;
-    rdfs:subClassOf brick:Electric_Power ;
-    owl:equivalentClass brick:Real_Power .
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Air Flow Deadband Setpoint" ;
@@ -4473,28 +4492,23 @@ brick:Air_Temperature_Setpoint_Limit a owl:Class ;
         tag:Temperature .
 
 brick:Alternating_Current_Frequency a owl:Class,
-        brick:Alternating_Current_Frequency,
-        brick:Electric_Current,
-        brick:Frequency ;
+        brick:Alternating_Current_Frequency ;
     rdfs:label "Alternating Current Frequency" ;
     rdfs:subClassOf brick:Electric_Current,
         brick:Frequency .
 
 brick:Apparent_Power a owl:Class,
-        brick:Apparent_Power,
-        brick:Electric_Power ;
+        brick:Apparent_Power ;
     rdfs:label "Apparent Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
 brick:Atmospheric_Pressure a owl:Class,
-        brick:Atmospheric_Pressure,
-        brick:Pressure ;
+        brick:Atmospheric_Pressure ;
     rdfs:label "Atmospheric Pressure" ;
     rdfs:subClassOf brick:Pressure .
 
 brick:Blowdown_Water a owl:Class,
-        brick:Blowdown_Water,
-        brick:Water ;
+        brick:Blowdown_Water ;
     rdfs:label "Blowdown Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
                         owl:hasValue tag:Blowdown ;
@@ -4514,9 +4528,7 @@ brick:CO2_Alarm a owl:Class ;
         tag:CO2 .
 
 brick:CO2_Level a owl:Class,
-        brick:Air_Quality,
-        brick:CO2_Level,
-        brick:Level ;
+        brick:CO2_Level ;
     rdfs:label "CO2 Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
@@ -4563,8 +4575,7 @@ brick:Chilled_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
         tag:Water .
 
 brick:Cloudage a owl:Class,
-        brick:Cloudage,
-        brick:Quantity ;
+        brick:Cloudage ;
     rdfs:label "Cloudage" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -4573,8 +4584,7 @@ brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:subClassOf brick:Zone_Air_Temperature_Sensor .
 
 brick:Complex_Power a owl:Class,
-        brick:Complex_Power,
-        brick:Electric_Power ;
+        brick:Complex_Power ;
     rdfs:label "Complex Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
@@ -4585,8 +4595,7 @@ brick:Computer_Room_Air_Conditioning a owl:Class ;
     skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " .
 
 brick:Condenser_Water a owl:Class,
-        brick:Condenser_Water,
-        brick:Water ;
+        brick:Condenser_Water ;
     rdfs:label "Condenser Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
                         owl:hasValue tag:Condenser ;
@@ -4635,26 +4644,22 @@ brick:Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
         tag:Supply .
 
 brick:Current_Angle a owl:Class,
-        brick:Current_Angle,
-        brick:Electric_Current ;
+        brick:Current_Angle ;
     rdfs:label "Current Angle" ;
     rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Imbalance a owl:Class,
-        brick:Current_Imbalance,
-        brick:Electric_Current ;
+        brick:Current_Imbalance ;
     rdfs:label "Current Imbalance" ;
     rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Magnitude a owl:Class,
-        brick:Current_Magnitude,
-        brick:Electric_Current ;
+        brick:Current_Magnitude ;
     rdfs:label "Current Magnitude" ;
     rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Total_Harmonic_Distortion a owl:Class,
-        brick:Current_Total_Harmonic_Distortion,
-        brick:Electric_Current ;
+        brick:Current_Total_Harmonic_Distortion ;
     rdfs:label "Current Total Harmonic Distortion" ;
     rdfs:subClassOf brick:Electric_Current .
 
@@ -4673,14 +4678,12 @@ brick:Damper_Command a owl:Class ;
         tag:Damper .
 
 brick:Daytime a owl:Class,
-        brick:Daytime,
-        brick:Quantity ;
+        brick:Daytime ;
     rdfs:label "Daytime" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Deceleration_Time a owl:Class,
-        brick:Deceleration_Time,
-        brick:Time ;
+        brick:Deceleration_Time ;
     rdfs:label "Deceleration Time" ;
     rdfs:subClassOf brick:Time .
 
@@ -4690,6 +4693,13 @@ brick:Delay_Parameter a owl:Class ;
         brick:Parameter ;
     brick:hasAssociatedTag tag:Delay,
         tag:Parameter .
+
+brick:Demand_Sensor a owl:Class ;
+    rdfs:label "Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Demand ) ],
+        brick:Sensor ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Sensor .
 
 brick:Differential_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Differential Pressure Step Parameter" ;
@@ -4848,8 +4858,7 @@ brick:Domestic_Hot_Water_Temperature_Setpoint a owl:Class ;
         tag:Water .
 
 brick:Domestic_Water a owl:Class,
-        brick:Domestic_Water,
-        brick:Water ;
+        brick:Domestic_Water ;
     rdfs:label "Domestic Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Domestic ) ],
         brick:Water ;
@@ -4860,14 +4869,12 @@ brick:Domestic_Water a owl:Class,
         tag:Water .
 
 brick:Dry_Bulb_Temperature a owl:Class,
-        brick:Dry_Bulb_Temperature,
-        brick:Temperature ;
+        brick:Dry_Bulb_Temperature ;
     rdfs:label "Dry Bulb Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
 brick:Electric_Energy a owl:Class,
-        brick:Electric_Energy,
-        brick:Energy ;
+        brick:Electric_Energy ;
     rdfs:label "Electric Energy" ;
     rdfs:subClassOf brick:Energy .
 
@@ -4991,7 +4998,6 @@ brick:Filter_Status a owl:Class ;
         tag:Status .
 
 brick:Flow_Loss a owl:Class,
-        brick:Flow,
         brick:Flow_Loss ;
     rdfs:label "Flow Loss" ;
     rdfs:subClassOf brick:Flow .
@@ -5030,8 +5036,7 @@ brick:Fresh_Air_Setpoint_Limit a owl:Class ;
         tag:Setpoint .
 
 brick:Fuel_Oil a owl:Class,
-        brick:Fuel_Oil,
-        brick:Oil ;
+        brick:Fuel_Oil ;
     rdfs:label "Fuel Oil" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Liquid _:has_Oil [ a owl:Restriction ;
                         owl:hasValue tag:Fuel ;
@@ -5043,8 +5048,7 @@ brick:Fuel_Oil a owl:Class,
         tag:Oil .
 
 brick:Gasoline a owl:Class,
-        brick:Gasoline,
-        brick:Liquid ;
+        brick:Gasoline ;
     rdfs:label "Gasoline" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid [ a owl:Restriction ;
                         owl:hasValue tag:Gasoline ;
@@ -5180,8 +5184,7 @@ brick:Humidity_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Ice a owl:Class,
-        brick:Ice,
-        brick:Solid ;
+        brick:Ice ;
     rdfs:label "Ice" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Ice ) ],
         brick:Solid ;
@@ -5230,7 +5233,6 @@ brick:Leaving_Water_Temperature_Sensor a owl:Class ;
         tag:Water .
 
 brick:Liquid_CO2 a owl:Class,
-        brick:Liquid,
         brick:Liquid_CO2 ;
     rdfs:label "Liquid CO2" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_CO2 ) ],
@@ -5274,20 +5276,17 @@ brick:Low_Temperature_Alarm a owl:Class ;
         tag:Temperature .
 
 brick:Luminous_Flux a owl:Class,
-        brick:Luminance,
         brick:Luminous_Flux ;
     rdfs:label "Luminous Flux" ;
     rdfs:subClassOf brick:Luminance .
 
 brick:Luminous_Intensity a owl:Class,
-        brick:Luminance,
         brick:Luminous_Intensity ;
     rdfs:label "Luminous Intensity" ;
     rdfs:subClassOf brick:Luminance .
 
 brick:Makeup_Water a owl:Class,
-        brick:Makeup_Water,
-        brick:Water ;
+        brick:Makeup_Water ;
     rdfs:label "Makeup Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
                         owl:hasValue tag:Makeup ;
@@ -5341,7 +5340,6 @@ brick:Motion_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Natural_Gas a owl:Class,
-        brick:Gas,
         brick:Natural_Gas ;
     rdfs:label "Natural Gas" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas [ a owl:Restriction ;
@@ -5354,13 +5352,11 @@ brick:Natural_Gas a owl:Class,
         tag:Natural .
 
 brick:Occupancy_Count a owl:Class,
-        brick:Occupancy,
         brick:Occupancy_Count ;
     rdfs:label "Occupancy Count" ;
     rdfs:subClassOf brick:Occupancy .
 
 brick:Occupancy_Percentage a owl:Class,
-        brick:Occupancy,
         brick:Occupancy_Percentage ;
     rdfs:label "Occupancy Percentage" ;
     rdfs:subClassOf brick:Occupancy .
@@ -5399,8 +5395,7 @@ brick:Operating_Mode_Status a owl:Class ;
         tag:Status .
 
 brick:Operative_Temperature a owl:Class,
-        brick:Operative_Temperature,
-        brick:Temperature ;
+        brick:Operative_Temperature ;
     rdfs:label "Operative Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -5423,16 +5418,12 @@ brick:Override_Command a owl:Class ;
         tag:Override .
 
 brick:PM10_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:PM10_Level ;
     rdfs:label "PM10 Level" ;
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
 
 brick:PM25_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:PM25_Level ;
     rdfs:label "PM25 Level" ;
     rdfs:subClassOf brick:Air_Quality,
@@ -5441,13 +5432,6 @@ brick:PM25_Level a owl:Class,
 brick:PV_Current_Output_Sensor a owl:Class ;
     rdfs:label "PV Current Output Sensor" ;
     rdfs:subClassOf brick:Current_Output_Sensor .
-
-brick:Peak_Power a owl:Class,
-        brick:Peak_Power,
-        brick:Power ;
-    rdfs:label "Peak Power" ;
-    rdfs:subClassOf brick:Power ;
-    skos:definition "Tracks the highest (peak) observed power in some interval" .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
@@ -5464,8 +5448,7 @@ brick:Power_Alarm a owl:Class ;
         tag:Power .
 
 brick:Power_Factor a owl:Class,
-        brick:Power_Factor,
-        brick:Quantity ;
+        brick:Power_Factor ;
     rdfs:label "Power Factor" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5494,8 +5477,7 @@ brick:Power_System a owl:Class ;
         tag:Power .
 
 brick:Precipitation a owl:Class,
-        brick:Precipitation,
-        brick:Quantity ;
+        brick:Precipitation ;
     rdfs:label "Precipitation" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -5523,8 +5505,7 @@ brick:RVAV a owl:Class ;
     rdfs:subClassOf brick:Variable_Air_Volume_Box .
 
 brick:Radiant_Temperature a owl:Class,
-        brick:Radiant_Temperature,
-        brick:Temperature ;
+        brick:Radiant_Temperature ;
     rdfs:label "Radiant Temperature" ;
     rdfs:subClassOf brick:Temperature .
 
@@ -5534,12 +5515,6 @@ brick:Rain_Sensor a owl:Class ;
         brick:Sensor ;
     brick:hasAssociatedTag tag:Rain,
         tag:Sensor .
-
-brick:Reactive_Power a owl:Class,
-        brick:Electric_Power,
-        brick:Reactive_Power ;
-    rdfs:label "Reactive Power" ;
-    rdfs:subClassOf brick:Electric_Power .
 
 brick:Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Return Air CO2 Setpoint" ;
@@ -5584,7 +5559,6 @@ brick:Smoke_Detected_Alarm a owl:Class ;
         tag:Smoke .
 
 brick:Solar_Irradiance a owl:Class,
-        brick:Irradiance,
         brick:Solar_Irradiance ;
     rdfs:label "Solar Irradiance" ;
     rdfs:subClassOf brick:Irradiance .
@@ -5617,7 +5591,6 @@ brick:Static_Pressure_Step_Parameter a owl:Class ;
         tag:Step .
 
 brick:Steam a owl:Class,
-        brick:Gas,
         brick:Steam ;
     rdfs:label "Steam" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Steam ) ],
@@ -5716,8 +5689,6 @@ brick:Switch a owl:Class ;
     rdfs:subClassOf brick:Interface .
 
 brick:TVOC_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:TVOC_Level ;
     rdfs:label "TVOC Level" ;
     rdfs:subClassOf brick:Air_Quality,
@@ -5737,13 +5708,11 @@ brick:Temperature_Step_Parameter a owl:Class ;
         tag:Temperature .
 
 brick:Thermal_Energy a owl:Class,
-        brick:Energy,
         brick:Thermal_Energy ;
     rdfs:label "Thermal Energy" ;
     rdfs:subClassOf brick:Energy .
 
 brick:Thermal_Power a owl:Class,
-        brick:Power,
         brick:Thermal_Power ;
     rdfs:label "Thermal Power" ;
     rdfs:subClassOf brick:Power .
@@ -5775,19 +5744,16 @@ brick:VAV a owl:Class ;
     rdfs:subClassOf brick:Terminal_Unit .
 
 brick:Voltage_Angle a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Angle ;
     rdfs:label "Voltage Angle" ;
     rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Voltage_Imbalance a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Imbalance ;
     rdfs:label "Voltage Imbalance" ;
     rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Voltage_Magnitude a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Magnitude ;
     rdfs:label "Voltage Magnitude" ;
     rdfs:subClassOf brick:Electric_Voltage .
@@ -5827,13 +5793,11 @@ brick:Water_Usage_Sensor a owl:Class ;
         tag:Water .
 
 brick:Weather_Condition a owl:Class,
-        brick:Quantity,
         brick:Weather_Condition ;
     rdfs:label "Weather Condition" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Wet_Bulb_Temperature a owl:Class,
-        brick:Temperature,
         brick:Wet_Bulb_Temperature ;
     rdfs:label "Wet Bulb Temperature" ;
     rdfs:subClassOf brick:Temperature .
@@ -5924,7 +5888,11 @@ brick:isTagOf a owl:AsymmetricProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Tag .
 
-tag:Point a brick:Tag .
+brick:Active_Power a owl:Class,
+        brick:Active_Power ;
+    rdfs:label "Active Power" ;
+    rdfs:subClassOf brick:Electric_Power ;
+    owl:equivalentClass brick:Real_Power .
 
 brick:Adjust_Sensor a owl:Class ;
     rdfs:label "Adjust Sensor" ;
@@ -5996,8 +5964,7 @@ brick:Air_Temperature_Step_Parameter a owl:Class ;
         tag:Temperature .
 
 brick:Angle a owl:Class,
-        brick:Angle,
-        brick:Quantity ;
+        brick:Angle ;
     rdfs:label "Angle" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6012,7 +5979,6 @@ brick:Angle_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Building_Air a owl:Class,
-        brick:Air,
         brick:Building_Air ;
     rdfs:label "Building Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Building ) ],
@@ -6024,7 +5990,6 @@ brick:Building_Air a owl:Class,
         tag:Gas .
 
 brick:Bypass_Air a owl:Class,
-        brick:Air,
         brick:Bypass_Air ;
     rdfs:label "Bypass Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Bypass ) ],
@@ -6036,8 +6001,7 @@ brick:Bypass_Air a owl:Class,
         tag:Gas .
 
 brick:Capacity a owl:Class,
-        brick:Capacity,
-        brick:Quantity ;
+        brick:Capacity ;
     rdfs:label "Capacity" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6135,7 +6099,6 @@ brick:Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
         tag:Temperature .
 
 brick:Discharge_Chilled_Water a owl:Class,
-        brick:Chilled_Water,
         brick:Discharge_Chilled_Water ;
     rdfs:label "Discharge Chilled Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Discharge ) ],
@@ -6171,8 +6134,7 @@ brick:Enable_Status a owl:Class ;
         tag:Status .
 
 brick:Entering_Water a owl:Class,
-        brick:Entering_Water,
-        brick:Water ;
+        brick:Entering_Water ;
     rdfs:label "Entering Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Entering ) ],
         brick:Water ;
@@ -6212,8 +6174,7 @@ brick:Flow_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Frost a owl:Class,
-        brick:Frost,
-        brick:Solid ;
+        brick:Frost ;
     rdfs:label "Frost" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Frost ) ],
         brick:Solid ;
@@ -6221,8 +6182,7 @@ brick:Frost a owl:Class,
         tag:Solid .
 
 brick:Hail a owl:Class,
-        brick:Hail,
-        brick:Solid ;
+        brick:Hail ;
     rdfs:label "Hail" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Hail ) ],
         brick:Solid ;
@@ -6264,8 +6224,7 @@ brick:Humidity_Alarm a owl:Class ;
         tag:Humidity .
 
 brick:Illuminance a owl:Class,
-        brick:Illuminance,
-        brick:Quantity ;
+        brick:Illuminance ;
     rdfs:label "Illuminance" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6273,9 +6232,13 @@ brick:Interface a owl:Class ;
     rdfs:label "Interface" ;
     rdfs:subClassOf brick:Lighting_System .
 
+brick:Irradiance a owl:Class,
+        brick:Irradiance ;
+    rdfs:label "Irradiance" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:Leaving_Water a owl:Class,
-        brick:Leaving_Water,
-        brick:Water ;
+        brick:Leaving_Water ;
     rdfs:label "Leaving Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Leaving ) ],
         brick:Water ;
@@ -6433,7 +6396,6 @@ brick:Min_Static_Pressure_Setpoint_Limit a owl:Class ;
         tag:Static .
 
 brick:Mixed_Air a owl:Class,
-        brick:Air,
         brick:Mixed_Air ;
     rdfs:label "Mixed Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Mixed ) ],
@@ -6463,6 +6425,15 @@ brick:Occupied_Supply_Air_Flow_Setpoint a owl:Class ;
         tag:Occupied,
         tag:Setpoint,
         tag:Supply .
+
+brick:Oil a owl:Class,
+        brick:Oil ;
+    rdfs:label "Oil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil ) ],
+        brick:Liquid ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Oil .
 
 brick:Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Lockout Temperature Differential Sensor" ;
@@ -6496,9 +6467,14 @@ brick:Overridden_Status a owl:Class ;
     brick:hasAssociatedTag tag:Overridden,
         tag:Status .
 
+brick:Peak_Power a owl:Class,
+        brick:Peak_Power ;
+    rdfs:label "Peak Power" ;
+    rdfs:subClassOf brick:Power ;
+    skos:definition "Tracks the highest (peak) observed power in some interval" .
+
 brick:Position a owl:Class,
-        brick:Position,
-        brick:Quantity ;
+        brick:Position ;
     rdfs:label "Position" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -6533,14 +6509,22 @@ brick:Pressure_Alarm a owl:Class ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Pressure .
 
+brick:Radiance a owl:Class,
+        brick:Radiance ;
+    rdfs:label "Radiance" ;
+    rdfs:subClassOf brick:Quantity .
+
+brick:Reactive_Power a owl:Class,
+        brick:Reactive_Power ;
+    rdfs:label "Reactive Power" ;
+    rdfs:subClassOf brick:Electric_Power .
+
 brick:Real_Power a owl:Class,
-        brick:Electric_Power,
         brick:Real_Power ;
     rdfs:label "Real Power" ;
     rdfs:subClassOf brick:Electric_Power .
 
 brick:Relative_Humidity a owl:Class,
-        brick:Humidity,
         brick:Relative_Humidity ;
     rdfs:label "Relative Humidity" ;
     rdfs:subClassOf brick:Humidity .
@@ -6562,8 +6546,7 @@ brick:Return_Air_Temperature_Alarm a owl:Class ;
         tag:Temperature .
 
 brick:Return_Water a owl:Class,
-        brick:Return_Water,
-        brick:Water ;
+        brick:Return_Water ;
     rdfs:label "Return Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Return ) ],
         brick:Water ;
@@ -6598,7 +6581,6 @@ brick:Run_Status a owl:Class ;
         tag:Status .
 
 brick:Solar_Radiance a owl:Class,
-        brick:Radiance,
         brick:Solar_Radiance ;
     rdfs:label "Solar Radiance" ;
     rdfs:subClassOf brick:Radiance .
@@ -6669,9 +6651,7 @@ brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
     rdfs:subClassOf brick:Temperature_Differential_Reset_Setpoint .
 
 brick:Supply_Hot_Water a owl:Class,
-        brick:Hot_Water,
-        brick:Supply_Hot_Water,
-        brick:Supply_Water ;
+        brick:Supply_Hot_Water ;
     rdfs:label "Supply Hot Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Supply ) ],
         brick:Hot_Water,
@@ -6748,7 +6728,6 @@ brick:Tolerance_Parameter a owl:Class ;
         tag:Tolerance .
 
 brick:Torque a owl:Class,
-        brick:Quantity,
         brick:Torque ;
     rdfs:label "Torque" ;
     rdfs:subClassOf brick:Quantity .
@@ -6784,13 +6763,11 @@ brick:Water_Temperature_Alarm a owl:Class ;
         tag:Water .
 
 brick:Wind_Direction a owl:Class,
-        brick:Direction,
         brick:Wind_Direction ;
     rdfs:label "Wind Direction" ;
     rdfs:subClassOf brick:Direction .
 
 brick:Wind_Speed a owl:Class,
-        brick:Speed,
         brick:Wind_Speed ;
     rdfs:label "Wind Speed" ;
     rdfs:subClassOf brick:Speed .
@@ -6875,9 +6852,6 @@ tag:Econcycle a brick:Tag ;
 
 tag:Economizer a brick:Tag ;
     rdfs:label "Economizer" .
-
-tag:Electrical a brick:Tag ;
-    rdfs:label "Electrical" .
 
 tag:Even a brick:Tag ;
     rdfs:label "Even" .
@@ -6978,6 +6952,9 @@ tag:Overload a brick:Tag ;
 tag:PIR a brick:Tag ;
     rdfs:label "PIR" .
 
+tag:Peak a brick:Tag ;
+    rdfs:label "Peak" .
+
 tag:Photovoltaic a brick:Tag ;
     rdfs:label "Photovoltaic" .
 
@@ -7002,8 +6979,14 @@ tag:Radiance a brick:Tag ;
 tag:Rated a brick:Tag ;
     rdfs:label "Rated" .
 
+tag:Reactive a brick:Tag ;
+    rdfs:label "Reactive" .
+
 tag:Ready a brick:Tag ;
     rdfs:label "Ready" .
+
+tag:Real a brick:Tag ;
+    rdfs:label "Real" .
 
 tag:Reheat a brick:Tag ;
     rdfs:label "Reheat" .
@@ -7126,9 +7109,13 @@ brick:Chilled_Water_Temperature_Sensor a owl:Class ;
         tag:Water .
 
 brick:Conductivity a owl:Class,
-        brick:Conductivity,
-        brick:Quantity ;
+        brick:Conductivity ;
     rdfs:label "Conductivity" ;
+    rdfs:subClassOf brick:Quantity .
+
+brick:Current a owl:Class,
+        brick:Current ;
+    rdfs:label "Current" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Current_Sensor a owl:Class ;
@@ -7142,8 +7129,7 @@ brick:Current_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Deionized_Water a owl:Class,
-        brick:Deionized_Water,
-        brick:Water ;
+        brick:Deionized_Water ;
     rdfs:label "Deionized Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Deionized _:has_Water ) ],
         brick:Water ;
@@ -7172,11 +7158,24 @@ brick:Differential_Speed_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Speed .
 
+brick:Direction a owl:Class,
+        brick:Direction ;
+    rdfs:label "Direction" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:Duration_Sensor a owl:Class ;
     rdfs:label "Duration Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Duration ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Duration,
+        tag:Sensor .
+
+brick:Electrical_Power_Sensor a owl:Class ;
+    rdfs:label "Electrical Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power _:has_Electrical ) ],
+        brick:Power_Sensor ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Power,
         tag:Sensor .
 
 brick:Fault_Status a owl:Class ;
@@ -7186,6 +7185,18 @@ brick:Fault_Status a owl:Class ;
     brick:hasAssociatedTag tag:Fault,
         tag:Status .
 
+brick:Fluid a owl:Class,
+        brick:Fluid ;
+    rdfs:label "Fluid" ;
+    rdfs:subClassOf _:has_Fluid,
+        brick:Substance ;
+    brick:hasAssociatedTag tag:Fluid .
+
+brick:Frequency a owl:Class,
+        brick:Frequency ;
+    rdfs:label "Frequency" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:Gain_Parameter a owl:Class ;
     rdfs:label "Gain Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain ) ],
@@ -7193,6 +7204,17 @@ brick:Gain_Parameter a owl:Class ;
     brick:hasAssociatedTag tag:Gain,
         tag:PID,
         tag:Parameter .
+
+brick:Hot_Water a owl:Class,
+        brick:Hot_Water ;
+    rdfs:label "Hot Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot ) ],
+        brick:Water ;
+    skos:definition "Hot water used for HVAC heating or supply to hot taps" ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Hot,
+        tag:Liquid,
+        tag:Water .
 
 brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Sensor" ;
@@ -7224,12 +7246,6 @@ brick:Humidity_Parameter a owl:Class ;
         brick:Parameter ;
     brick:hasAssociatedTag tag:Humidity,
         tag:Parameter .
-
-brick:Irradiance a owl:Class,
-        brick:Irradiance,
-        brick:Quantity ;
-    rdfs:label "Irradiance" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Load Shed Setpoint" ;
@@ -7275,16 +7291,6 @@ brick:Mode_Status a owl:Class ;
     brick:hasAssociatedTag tag:Mode,
         tag:Status .
 
-brick:Oil a owl:Class,
-        brick:Liquid,
-        brick:Oil ;
-    rdfs:label "Oil" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil ) ],
-        brick:Liquid ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Liquid,
-        tag:Oil .
-
 brick:On_Status a owl:Class ;
     rdfs:label "On Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Status ) ],
@@ -7316,10 +7322,9 @@ brick:Pressure_Status a owl:Class ;
     brick:hasAssociatedTag tag:Pressure,
         tag:Status .
 
-brick:Radiance a owl:Class,
-        brick:Quantity,
-        brick:Radiance ;
-    rdfs:label "Radiance" ;
+brick:Speed a owl:Class,
+        brick:Speed ;
+    rdfs:label "Speed" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Speed_Sensor a owl:Class ;
@@ -7369,9 +7374,7 @@ brick:Step_Parameter a owl:Class ;
         tag:Step .
 
 brick:Supply_Chilled_Water a owl:Class,
-        brick:Chilled_Water,
-        brick:Supply_Chilled_Water,
-        brick:Supply_Water ;
+        brick:Supply_Chilled_Water ;
     rdfs:label "Supply Chilled Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Supply ) ],
         brick:Chilled_Water,
@@ -7389,6 +7392,11 @@ brick:System_Status a owl:Class ;
     brick:hasAssociatedTag tag:Status,
         tag:System .
 
+brick:Time a owl:Class,
+        brick:Time ;
+    rdfs:label "Time" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:VFD a owl:Class ;
     rdfs:label "VFD" ;
     rdfs:subClassOf brick:HVAC .
@@ -7403,6 +7411,11 @@ brick:Velocity_Pressure_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Pressure,
         tag:Sensor,
         tag:Velocity .
+
+brick:Voltage a owl:Class,
+        brick:Voltage ;
+    rdfs:label "Voltage" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
@@ -7447,7 +7460,6 @@ brick:Zone a owl:Class ;
         tag:Zone .
 
 brick:Zone_Air a owl:Class,
-        brick:Air,
         brick:Zone_Air ;
     rdfs:label "Zone Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Zone ) ],
@@ -7548,6 +7560,9 @@ tag:Override a brick:Tag ;
 tag:Percent a brick:Tag ;
     rdfs:label "Percent" .
 
+tag:Point a brick:Tag ;
+    rdfs:label "Point" .
+
 tag:Rain a brick:Tag ;
     rdfs:label "Rain" .
 
@@ -7570,8 +7585,7 @@ brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
         tag:Time .
 
 brick:CO2 a owl:Class,
-        brick:CO2,
-        brick:Gas ;
+        brick:CO2 ;
     rdfs:label "CO2" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_CO2 ) ],
         brick:Gas ;
@@ -7593,12 +7607,6 @@ brick:CO2_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Class a owl:Class .
-
-brick:Current a owl:Class,
-        brick:Current,
-        brick:Quantity ;
-    rdfs:label "Current" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Damper a owl:Class ;
     rdfs:label "Damper" ;
@@ -7623,8 +7631,7 @@ brick:Demand_Setpoint a owl:Class ;
         tag:Setpoint .
 
 brick:Dewpoint a owl:Class,
-        brick:Dewpoint,
-        brick:Quantity ;
+        brick:Dewpoint ;
     rdfs:label "Dewpoint" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7685,12 +7692,6 @@ brick:Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Pressure,
         tag:Setpoint .
 
-brick:Direction a owl:Class,
-        brick:Direction,
-        brick:Quantity ;
-    rdfs:label "Direction" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
@@ -7701,8 +7702,7 @@ brick:Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Setpoint .
 
 brick:Discharge_Water a owl:Class,
-        brick:Discharge_Water,
-        brick:Water ;
+        brick:Discharge_Water ;
     rdfs:label "Discharge Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Discharge ) ],
         brick:Water ;
@@ -7710,6 +7710,11 @@ brick:Discharge_Water a owl:Class,
         tag:Fluid,
         tag:Liquid,
         tag:Water .
+
+brick:Electric_Voltage a owl:Class,
+        brick:Electric_Voltage ;
+    rdfs:label "Electric Voltage" ;
+    rdfs:subClassOf brick:Voltage .
 
 brick:Emergency_Power_Off_Status a owl:Class ;
     rdfs:label "Emergency Power Off Status" ;
@@ -7721,15 +7726,13 @@ brick:Emergency_Power_Off_Status a owl:Class ;
         tag:Power,
         tag:Status .
 
-brick:Frequency a owl:Class,
-        brick:Frequency,
-        brick:Quantity ;
-    rdfs:label "Frequency" ;
+brick:Energy a owl:Class,
+        brick:Energy ;
+    rdfs:label "Energy" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Grains a owl:Class,
-        brick:Grains,
-        brick:Quantity ;
+        brick:Grains ;
     rdfs:label "Grains" ;
     rdfs:subClassOf brick:Quantity .
 
@@ -7741,18 +7744,6 @@ brick:Heating_Valve a owl:Class ;
         tag:Heat,
         tag:Valve .
 
-brick:Hot_Water a owl:Class,
-        brick:Hot_Water,
-        brick:Water ;
-    rdfs:label "Hot Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot ) ],
-        brick:Water ;
-    skos:definition "Hot water used for HVAC heating or supply to hot taps" ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Hot,
-        tag:Liquid,
-        tag:Water .
-
 brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
     rdfs:subClassOf brick:Temperature_Low_Reset_Setpoint .
@@ -7760,6 +7751,11 @@ brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
 brick:Laboratory a owl:Class ;
     rdfs:label "Laboratory" ;
     rdfs:subClassOf brick:Room .
+
+brick:Luminance a owl:Class,
+        brick:Luminance ;
+    rdfs:label "Luminance" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Air Flow Setpoint Limit" ;
@@ -7774,7 +7770,13 @@ brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Setpoint .
 
 brick:Measurable a owl:Class ;
+    rdfs:label "Measurable" ;
     rdfs:subClassOf brick:Class .
+
+brick:Occupancy a owl:Class,
+        brick:Occupancy ;
+    rdfs:label "Occupancy" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Off_Status a owl:Class ;
     rdfs:label "Off Status" ;
@@ -7797,11 +7799,12 @@ brick:Reset_Command a owl:Class ;
     brick:hasAssociatedTag tag:Command,
         tag:Reset .
 
-brick:Speed a owl:Class,
-        brick:Quantity,
-        brick:Speed ;
-    rdfs:label "Speed" ;
-    rdfs:subClassOf brick:Quantity .
+brick:Solid a owl:Class,
+        brick:Solid ;
+    rdfs:label "Solid" ;
+    rdfs:subClassOf _:has_Solid,
+        brick:Substance ;
+    brick:hasAssociatedTag tag:Solid .
 
 brick:Start_Stop_Status a owl:Class ;
     rdfs:label "Start Stop Status" ;
@@ -7828,6 +7831,16 @@ brick:Supply_Air_Flow_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Supply .
 
+brick:Supply_Water a owl:Class,
+        brick:Supply_Water ;
+    rdfs:label "Supply Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Supply ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
 brick:Temperature_Alarm a owl:Class ;
     rdfs:label "Temperature Alarm" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Alarm ) ],
@@ -7846,12 +7859,6 @@ brick:Valve a owl:Class ;
         brick:HVAC ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Valve .
-
-brick:Voltage a owl:Class,
-        brick:Quantity,
-        brick:Voltage ;
-    rdfs:label "Voltage" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
@@ -7914,6 +7921,22 @@ tag:Tolerance a brick:Tag ;
 tag:Unit a brick:Tag ;
     rdfs:label "Unit" .
 
+brick:Air_Quality a owl:Class,
+        brick:Air_Quality ;
+    rdfs:label "Air Quality" ;
+    rdfs:subClassOf brick:Quantity .
+
+brick:Chilled_Water a owl:Class,
+        brick:Chilled_Water ;
+    rdfs:label "Chilled Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled ) ],
+        brick:Water ;
+    skos:definition "water used as a cooling medium (particularly in air-conditioning systems or in processes) at below ambient temperature." ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
 brick:Cooling_Temperature_Setpoint a owl:Class ;
     rdfs:label "Cooling Temperature Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
@@ -7939,19 +7962,26 @@ brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
         tag:Temperature .
 
 brick:Enthalpy a owl:Class,
-        brick:Enthalpy,
-        brick:Quantity ;
+        brick:Enthalpy ;
     rdfs:label "Enthalpy" ;
     rdfs:subClassOf brick:Quantity ;
     skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
 
-brick:Fluid a owl:Class,
-        brick:Fluid,
-        brick:Substance ;
-    rdfs:label "Fluid" ;
-    rdfs:subClassOf _:has_Fluid,
-        brick:Substance ;
-    brick:hasAssociatedTag tag:Fluid .
+brick:Gas a owl:Class,
+        brick:Gas ;
+    rdfs:label "Gas" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas ) ],
+        brick:Fluid ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Gas .
+
+brick:Liquid a owl:Class,
+        brick:Liquid ;
+    rdfs:label "Liquid" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid ) ],
+        brick:Fluid ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid .
 
 brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Air Flow Setpoint Limit" ;
@@ -7983,6 +8013,11 @@ brick:Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
+brick:Power a owl:Class,
+        brick:Power ;
+    rdfs:label "Power" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:Reset_Setpoint a owl:Class ;
     rdfs:label "Reset Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Setpoint ) ],
@@ -7991,7 +8026,6 @@ brick:Reset_Setpoint a owl:Class ;
         tag:Setpoint .
 
 brick:Static_Pressure a owl:Class,
-        brick:Pressure,
         brick:Static_Pressure ;
     rdfs:label "Static Pressure" ;
     rdfs:subClassOf brick:Pressure .
@@ -8005,14 +8039,7 @@ brick:Temperature_Deadband_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Time a owl:Class,
-        brick:Quantity,
-        brick:Time ;
-    rdfs:label "Time" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Velocity_Pressure a owl:Class,
-        brick:Pressure,
         brick:Velocity_Pressure ;
     rdfs:label "Velocity Pressure" ;
     rdfs:subClassOf brick:Pressure .
@@ -8057,6 +8084,9 @@ tag:Coil a brick:Tag ;
 
 tag:Dewpoint a brick:Tag ;
     rdfs:label "Dewpoint" .
+
+tag:Electrical a brick:Tag ;
+    rdfs:label "Electrical" .
 
 tag:Fault a brick:Tag ;
     rdfs:label "Fault" .
@@ -8107,7 +8137,6 @@ tag:Voltage a brick:Tag ;
     rdfs:label "Voltage" .
 
 brick:Discharge_Air a owl:Class,
-        brick:Air,
         brick:Discharge_Air ;
     rdfs:label "Discharge Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Discharge ) ],
@@ -8117,18 +8146,21 @@ brick:Discharge_Air a owl:Class,
         tag:Fluid,
         tag:Gas .
 
+brick:Electric_Current a owl:Class,
+        brick:Electric_Current ;
+    rdfs:label "Electric Current" ;
+    rdfs:subClassOf brick:Current .
+
+brick:Electric_Power a owl:Class,
+        brick:Electric_Power ;
+    rdfs:label "Electric Power" ;
+    rdfs:subClassOf brick:Power .
+
 brick:Electrical_System a owl:Class ;
     rdfs:label "Electrical System" ;
     rdfs:subClassOf brick:Equipment .
 
-brick:Energy a owl:Class,
-        brick:Energy,
-        brick:Quantity ;
-    rdfs:label "Energy" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Exhaust_Air a owl:Class,
-        brick:Air,
         brick:Exhaust_Air ;
     rdfs:label "Exhaust Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Exhaust ) ],
@@ -8164,20 +8196,11 @@ brick:Integral_Time_Parameter a owl:Class ;
         tag:Parameter,
         tag:Time .
 
-brick:Luminance a owl:Class,
-        brick:Luminance,
-        brick:Quantity ;
-    rdfs:label "Luminance" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Occupancy a owl:Class,
-        brick:Occupancy,
-        brick:Quantity ;
-    rdfs:label "Occupancy" ;
-    rdfs:subClassOf brick:Quantity .
+brick:Substance a owl:Class ;
+    rdfs:subClassOf sosa:FeatureOfInterest,
+        brick:Measurable .
 
 brick:Supply_Air a owl:Class,
-        brick:Air,
         brick:Supply_Air ;
     rdfs:label "Supply Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Supply ) ],
@@ -8187,17 +8210,6 @@ brick:Supply_Air a owl:Class,
         tag:Fluid,
         tag:Gas,
         tag:Supply .
-
-brick:Supply_Water a owl:Class,
-        brick:Supply_Water,
-        brick:Water ;
-    rdfs:label "Supply Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Supply ) ],
-        brick:Water ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Liquid,
-        tag:Supply,
-        tag:Water .
 
 brick:Temperature_Setpoint a owl:Class ;
     rdfs:label "Temperature Setpoint" ;
@@ -8261,23 +8273,10 @@ brick:Air_Humidity_Sensor a owl:Class ;
         tag:Humidity,
         tag:Sensor .
 
-brick:Chilled_Water a owl:Class,
-        brick:Chilled_Water,
-        brick:Water ;
-    rdfs:label "Chilled Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled ) ],
-        brick:Water ;
-    skos:definition "water used as a cooling medium (particularly in air-conditioning systems or in processes) at below ambient temperature." ;
-    brick:hasAssociatedTag tag:Chilled,
-        tag:Fluid,
-        tag:Liquid,
-        tag:Water .
-
-brick:Electric_Voltage a owl:Class,
-        brick:Electric_Voltage,
-        brick:Voltage ;
-    rdfs:label "Electric Voltage" ;
-    rdfs:subClassOf brick:Voltage .
+brick:Level a owl:Class,
+        brick:Level ;
+    rdfs:label "Level" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Proportional Band Parameter" ;
@@ -8287,14 +8286,6 @@ brick:Proportional_Band_Parameter a owl:Class ;
         tag:PID,
         tag:Parameter,
         tag:Proportional .
-
-brick:Solid a owl:Class,
-        brick:Solid,
-        brick:Substance ;
-    rdfs:label "Solid" ;
-    rdfs:subClassOf _:has_Solid,
-        brick:Substance ;
-    brick:hasAssociatedTag tag:Solid .
 
 brick:Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Static Pressure Setpoint" ;
@@ -8357,7 +8348,6 @@ brick:On_Off_Status a owl:Class ;
         tag:Status .
 
 brick:Outside_Air a owl:Class,
-        brick:Air,
         brick:Outside_Air ;
     rdfs:label "Outside Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Outside ) ],
@@ -8368,14 +8358,12 @@ brick:Outside_Air a owl:Class,
         tag:Gas,
         tag:Outside .
 
-brick:Power a owl:Class,
-        brick:Power,
-        brick:Quantity ;
-    rdfs:label "Power" ;
+brick:Pressure a owl:Class,
+        brick:Pressure ;
+    rdfs:label "Pressure" ;
     rdfs:subClassOf brick:Quantity .
 
 brick:Return_Air a owl:Class,
-        brick:Air,
         brick:Return_Air ;
     rdfs:label "Return Air" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Return ) ],
@@ -8385,10 +8373,6 @@ brick:Return_Air a owl:Class,
         tag:Fluid,
         tag:Gas,
         tag:Return .
-
-brick:Substance a owl:Class ;
-    rdfs:subClassOf sosa:FeatureOfInterest,
-        brick:Measurable .
 
 tag:Disable a brick:Tag ;
     rdfs:label "Disable" .
@@ -8408,12 +8392,6 @@ tag:Thermal a brick:Tag ;
 tag:Usage a brick:Tag ;
     rdfs:label "Usage" .
 
-brick:Air_Quality a owl:Class,
-        brick:Air_Quality,
-        brick:Quantity ;
-    rdfs:label "Air Quality" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Air Temperature Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Setpoint ) ],
@@ -8422,24 +8400,6 @@ brick:Air_Temperature_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Gas a owl:Class,
-        brick:Fluid,
-        brick:Gas ;
-    rdfs:label "Gas" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas ) ],
-        brick:Fluid ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Gas .
-
-brick:Liquid a owl:Class,
-        brick:Fluid,
-        brick:Liquid ;
-    rdfs:label "Liquid" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid ) ],
-        brick:Fluid ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Liquid .
-
 brick:Max_Limit a owl:Class ;
     rdfs:label "Max Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Limit _:has_Parameter ) ],
@@ -8447,9 +8407,6 @@ brick:Max_Limit a owl:Class ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
         tag:Parameter .
-
-tag:Demand a brick:Tag ;
-    rdfs:label "Demand" .
 
 tag:Emergency a brick:Tag ;
     rdfs:label "Emergency" .
@@ -8463,6 +8420,11 @@ tag:Meter a brick:Tag ;
 tag:System a brick:Tag ;
     rdfs:label "System" .
 
+brick:Humidity a owl:Class,
+        brick:Humidity ;
+    rdfs:label "Humidity" ;
+    rdfs:subClassOf brick:Quantity .
+
 brick:Min_Limit a owl:Class ;
     rdfs:label "Min Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Limit _:has_Parameter ) ],
@@ -8472,46 +8434,24 @@ brick:Min_Limit a owl:Class ;
         tag:Parameter .
 
 brick:Point a owl:Class ;
-    rdfs:subClassOf brick:Class .
+    rdfs:label "Point" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:Point ;
+            owl:onProperty brick:hasTag ],
+        brick:Class ;
+    brick:hasAssociatedTag tag:Point .
 
 tag:Damper a brick:Tag ;
     rdfs:label "Damper" .
+
+tag:Demand a brick:Tag ;
+    rdfs:label "Demand" .
 
 tag:Enthalpy a brick:Tag ;
     rdfs:label "Enthalpy" .
 
 tag:Position a brick:Tag ;
     rdfs:label "Position" .
-
-brick:Electric_Current a owl:Class,
-        brick:Current,
-        brick:Electric_Current ;
-    rdfs:label "Electric Current" ;
-    rdfs:subClassOf brick:Current .
-
-brick:Electric_Power a owl:Class,
-        brick:Electric_Power,
-        brick:Power ;
-    rdfs:label "Electric Power" ;
-    rdfs:subClassOf brick:Power .
-
-brick:Humidity a owl:Class,
-        brick:Humidity,
-        brick:Quantity ;
-    rdfs:label "Humidity" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Level a owl:Class,
-        brick:Level,
-        brick:Quantity ;
-    rdfs:label "Level" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Pressure a owl:Class,
-        brick:Pressure,
-        brick:Quantity ;
-    rdfs:label "Pressure" ;
-    rdfs:subClassOf brick:Quantity .
 
 tag:High a brick:Tag ;
     rdfs:label "High" .
@@ -8530,6 +8470,7 @@ brick:Limit a owl:Class ;
         tag:Parameter .
 
 brick:Location a owl:Class ;
+    rdfs:label "Location" ;
     rdfs:subClassOf _:has_Location,
         brick:Class ;
     brick:hasAssociatedTag tag:Location .
@@ -8561,6 +8502,7 @@ tag:Unoccupied a brick:Tag ;
     rdfs:label "Unoccupied" .
 
 brick:Equipment a owl:Class ;
+    rdfs:label "Equipment" ;
     rdfs:subClassOf _:has_Equipment,
         brick:Class ;
     brick:hasAssociatedTag tag:Equipment .
@@ -8578,11 +8520,13 @@ tag:Location a brick:Tag ;
 tag:On a brick:Tag ;
     rdfs:label "On" .
 
-tag:Power a brick:Tag ;
-    rdfs:label "Power" .
-
 tag:Valve a brick:Tag ;
     rdfs:label "Valve" .
+
+brick:Flow a owl:Class,
+        brick:Flow ;
+    rdfs:label "Flow" ;
+    rdfs:subClassOf brick:Quantity .
 
 tag:Off a brick:Tag ;
     rdfs:label "Off" .
@@ -8590,11 +8534,15 @@ tag:Off a brick:Tag ;
 tag:Speed a brick:Tag ;
     rdfs:label "Speed" .
 
-brick:Flow a owl:Class,
-        brick:Flow,
-        brick:Quantity ;
-    rdfs:label "Flow" ;
-    rdfs:subClassOf brick:Quantity .
+brick:Water a owl:Class,
+        brick:Water ;
+    rdfs:label "Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water ) ],
+        brick:Liquid ;
+    skos:definition "transparent, odorless, tasteless liquid; a compound of hydrogen and oxygen (H2O), containing 11.188% hydrogen and 88.812% oxygen by mass; freezing at 32°F (0°C); boiling near 212°F (100°C)." ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Water .
 
 tag:Fan a brick:Tag ;
     rdfs:label "Fan" .
@@ -8604,6 +8552,18 @@ tag:Gas a brick:Tag ;
 
 tag:Load a brick:Tag ;
     rdfs:label "Load" .
+
+tag:Power a brick:Tag ;
+    rdfs:label "Power" .
+
+brick:Air a owl:Class,
+        brick:Air ;
+    rdfs:label "Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air ) ],
+        brick:Gas ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas .
 
 tag:Humidity a brick:Tag ;
     rdfs:label "Humidity" .
@@ -8627,6 +8587,11 @@ brick:Setpoint a owl:Class ;
         brick:Sensor,
         brick:Status ;
     brick:hasAssociatedTag tag:Setpoint .
+
+brick:Temperature a owl:Class,
+        brick:Temperature ;
+    rdfs:label "Temperature" ;
+    rdfs:subClassOf brick:Quantity .
 
 tag:Band a brick:Tag ;
     rdfs:label "Band" .
@@ -8668,24 +8633,8 @@ brick:HVAC a owl:Class ;
 tag:Deadband a brick:Tag ;
     rdfs:label "Deadband" .
 
-brick:Temperature a owl:Class,
-        brick:Quantity,
-        brick:Temperature ;
-    rdfs:label "Temperature" ;
-    rdfs:subClassOf brick:Quantity .
-
 tag:Min a brick:Tag ;
     rdfs:label "Min" .
-
-brick:Air a owl:Class,
-        brick:Air,
-        brick:Gas ;
-    rdfs:label "Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air ) ],
-        brick:Gas ;
-    brick:hasAssociatedTag tag:Air,
-        tag:Fluid,
-        tag:Gas .
 
 tag:Max a brick:Tag ;
     rdfs:label "Max" .
@@ -8701,22 +8650,15 @@ brick:Command a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Command .
 
-brick:Water a owl:Class,
-        brick:Liquid,
-        brick:Water ;
-    rdfs:label "Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water ) ],
-        brick:Liquid ;
-    skos:definition "transparent, odorless, tasteless liquid; a compound of hydrogen and oxygen (H2O), containing 11.188% hydrogen and 88.812% oxygen by mass; freezing at 32°F (0°C); boiling near 212°F (100°C)." ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Liquid,
-        tag:Water .
-
 tag:Chilled a brick:Tag ;
     rdfs:label "Chilled" .
 
 tag:Hot a brick:Tag ;
     rdfs:label "Hot" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf sosa:ObservableProperty,
+        brick:Measurable .
 
 tag:Cooling a brick:Tag ;
     rdfs:label "Cooling" .
@@ -8769,10 +8711,6 @@ tag:Differential a brick:Tag ;
 
 tag:Limit a brick:Tag ;
     rdfs:label "Limit" .
-
-brick:Quantity a owl:Class ;
-    rdfs:subClassOf sosa:ObservableProperty,
-        brick:Measurable .
 
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
@@ -9050,6 +8988,10 @@ _:has_Dewpoint a owl:Restriction ;
     owl:hasValue tag:Dewpoint ;
     owl:onProperty brick:hasTag .
 
+_:has_Electrical a owl:Restriction ;
+    owl:hasValue tag:Electrical ;
+    owl:onProperty brick:hasTag .
+
 _:has_Fault a owl:Restriction ;
     owl:hasValue tag:Fault ;
     owl:onProperty brick:hasTag .
@@ -9174,10 +9116,6 @@ _:has_Usage a owl:Restriction ;
     owl:hasValue tag:Usage ;
     owl:onProperty brick:hasTag .
 
-_:has_Demand a owl:Restriction ;
-    owl:hasValue tag:Demand ;
-    owl:onProperty brick:hasTag .
-
 _:has_Emergency a owl:Restriction ;
     owl:hasValue tag:Emergency ;
     owl:onProperty brick:hasTag .
@@ -9196,6 +9134,10 @@ _:has_System a owl:Restriction ;
 
 _:has_Damper a owl:Restriction ;
     owl:hasValue tag:Damper ;
+    owl:onProperty brick:hasTag .
+
+_:has_Demand a owl:Restriction ;
+    owl:hasValue tag:Demand ;
     owl:onProperty brick:hasTag .
 
 _:has_Enthalpy a owl:Restriction ;
@@ -9250,10 +9192,6 @@ _:has_On a owl:Restriction ;
     owl:hasValue tag:On ;
     owl:onProperty brick:hasTag .
 
-_:has_Power a owl:Restriction ;
-    owl:hasValue tag:Power ;
-    owl:onProperty brick:hasTag .
-
 _:has_Off a owl:Restriction ;
     owl:hasValue tag:Off ;
     owl:onProperty brick:hasTag .
@@ -9272,6 +9210,10 @@ _:has_Gas a owl:Restriction ;
 
 _:has_Load a owl:Restriction ;
     owl:hasValue tag:Load ;
+    owl:onProperty brick:hasTag .
+
+_:has_Power a owl:Restriction ;
+    owl:hasValue tag:Power ;
     owl:onProperty brick:hasTag .
 
 _:has_Humidity a owl:Restriction ;

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -6,10 +6,10 @@ Set up subclasses of the equipment superclass
 """
 equipment_subclasses = {
     "HVAC": {
-        OWL.equivalentClass: "Heating_Ventilation_Air_Conditioning_System",
+        OWL.equivalentClass: BRICK["Heating_Ventilation_Air_Conditioning_System"],
     },
     "Heating_Ventilation_Air_Conditioning_System": {
-        OWL.equivalentClass: "HVAC",
+        OWL.equivalentClass: BRICK["HVAC"],
     },
     "Weather": {
         "tags": [TAG.Weather],
@@ -78,11 +78,11 @@ equipment_subclasses = {
         "tags": [TAG.Water, TAG.Equipment],
         "subclasses": {
             "Chilled_Water_System": {
-                OWL.equivalentClass: "CWS",
+                OWL.equivalentClass: BRICK["CWS"],
                 "tags": [TAG.Water, TAG.Chilled, TAG.Equipment],
             },
             "Hot_Water_System": {
-                OWL.equivalentClass: "HWS",
+                OWL.equivalentClass: BRICK["HWS"],
                 "tags": [TAG.Water, TAG.Hot, TAG.Equipment],
                 "subclasses": {
                     "Domestic_Hot_Water_System": {
@@ -91,10 +91,10 @@ equipment_subclasses = {
                 },
             },
             "CWS": {
-                OWL.equivalentClass: "Chilled_Water_System",
+                OWL.equivalentClass: BRICK["Chilled_Water_System"],
             },
             "HWS": {
-                OWL.equivalentClass: "Hot_Water_System",
+                OWL.equivalentClass: BRICK["Hot_Water_System"],
             }
         }
     },
@@ -133,7 +133,7 @@ equipment_subclasses = {
     "Fire_Safety_System": {
         "subclasses": {
             "Fire_Control_Panel": {
-                OWL.equivalentClass: "FCP",
+                OWL.equivalentClass: BRICK["FCP"],
             },
             "FCP": {},
         },
@@ -148,7 +148,7 @@ Define classes of HVAC equipment
 """
 hvac_subclasses = {
     "Variable_Frequency_Drive": {
-        OWL.equivalentClass: "VFD",
+        OWL.equivalentClass: BRICK["VFD"],
         SKOS.definition: Literal("Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure."),
     },
     "Valve": {
@@ -168,14 +168,14 @@ hvac_subclasses = {
         SKOS.definition: Literal("A device that regulates the volumetric flow rate and/or the temperature of the controlled medium."),
         "subclasses": {
             "Fan_Coil_Unit": {
-                OWL.equivalentClass: "FCU",
+                OWL.equivalentClass: BRICK["FCU"],
             },
             "FCU": {},
             "Variable_Air_Volume_Box": {
-                OWL.equivalentClass: "VAV",
+                OWL.equivalentClass: BRICK["VAV"],
                 "subclasses": {
                     "Variable_Air_Volume_Box_With_Reheat": {
-                        OWL.equivalentClass: "RVAV",
+                        OWL.equivalentClass: BRICK["RVAV"],
                     },
                     "RVAV": {},
                 },
@@ -199,7 +199,7 @@ hvac_subclasses = {
         },
     },
     "Heat_Exchanger": {
-        OWL.equivalentClass: "HX",
+        OWL.equivalentClass: BRICK["HX"],
         "subclasses": {
             "Evaporative_Heat_Exchanger": {},
             "Condenser_Heat_Exchanger": {},
@@ -269,10 +269,10 @@ hvac_subclasses = {
     },
     "Computer_Room_Air_Conditioning": {
         SKOS.definition: Literal("A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. "),
-        OWL.equivalentClass: "CRAC",
+        OWL.equivalentClass: BRICK["CRAC"],
     },
     "CRAC": {
-        OWL.equivalentClass: "Computer_Room_Air_Conditioning",
+        OWL.equivalentClass: BRICK["Computer_Room_Air_Conditioning"],
     },
     "Compressor": {
         SKOS.definition: Literal("(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor."),
@@ -301,17 +301,17 @@ hvac_subclasses = {
     },
     "Air_Handler_Unit": {
         SKOS.definition: Literal("Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system."),
-        OWL.equivalentClass: "AHU",
+        OWL.equivalentClass: BRICK["AHU"],
     },
     "AHU": {
         "tags": [TAG.Equipment, TAG.AHU],
         "subclasses": {
             "Rooftop_Unit": {
-                OWL.equivalentClass: "RTU",
+                OWL.equivalentClass: BRICK["RTU"],
                 "tags": [TAG.Equipment, TAG.Rooftop, TAG.AHU],
             },
             "RTU": {
-                OWL.equivalentClass: "Rooftop_Unit",
+                OWL.equivalentClass: BRICK["Rooftop_Unit"],
             },
         },
     },

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -7,13 +7,13 @@ Defining properties
 properties = {
     "isLocationOf": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "hasLocation",
+        OWL.inverseOf: BRICK["hasLocation"],
         RDFS.domain: BRICK.Location,
         SKOS.definition: Literal("Subject is the physical location encapsulating the object"),
     },
     "hasLocation": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isLocationOf",
+        OWL.inverseOf: BRICK["isLocationOf"],
         RDFS.range: BRICK.Location,
         SKOS.definition: Literal("Subject is physically located in the location given by the object"),
     },
@@ -31,17 +31,17 @@ properties = {
 
     "controls": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isControlledBy",
+        OWL.inverseOf: BRICK["isControlledBy"],
     },
     "isControlledBy": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "controls",
+        OWL.inverseOf: BRICK["controls"],
     },
 
     "feeds": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         SKOS.definition: Literal("The subject is upstream of the object in the context of some sequential process; some media is passed between them"),
-        OWL.inverseOf: "isFedBy",
+        OWL.inverseOf: BRICK["isFedBy"],
         "subproperties": {
             "feedsAir": {
                 SKOS.definition: Literal("Passes air"),
@@ -62,34 +62,34 @@ properties = {
     },
     "isFedBy": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "feeds",
+        OWL.inverseOf: BRICK["feeds"],
     },
 
     "hasPoint": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isPointOf",
+        OWL.inverseOf: BRICK["isPointOf"],
         SKOS.definition: Literal("The subject has a digital/analog input/output point given by the object"),
         RDFS.range: BRICK.Point,
     },
     "isPointOf": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "hasPoint",
+        OWL.inverseOf: BRICK["hasPoint"],
         RDFS.domain: BRICK.Point,
     },
 
     "hasPart": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         SKOS.definition: Literal("The subject is composed in part of the entity given by the object"),
-        OWL.inverseOf: "isPartOf",
+        OWL.inverseOf: BRICK["isPartOf"],
     },
     "isPartOf": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "hasPart",
+        OWL.inverseOf: BRICK["hasPart"],
     },
 
     "hasTag": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isTagOf",
+        OWL.inverseOf: BRICK["isTagOf"],
         SKOS.definition: Literal("The subject has the given tag"),
         RDFS.range: BRICK.Tag,
     },
@@ -100,7 +100,7 @@ properties = {
 
     "measures": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isMeasuredBy",
+        OWL.inverseOf: BRICK["isMeasuredBy"],
         SKOS.definition: Literal("The subject measures a quantity or substance given by the object"),
         RDFS.domain: BRICK.Point,
         RDFS.range: BRICK.Measurable,
@@ -112,7 +112,7 @@ properties = {
     },
     "regulates": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isRegulatedBy",
+        OWL.inverseOf: BRICK["isRegulatedBy"],
         SKOS.definition: Literal("The subject contributes to or performs the regulation of the substance given by the object"),
         RDFS.domain: BRICK.Equipment,
         RDFS.range: BRICK.Substance,
@@ -125,14 +125,14 @@ properties = {
 
     "hasAssociatedTag": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "isAssociatedWith",
+        OWL.inverseOf: BRICK["isAssociatedWith"],
         SKOS.definition: Literal("The class is associated with the given tag"),
         RDFS.domain: OWL.Class,
         RDFS.range: BRICK.Tag,
     },
     "isAssociatedWith": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        OWL.inverseOf: "hasAssociatedTag",
+        OWL.inverseOf: BRICK["hasAssociatedTag"],
         SKOS.definition: Literal("The tag is associated with the given class"),
         RDFS.domain: BRICK.Tag,
         RDFS.range: OWL.Class,

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import SKOS, OWL
+from .namespaces import SKOS, OWL, BRICK
 
 
 quantity_definitions = {
@@ -25,7 +25,7 @@ quantity_definitions = {
                 "subclasses": {
                     "Apparent_Power": {},
                     "Active_Power": {
-                        OWL.equivalentClass: "Real_Power",
+                        OWL.equivalentClass: BRICK["Real_Power"],
                     },
                     "Real_Power": {},
                     "Reactive_Power": {},

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -103,7 +103,7 @@ sensor_definitions = {
                         "tags": [TAG.Current, TAG.Output, TAG.Sensor],
                         "subclasses": {
                             "Photovoltaic_Current_Output_Sensor": {
-                                OWL.equivalentClass: "PV_Current_Output_Sensor",
+                                OWL.equivalentClass: BRICK["PV_Current_Output_Sensor"],,
                                 "tags": [TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor],
                             },
                             "PV_Current_Output_Sensor": {},
@@ -617,11 +617,11 @@ sensor_definitions = {
                                     },
                                     "Highest_Zone_Air_Temperature_Sensor": {
                                         "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Highest, TAG.Air],
-                                        OWL.equivalentClass: "Warmest_Zone_Air_Temperature_Sensor"
+                                        OWL.equivalentClass: BRICK["Warmest_Zone_Air_Temperature_Sensor"],
                                     },
                                     "Lowest_Zone_Air_Temperature_Sensor": {
                                         "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Lowest, TAG.Air],
-                                        OWL.equivalentClass: "Coldest_Zone_Air_Temperature_Sensor"
+                                        OWL.equivalentClass: BRICK["Coldest_Zone_Air_Temperature_Sensor"],
                                     },
                                     "Coldest_Zone_Air_Temperature_Sensor": {},
                                     "Warmest_Zone_Air_Temperature_Sensor": {},

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -103,7 +103,7 @@ sensor_definitions = {
                         "tags": [TAG.Current, TAG.Output, TAG.Sensor],
                         "subclasses": {
                             "Photovoltaic_Current_Output_Sensor": {
-                                OWL.equivalentClass: BRICK["PV_Current_Output_Sensor"],,
+                                OWL.equivalentClass: BRICK["PV_Current_Output_Sensor"],
                                 "tags": [TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor],
                             },
                             "PV_Current_Output_Sensor": {},

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -456,18 +456,20 @@ sensor_definitions = {
                     },
                     "Electrical_Power_Sensor": {
                         "tags": [TAG.Sensor, TAG.Power, TAG.Electrical],
-                        "Reactive_Power_Sensor": {
-                            "tags": [TAG.Sensor, TAG.Power, TAG.Reactive, TAG.Electrical],
-                            "substances": [[BRICK.measures, BRICK.Reactive_Power]],
-                        },
-                        "Active_Power_Sensor": {
-                            "tags": [TAG.Sensor, TAG.Power, TAG.Real, TAG.Electrical],
-                            "substances": [[BRICK.measures, BRICK.Active_Power]],
-                        },
-                        "Peak_Power_Demand_Sensor": {
-                            "tags": [TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor, TAG.Electrical],
-                            "substances": [[BRICK.measures, BRICK.Peak_Power]],
-                            "parents": [BRICK.Demand_Sensor],
+                        "subclasses": {
+                            "Reactive_Power_Sensor": {
+                                "tags": [TAG.Sensor, TAG.Power, TAG.Reactive, TAG.Electrical],
+                                "substances": [[BRICK.measures, BRICK.Reactive_Power]],
+                            },
+                            "Active_Power_Sensor": {
+                                "tags": [TAG.Sensor, TAG.Power, TAG.Real, TAG.Electrical],
+                                "substances": [[BRICK.measures, BRICK.Active_Power]],
+                            },
+                            "Peak_Power_Demand_Sensor": {
+                                "tags": [TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor, TAG.Electrical],
+                                "substances": [[BRICK.measures, BRICK.Peak_Power]],
+                                "parents": [BRICK.Demand_Sensor],
+                            }
                         }
                     },
                 }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -425,14 +425,14 @@ setpoint_definitions = {
                                 "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Discharge_Air_Temperature_Heating_Setpoint": {
-                                        OWL.equivalentClass: "Minimum_Discharge_Air_Temperature_Setpoint",
+                                        OWL.equivalentClass: BRICK["Minimum_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                         "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint],
                                     },
                                     "Minimum_Discharge_Air_Temperature_Setpoint": {},
                                     "Maximum_Discharge_Air_Temperature_Setpoint": {},
                                     "Discharge_Air_Temperature_Cooling_Setpoint": {
-                                        OWL.equivalentClass: "Maximum_Discharge_Air_Temperature_Setpoint",
+                                        OWL.equivalentClass: BRICK["Maximum_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
                                         "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Cooling, TAG.Setpoint],
                                     }

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -222,6 +222,7 @@ def define_properties(definitions, superprop=None):
                 G.add((BRICK[prop], propname, propval))
 
 
+logging.info("Beginning BRICK Ontology compilation")
 # handle ontology definition
 define_ontology(G)
 
@@ -244,9 +245,11 @@ roots = {
 }
 define_classes(roots, BRICK.Class)
 
+logging.info("Defining properties")
 # define BRICK properties
 define_properties(properties)
 
+logging.info("Defining Point subclasses")
 # define Point subclasses
 define_classes(setpoint_definitions, BRICK.Point)
 define_classes(sensor_definitions, BRICK.Point)
@@ -261,12 +264,14 @@ for pc in pointclasses:
     for o in filter(lambda x: x != pc, pointclasses):
         G.add((BRICK[pc], OWL.disjointWith, BRICK[o]))
 
+logging.info("Defining Equipment, Location subclasses")
 # define other root class structures
 define_classes(location_subclasses, BRICK.Location)
 define_classes(equipment_subclasses, BRICK.Equipment)
 define_classes(hvac_subclasses, BRICK.HVAC)
 define_classes(valve_subclasses, BRICK.Valve)
 
+logging.info("Defining Measurable hierarchy")
 # define measurable hierarchy
 G.add((BRICK.Measurable, RDFS.subClassOf, BRICK.Class))
 # set up Quantity definition
@@ -289,6 +294,7 @@ G.add((BRICK.Substance, A, OWL.Class))
 define_classes(substances, BRICK.Substance, pun_classes=True)
 define_classes(quantity_definitions, BRICK.Quantity, pun_classes=True)
 
+logging.info("Finishing Tag definitions")
 # declares that all tags are pairwise different; i.e. no two tags refer
 # to the same tag
 different_tag_list = []
@@ -300,6 +306,6 @@ G.add((BRICK.Tag, A, OWL.AllDifferent))
 G.add((BRICK.Tag, OWL.distinctMembers, different_tag))
 Collection(G, different_tag, different_tag_list)
 
+logging.info(f"Brick ontology compilation finished! Generated {len(G)} triples")
 # serialize to output
-print('base:',len(G))
 G.serialize('Brick.ttl', format='turtle')

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -164,7 +164,7 @@ def define_classes(definitions, parent):
         for propname in other_properties:
             propval = defn[propname]
             if isinstance(propval, str):
-                propval = Literal(str)
+                propval = Brick[propval]
             G.add((classname, propname, propval))
 
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -44,7 +44,7 @@ def add_restriction(klass, definition):
         G.add((restriction, A, OWL.Restriction))
         G.add((restriction, OWL.onProperty, item[0]))
         G.add((restriction, OWL.hasValue, item[1]))
-    G.add((BRICK[klass], OWL.equivalentClass, equivalent_class))
+    G.add((klass, OWL.equivalentClass, equivalent_class))
     G.add((equivalent_class, OWL.intersectionOf, list_name))
     Collection(G, list_name, elements)
 
@@ -61,7 +61,7 @@ def add_tags(klass, definition):
     list_name = BNode()
 
     for tag in definition:
-        G.add((BRICK[klass], BRICK.hasAssociatedTag, tag))
+        G.add((klass, BRICK.hasAssociatedTag, tag))
 
     for idnum, item in enumerate(definition):
         restriction = BNode(f"has_{item.split('#')[-1]}")
@@ -80,10 +80,10 @@ def add_tags(klass, definition):
     if klass in intersection_classes:
         return
     if len(all_restrictions) == 1:
-        G.add( (BRICK[klass], RDFS.subClassOf, all_restrictions[0]) )
+        G.add((klass, RDFS.subClassOf, all_restrictions[0]) )
     if len(all_restrictions) > 1:
-        G.add( (BRICK[klass], RDFS.subClassOf, equivalent_class) )
-        G.add( (equivalent_class, OWL.intersectionOf, list_name) )
+        G.add((klass, RDFS.subClassOf, equivalent_class) )
+        G.add((equivalent_class, OWL.intersectionOf, list_name) )
         Collection(G, list_name, all_restrictions)
     intersection_classes[klass] = tuple(sorted(definition))
 
@@ -104,7 +104,7 @@ def define_measurable_subclasses(definitions, measurable_class):
         G.add((BRICK[subclass], RDFS.subClassOf, measurable_class))
         for k, v in properties.items():
             if isinstance(v, list) and k == "tags":
-                add_tags(subclass, v)
+                add_tags(BRICK[subclass], v)
             elif isinstance(v, list) and k == "parents":
                 for parent in v:
                     G.add( (BRICK[subclass], RDFS.subClassOf, parent) )
@@ -163,8 +163,10 @@ def define_classes(definitions, parent):
                             if prop not in expected_properties]
         for propname in other_properties:
             propval = defn[propname]
-            if isinstance(propval, str):
-                propval = Brick[propval]
+            if isinstance(propval, Literal):
+                propval = propval
+            elif isinstance(propval, str):
+                propval = BRICK[propval]
             G.add((classname, propname, propval))
 
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -160,8 +160,8 @@ def define_classes(definitions, parent, pun_classes=False):
         # handle 'parents' subclasses (links outside of tree-based hierarchy)
         parents = defn.get('parents', [])
         assert isinstance(parents, list)
-        for parent in parents:
-            G.add((classname, RDFS.subClassOf, parent))
+        for _parent in parents:
+            G.add((classname, RDFS.subClassOf, _parent))
 
         # all other key-value pairs in the definition are
         # property-object pairs

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -115,13 +115,15 @@ def define_measurable_subclasses(definitions, measurable_class):
                     define_measurable_subclasses(v, BRICK[subclass])
 
 
-def define_classes(definitions, parent):
+def define_classes(definitions, parent, pun_classes=False):
     """
     Generates triples for the hierarchy given by 'definitions', rooted
     at the class given by 'parent'
     - class hierarchy ('subclasses')
     - tag mappings
     - substance + quantity modeling
+
+    If pun_classes is True, then create punned instances of the classes
     """
     for classname, defn in definitions.items():
         classname = BRICK[classname]
@@ -129,6 +131,10 @@ def define_classes(definitions, parent):
         G.add((classname, A, OWL.Class))
         # subclass of parent
         G.add((classname, RDFS.subClassOf, parent))
+        # add label
+        G.add((classname, RDFS.label, Literal(classname.replace("_"," "))))
+        if pun_classes:
+            G.add((classname, A, classname))
 
         # define mapping to tags if it exists
         # "tags" property is a list of URIs naming Tags
@@ -148,7 +154,7 @@ def define_classes(definitions, parent):
         # this is a nested dictionary
         subclassdef = defn.get('subclasses', {})
         assert isinstance(subclassdef, dict)
-        define_classes(subclassdef, classname)
+        define_classes(subclassdef, classname, pun_classes=pun_classes)
 
         # handle 'parents' subclasses (links outside of tree-based hierarchy)
         parents = defn.get('parents', [])
@@ -263,8 +269,8 @@ G.add((BRICK.Substance, A, OWL.Class))
 #               brick:measures  brick:Air ,
 #                               brick:Temperature .
 # This makes Substance and Quantity metaclasses.
-define_measurable_subclasses(substances, BRICK.Substance)
-define_measurable_subclasses(quantity_definitions, BRICK.Quantity)
+define_classes(substances, BRICK.Substance, pun_classes=True)
+define_classes(quantity_definitions, BRICK.Quantity, pun_classes=True)
 
 different_tag_list = []
 # define tags

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -169,23 +169,6 @@ def define_classes(definitions, parent, pun_classes=False):
             G.add((classname, propname, propval))
 
 
-def apply_prop(prop, pred, obj):
-    if isinstance(obj, Literal):
-        G.add((BRICK[prop], pred, obj))
-        return True
-    elif isinstance(obj, URIRef):
-        G.add((BRICK[prop], pred, obj))
-        return True
-    elif isinstance(obj, str):
-        G.add((BRICK[prop], pred, BRICK[obj]))
-        return True
-    elif isinstance(obj, list):
-        for l in obj:
-            apply_prop(prop, pred, l)
-        return True
-    return False
-
-
 def define_properties(definitions, superprop=None):
     """
     Define BRICK properties

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -132,7 +132,8 @@ def define_classes(definitions, parent, pun_classes=False):
         # subclass of parent
         G.add((classname, RDFS.subClassOf, parent))
         # add label
-        G.add((classname, RDFS.label, Literal(classname.replace("_"," "))))
+        class_label = classname.split('#')[-1].replace("_", " ")
+        G.add((classname, RDFS.label, Literal(class_label)))
         if pun_classes:
             G.add((classname, A, classname))
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -74,7 +74,9 @@ def test_tag1():
     res1 = make_readable(g.query("SELECT DISTINCT ?co2tag WHERE {\
                                    bldg:co2s1 brick:hasTag ?co2tag\
                                   }"))
-    assert len(res1) == 3
+    assert len(res1) == 4
+    res1 = [x[0] for x in res1]
+    assert set(res1) == {'CO2', 'Level', 'Sensor', 'Point'}
 
 
 def test_sensors_measure_co2():


### PR DESCRIPTION
Props to @jbkoh and #98 for the impetus and initial implementation

Wanted to take another stab at reworking `generate_brick.py` to make it cleaner, easier to understand, more consistent, and to remove old code. The new structure has fewer methods and has a more structured approach from which it should be more evident how the code is working.

This includes the Python `logging` package to log the stages of ontology generation and to issue warnings when Tags are not defined. As @jbkoh pointed out, we will still need a PR to fill in the rest of the tags.

The new code structure uncovered a few issues in the existing definition: consistent datatypes in the ontology definition files and some mistakes in the structure. This explains why the PR touches files that aren't `generate_brick.py`