### PR TITLE
Add missing tags for classes

### DIFF
--- a/Brick.ttl
+++ b/Brick.ttl
@@ -33,17 +33,18 @@ brick:Absorption_Chiller a owl:Class ;
 
 brick:Acceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Acceleration Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Acceleration ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Time_Setpoint ;
     brick:hasAssociatedTag tag:Acceleration,
+        tag:Point,
         tag:Setpoint,
         tag:Time .
 
 brick:Active_Power_Sensor a owl:Class ;
     rdfs:label "Active Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
                         owl:hasValue tag:Real ;
                         owl:onProperty brick:hasTag ] _:has_Electrical ) ],
         brick:Electrical_Power_Sensor ;
@@ -51,13 +52,14 @@ brick:Active_Power_Sensor a owl:Class ;
                         owl:hasValue brick:Active_Power ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
         tag:Power,
         tag:Real,
         tag:Sensor .
 
 brick:Air_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Air Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -66,6 +68,7 @@ brick:Air_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
@@ -84,59 +87,65 @@ brick:Air_Handler_Unit a owl:Class ;
 
 brick:Alarm_Delay_Parameter a owl:Class ;
     rdfs:label "Alarm Delay Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Alarm _:has_Delay _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm _:has_Delay _:has_Parameter ) ],
         brick:Delay_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Delay,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Automatic_Mode_Command a owl:Class ;
     rdfs:label "Automatic Mode Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Automatic ;
                         owl:onProperty brick:hasTag ] _:has_Mode _:has_Command ) ],
         brick:Mode_Command ;
     brick:hasAssociatedTag tag:Automatic,
         tag:Command,
-        tag:Mode .
+        tag:Mode,
+        tag:Point .
 
 brick:Average_Discharge_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Average Discharge Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Discharge _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Discharge _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Discharge_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Average_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Average Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Exhaust_Air_Static_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Average_Supply_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Average Supply Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Supply _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Supply _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Supply_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Average_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Average Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Average _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Average _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -161,9 +170,10 @@ brick:Battery a owl:Class ;
 
 brick:Battery_Voltage_Sensor a owl:Class ;
     rdfs:label "Battery Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Voltage _:has_Battery ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage _:has_Battery ) ],
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Battery,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
@@ -189,11 +199,12 @@ brick:Booster_Fan a owl:Class ;
 
 brick:Box_Mode_Command a owl:Class ;
     rdfs:label "Box Mode Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Box _:has_Mode _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Box _:has_Mode _:has_Command ) ],
         brick:Mode_Command ;
     brick:hasAssociatedTag tag:Box,
         tag:Command,
-        tag:Mode .
+        tag:Mode,
+        tag:Point .
 
 brick:Building a owl:Class ;
     rdfs:label "Building" ;
@@ -205,7 +216,7 @@ brick:Building a owl:Class ;
 
 brick:Building_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Building Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -214,16 +225,18 @@ brick:Building_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Building,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Building_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Building Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Building,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
@@ -238,7 +251,7 @@ brick:Building_Meter a owl:Class ;
 
 brick:Bypass_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Bypass Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Bypass ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Bypass ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -248,34 +261,38 @@ brick:Bypass_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Bypass,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Bypass_Command a owl:Class ;
     rdfs:label "Bypass Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Bypass _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Bypass _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Bypass,
-        tag:Command .
+        tag:Command,
+        tag:Point .
 
 brick:CO2_Differential_Sensor a owl:Class ;
     rdfs:label "CO2 Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Differential _:has_Sensor ) ],
         brick:CO2_Sensor ;
     brick:hasAssociatedTag tag:CO2,
         tag:Differential,
+        tag:Point,
         tag:Sensor .
 
 brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Level _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Level _:has_Sensor ) ],
         brick:CO2_Sensor ;
     brick:hasAssociatedTag tag:CO2,
         tag:Level,
+        tag:Point,
         tag:Sensor .
 
 brick:Capacity_Sensor a owl:Class ;
     rdfs:label "Capacity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Capacity ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
@@ -283,6 +300,7 @@ brick:Capacity_Sensor a owl:Class ;
                         owl:hasValue brick:Capacity ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Capacity,
+        tag:Point,
         tag:Sensor .
 
 brick:Centrifugal_Chiller a owl:Class ;
@@ -297,34 +315,37 @@ brick:Centrifugal_Chiller a owl:Class ;
 
 brick:Change_Filter_Alarm a owl:Class ;
     rdfs:label "Change Filter Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Change ;
                         owl:onProperty brick:hasTag ] _:has_Filter _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Change,
-        tag:Filter .
+        tag:Filter,
+        tag:Point .
 
 brick:Chilled_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
         brick:Chilled_Water_Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Reset,
         tag:Shed,
@@ -333,12 +354,13 @@ brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Setpoint,
         brick:Load_Shed_Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed,
@@ -346,20 +368,21 @@ brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Chilled,
         tag:Differential,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Chilled ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -368,34 +391,37 @@ brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Differential_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Step,
         tag:Water .
 
 brick:Chilled_Water_Differential_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Differential Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Temperature _:has_Sensor ) ],
         brick:Chilled_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Chilled_Water_Discharge_Flow_Sensor a owl:Class ;
     rdfs:label "Chilled Water Discharge Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Discharge _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge _:has_Chilled ) ],
         brick:Discharge_Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -405,6 +431,7 @@ brick:Chilled_Water_Discharge_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -429,11 +456,12 @@ brick:Chilled_Water_Pump a owl:Class ;
 
 brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Pump Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Pump _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Pump _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Pump,
         tag:Setpoint,
@@ -441,10 +469,11 @@ brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Chilled_Water_Temperature_Sensor,
         brick:Return_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -452,9 +481,10 @@ brick:Chilled_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Chilled_Water_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -462,7 +492,7 @@ brick:Chilled_Water_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Supply_Flow_Sensor a owl:Class ;
     rdfs:label "Chilled Water Supply Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Chilled ) ],
         brick:Supply_Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -471,13 +501,14 @@ brick:Chilled_Water_Supply_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Water .
 
 brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled _:has_Supply ) ],
         brick:Chilled_Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -485,6 +516,7 @@ brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Chilled_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -492,11 +524,12 @@ brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Chilled_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Chilled Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Chilled _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Chilled _:has_Water _:has_System ) ],
         brick:System_Enable_Command ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Command,
         tag:Enable,
+        tag:Point,
         tag:System,
         tag:Water .
 
@@ -521,13 +554,14 @@ brick:City a owl:Class ;
 
 brick:Close_Limit a owl:Class ;
     rdfs:label "Close Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Close ;
                         owl:onProperty brick:hasTag ] _:has_Parameter _:has_Limit ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Close,
         tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
@@ -543,13 +577,14 @@ brick:Cold_Box a owl:Class ;
 
 brick:Communication_Loss_Alarm a owl:Class ;
     rdfs:label "Communication Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Communication ;
                         owl:onProperty brick:hasTag ] _:has_Loss _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Communication,
-        tag:Loss .
+        tag:Loss,
+        tag:Point .
 
 brick:Compressor a owl:Class ;
     rdfs:label "Compressor" ;
@@ -563,13 +598,14 @@ brick:Compressor a owl:Class ;
 
 brick:Condensate_Leak_Alarm a owl:Class ;
     rdfs:label "Condensate Leak Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Condensate ;
                         owl:onProperty brick:hasTag ] _:has_Leak _:has_Alarm ) ],
         brick:Leak_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Condensate,
-        tag:Leak .
+        tag:Leak,
+        tag:Point .
 
 brick:Condenser a owl:Class ;
     rdfs:label "Condenser" ;
@@ -599,12 +635,13 @@ brick:Condenser_Water_Pump a owl:Class ;
 
 brick:Contact_Sensor a owl:Class ;
     rdfs:label "Contact Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Contact ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     skos:definition "Senses or detects contact, such as for detecting if a door is closed." ;
     brick:hasAssociatedTag tag:Contact,
+        tag:Point,
         tag:Sensor .
 
 brick:Cooling_Coil a owl:Class ;
@@ -617,27 +654,29 @@ brick:Cooling_Coil a owl:Class ;
 
 brick:Cooling_Demand_Setpoint a owl:Class ;
     rdfs:label "Cooling Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Demand,
+        tag:Point,
         tag:Setpoint .
 
 brick:Cooling_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Cooling_Setpoint,
         brick:Discharge_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -645,12 +684,13 @@ brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
 brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -658,61 +698,67 @@ brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class 
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Cooling_On_Off_Status a owl:Class ;
     rdfs:label "Cooling On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Cooling_Request_Percent_Setpoint a owl:Class ;
     rdfs:label "Cooling Request Percent Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Request _:has_Percent _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Request _:has_Percent _:has_Setpoint ) ],
         brick:Cooling_Request_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Percent,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Cooling_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Supply_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Cooling_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time .
 
 brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Cooling,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
@@ -748,25 +794,27 @@ brick:Cooling_Valve a owl:Class ;
 
 brick:Current_Limit a owl:Class ;
     rdfs:label "Current Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Current _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Current,
         tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Curtailment_Override_Command a owl:Class ;
     rdfs:label "Curtailment Override Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Curtailment ;
                         owl:onProperty brick:hasTag ] _:has_Override _:has_Command ) ],
         brick:Override_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Curtailment,
-        tag:Override .
+        tag:Override,
+        tag:Point .
 
 brick:DC_Bus_Voltage_Sensor a owl:Class ;
     rdfs:label "DC Bus Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dc ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Bus ;
@@ -774,58 +822,64 @@ brick:DC_Bus_Voltage_Sensor a owl:Class ;
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Bus,
         tag:Dc,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
 brick:Damper_Position_Command a owl:Class ;
     rdfs:label "Damper Position Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Command ) ],
         brick:Damper_Command,
         brick:Position_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Damper,
+        tag:Point,
         tag:Position .
 
 brick:Damper_Position_Sensor a owl:Class ;
     rdfs:label "Damper Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Sensor ) ],
         brick:Position_Sensor ;
     brick:hasAssociatedTag tag:Damper,
+        tag:Point,
         tag:Position,
         tag:Sensor .
 
 brick:Damper_Position_Setpoint a owl:Class ;
     rdfs:label "Damper Position Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Damper,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Deceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Deceleration Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Deceleration ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Time_Setpoint ;
     brick:hasAssociatedTag tag:Deceleration,
+        tag:Point,
         tag:Setpoint,
         tag:Time .
 
 brick:Dehumidification_On_Off_Status a owl:Class ;
     rdfs:label "Dehumidification On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dehumidification ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Dehumidification,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Deionised_Water_Conductivity_Sensor a owl:Class ;
     rdfs:label "Deionised Water Conductivity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Conductivity _:has_Water _:has_Deionised ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity _:has_Water _:has_Deionised ) ],
         brick:Conductivity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Conductivity ;
@@ -834,12 +888,13 @@ brick:Deionised_Water_Conductivity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Conductivity,
         tag:Deionised,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Deionised_Water_Level_Sensor a owl:Class ;
     rdfs:label "Deionised Water Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Water _:has_Level _:has_Deionised ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level _:has_Deionised ) ],
         brick:Water_Level_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Deionized_Water ;
@@ -848,56 +903,63 @@ brick:Deionised_Water_Level_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Deionised,
         tag:Level,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Deionized_Water_Alarm a owl:Class ;
     rdfs:label "Deionized Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Deionized _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deionized _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Deionized,
+        tag:Point,
         tag:Water .
 
 brick:Derivative_Gain_Parameter a owl:Class ;
     rdfs:label "Derivative Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Derivative,
         tag:Gain,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Derivative_Time_Parameter a owl:Class ;
     rdfs:label "Derivative Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Time _:has_Derivative ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Derivative ) ],
         brick:Time_Parameter ;
     brick:hasAssociatedTag tag:Derivative,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Dew_Point_Setpoint a owl:Class ;
     rdfs:label "Dew Point Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Dewpoint _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Dewpoint _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
         tag:Setpoint .
 
 brick:Differential_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Differential Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Differential_Speed_Sensor a owl:Class ;
     rdfs:label "Differential Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Differential ) ],
         brick:Speed_Sensor ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Sensor,
         tag:Speed .
 
@@ -914,56 +976,62 @@ brick:Dimmer a owl:Class ;
 
 brick:Direction_Command a owl:Class ;
     rdfs:label "Direction Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Direction _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Direction .
+        tag:Direction,
+        tag:Point .
 
 brick:Disable_Differential_Enthalpy_Command a owl:Class ;
     rdfs:label "Disable Differential Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Enthalpy ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Disable,
-        tag:Enthalpy .
+        tag:Enthalpy,
+        tag:Point .
 
 brick:Disable_Differential_Temperature_Command a owl:Class ;
     rdfs:label "Disable Differential Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Differential _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Temperature ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Disable,
+        tag:Point,
         tag:Temperature .
 
 brick:Disable_Fixed_Enthalpy_Command a owl:Class ;
     rdfs:label "Disable Fixed Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Enthalpy,
-        tag:Fixed .
+        tag:Fixed,
+        tag:Point .
 
 brick:Disable_Fixed_Temperature_Command a owl:Class ;
     rdfs:label "Disable Fixed Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fixed _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Temperature ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Fixed,
+        tag:Point,
         tag:Temperature .
 
 brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Disable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     skos:definition "Disables hot water system when outside air temperature reaches the indicated value" ;
     brick:hasAssociatedTag tag:Air,
         tag:Disable,
         tag:Hot,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:System,
         tag:Temperature,
@@ -971,57 +1039,62 @@ brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
 
 brick:Disable_Status a owl:Class ;
     rdfs:label "Disable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Disable,
+        tag:Point,
         tag:Status .
 
 brick:Discharge_Air_Duct_Pressure_Status a owl:Class ;
     rdfs:label "Discharge Air Duct Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Duct,
+        tag:Point,
         tag:Pressure,
         tag:Status .
 
 brick:Discharge_Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Demand_Setpoint,
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Discharge_Air_Flow_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset High Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_High ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_High ) ],
         brick:Discharge_Air_Flow_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:High,
+        tag:Point,
         tag:Reset,
         tag:Setpoint .
 
 brick:Discharge_Air_Flow_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Low Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_Low ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_Low ) ],
         brick:Discharge_Air_Flow_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:Low,
+        tag:Point,
         tag:Reset,
         tag:Setpoint .
 
 brick:Discharge_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Discharge Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Discharge ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -1031,60 +1104,65 @@ brick:Discharge_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Smoke_Detected_Alarm a owl:Class ;
     rdfs:label "Discharge Air Smoke Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Smoke _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Smoke _:has_Detected _:has_Alarm ) ],
         brick:Air_Alarm,
         brick:Smoke_Detected_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Detected,
         tag:Discharge,
+        tag:Point,
         tag:Smoke .
 
 brick:Discharge_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Static_Pressure_Setpoint,
         brick:Static_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Time .
 
 brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Discharge ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -1093,58 +1171,63 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Air_Static_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
 
 brick:Discharge_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_High ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_High ) ],
         brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Discharge,
         tag:High,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_Low ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_Low ) ],
         brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Discharge,
         tag:Low,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Discharge Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Air_Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
 brick:Discharge_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Discharge _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Discharge _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -1153,6 +1236,7 @@ brick:Discharge_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Velocity .
@@ -1167,52 +1251,56 @@ brick:Discharge_Fan a owl:Class ;
 
 brick:Discharge_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Discharge Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Discharge,
         tag:Fan,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Discharge_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Discharge,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Discharge Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Water_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Discharge,
+        tag:Point,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Water Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Discharge ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1220,25 +1308,28 @@ brick:Discharge_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Discharge_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Discharge Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Domestic_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Domestic Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -1246,11 +1337,12 @@ brick:Domestic_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Domestic_Hot_Water_Supply_Temperature_Setpoint a owl:Class ;
     rdfs:label "Domestic Hot Water Supply Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Domestic_Hot_Water_Temperature_Setpoint,
         brick:Supply_Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature,
@@ -1258,12 +1350,13 @@ brick:Domestic_Hot_Water_Supply_Temperature_Setpoint a owl:Class ;
 
 brick:Domestic_Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Domestic Hot Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Domestic _:has_Hot _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Domestic _:has_Hot _:has_Water _:has_System ) ],
         brick:Hot_Water_System_Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Domestic,
         tag:Enable,
         tag:Hot,
+        tag:Point,
         tag:System,
         tag:Water .
 
@@ -1282,34 +1375,37 @@ brick:Domestic_Hot_Water_Valve a owl:Class ;
 
 brick:Drive_Ready_Status a owl:Class ;
     rdfs:label "Drive Ready Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Drive [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Drive [ a owl:Restriction ;
                         owl:hasValue tag:Ready ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Drive,
+        tag:Point,
         tag:Ready,
         tag:Status .
 
 brick:Dual_Band_Mode_Setpoint a owl:Class ;
     rdfs:label "Dual Band Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dual ;
                         owl:onProperty brick:hasTag ] _:has_Band _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Band,
         tag:Dual,
         tag:Mode,
+        tag:Point,
         tag:Setpoint .
 
 brick:EconCycle_On_Off_Status a owl:Class ;
     rdfs:label "EconCycle On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Econcycle ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Econcycle,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Economizer a owl:Class ;
@@ -1330,23 +1426,25 @@ brick:Economizer_Damper a owl:Class ;
 
 brick:Effective_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Cooling _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Cooling _:has_Temperature _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Effective_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Effective,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Heating _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Heating _:has_Temperature _:has_Setpoint ) ],
         brick:Effective_Air_Temperature_Setpoint,
         brick:Heating_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Effective,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -1361,69 +1459,76 @@ brick:Elevator a owl:Class ;
 
 brick:Emergency_Air_Flow_Status a owl:Class ;
     rdfs:label "Emergency Air Flow Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Air _:has_Flow _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Air _:has_Flow _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Emergency,
         tag:Flow,
+        tag:Point,
         tag:Status .
 
 brick:Emergency_Generator_Alarm a owl:Class ;
     rdfs:label "Emergency Generator Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Generator _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Generator _:has_Emergency _:has_Alarm ) ],
         brick:Emergency_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Emergency,
-        tag:Generator .
+        tag:Generator,
+        tag:Point .
 
 brick:Emergency_Generator_Status a owl:Class ;
     rdfs:label "Emergency Generator Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Generator _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Generator _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:Generator,
+        tag:Point,
         tag:Status .
 
 brick:Emergency_Power_Loss_Alarm a owl:Class ;
     rdfs:label "Emergency Power Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Loss _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Emergency _:has_Alarm ) ],
         brick:Emergency_Alarm,
         brick:Power_Loss_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Emergency,
         tag:Loss,
+        tag:Point,
         tag:Power .
 
 brick:Emergency_Power_Off_Activated_By_High_Temperature_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By High Temperature Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_High _:has_Temperature _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_High _:has_Temperature _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:High,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status,
         tag:Temperature .
 
 brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By Leak Detection System Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
     brick:hasAssociatedTag tag:Detection,
         tag:Emergency,
         tag:Leak,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status .
 
 brick:Emergency_Power_Off_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
     brick:hasAssociatedTag tag:Detection,
         tag:Emergency,
         tag:Leak,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status .
 
@@ -1438,17 +1543,18 @@ brick:Emergency_Power_Off_System a owl:Class ;
 
 brick:Emergency_Power_Off_System_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off System Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:Enable,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status .
 
 brick:Emergency_Push_Button_Status a owl:Class ;
     rdfs:label "Emergency Push Button Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency [ a owl:Restriction ;
                         owl:hasValue tag:Push ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Button ;
@@ -1456,54 +1562,60 @@ brick:Emergency_Push_Button_Status a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Button,
         tag:Emergency,
+        tag:Point,
         tag:Push,
         tag:Status .
 
 brick:Enable_Differential_Enthalpy_Command a owl:Class ;
     rdfs:label "Enable Differential Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Enthalpy ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Enable,
-        tag:Enthalpy .
+        tag:Enthalpy,
+        tag:Point .
 
 brick:Enable_Differential_Temperature_Command a owl:Class ;
     rdfs:label "Enable Differential Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Differential _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Temperature ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Enable,
+        tag:Point,
         tag:Temperature .
 
 brick:Enable_Fixed_Enthalpy_Command a owl:Class ;
     rdfs:label "Enable Fixed Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Enthalpy,
-        tag:Fixed .
+        tag:Fixed,
+        tag:Point .
 
 brick:Enable_Fixed_Temperature_Command a owl:Class ;
     rdfs:label "Enable Fixed Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fixed _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Temperature ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Fixed,
+        tag:Point,
         tag:Temperature .
 
 brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Enable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     skos:definition "Enables hot water system when outside air temperature reaches the indicated value" ;
     brick:hasAssociatedTag tag:Air,
         tag:Enable,
         tag:Hot,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:System,
         tag:Temperature,
@@ -1511,7 +1623,7 @@ brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
 
 brick:Entering_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Entering Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Entering ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Entering ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1519,24 +1631,27 @@ brick:Entering_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Entering_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Entering,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Entering_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Entering Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Entering _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Entering _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Entering,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Enthalpy_Setpoint a owl:Class ;
     rdfs:label "Enthalpy Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Setpoint _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint _:has_Enthalpy ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
         tag:Setpoint .
 
 brick:Environment_Box a owl:Class ;
@@ -1564,7 +1679,7 @@ brick:Evaporative_Heat_Exchanger a owl:Class ;
 
 brick:Even_Month_Status a owl:Class ;
     rdfs:label "Even Month Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Even ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Month ;
@@ -1572,11 +1687,12 @@ brick:Even_Month_Status a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Even,
         tag:Month,
+        tag:Point,
         tag:Status .
 
 brick:Exhaust_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Exhaust ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -1586,23 +1702,25 @@ brick:Exhaust_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Stack_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Flow_Deadband_Setpoint,
         brick:Exhaust_Air_Stack_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Stack .
 
 brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Exhaust_Air_Flow_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
@@ -1610,12 +1728,13 @@ brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Stack,
         tag:Time .
 
 brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Exhaust_Air_Flow_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -1623,45 +1742,49 @@ brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter a owl:Class ;
         tag:Flow,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Stack .
 
 brick:Exhaust_Air_Stack_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Sensor ) ],
         brick:Exhaust_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Stack .
 
 brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Exhaust,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Exhaust_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Exhaust_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Exhaust ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1670,12 +1793,13 @@ brick:Exhaust_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Exhaust_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Exhaust _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Exhaust _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -1684,6 +1808,7 @@ brick:Exhaust_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Velocity .
@@ -1706,25 +1831,27 @@ brick:Exhaust_Fan a owl:Class ;
 
 brick:Exhaust_Fan_Disable_Command a owl:Class ;
     rdfs:label "Exhaust Fan Disable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fan _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fan _:has_Exhaust ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Exhaust,
-        tag:Fan .
+        tag:Fan,
+        tag:Point .
 
 brick:Exhaust_Fan_Enable_Command a owl:Class ;
     rdfs:label "Exhaust Fan Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fan _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fan _:has_Exhaust ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Exhaust,
-        tag:Fan .
+        tag:Fan,
+        tag:Point .
 
 brick:Exhaust_Fan_Fire_Control_Panel_Off_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_Off _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_Off _:has_Command ) ],
         brick:Off_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Control,
@@ -1732,11 +1859,12 @@ brick:Exhaust_Fan_Fire_Control_Panel_Off_Command a owl:Class ;
         tag:Fan,
         tag:Fire,
         tag:Off,
-        tag:Panel .
+        tag:Panel,
+        tag:Point .
 
 brick:Exhaust_Fan_Fire_Control_Panel_On_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel On Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_On _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_On _:has_Command ) ],
         brick:On_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Control,
@@ -1744,15 +1872,17 @@ brick:Exhaust_Fan_Fire_Control_Panel_On_Command a owl:Class ;
         tag:Fan,
         tag:Fire,
         tag:On,
-        tag:Panel .
+        tag:Panel,
+        tag:Point .
 
 brick:Fan_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Fan Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Fan,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Fan_Coil_Unit a owl:Class ;
@@ -1767,56 +1897,62 @@ brick:Fan_Coil_Unit a owl:Class ;
 
 brick:Fan_Speed_Reset_Command a owl:Class ;
     rdfs:label "Fan Speed Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Speed _:has_Reset _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Speed _:has_Reset _:has_Command ) ],
         brick:Speed_Reset_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Fan,
+        tag:Point,
         tag:Reset,
         tag:Speed .
 
 brick:Fan_Start_Stop_Status a owl:Class ;
     rdfs:label "Fan Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Start _:has_Stop _:has_Status ) ],
         brick:Fan_Status,
         brick:Start_Stop_Status ;
     brick:hasAssociatedTag tag:Fan,
+        tag:Point,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Fault_Indicator_Status a owl:Class ;
     rdfs:label "Fault Indicator Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Indicator ;
                         owl:onProperty brick:hasTag ] _:has_Fault _:has_Status ) ],
         brick:Fault_Status ;
     brick:hasAssociatedTag tag:Fault,
         tag:Indicator,
+        tag:Point,
         tag:Status .
 
 brick:Fault_Reset_Command a owl:Class ;
     rdfs:label "Fault Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fault _:has_Reset _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Reset _:has_Command ) ],
         brick:Reset_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Fault,
+        tag:Point,
         tag:Reset .
 
 brick:Filter_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Filter Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Filter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Filter ) ],
         brick:Differential_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Differential,
         tag:Filter,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
 brick:Filter_Reset_Command a owl:Class ;
     rdfs:label "Filter Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Filter _:has_Reset _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Reset _:has_Command ) ],
         brick:Reset_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Filter,
+        tag:Point,
         tag:Reset .
 
 brick:Fire_Control_Panel a owl:Class ;
@@ -1831,10 +1967,11 @@ brick:Fire_Control_Panel a owl:Class ;
 
 brick:Fire_Sensor a owl:Class ;
     rdfs:label "Fire Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Fire ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Fire ) ],
         brick:Sensor ;
     skos:definition "senses or detects fire" ;
     brick:hasAssociatedTag tag:Fire,
+        tag:Point,
         tag:Sensor .
 
 brick:Fire_Zone a owl:Class ;
@@ -1856,9 +1993,10 @@ brick:Floor a owl:Class ;
 
 brick:Freeze_Status a owl:Class ;
     rdfs:label "Freeze Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Freeze _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Freeze _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Freeze,
+        tag:Point,
         tag:Status .
 
 brick:Freezer a owl:Class ;
@@ -1874,12 +2012,13 @@ brick:Freezer a owl:Class ;
 
 brick:Frost_Sensor a owl:Class ;
     rdfs:label "Frost Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Frost ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frost ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Frost ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Frost,
+        tag:Point,
         tag:Sensor .
 
 brick:Fume_Hood a owl:Class ;
@@ -1893,12 +2032,13 @@ brick:Fume_Hood a owl:Class ;
 
 brick:Fume_Hood_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Fume Hood Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fume _:has_Hood _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fume _:has_Hood _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Fume,
         tag:Hood,
+        tag:Point,
         tag:Sensor .
 
 brick:Furniture a owl:Class ;
@@ -1912,10 +2052,11 @@ brick:Furniture a owl:Class ;
 
 brick:Gas_Sensor a owl:Class ;
     rdfs:label "Gas Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Gas ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Gas ) ],
         brick:Sensor ;
     skos:definition "senses or detects gas concentration (other than CO2)" ;
     brick:hasAssociatedTag tag:Gas,
+        tag:Point,
         tag:Sensor .
 
 brick:HVAC_Zone a owl:Class ;
@@ -1928,30 +2069,33 @@ brick:HVAC_Zone a owl:Class ;
 
 brick:Hail_Sensor a owl:Class ;
     rdfs:label "Hail Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Hail ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Hail ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Hail ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Hail,
+        tag:Point,
         tag:Sensor .
 
 brick:Hand_Auto_Status a owl:Class ;
     rdfs:label "Hand Auto Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Hand ;
                         owl:onProperty brick:hasTag ] _:has_Auto _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Auto,
         tag:Hand,
+        tag:Point,
         tag:Status .
 
 brick:Heat_Exchanger_Supply_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Heat Exchanger Supply Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Exchanger _:has_Supply _:has_Water _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_Supply _:has_Water _:has_Temperature _:has_Sensor ) ],
         brick:Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Exchanger,
         tag:Heat,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -1959,12 +2103,13 @@ brick:Heat_Exchanger_Supply_Water_Temperature_Sensor a owl:Class ;
 
 brick:Heat_Exchanger_System_Enable_Status a owl:Class ;
     rdfs:label "Heat Exchanger System Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Exchanger _:has_System _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_System _:has_Enable _:has_Status ) ],
         brick:Enable_Status,
         brick:System_Status ;
     brick:hasAssociatedTag tag:Enable,
         tag:Exchanger,
         tag:Heat,
+        tag:Point,
         tag:Status,
         tag:System .
 
@@ -1989,34 +2134,37 @@ brick:Heating_Coil a owl:Class ;
 
 brick:Heating_Command a owl:Class ;
     rdfs:label "Heating Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Heat .
+        tag:Heat,
+        tag:Point .
 
 brick:Heating_Demand_Setpoint a owl:Class ;
     rdfs:label "Heating Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Demand,
         tag:Heating,
+        tag:Point,
         tag:Setpoint .
 
 brick:Heating_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Deadband_Setpoint,
         brick:Discharge_Air_Temperature_Heating_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2024,12 +2172,13 @@ brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
 brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -2037,61 +2186,67 @@ brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class 
         tag:Heating,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Heating_On_Off_Status a owl:Class ;
     rdfs:label "Heating On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Heating,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Heating_Request_Percent_Setpoint a owl:Class ;
     rdfs:label "Heating Request Percent Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Request _:has_Percent _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Request _:has_Percent _:has_Setpoint ) ],
         brick:Heating_Request_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
         tag:Percent,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Heating_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Supply_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Heating_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Heating,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time .
 
 brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Heating,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
@@ -2108,111 +2263,122 @@ brick:Heating_Thermal_Power_Meter a owl:Class ;
 
 brick:Heating_Thermal_Power_Sensor a owl:Class ;
     rdfs:label "Heating Thermal Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Sensor _:has_Power _:has_Thermal ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Sensor _:has_Power _:has_Thermal ) ],
         brick:Thermal_Power_Sensor ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Power,
         tag:Sensor,
         tag:Thermal .
 
 brick:High_CO2_Alarm a owl:Class ;
     rdfs:label "High CO2 Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_CO2 _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_CO2 _:has_Alarm ) ],
         brick:CO2_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:CO2,
-        tag:High .
+        tag:High,
+        tag:Point .
 
 brick:High_Discharge_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "High Discharge Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Discharge_Air_Temperature_Alarm,
         brick:High_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Discharge,
         tag:High,
+        tag:Point,
         tag:Temperature .
 
 brick:High_Head_Pressure_Alarm a owl:Class ;
     rdfs:label "High Head Pressure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High [ a owl:Restriction ;
                         owl:hasValue tag:Head ;
                         owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
         brick:Pressure_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Head,
         tag:High,
+        tag:Point,
         tag:Pressure .
 
 brick:High_Humidity_Alarm a owl:Class ;
     rdfs:label "High Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm ) ],
         brick:Humidity_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
-        tag:Humidity .
+        tag:Humidity,
+        tag:Point .
 
 brick:High_Humidity_Alarm_Parameter a owl:Class ;
     rdfs:label "High Humidity Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm _:has_Parameter ) ],
         brick:Humidity_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
         tag:Humidity,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:High_Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "High Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Lockout_Temperature_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:High,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:High_Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "High Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:High_Temperature_Alarm,
         brick:Return_Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:High,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
 brick:High_Static_Pressure_Cutout_Setpoint_Limit a owl:Class ;
     rdfs:label "High Static Pressure Cutout Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Static _:has_Pressure [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Static _:has_Pressure [ a owl:Restriction ;
                         owl:hasValue tag:Cutout ;
                         owl:onProperty brick:hasTag ] _:has_Limit _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Cutout,
         tag:High,
         tag:Limit,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:High_Temperature_Alarm_Parameter a owl:Class ;
     rdfs:label "High Temperature Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm _:has_Parameter ) ],
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
         tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
 brick:High_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Return_Temperature_Sensor ;
     brick:hasAssociatedTag tag:High,
         tag:Hot,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -2220,10 +2386,11 @@ brick:High_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:High,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -2231,31 +2398,34 @@ brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Highest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Highest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Highest _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Highest _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     owl:equivalentClass brick:Warmest_Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Highest,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
 
 brick:Highest_Zone_Cooling_Command a owl:Class ;
     rdfs:label "Highest Zone Cooling Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Highest _:has_Zone _:has_Cool _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Highest _:has_Zone _:has_Cool _:has_Command ) ],
         brick:Cooling_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Cool,
         tag:Highest,
+        tag:Point,
         tag:Zone .
 
 brick:Hold_Status a owl:Class ;
     rdfs:label "Hold Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Hold ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Hold,
+        tag:Point,
         tag:Status .
 
 brick:Hot_Box a owl:Class ;
@@ -2270,36 +2440,39 @@ brick:Hot_Box a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint,
         brick:Hot_Water_Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
         brick:Hot_Water_Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Reset,
         tag:Shed,
@@ -2308,24 +2481,26 @@ brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:Hot,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Hot_Water_Discharge_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Discharge Temperature Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status,
         tag:Temperature,
@@ -2333,10 +2508,11 @@ brick:Hot_Water_Discharge_Temperature_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Hot Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Hot ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Hot ) ],
         brick:Water_Flow_Sensor ;
     brick:hasAssociatedTag tag:Flow,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -2351,9 +2527,10 @@ brick:Hot_Water_Pump a owl:Class ;
 
 brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Hot Water Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -2361,22 +2538,24 @@ brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Hot_Water_Usage_Sensor a owl:Class ;
     rdfs:label "Hot Water Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Hot _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Hot _:has_Water ) ],
         brick:Water_Usage_Sensor ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Usage,
         tag:Water .
 
 brick:Humidification_On_Off_Status a owl:Class ;
     rdfs:label "Humidification On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Humidification ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Humidification,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Humidifier a owl:Class ;
@@ -2388,45 +2567,50 @@ brick:Humidifier a owl:Class ;
 
 brick:Humidifier_Fault_Status a owl:Class ;
     rdfs:label "Humidifier Fault Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidifier _:has_Fault _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidifier _:has_Fault _:has_Status ) ],
         brick:Fault_Status ;
     brick:hasAssociatedTag tag:Fault,
         tag:Humidifier,
+        tag:Point,
         tag:Status .
 
 brick:Humidify_Command a owl:Class ;
     rdfs:label "Humidify Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Humidify ;
                         owl:onProperty brick:hasTag ] _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Humidify .
+        tag:Humidify,
+        tag:Point .
 
 brick:Humidity_Setpoint a owl:Class ;
     rdfs:label "Humidity Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
         tag:Setpoint .
 
 brick:Humidity_Tolerance_Parameter a owl:Class ;
     rdfs:label "Humidity Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter _:has_Humidity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Humidity ) ],
         brick:Humidity_Parameter,
         brick:Tolerance_Parameter ;
     brick:hasAssociatedTag tag:Humidity,
         tag:Parameter,
+        tag:Point,
         tag:Tolerance .
 
 brick:Ice_Tank_Leaving_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Ice Tank Leaving Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Ice [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ice [ a owl:Restriction ;
                         owl:hasValue tag:Tank ;
                         owl:onProperty brick:hasTag ] _:has_Leaving _:has_Water _:has_Temperature _:has_Sensor ) ],
         brick:Leaving_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Ice,
         tag:Leaving,
+        tag:Point,
         tag:Sensor,
         tag:Tank,
         tag:Temperature,
@@ -2453,7 +2637,7 @@ brick:Isolation_Valve a owl:Class ;
 
 brick:Last_Fault_Code_Status a owl:Class ;
     rdfs:label "Last Fault Code Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Last ;
                         owl:onProperty brick:hasTag ] _:has_Fault [ a owl:Restriction ;
                         owl:hasValue tag:Code ;
@@ -2462,38 +2646,43 @@ brick:Last_Fault_Code_Status a owl:Class ;
     brick:hasAssociatedTag tag:Code,
         tag:Fault,
         tag:Last,
+        tag:Point,
         tag:Status .
 
 brick:Lead_Lag_Command a owl:Class ;
     rdfs:label "Lead Lag Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_Lag _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Lag,
-        tag:Lead .
+        tag:Lead,
+        tag:Point .
 
 brick:Lead_Lag_Status a owl:Class ;
     rdfs:label "Lead Lag Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_Lag _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Lag,
         tag:Lead,
+        tag:Point,
         tag:Status .
 
 brick:Lead_On_Off_Command a owl:Class ;
     rdfs:label "Lead On Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_On _:has_Off _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_On _:has_Off _:has_Command ) ],
         brick:On_Off_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Lead,
         tag:Off,
-        tag:On .
+        tag:On,
+        tag:Point .
 
 brick:Leaving_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Leaving Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Leaving _:has_Setpoint _:has_Temperature _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leaving _:has_Setpoint _:has_Temperature _:has_Water ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
@@ -2508,151 +2697,166 @@ brick:Lighting_Zone a owl:Class ;
 
 brick:Liquid_Detected_Alarm a owl:Class ;
     rdfs:label "Liquid Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Liquid _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Liquid _:has_Detected _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Detected,
-        tag:Liquid .
+        tag:Liquid,
+        tag:Point .
 
 brick:Load_Current_Sensor a owl:Class ;
     rdfs:label "Load Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Current _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Current _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Load,
+        tag:Point,
         tag:Sensor .
 
 brick:Locally_On_Off_Status a owl:Class ;
     rdfs:label "Locally On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Locally ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Locally,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Lockout_Command a owl:Class ;
     rdfs:label "Lockout Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lockout _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lockout _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Lockout .
+        tag:Lockout,
+        tag:Point .
 
 brick:Low_Freeze_Protect_Temperature_Parameter a owl:Class ;
     rdfs:label "Low Freeze Protect Temperature Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Freeze [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Freeze [ a owl:Restriction ;
                         owl:hasValue tag:Protect ;
                         owl:onProperty brick:hasTag ] _:has_Temperature _:has_Parameter ) ],
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Freeze,
         tag:Low,
         tag:Parameter,
+        tag:Point,
         tag:Protect,
         tag:Temperature .
 
 brick:Low_Humidity_Alarm a owl:Class ;
     rdfs:label "Low Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm ) ],
         brick:Humidity_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Humidity,
-        tag:Low .
+        tag:Low,
+        tag:Point .
 
 brick:Low_Humidity_Alarm_Parameter a owl:Class ;
     rdfs:label "Low Humidity Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm _:has_Parameter ) ],
         brick:Humidity_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Humidity,
         tag:Low,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Low_Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "Low Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Lockout_Temperature_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Lockout,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Low_Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
     rdfs:label "Low Outside Air Temperature Enable Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Enable_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Enable,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Low_Outside_Air_Temperature_Enable_Setpoint a owl:Class ;
     rdfs:label "Low Outside Air Temperature Enable Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Enable,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Low_Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Low Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Low_Temperature_Alarm,
         brick:Return_Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Low,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
 brick:Low_Suction_Pressure_Alarm a owl:Class ;
     rdfs:label "Low Suction Pressure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low [ a owl:Restriction ;
                         owl:hasValue tag:Suction ;
                         owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
         brick:Pressure_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Low,
+        tag:Point,
         tag:Pressure,
         tag:Suction .
 
 brick:Low_Temperature_Alarm_Parameter a owl:Class ;
     rdfs:label "Low Temperature Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm _:has_Parameter ) ],
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Low,
         tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
 brick:Lowest_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Lowest Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lowest _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lowest _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Exhaust_Air_Static_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Lowest,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Lowest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Lowest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Lowest _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Lowest _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     owl:equivalentClass brick:Coldest_Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Lowest,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -2676,66 +2880,73 @@ brick:Luminaire_Driver a owl:Class ;
 
 brick:Luminance_Alarm a owl:Class ;
     rdfs:label "Luminance Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Luminance .
+        tag:Luminance,
+        tag:Point .
 
 brick:Luminance_Command a owl:Class ;
     rdfs:label "Luminance Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Luminance .
+        tag:Luminance,
+        tag:Point .
 
 brick:Luminance_Sensor a owl:Class ;
     rdfs:label "Luminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Luminance ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Luminance ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Luminance ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
         tag:Sensor .
 
 brick:Luminance_Setpoint a owl:Class ;
     rdfs:label "Luminance Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
         tag:Setpoint .
 
 brick:Maintenance_Mode_Command a owl:Class ;
     rdfs:label "Maintenance Mode Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Maintenance _:has_Mode _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance _:has_Mode _:has_Command ) ],
         brick:Mode_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Maintenance,
-        tag:Mode .
+        tag:Mode,
+        tag:Point .
 
 brick:Maintenance_Required_Alarm a owl:Class ;
     rdfs:label "Maintenance Required Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Maintenance [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance [ a owl:Restriction ;
                         owl:hasValue tag:Required ;
                         owl:onProperty brick:hasTag ] _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Maintenance,
+        tag:Point,
         tag:Required .
 
 brick:Manual_Auto_Status a owl:Class ;
     rdfs:label "Manual Auto Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Manual ;
                         owl:onProperty brick:hasTag ] _:has_Auto _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Auto,
         tag:Manual,
+        tag:Point,
         tag:Status .
 
 brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Chilled Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Chilled,
@@ -2743,13 +2954,14 @@ brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Discharge Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Max_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -2757,33 +2969,36 @@ brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Max_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint_Limit,
         brick:Max_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Max_Frequency_Command a owl:Class ;
     rdfs:label "Max Frequency Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Fequency _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Fequency _:has_Command ) ],
         brick:Frequency_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Fequency,
-        tag:Max .
+        tag:Max,
+        tag:Point .
 
 brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Hot Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Differential,
@@ -2791,22 +3006,24 @@ brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Max_Load_Setpoint a owl:Class ;
     rdfs:label "Max Load Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Load _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Load _:has_Parameter _:has_Setpoint ) ],
         brick:Load_Parameter ;
     brick:hasAssociatedTag tag:Load,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2816,11 +3033,12 @@ brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2829,12 +3047,13 @@ brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2844,11 +3063,12 @@ brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2857,49 +3077,54 @@ brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Position_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Position Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Position _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Position _:has_Limit _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Position_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Max_Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Max Return Air CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
         brick:Return_Air_CO2_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
         tag:Max,
+        tag:Point,
         tag:Return,
         tag:Setpoint .
 
 brick:Max_Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Speed_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Supply Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Max_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -2907,7 +3132,7 @@ brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
 
 brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2916,12 +3141,13 @@ brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2929,13 +3155,14 @@ brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2944,12 +3171,13 @@ brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2957,17 +3185,19 @@ brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
         brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
         tag:Medium,
+        tag:Point,
         tag:Pressure,
         tag:Reset,
         tag:Shed,
@@ -2976,12 +3206,13 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status 
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
         brick:Load_Shed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Load,
         tag:Medium,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed,
@@ -2990,11 +3221,12 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a ow
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
         brick:Hot_Water_Differential_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Temperature,
@@ -3002,12 +3234,13 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature High Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Discharge,
         tag:High,
         tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature,
@@ -3015,12 +3248,13 @@ brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a o
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Hot,
         tag:Low,
         tag:Medium,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature,
@@ -3028,10 +3262,11 @@ brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a ow
 
 brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Return_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -3039,11 +3274,12 @@ brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
     brick:hasAssociatedTag tag:High,
         tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -3052,11 +3288,12 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
         brick:Load_Shed_Setpoint ;
     brick:hasAssociatedTag tag:Hot,
         tag:Load,
         tag:Medium,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed,
@@ -3066,11 +3303,12 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:C
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
         brick:Hot_Water_Supply_Temperature_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Hot,
         tag:Load,
         tag:Medium,
+        tag:Point,
         tag:Shed,
         tag:Status,
         tag:Supply,
@@ -3079,11 +3317,12 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Cla
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Hot,
         tag:Low,
         tag:Medium,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -3092,10 +3331,11 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:C
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -3103,7 +3343,7 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Chilled Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Chilled,
@@ -3111,13 +3351,14 @@ brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Discharge Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Min_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -3125,36 +3366,39 @@ brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Min_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint_Limit,
         brick:Min_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Min_Fresh_Air_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Fresh Air Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
         brick:Fresh_Air_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Fresh,
         tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Hot Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Differential,
@@ -3162,13 +3406,14 @@ brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -3178,11 +3423,12 @@ brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -3191,12 +3437,13 @@ brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -3206,11 +3453,12 @@ brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -3219,12 +3467,13 @@ brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Outside_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Outside Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Outside _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Outside _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -3232,38 +3481,42 @@ brick:Min_Outside_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Outside,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Position_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Position Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Position _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Position _:has_Limit _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Position_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Min_Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Speed_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Supply Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Min_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -3271,7 +3524,7 @@ brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
 
 brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -3280,12 +3533,13 @@ brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -3293,13 +3547,14 @@ brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -3308,12 +3563,13 @@ brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -3321,6 +3577,7 @@ brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
@@ -3336,7 +3593,7 @@ brick:Mixed_Air_Filter a owl:Class ;
 
 brick:Mixed_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Mixed Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Mixed ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Mixed ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -3345,90 +3602,100 @@ brick:Mixed_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Mixed,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Mixed_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Mixed Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mixed _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mixed _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Mixed,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Monthly_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Monthly Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Monthly ;
                         owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
     brick:hasAssociatedTag tag:Monthly,
+        tag:Point,
         tag:Sensor,
         tag:Steam,
         tag:Usage .
 
 brick:Motor_Current_Sensor a owl:Class ;
     rdfs:label "Motor Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Current _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Current _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Motor,
+        tag:Point,
         tag:Sensor .
 
 brick:Motor_Direction_Status a owl:Class ;
     rdfs:label "Motor Direction Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Direction _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Direction _:has_Status ) ],
         brick:Direction_Status ;
     brick:hasAssociatedTag tag:Direction,
         tag:Motor,
+        tag:Point,
         tag:Status .
 
 brick:Motor_Speed_Sensor a owl:Class ;
     rdfs:label "Motor Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Speed _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Speed _:has_Sensor ) ],
         brick:Speed_Sensor ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Sensor,
         tag:Speed .
 
 brick:Motor_Start_Stop_Status a owl:Class ;
     rdfs:label "Motor Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Start _:has_Stop _:has_Status ) ],
         brick:Start_Stop_Status ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Motor_Torque_Sensor a owl:Class ;
     rdfs:label "Motor Torque Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Torque _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Torque _:has_Sensor ) ],
         brick:Torque_Sensor ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Sensor,
         tag:Torque .
 
 brick:No_Water_Alarm a owl:Class ;
     rdfs:label "No Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:No ;
                         owl:onProperty brick:hasTag ] _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:No,
+        tag:Point,
         tag:Water .
 
 brick:Occupancy_Command a owl:Class ;
     rdfs:label "Occupancy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupancy _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Occupancy .
+        tag:Occupancy,
+        tag:Point .
 
 brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Cooling_Discharge_Air_Flow_Setpoint,
         brick:Occupied_Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
@@ -3436,34 +3703,37 @@ brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Discharge,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Cooling_Supply_Air_Flow_Setpoint,
         brick:Occupied_Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Occupied_Cooling_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Deadband,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Occupied_Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Heating_Discharge_Air_Flow_Setpoint,
         brick:Occupied_Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
@@ -3471,60 +3741,66 @@ brick:Occupied_Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Flow,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Heating_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Heating_Supply_Air_Flow_Setpoint,
         brick:Occupied_Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Occupied_Heating_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Occupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Occupied Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Mode,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Mode_Status a owl:Class ;
     rdfs:label "Occupied Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Mode _:has_Status ) ],
         brick:Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Occupied,
+        tag:Point,
         tag:Status .
 
 brick:On_Timer_Sensor a owl:Class ;
     rdfs:label "On Timer Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On [ a owl:Restriction ;
                         owl:hasValue tag:Timer ;
                         owl:onProperty brick:hasTag ] _:has_Sensor ) ],
         brick:Duration_Sensor ;
     brick:hasAssociatedTag tag:On,
+        tag:Point,
         tag:Sensor,
         tag:Timer .
 
 brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Open Heating Valve Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Open ;
                         owl:onProperty brick:hasTag ] _:has_Heating _:has_Valve _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
@@ -3533,23 +3809,26 @@ brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Heating,
         tag:Open,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Valve .
 
 brick:Output_Frequency_Sensor a owl:Class ;
     rdfs:label "Output Frequency Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Output _:has_Frequency _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Frequency _:has_Sensor ) ],
         brick:Frequency_Sensor ;
     brick:hasAssociatedTag tag:Frequency,
         tag:Output,
+        tag:Point,
         tag:Sensor .
 
 brick:Output_Voltage_Sensor a owl:Class ;
     rdfs:label "Output Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Output _:has_Voltage _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Voltage _:has_Sensor ) ],
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Output,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
@@ -3562,7 +3841,7 @@ brick:Outside a owl:Class ;
 
 brick:Outside_Air_CO2_Sensor a owl:Class ;
     rdfs:label "Outside Air CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_CO2 _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_CO2 _:has_Sensor ) ],
         brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Outside_Air ;
@@ -3572,11 +3851,12 @@ brick:Outside_Air_CO2_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Dewpoint_Sensor a owl:Class ;
     rdfs:label "Outside Air Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Outside ) ],
         brick:Dewpoint_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
@@ -3586,11 +3866,12 @@ brick:Outside_Air_Dewpoint_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Dewpoint,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Outside Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Air_Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -3600,11 +3881,12 @@ brick:Outside_Air_Enthalpy_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Outside Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Outside ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -3614,20 +3896,22 @@ brick:Outside_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Outside Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Outside,
+        tag:Point,
         tag:Setpoint .
 
 brick:Outside_Air_Grains_Sensor a owl:Class ;
     rdfs:label "Outside Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Grains _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Grains _:has_Sensor ) ],
         brick:Air_Grains_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Outside_Air ;
@@ -3637,11 +3921,12 @@ brick:Outside_Air_Grains_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Outside Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Outside ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -3651,36 +3936,40 @@ brick:Outside_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Lockout_Temperature_Setpoint a owl:Class ;
     rdfs:label "Outside Air Lockout Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Outside_Air_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature High Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_High_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:High,
         tag:Outside,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Outside_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_Low_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
@@ -3695,53 +3984,58 @@ brick:Outside_Damper a owl:Class ;
 
 brick:Outside_Illuminance_Sensor a owl:Class ;
     rdfs:label "Outside Illuminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Illuminance _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance _:has_Outside ) ],
         brick:Illuminance_Sensor ;
     brick:hasAssociatedTag tag:Illuminance,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Overload_Alarm a owl:Class ;
     rdfs:label "Overload Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Overload ;
                         owl:onProperty brick:hasTag ] _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Overload .
+        tag:Overload,
+        tag:Point .
 
 brick:Overridden_Off_Status a owl:Class ;
     rdfs:label "Overridden Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:Overridden_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:Overridden,
+        tag:Point,
         tag:Status .
 
 brick:Overridden_On_Status a owl:Class ;
     rdfs:label "Overridden On Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_On _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_On _:has_Status ) ],
         brick:On_Status,
         brick:Overridden_Status ;
     brick:hasAssociatedTag tag:On,
         tag:Overridden,
+        tag:Point,
         tag:Status .
 
 brick:PIR_Sensor a owl:Class ;
     rdfs:label "PIR Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:PIR ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Motion_Sensor,
         brick:Occupancy_Sensor ;
     brick:hasAssociatedTag tag:PIR,
         tag:Pir,
+        tag:Point,
         tag:Sensor .
 
 brick:Peak_Power_Demand_Sensor a owl:Class ;
     rdfs:label "Peak Power Demand Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Peak _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Peak _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
         brick:Demand_Sensor,
         brick:Electrical_Power_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3750,12 +4044,13 @@ brick:Peak_Power_Demand_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Demand,
         tag:Electrical,
         tag:Peak,
+        tag:Point,
         tag:Power,
         tag:Sensor .
 
 brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     rdfs:label "Photovoltaic Current Output Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Photovoltaic ;
                         owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
         brick:Current_Output_Sensor ;
@@ -3763,15 +4058,17 @@ brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Current,
         tag:Output,
         tag:Photovoltaic,
+        tag:Point,
         tag:Sensor .
 
 brick:Piezoelectric_Sensor a owl:Class ;
     rdfs:label "Piezoelectric Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Piezoelectric ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Piezoelectric,
+        tag:Point,
         tag:Sensor .
 
 brick:PlugStrip a owl:Class ;
@@ -3785,28 +4082,31 @@ brick:PlugStrip a owl:Class ;
 
 brick:Pre_Filter_Status a owl:Class ;
     rdfs:label "Pre Filter Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Pre ;
                         owl:onProperty brick:hasTag ] _:has_Filter _:has_Status ) ],
         brick:Filter_Status ;
     brick:hasAssociatedTag tag:Filter,
+        tag:Point,
         tag:Pre,
         tag:Status .
 
 brick:Preheat_Demand_Setpoint a owl:Class ;
     rdfs:label "Preheat Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Demand,
+        tag:Point,
         tag:Preheat,
         tag:Setpoint .
 
 brick:Preheat_Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Preheat Discharge Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Discharge _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Discharge _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Discharge_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Preheat,
         tag:Sensor,
         tag:Temperature .
@@ -3826,9 +4126,10 @@ brick:Preheat_Hot_Water_Valve a owl:Class ;
 
 brick:Preheat_Supply_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Preheat Supply Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Supply _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Supply _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Supply_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Preheat,
         tag:Sensor,
         tag:Supply,
@@ -3844,42 +4145,46 @@ brick:Preheat_Valve_VFD a owl:Class ;
 
 brick:Pump_Command a owl:Class ;
     rdfs:label "Pump Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pump _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Pump .
 
 brick:Pump_Start_Stop_Status a owl:Class ;
     rdfs:label "Pump Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pump _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_Start _:has_Stop _:has_Status ) ],
         brick:Start_Stop_Status ;
-    brick:hasAssociatedTag tag:Pump,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pump,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:label "Rain Duration Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Rain _:has_Duration ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain _:has_Duration ) ],
         brick:Duration_Sensor,
         brick:Rain_Sensor ;
     brick:hasAssociatedTag tag:Duration,
+        tag:Point,
         tag:Rain,
         tag:Sensor .
 
 brick:Rated_Speed_Setpoint a owl:Class ;
     rdfs:label "Rated Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Rated ;
                         owl:onProperty brick:hasTag ] _:has_Speed _:has_Setpoint ) ],
         brick:Speed_Setpoint ;
-    brick:hasAssociatedTag tag:Rated,
+    brick:hasAssociatedTag tag:Point,
+        tag:Rated,
         tag:Setpoint,
         tag:Speed .
 
 brick:Reactive_Power_Sensor a owl:Class ;
     rdfs:label "Reactive Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
                         owl:hasValue tag:Reactive ;
                         owl:onProperty brick:hasTag ] _:has_Electrical ) ],
         brick:Electrical_Power_Sensor ;
@@ -3887,6 +4192,7 @@ brick:Reactive_Power_Sensor a owl:Class ;
                         owl:hasValue brick:Reactive_Power ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
         tag:Power,
         tag:Reactive,
         tag:Sensor .
@@ -3902,7 +4208,7 @@ brick:Reheat_Valve a owl:Class ;
 
 brick:Relative_Humidity_Sensor a owl:Class ;
     rdfs:label "Relative Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air [ a owl:Restriction ;
                         owl:hasValue tag:Relative ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Air_Humidity_Sensor ;
@@ -3913,23 +4219,25 @@ brick:Relative_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Relative,
         tag:Sensor .
 
 brick:Remotely_On_Off_Status a owl:Class ;
     rdfs:label "Remotely On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Remotely ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Remotely,
         tag:Status .
 
 brick:Return_Air_CO2_Sensor a owl:Class ;
     rdfs:label "Return Air CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_CO2 _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Sensor ) ],
         brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Return_Air ;
@@ -3938,12 +4246,13 @@ brick:Return_Air_CO2_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Dewpoint_Sensor a owl:Class ;
     rdfs:label "Return Air Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Return ) ],
         brick:Dewpoint_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
@@ -3952,12 +4261,13 @@ brick:Return_Air_Dewpoint_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Dewpoint,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Return Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Air_Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -3966,12 +4276,13 @@ brick:Return_Air_Enthalpy_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Return Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Return ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -3980,12 +4291,13 @@ brick:Return_Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Grains_Sensor a owl:Class ;
     rdfs:label "Return Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Grains _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Grains _:has_Sensor ) ],
         brick:Air_Grains_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Return_Air ;
@@ -3994,12 +4306,13 @@ brick:Return_Air_Grains_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Return Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Return ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -4008,12 +4321,13 @@ brick:Return_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Return Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Return ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -4021,6 +4335,7 @@ brick:Return_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Return_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature .
@@ -4043,10 +4358,11 @@ brick:Return_Fan a owl:Class ;
 
 brick:Return_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Return Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Fan,
+        tag:Point,
         tag:Return,
         tag:Setpoint,
         tag:Speed .
@@ -4072,72 +4388,80 @@ brick:Roof a owl:Class ;
 
 brick:Room_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Room Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Room _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Room,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Run_Enable_Command a owl:Class ;
     rdfs:label "Run Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Run ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Run ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:Run .
 
 brick:Run_Enable_Status a owl:Class ;
     rdfs:label "Run Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Enable _:has_Status ) ],
         brick:Enable_Status,
         brick:Run_Status ;
     brick:hasAssociatedTag tag:Enable,
+        tag:Point,
         tag:Run,
         tag:Status .
 
 brick:Run_Request_Command a owl:Class ;
     rdfs:label "Run Request Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Request _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Request _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Request,
         tag:Run .
 
 brick:Run_Request_Status a owl:Class ;
     rdfs:label "Run Request Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Request _:has_Run _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Request _:has_Run _:has_Status ) ],
         brick:Run_Status ;
-    brick:hasAssociatedTag tag:Request,
+    brick:hasAssociatedTag tag:Point,
+        tag:Request,
         tag:Run,
         tag:Status .
 
 brick:Run_Time_Sensor a owl:Class ;
     rdfs:label "Run Time Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Time _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Time _:has_Sensor ) ],
         brick:Duration_Sensor ;
-    brick:hasAssociatedTag tag:Run,
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
         tag:Sensor,
         tag:Time .
 
 brick:Sash_Position_Sensor a owl:Class ;
     rdfs:label "Sash Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Sash ;
                         owl:onProperty brick:hasTag ] _:has_Position _:has_Sensor ) ],
         brick:Position_Sensor ;
-    brick:hasAssociatedTag tag:Position,
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
         tag:Sash,
         tag:Sensor .
 
 brick:Schedule_Temperature_Setpoint a owl:Class ;
     rdfs:label "Schedule Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Schedule ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Temperature_Setpoint ;
     skos:definition "The current setpoint as indicated by the schedule" ;
-    brick:hasAssociatedTag tag:Schedule,
+    brick:hasAssociatedTag tag:Point,
+        tag:Schedule,
         tag:Setpoint,
         tag:Temperature .
 
@@ -4162,22 +4486,24 @@ brick:Shading_System a owl:Class ;
 
 brick:Short_Cycle_Alarm a owl:Class ;
     rdfs:label "Short Cycle Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Short ;
                         owl:onProperty brick:hasTag ] _:has_Cycle _:has_Alarm ) ],
         brick:Cycle_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Cycle,
+        tag:Point,
         tag:Short .
 
 brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
     rdfs:label "Solar Azimuth Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solar [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
                         owl:hasValue tag:Azimuth ;
                         owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
         brick:Angle_Sensor ;
     brick:hasAssociatedTag tag:Angle,
         tag:Azimuth,
+        tag:Point,
         tag:Sensor,
         tag:Solar .
 
@@ -4190,24 +4516,26 @@ brick:Solar_Panel a owl:Class ;
 
 brick:Solar_Radiance_Sensor a owl:Class ;
     rdfs:label "Solar Radiance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Radiance ;
                         owl:onProperty brick:hasTag ] _:has_Solar ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Solar_Radiance ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Radiance,
+    brick:hasAssociatedTag tag:Point,
+        tag:Radiance,
         tag:Sensor,
         tag:Solar .
 
 brick:Solar_Zenith_Angle_Sensor a owl:Class ;
     rdfs:label "Solar Zenith Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solar [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
                         owl:hasValue tag:Zenith ;
                         owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
         brick:Angle_Sensor ;
     brick:hasAssociatedTag tag:Angle,
+        tag:Point,
         tag:Sensor,
         tag:Solar,
         tag:Zenith .
@@ -4232,18 +4560,20 @@ brick:Space_Heater a owl:Class ;
 
 brick:Speed_Status a owl:Class ;
     rdfs:label "Speed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Speed,
+    brick:hasAssociatedTag tag:Point,
+        tag:Speed,
         tag:Status .
 
 brick:Stages_Status a owl:Class ;
     rdfs:label "Stages Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Stages ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Stages,
+    brick:hasAssociatedTag tag:Point,
+        tag:Stages,
         tag:Status .
 
 brick:Standby_Fan a owl:Class ;
@@ -4256,32 +4586,35 @@ brick:Standby_Fan a owl:Class ;
 
 brick:Standby_Glycool_Unit_On_Off_Status a owl:Class ;
     rdfs:label "Standby Glycool Unit On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby [ a owl:Restriction ;
                         owl:hasValue tag:Glycool ;
                         owl:onProperty brick:hasTag ] _:has_Unit _:has_On _:has_Off _:has_Status ) ],
         brick:Standby_Unit_On_Off_Status ;
     brick:hasAssociatedTag tag:Glycool,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Standby,
         tag:Status,
         tag:Unit .
 
 brick:Start_Stop_Command a owl:Class ;
     rdfs:label "Start Stop Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Start _:has_Stop _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Command ) ],
         brick:On_Off_Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Start,
         tag:Stop .
 
 brick:Steam_On_Off_Command a owl:Class ;
     rdfs:label "Steam On Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Steam _:has_On _:has_Off _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Steam _:has_On _:has_Off _:has_Command ) ],
         brick:On_Off_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Steam .
 
 brick:Steam_System a owl:Class ;
@@ -4293,28 +4626,30 @@ brick:Steam_System a owl:Class ;
 
 brick:Supply_Air_Duct_Pressure_Status a owl:Class ;
     rdfs:label "Supply Air Duct Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Duct,
+        tag:Point,
         tag:Pressure,
         tag:Status,
         tag:Supply .
 
 brick:Supply_Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Supply Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Demand_Setpoint,
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Supply_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Supply Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Supply ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -4323,38 +4658,42 @@ brick:Supply_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Supply_Air_Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Supply Air Integral Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Integral _:has_Gain _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Integral _:has_Gain _:has_Parameter _:has_PID ) ],
         brick:Integral_Gain_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Gain,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply .
 
 brick:Supply_Air_Proportional_Gain_Parameter a owl:Class ;
     rdfs:label "Supply Air Proportional Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Proportional _:has_Supply _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional _:has_Supply _:has_Air ) ],
         brick:Proportional_Gain_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Gain,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply .
 
 brick:Supply_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Air Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Static_Pressure_Deadband_Setpoint,
         brick:Supply_Air_Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -4362,12 +4701,13 @@ brick:Supply_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Air Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Supply,
@@ -4375,12 +4715,13 @@ brick:Supply_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static,
@@ -4388,7 +4729,7 @@ brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Supply Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Supply ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -4396,6 +4737,7 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static,
@@ -4403,19 +4745,21 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
 
 brick:Supply_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Supply Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_Differential_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -4423,10 +4767,11 @@ brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
 
 brick:Supply_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_High_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:High,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -4434,10 +4779,11 @@ brick:Supply_Air_Temperature_Reset_High_Setpoint a owl:Class ;
 
 brick:Supply_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_Low_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Low,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -4445,17 +4791,18 @@ brick:Supply_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
 
 brick:Supply_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Supply Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Air_Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Supply Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Supply _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Supply _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -4463,6 +4810,7 @@ brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Supply,
@@ -4470,23 +4818,25 @@ brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
 
 brick:Supply_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Supply Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Fan,
+        tag:Point,
         tag:Setpoint,
         tag:Speed,
         tag:Supply .
 
 brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter,
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Supply,
         tag:Time,
@@ -4494,19 +4844,21 @@ brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Supply Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Water_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Water .
 
 brick:Supply_Water_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Water Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Supply_Water_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature,
@@ -4514,12 +4866,13 @@ brick:Supply_Water_Temperature_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Water_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Water Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time,
@@ -4527,12 +4880,13 @@ brick:Supply_Water_Temperature_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Water Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature,
@@ -4540,57 +4894,63 @@ brick:Supply_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
 
 brick:System_Mode_Status a owl:Class ;
     rdfs:label "System Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Mode _:has_Status ) ],
         brick:Mode_Status,
         brick:System_Status ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Status,
         tag:System .
 
 brick:System_Shutdown_Status a owl:Class ;
     rdfs:label "System Shutdown Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Shutdown _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Shutdown _:has_Status ) ],
         brick:Status,
         brick:System_Status ;
-    brick:hasAssociatedTag tag:Shutdown,
+    brick:hasAssociatedTag tag:Point,
+        tag:Shutdown,
         tag:Status,
         tag:System .
 
 brick:Temperature_Adjust_Sensor a owl:Class ;
     rdfs:label "Temperature Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust _:has_Temperature ) ],
         brick:Adjust_Sensor ;
     brick:hasAssociatedTag tag:Adjust,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Temperature_Tolerance_Parameter a owl:Class ;
     rdfs:label "Temperature Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Temperature ) ],
         brick:Temperature_Parameter,
         brick:Tolerance_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Tolerance .
 
 brick:Temporary_Occupancy_Status a owl:Class ;
     rdfs:label "Temporary Occupancy Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Temporary ;
                         owl:onProperty brick:hasTag ] _:has_Occupancy _:has_Status ) ],
         brick:Occupancy_Status ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Status,
         tag:Temporary .
 
 brick:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Thermal Energy Storage Discharge Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Thermal _:has_Energy _:has_Storage _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Thermal _:has_Energy _:has_Storage _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Discharge,
         tag:Energy,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Storage,
@@ -4599,11 +4959,12 @@ brick:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setp
 
 brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Thermal Energy Storage Supply Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Thermal _:has_Energy _:has_Storage _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Thermal _:has_Energy _:has_Storage _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Supply_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Energy,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Storage,
@@ -4623,18 +4984,20 @@ brick:Thermostat a owl:Class ;
 
 brick:Today_Peak_Energy_Sensor a owl:Class ;
     rdfs:label "Today Peak Energy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Energy _:has_Today _:has_Peak ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy _:has_Today _:has_Peak ) ],
         brick:Energy_Sensor ;
     brick:hasAssociatedTag tag:Energy,
         tag:Peak,
+        tag:Point,
         tag:Sensor,
         tag:Today .
 
 brick:Today_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Today Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Today _:has_Sensor _:has_Usage _:has_Steam ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Today _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Today,
         tag:Usage .
@@ -4651,113 +5014,125 @@ brick:Touchpanel a owl:Class ;
 
 brick:Trace_Heat_Sensor a owl:Class ;
     rdfs:label "Trace Heat Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Trace ;
                         owl:onProperty brick:hasTag ] _:has_Heat _:has_Sensor ) ],
         brick:Heat_Sensor ;
     brick:hasAssociatedTag tag:Heat,
+        tag:Point,
         tag:Sensor,
         tag:Trace .
 
 brick:Turn_Off_Status a owl:Class ;
     rdfs:label "Turn Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Turn _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Turn _:has_Off _:has_Status ) ],
         brick:Off_Status ;
     brick:hasAssociatedTag tag:Off,
+        tag:Point,
         tag:Status,
         tag:Turn .
 
 brick:Turn_On_Status a owl:Class ;
     rdfs:label "Turn On Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Turn _:has_On _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Turn _:has_On _:has_Status ) ],
         brick:On_Status ;
     brick:hasAssociatedTag tag:On,
+        tag:Point,
         tag:Status,
         tag:Turn .
 
 brick:Underfloor_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Underfloor Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Underfloor ;
                         owl:onProperty brick:hasTag ] _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Underfloor .
 
 brick:Unit_Failure_Alarm a owl:Class ;
     rdfs:label "Unit Failure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unit _:has_Failure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unit _:has_Failure _:has_Alarm ) ],
         brick:Failure_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Failure,
+        tag:Point,
         tag:Unit .
 
 brick:Unoccupied_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Cooling _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cooling _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Unoccupied_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Unoccupied_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Heating _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Heating _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Unoccupied_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Cooling_Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Unoccupied_Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Unoccupied Hot Water Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
         brick:Hot_Water_Shutdown_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Hot,
+        tag:Point,
         tag:Shutdown,
         tag:Unoccupied,
         tag:Water .
 
 brick:Unoccupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:VFD_Enable_Command a owl:Class ;
     rdfs:label "VFD Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_VFD ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_VFD ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:VFD .
 
 brick:Valve_Command a owl:Class ;
     rdfs:label "Valve Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Valve _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Valve .
 
 brick:Variable_Air_Volume_Box_With_Reheat a owl:Class ;
@@ -4784,51 +5159,56 @@ brick:Variable_Frequency_Drive a owl:Class ;
 
 brick:Velocity_Pressure_Setpoint a owl:Class ;
     rdfs:label "Velocity Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Velocity _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Velocity _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint,
         tag:Velocity .
 
 brick:Vent_Operating_Mode_Status a owl:Class ;
     rdfs:label "Vent Operating Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Vent ;
                         owl:onProperty brick:hasTag ] _:has_Operating _:has_Mode _:has_Status ) ],
         brick:Operating_Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Operating,
+        tag:Point,
         tag:Status,
         tag:Vent .
 
 brick:Ventilation_Air_Flow_Ratio_Limit a owl:Class ;
     rdfs:label "Ventilation Air Flow Ratio Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Ventilation _:has_Air [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ventilation _:has_Air [ a owl:Restriction ;
                         owl:hasValue tag:Ratio ;
                         owl:onProperty brick:hasTag ] _:has_Limit ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
+        tag:Point,
         tag:Ratio,
         tag:Ventilation .
 
 brick:Warm_Cool_Adjust_Sensor a owl:Class ;
     rdfs:label "Warm Cool Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust [ a owl:Restriction ;
                         owl:hasValue tag:Warm ;
                         owl:onProperty brick:hasTag ] _:has_Cool ) ],
         brick:Adjust_Sensor ;
     brick:hasAssociatedTag tag:Adjust,
         tag:Cool,
+        tag:Point,
         tag:Sensor,
         tag:Warm .
 
 brick:Water_Loss_Alarm a owl:Class ;
     rdfs:label "Water Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Loss _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Loss _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Loss,
+        tag:Point,
         tag:Water .
 
 brick:Weather a owl:Class ;
@@ -4841,23 +5221,25 @@ brick:Weather a owl:Class ;
 
 brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Direction _:has_Wind ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction _:has_Wind ) ],
         brick:Direction_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Wind_Direction ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Sensor,
         tag:Wind .
 
 brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed _:has_Wind ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Wind ) ],
         brick:Speed_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Wind_Speed ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Speed,
         tag:Wind .
 
@@ -4872,18 +5254,19 @@ brick:Wing a owl:Class ;
 
 brick:Yearly_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Yearly Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Yearly ;
                         owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Usage,
         tag:Yearly .
 
 brick:Zone_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Zone Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Zone ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Zone ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -4892,34 +5275,38 @@ brick:Zone_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor,
         tag:Zone .
 
 brick:Zone_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Zone Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Zone .
 
 brick:Zone_Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Standby Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
         brick:Standby_Load_Shed_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Standby,
         tag:Zone .
 
 brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Unoccupied Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
         brick:Unoccupied_Load_Shed_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Unoccupied,
         tag:Zone .
@@ -4955,31 +5342,34 @@ brick:Acceleration_Time a owl:Class,
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Air Flow Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint,
         brick:Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Air Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Static_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
 
 brick:Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -5014,10 +5404,11 @@ brick:Blowdown_Water a owl:Class,
 
 brick:CO2_Alarm a owl:Class ;
     rdfs:label "CO2 Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:CO2 .
+        tag:CO2,
+        tag:Point .
 
 brick:CO2_Level a owl:Class,
         brick:CO2_Level ;
@@ -5027,9 +5418,10 @@ brick:CO2_Level a owl:Class,
 
 brick:CO2_Setpoint a owl:Class ;
     rdfs:label "CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:CO2,
+        tag:Point,
         tag:Setpoint .
 
 brick:CRAC a owl:Class ;
@@ -5053,23 +5445,25 @@ brick:CWS a owl:Class ;
 
 brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Setpoint,
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status,
@@ -5082,12 +5476,13 @@ brick:Cloudage a owl:Class,
 
 brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Coldest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Coldest ;
                         owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Coldest,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -5124,37 +5519,41 @@ brick:Condenser_Water a owl:Class,
 
 brick:Conductivity_Sensor a owl:Class ;
     rdfs:label "Conductivity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Conductivity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Conductivity ;
                         owl:onProperty brick:measures ] ) ] ;
     skos:definition "senses or detects electrical conductance" ;
     brick:hasAssociatedTag tag:Conductivity,
+        tag:Point,
         tag:Sensor .
 
 brick:Cooling_Command a owl:Class ;
     rdfs:label "Cooling Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cool _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Cool .
+        tag:Cool,
+        tag:Point .
 
 brick:Cooling_Request_Setpoint a owl:Class ;
     rdfs:label "Cooling Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Request _:has_Setpoint ) ],
         brick:Request_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
@@ -5180,17 +5579,19 @@ brick:Current_Total_Harmonic_Distortion a owl:Class,
 
 brick:Cycle_Alarm a owl:Class ;
     rdfs:label "Cycle Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cycle _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cycle _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Cycle .
+        tag:Cycle,
+        tag:Point .
 
 brick:Damper_Command a owl:Class ;
     rdfs:label "Damper Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Damper .
+        tag:Damper,
+        tag:Point .
 
 brick:Daytime a owl:Class,
         brick:Daytime ;
@@ -5204,47 +5605,52 @@ brick:Deceleration_Time a owl:Class,
 
 brick:Delay_Parameter a owl:Class ;
     rdfs:label "Delay Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Delay _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Delay _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Delay,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Demand_Sensor a owl:Class ;
     rdfs:label "Demand Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Demand ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Demand,
+        tag:Point,
         tag:Sensor .
 
 brick:Differential_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Differential Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Step .
 
 brick:Direction_Sensor a owl:Class ;
     rdfs:label "Direction Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Direction ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Direction ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Sensor .
 
 brick:Direction_Status a owl:Class ;
     rdfs:label "Direction Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Direction _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Status .
 
 brick:Discharge_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Discharge Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Discharge ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -5254,54 +5660,59 @@ brick:Discharge_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Discharge_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Discharge Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Discharge,
+        tag:Point,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Cooling _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Cooling _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Discharge_Air_Temperature_Setpoint ;
     owl:equivalentClass brick:Max_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Heating _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heating _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint,
         brick:Heating_Temperature_Setpoint ;
     owl:equivalentClass brick:Min_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Discharge ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -5310,23 +5721,25 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band,
         brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter,
         brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter ;
@@ -5335,13 +5748,14 @@ brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Cl
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Discharge_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Discharge Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge ) ],
         brick:Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -5350,6 +5764,7 @@ brick:Discharge_Water_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -5364,10 +5779,11 @@ brick:Domestic_Hot_Water_System a owl:Class ;
 
 brick:Domestic_Hot_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Domestic Hot Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
@@ -5395,12 +5811,13 @@ brick:Electric_Energy a owl:Class,
 
 brick:Energy_Sensor a owl:Class ;
     rdfs:label "Energy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Energy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Energy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Energy,
+        tag:Point,
         tag:Sensor .
 
 brick:Energy_Storage a owl:Class ;
@@ -5413,17 +5830,18 @@ brick:Energy_Storage a owl:Class ;
 
 brick:Enthalpy_Sensor a owl:Class ;
     rdfs:label "Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Enthalpy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Flow_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Flow Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
@@ -5431,11 +5849,12 @@ brick:Exhaust_Air_Flow_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Exhaust_Air_Flow_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Flow Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -5443,11 +5862,12 @@ brick:Exhaust_Air_Flow_Proportional_Band_Parameter a owl:Class ;
         tag:Flow,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Exhaust ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -5457,24 +5877,27 @@ brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Exhaust_Air_Stack_Flow_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Setpoint ) ],
         brick:Exhaust_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Stack .
 
@@ -5497,16 +5920,18 @@ brick:FCU a owl:Class ;
 
 brick:Failure_Alarm a owl:Class ;
     rdfs:label "Failure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Failure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Failure _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Failure .
+        tag:Failure,
+        tag:Point .
 
 brick:Fan_Status a owl:Class ;
     rdfs:label "Fan Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Fan,
+        tag:Point,
         tag:Status .
 
 brick:Filter a owl:Class ;
@@ -5519,9 +5944,10 @@ brick:Filter a owl:Class ;
 
 brick:Filter_Status a owl:Class ;
     rdfs:label "Filter Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Filter _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Filter,
+        tag:Point,
         tag:Status .
 
 brick:Flow_Loss a owl:Class,
@@ -5531,35 +5957,39 @@ brick:Flow_Loss a owl:Class,
 
 brick:Flow_Setpoint a owl:Class ;
     rdfs:label "Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Flow _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Frequency_Command a owl:Class ;
     rdfs:label "Frequency Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fequency _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fequency _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Fequency .
+        tag:Fequency,
+        tag:Point .
 
 brick:Frequency_Sensor a owl:Class ;
     rdfs:label "Frequency Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Frequency ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frequency ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Frequency ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Frequency,
+        tag:Point,
         tag:Sensor .
 
 brick:Fresh_Air_Setpoint_Limit a owl:Class ;
     rdfs:label "Fresh Air Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Fresh,
         tag:Limit,
+        tag:Point,
         tag:Setpoint .
 
 brick:Fuel_Oil a owl:Class,
@@ -5606,36 +6036,40 @@ brick:HX a owl:Class ;
 
 brick:Heat_Sensor a owl:Class ;
     rdfs:label "Heat Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Heat ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Heat ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Heat,
+        tag:Point,
         tag:Sensor .
 
 brick:Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Heating Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:Heating,
+        tag:Point,
         tag:Setpoint .
 
 brick:Heating_Request_Setpoint a owl:Class ;
     rdfs:label "Heating Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Request _:has_Setpoint ) ],
         brick:Request_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Heating_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Heating Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
@@ -5648,11 +6082,12 @@ brick:Heating_Ventilation_Air_Conditioning_System a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status,
@@ -5660,7 +6095,7 @@ brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -5669,35 +6104,39 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Hot Water Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
         brick:Shutdown_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Hot,
+        tag:Point,
         tag:Shutdown,
         tag:Water .
 
 brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status ;
     brick:hasAssociatedTag tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status,
         tag:Supply,
@@ -5706,22 +6145,24 @@ brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Hot Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Hot _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Hot _:has_Water _:has_System ) ],
         brick:System_Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Hot,
+        tag:Point,
         tag:System,
         tag:Water .
 
 brick:Humidity_Sensor a owl:Class ;
     rdfs:label "Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Ice a owl:Class,
@@ -5735,33 +6176,36 @@ brick:Ice a owl:Class,
 
 brick:Illuminance_Sensor a owl:Class ;
     rdfs:label "Illuminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Illuminance ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Illuminance ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Illuminance,
+        tag:Point,
         tag:Sensor .
 
 brick:Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Integral Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Integral ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:Integral,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Leak_Alarm a owl:Class ;
     rdfs:label "Leak Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Leak _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leak _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Leak .
+        tag:Leak,
+        tag:Point .
 
 brick:Leaving_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Leaving Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Leaving ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Leaving ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -5769,6 +6213,7 @@ brick:Leaving_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Leaving_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
@@ -5785,35 +6230,39 @@ brick:Liquid_CO2 a owl:Class,
 
 brick:Load_Parameter a owl:Class ;
     rdfs:label "Load Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Load,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Load_Setpoint a owl:Class ;
     rdfs:label "Load Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Setpoint .
 
 brick:Load_Shed_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Load Shed Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint,
         brick:Load_Shed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed .
 
 brick:Low_Temperature_Alarm a owl:Class ;
     rdfs:label "Low Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Low,
+        tag:Point,
         tag:Temperature .
 
 brick:Luminous_Flux a owl:Class,
@@ -5841,31 +6290,34 @@ brick:Makeup_Water a owl:Class,
 
 brick:Max_Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Max Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Max _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Max _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Max,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Max_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
         tag:Medium,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status,
@@ -5873,31 +6325,34 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:
 
 brick:Min_Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Min Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Min _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Min _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Min,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Min_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Motion_Sensor a owl:Class ;
     rdfs:label "Motion Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Motion ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Motion,
+        tag:Point,
         tag:Sensor .
 
 brick:Natural_Gas a owl:Class,
@@ -5924,41 +6379,46 @@ brick:Occupancy_Percentage a owl:Class,
 
 brick:Occupancy_Sensor a owl:Class ;
     rdfs:label "Occupancy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Occupancy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Occupancy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Occupancy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Sensor .
 
 brick:Occupancy_Status a owl:Class ;
     rdfs:label "Occupancy Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupancy _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Status .
 
 brick:Off_Command a owl:Class ;
     rdfs:label "Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Off _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Command ) ],
         brick:On_Off_Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Off .
+        tag:Off,
+        tag:Point .
 
 brick:On_Command a owl:Class ;
     rdfs:label "On Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Command ) ],
         brick:On_Off_Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:On .
+        tag:On,
+        tag:Point .
 
 brick:Operating_Mode_Status a owl:Class ;
     rdfs:label "Operating Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Operating _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Operating _:has_Mode _:has_Status ) ],
         brick:Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Operating,
+        tag:Point,
         tag:Status .
 
 brick:Operative_Temperature a owl:Class,
@@ -5968,21 +6428,23 @@ brick:Operative_Temperature a owl:Class,
 
 brick:Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Temperature Enable Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Enable,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Override_Command a owl:Class ;
     rdfs:label "Override Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Override _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Override _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Override .
+        tag:Override,
+        tag:Point .
 
 brick:PM10_Level a owl:Class,
         brick:PM10_Level ;
@@ -5998,27 +6460,30 @@ brick:PM25_Level a owl:Class,
 
 brick:PV_Current_Output_Sensor a owl:Class ;
     rdfs:label "PV Current Output Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:PV ;
                         owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
         brick:Current_Output_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Output,
         tag:PV,
+        tag:Point,
         tag:Sensor .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Position .
 
 brick:Power_Alarm a owl:Class ;
     rdfs:label "Power Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Power .
 
 brick:Power_Factor a owl:Class,
@@ -6028,10 +6493,11 @@ brick:Power_Factor a owl:Class,
 
 brick:Power_Loss_Alarm a owl:Class ;
     rdfs:label "Power Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Loss _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Alarm ) ],
         brick:Power_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Loss,
+        tag:Point,
         tag:Power .
 
 brick:Power_Meter a owl:Class ;
@@ -6057,11 +6523,12 @@ brick:Precipitation a owl:Class,
 
 brick:Proportional_Gain_Parameter a owl:Class ;
     rdfs:label "Proportional Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Proportional ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Pump a owl:Class ;
@@ -6098,17 +6565,19 @@ brick:Radiant_Temperature a owl:Class,
 
 brick:Rain_Sensor a owl:Class ;
     rdfs:label "Rain Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Rain ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain ) ],
         brick:Sensor ;
-    brick:hasAssociatedTag tag:Rain,
+    brick:hasAssociatedTag tag:Point,
+        tag:Rain,
         tag:Sensor .
 
 brick:Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Return Air CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
         brick:CO2_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
+        tag:Point,
         tag:Return,
         tag:Setpoint .
 
@@ -6125,24 +6594,27 @@ brick:Rooftop_Unit a owl:Class ;
 
 brick:Shutdown_Command a owl:Class ;
     rdfs:label "Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shutdown _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shutdown _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Shutdown .
 
 brick:Smoke_Alarm a owl:Class ;
     rdfs:label "Smoke Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Smoke _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Smoke .
 
 brick:Smoke_Detected_Alarm a owl:Class ;
     rdfs:label "Smoke Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Smoke _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Detected _:has_Alarm ) ],
         brick:Smoke_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Detected,
+        tag:Point,
         tag:Smoke .
 
 brick:Solar_Irradiance a owl:Class,
@@ -6152,36 +6624,40 @@ brick:Solar_Irradiance a owl:Class,
 
 brick:Speed_Reset_Command a owl:Class ;
     rdfs:label "Speed Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Reset _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Reset _:has_Command ) ],
         brick:Reset_Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Reset,
         tag:Speed .
 
 brick:Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Standby Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
         brick:Load_Shed_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Standby .
 
 brick:Standby_Unit_On_Off_Status a owl:Class ;
     rdfs:label "Standby Unit On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby _:has_Unit _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Unit _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Standby,
         tag:Status,
         tag:Unit .
 
 brick:Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
@@ -6198,7 +6674,7 @@ brick:Steam a owl:Class,
 
 brick:Supply_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Supply Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Supply ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -6207,14 +6683,16 @@ brick:Supply_Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Supply Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -6222,7 +6700,7 @@ brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Supply_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Supply Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Supply ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -6230,6 +6708,7 @@ brick:Supply_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature .
@@ -6244,10 +6723,11 @@ brick:Supply_Fan a owl:Class ;
 
 brick:Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Supply,
@@ -6255,12 +6735,13 @@ brick:Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Supply,
@@ -6268,7 +6749,7 @@ brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class
 
 brick:Supply_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Supply Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply ) ],
         brick:Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -6276,6 +6757,7 @@ brick:Supply_Water_Flow_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Water .
@@ -6296,10 +6778,11 @@ brick:TVOC_Level a owl:Class,
 
 brick:Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
@@ -6315,28 +6798,31 @@ brick:Thermal_Power a owl:Class,
 
 brick:Thermal_Power_Sensor a owl:Class ;
     rdfs:label "Thermal Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power _:has_Thermal ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Thermal ) ],
         brick:Power_Sensor ;
-    brick:hasAssociatedTag tag:Power,
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
         tag:Sensor,
         tag:Thermal .
 
 brick:Torque_Sensor a owl:Class ;
     rdfs:label "Torque Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Torque ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Torque ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Torque ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Torque .
 
 brick:Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Unoccupied Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
         brick:Load_Shed_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Unoccupied .
 
@@ -6366,11 +6852,12 @@ brick:Voltage_Magnitude a owl:Class,
 
 brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Warmest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Warmest ;
                         owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Warmest,
@@ -6378,7 +6865,7 @@ brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
 
 brick:Water_Level_Sensor a owl:Class ;
     rdfs:label "Water Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Water _:has_Level ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Water ;
@@ -6386,6 +6873,7 @@ brick:Water_Level_Sensor a owl:Class ;
                         owl:hasValue brick:Level ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Level,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -6400,9 +6888,10 @@ brick:Water_Meter a owl:Class ;
 
 brick:Water_Usage_Sensor a owl:Class ;
     rdfs:label "Water Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Water ) ],
         brick:Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Usage,
         tag:Water .
 
@@ -6510,21 +6999,23 @@ brick:Active_Power a owl:Class,
 
 brick:Adjust_Sensor a owl:Class ;
     rdfs:label "Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Adjust,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Alarm a owl:Class ;
     rdfs:label "Air Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Air,
-        tag:Alarm .
+        tag:Alarm,
+        tag:Point .
 
 brick:Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -6533,31 +7024,34 @@ brick:Air_Enthalpy_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint,
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Grains_Sensor a owl:Class ;
     rdfs:label "Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Air _:has_Grains ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Air _:has_Grains ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Air ;
@@ -6566,14 +7060,16 @@ brick:Air_Grains_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
@@ -6584,12 +7080,13 @@ brick:Angle a owl:Class,
 
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Angle _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Angle _:has_Sensor ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Angle ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Angle,
+        tag:Point,
         tag:Sensor .
 
 brick:Building_Air a owl:Class,
@@ -6621,10 +7118,11 @@ brick:Capacity a owl:Class,
 
 brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
@@ -6646,56 +7144,61 @@ brick:Coil a owl:Class ;
 
 brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Current_Output_Sensor a owl:Class ;
     rdfs:label "Current Output Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Current _:has_Output _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Output _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Output,
+        tag:Point,
         tag:Sensor .
 
 brick:Dewpoint_Sensor a owl:Class ;
     rdfs:label "Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint ) ],
         brick:Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Reset,
         tag:Setpoint .
 
 brick:Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
@@ -6703,27 +7206,30 @@ brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_Differential_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Discharge,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -6741,25 +7247,28 @@ brick:Discharge_Chilled_Water a owl:Class,
 
 brick:Effective_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Effective,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Emergency_Alarm a owl:Class ;
     rdfs:label "Emergency Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Emergency .
+        tag:Emergency,
+        tag:Point .
 
 brick:Enable_Status a owl:Class ;
     rdfs:label "Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Enable,
+        tag:Point,
         tag:Status .
 
 brick:Entering_Water a owl:Class,
@@ -6774,7 +7283,7 @@ brick:Entering_Water a owl:Class,
 
 brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Exhaust ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -6783,6 +7292,7 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
@@ -6798,13 +7308,14 @@ brick:Fire_Safety_System a owl:Class ;
 
 brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
                         owl:onProperty brick:measures ] ) ] ;
     skos:definition "senses or detects flow in a fluid" ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Frost a owl:Class,
@@ -6834,17 +7345,19 @@ brick:Heat_Exchanger a owl:Class ;
 
 brick:High_Temperature_Alarm a owl:Class ;
     rdfs:label "High Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
+        tag:Point,
         tag:Temperature .
 
 brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Return_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -6852,10 +7365,11 @@ brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_High_Reset_Setpoint ;
     brick:hasAssociatedTag tag:High,
         tag:Hot,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -6864,10 +7378,11 @@ brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
 
 brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Temperature_Low_Reset_Setpoint ;
     brick:hasAssociatedTag tag:Hot,
         tag:Low,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Supply,
@@ -6876,10 +7391,11 @@ brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
 
 brick:Humidity_Alarm a owl:Class ;
     rdfs:label "Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Humidity .
+        tag:Humidity,
+        tag:Point .
 
 brick:Illuminance a owl:Class,
         brick:Illuminance ;
@@ -6921,15 +7437,16 @@ brick:Lighting_System a owl:Class ;
 
 brick:Load_Shed_Command a owl:Class ;
     rdfs:label "Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Load,
+        tag:Point,
         tag:Shed .
 
 brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6938,11 +7455,12 @@ brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6950,12 +7468,13 @@ brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -6964,11 +7483,12 @@ brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -6976,24 +7496,26 @@ brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -7002,11 +7524,12 @@ brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -7014,12 +7537,13 @@ brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -7028,11 +7552,12 @@ brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -7040,17 +7565,19 @@ brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
@@ -7068,21 +7595,23 @@ brick:Mixed_Air a owl:Class,
 
 brick:Occupied_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
@@ -7097,18 +7626,19 @@ brick:Oil a owl:Class,
 
 brick:Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Outside_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Outside Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Outside ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -7117,14 +7647,16 @@ brick:Outside_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Overridden_Status a owl:Class ;
     rdfs:label "Overridden Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Overridden,
+        tag:Point,
         tag:Status .
 
 brick:Peak_Power a owl:Class,
@@ -7140,36 +7672,40 @@ brick:Position a owl:Class,
 
 brick:Position_Limit a owl:Class ;
     rdfs:label "Position Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Limit ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Limit ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
+        tag:Point,
         tag:Position .
 
 brick:Position_Sensor a owl:Class ;
     rdfs:label "Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Sensor ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Position ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Position,
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
         tag:Sensor .
 
 brick:Power_Sensor a owl:Class ;
     rdfs:label "Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Power ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Power,
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
         tag:Sensor .
 
 brick:Pressure_Alarm a owl:Class ;
     rdfs:label "Pressure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Pressure .
 
 brick:Radiance a owl:Class,
@@ -7194,17 +7730,19 @@ brick:Relative_Humidity a owl:Class,
 
 brick:Request_Setpoint a owl:Class ;
     rdfs:label "Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Request _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Request,
+    brick:hasAssociatedTag tag:Point,
+        tag:Request,
         tag:Setpoint .
 
 brick:Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
@@ -7220,14 +7758,15 @@ brick:Return_Water a owl:Class,
 
 brick:Return_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Return Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Return ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] [ a owl:Restriction ;
                         owl:hasValue brick:Return_Water ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Return,
+    brick:hasAssociatedTag tag:Point,
+        tag:Return,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
@@ -7241,9 +7780,10 @@ brick:Room a owl:Class ;
 
 brick:Run_Status a owl:Class ;
     rdfs:label "Run Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Status ) ],
         brick:Start_Stop_Status ;
-    brick:hasAssociatedTag tag:Run,
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
         tag:Status .
 
 brick:Solar_Radiance a owl:Class,
@@ -7253,61 +7793,67 @@ brick:Solar_Radiance a owl:Class,
 
 brick:Speed_Setpoint a owl:Class ;
     rdfs:label "Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Speed .
 
 brick:Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Time .
 
 brick:Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
@@ -7326,38 +7872,42 @@ brick:Supply_Hot_Water a owl:Class,
 
 brick:Supply_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Supply Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Supply,
         tag:Temperature,
         tag:Water .
 
 brick:System_Enable_Command a owl:Class ;
     rdfs:label "System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_System ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:System .
 
 brick:Temperature_Differential_Reset_Setpoint a owl:Class ;
     rdfs:label "Temperature Differential Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
         brick:Reset_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Temperature .
 
 brick:Thermal_Power_Meter a owl:Class ;
@@ -7371,23 +7921,26 @@ brick:Thermal_Power_Meter a owl:Class ;
 
 brick:Time_Parameter a owl:Class ;
     rdfs:label "Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Time ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Time ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Time_Setpoint a owl:Class ;
     rdfs:label "Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Time .
 
 brick:Tolerance_Parameter a owl:Class ;
     rdfs:label "Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Tolerance .
 
 brick:Torque a owl:Class,
@@ -7397,18 +7950,20 @@ brick:Torque a owl:Class,
 
 brick:Unoccupied_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Usage_Sensor a owl:Class ;
     rdfs:label "Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage ) ],
         brick:Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Usage .
 
 brick:Variable_Air_Volume_Box a owl:Class ;
@@ -7423,10 +7978,11 @@ brick:Variable_Air_Volume_Box a owl:Class ;
 
 brick:Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm,
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Temperature,
         tag:Water .
 
@@ -7806,11 +8362,12 @@ brick:AHU a owl:Class ;
 
 brick:Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Alarm,
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
         tag:Temperature .
 
 brick:Chilled_Water_System a owl:Class ;
@@ -7824,7 +8381,7 @@ brick:Chilled_Water_System a owl:Class ;
 
 brick:Chilled_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -7832,6 +8389,7 @@ brick:Chilled_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Chilled_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
@@ -7848,12 +8406,13 @@ brick:Current a owl:Class,
 
 brick:Current_Sensor a owl:Class ;
     rdfs:label "Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Current ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Current ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Current ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Current,
+        tag:Point,
         tag:Sensor .
 
 brick:Deionized_Water a owl:Class,
@@ -7869,20 +8428,22 @@ brick:Deionized_Water a owl:Class,
 
 brick:Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status,
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status .
 
 brick:Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
@@ -7893,24 +8454,27 @@ brick:Direction a owl:Class,
 
 brick:Duration_Sensor a owl:Class ;
     rdfs:label "Duration Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Duration ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Duration ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Duration,
+        tag:Point,
         tag:Sensor .
 
 brick:Electrical_Power_Sensor a owl:Class ;
     rdfs:label "Electrical Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power _:has_Electrical ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Electrical ) ],
         brick:Power_Sensor ;
     brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
         tag:Power,
         tag:Sensor .
 
 brick:Fault_Status a owl:Class ;
     rdfs:label "Fault Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fault _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Fault,
+        tag:Point,
         tag:Status .
 
 brick:Fluid a owl:Class,
@@ -7927,11 +8491,12 @@ brick:Frequency a owl:Class,
 
 brick:Gain_Parameter a owl:Class ;
     rdfs:label "Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Hot_Water a owl:Class,
         brick:Hot_Water ;
@@ -7946,7 +8511,7 @@ brick:Hot_Water a owl:Class,
 
 brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Hot _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Hot _:has_Supply ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -7954,6 +8519,7 @@ brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Hot_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -7970,24 +8536,27 @@ brick:Hot_Water_System a owl:Class ;
 
 brick:Humidity_Parameter a owl:Class ;
     rdfs:label "Humidity Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Humidity,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shed _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shed _:has_Load _:has_Setpoint ) ],
         brick:Load_Setpoint ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Setpoint,
         tag:Shed .
 
 brick:Load_Shed_Status a owl:Class ;
     rdfs:label "Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status .
 
@@ -8000,61 +8569,69 @@ brick:Meter a owl:Class ;
 
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Mode .
+        tag:Mode,
+        tag:Point .
 
 brick:Mode_Setpoint a owl:Class ;
     rdfs:label "Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Setpoint .
 
 brick:Mode_Status a owl:Class ;
     rdfs:label "Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Status .
 
 brick:On_Status a owl:Class ;
     rdfs:label "On Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Pressure_Sensor a owl:Class ;
     rdfs:label "Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor .
 
 brick:Pressure_Setpoint a owl:Class ;
     rdfs:label "Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint .
 
 brick:Pressure_Status a owl:Class ;
     rdfs:label "Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Status .
 
 brick:Reset_Command a owl:Class ;
     rdfs:label "Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Reset .
 
 brick:Speed a owl:Class,
@@ -8064,48 +8641,53 @@ brick:Speed a owl:Class,
 
 brick:Speed_Sensor a owl:Class ;
     rdfs:label "Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Speed ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Speed .
 
 brick:Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Steam ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Usage .
 
 brick:Step_Parameter a owl:Class ;
     rdfs:label "Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Step ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Step ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Step .
 
 brick:Supply_Chilled_Water a owl:Class,
@@ -8122,25 +8704,28 @@ brick:Supply_Chilled_Water a owl:Class,
 
 brick:System_Status a owl:Class ;
     rdfs:label "System Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Status,
+    brick:hasAssociatedTag tag:Point,
+        tag:Status,
         tag:System .
 
 brick:Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Temperature High Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
         brick:Reset_Setpoint ;
     brick:hasAssociatedTag tag:High,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
         brick:Reset_Setpoint ;
     brick:hasAssociatedTag tag:Low,
+        tag:Point,
         tag:Reset,
         tag:Setpoint,
         tag:Temperature .
@@ -8159,12 +8744,13 @@ brick:VFD a owl:Class ;
 
 brick:Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity ) ],
         brick:Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor,
         tag:Velocity .
 
@@ -8175,17 +8761,18 @@ brick:Voltage a owl:Class,
 
 brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Voltage ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Voltage ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Voltage .
 
 brick:Water_Flow_Sensor a owl:Class ;
     rdfs:label "Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water ) ],
         brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -8193,6 +8780,7 @@ brick:Water_Flow_Sensor a owl:Class ;
                         owl:hasValue brick:Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -8341,9 +8929,6 @@ tag:Peak a brick:Tag ;
 tag:Percent a brick:Tag ;
     rdfs:label "Percent" .
 
-tag:Point a brick:Tag ;
-    rdfs:label "Point" .
-
 tag:Rain a brick:Tag ;
     rdfs:label "Rain" .
 
@@ -8379,13 +8964,14 @@ tag:Wind a brick:Tag ;
 
 brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
         brick:Integral_Time_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
@@ -8401,7 +8987,7 @@ brick:CO2 a owl:Class,
 
 brick:CO2_Sensor a owl:Class ;
     rdfs:label "CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_CO2 ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_CO2 ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Air ;
@@ -8409,6 +8995,7 @@ brick:CO2_Sensor a owl:Class ;
                         owl:hasValue brick:CO2 ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:CO2,
+        tag:Point,
         tag:Sensor .
 
 brick:Class a owl:Class .
@@ -8423,16 +9010,18 @@ brick:Damper a owl:Class ;
 
 brick:Deadband_Setpoint a owl:Class ;
     rdfs:label "Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deadband _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint .
 
 brick:Demand_Setpoint a owl:Class ;
     rdfs:label "Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Demand _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Demand,
+        tag:Point,
         tag:Setpoint .
 
 brick:Dewpoint a owl:Class,
@@ -8442,68 +9031,75 @@ brick:Dewpoint a owl:Class,
 
 brick:Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time .
 
 brick:Differential_Pressure_Proportional_Band a owl:Class ;
     rdfs:label "Differential Pressure Proportional Band" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:PID,
+        tag:Point,
         tag:Pressure,
         tag:Proportional .
 
 brick:Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential ) ],
         brick:Pressure_Sensor ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
 brick:Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Differential,
         tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Discharge_Water a owl:Class,
@@ -8523,11 +9119,12 @@ brick:Electric_Voltage a owl:Class,
 
 brick:Emergency_Power_Off_Status a owl:Class ;
     rdfs:label "Emergency Power Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status .
 
@@ -8564,7 +9161,7 @@ brick:Luminance a owl:Class,
 
 brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -8572,6 +9169,7 @@ brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Measurable a owl:Class ;
@@ -8585,24 +9183,27 @@ brick:Occupancy a owl:Class,
 
 brick:Off_Status a owl:Class ;
     rdfs:label "Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Off,
+        tag:Point,
         tag:Status .
 
 brick:PID_Parameter a owl:Class ;
     rdfs:label "PID Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Reset_Setpoint a owl:Class ;
     rdfs:label "Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Setpoint ) ],
         brick:Setpoint ;
     skos:definition "Setpoints used in Reset strategies" ;
-    brick:hasAssociatedTag tag:Reset,
+    brick:hasAssociatedTag tag:Point,
+        tag:Reset,
         tag:Setpoint .
 
 brick:Solid a owl:Class,
@@ -8614,26 +9215,29 @@ brick:Solid a owl:Class,
 
 brick:Start_Stop_Status a owl:Class ;
     rdfs:label "Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Start,
+    brick:hasAssociatedTag tag:Point,
+        tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static ) ],
         brick:Pressure_Sensor ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
@@ -8649,9 +9253,10 @@ brick:Supply_Water a owl:Class,
 
 brick:Temperature_Alarm a owl:Class ;
     rdfs:label "Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Temperature .
 
 brick:Terminal_Unit a owl:Class ;
@@ -8674,9 +9279,10 @@ brick:Valve a owl:Class ;
 
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Water .
 
 tag:Adjust a brick:Tag ;
@@ -8754,25 +9360,28 @@ brick:Chilled_Water a owl:Class,
 
 brick:Cooling_Temperature_Setpoint a owl:Class ;
     rdfs:label "Cooling Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Disable_Command a owl:Class ;
     rdfs:label "Disable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Disable .
+        tag:Disable,
+        tag:Point .
 
 brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -8800,7 +9409,7 @@ brick:Liquid a owl:Class,
 
 brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -8808,22 +9417,25 @@ brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:On_Off_Command a owl:Class ;
     rdfs:label "On Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Off _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Off,
-        tag:On .
+        tag:On,
+        tag:Point .
 
 brick:Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -8839,10 +9451,11 @@ brick:Static_Pressure a owl:Class,
 
 brick:Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
@@ -8860,15 +9473,16 @@ brick:Water_System a owl:Class ;
 
 brick:Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Temperature_Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -8876,6 +9490,7 @@ brick:Zone_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Zone_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -8982,19 +9597,21 @@ brick:Fan a owl:Class ;
 
 brick:Heating_Temperature_Setpoint a owl:Class ;
     rdfs:label "Heating Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint _:has_Heating ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Heating ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Integral_Time_Parameter a owl:Class ;
     rdfs:label "Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
         brick:Time_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Substance a owl:Class ;
@@ -9014,9 +9631,10 @@ brick:Supply_Air a owl:Class,
 
 brick:Temperature_Setpoint a owl:Class ;
     rdfs:label "Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Temperature .
 
 tag:Coil a brick:Tag ;
@@ -9066,7 +9684,7 @@ tag:Velocity a brick:Tag ;
 
 brick:Air_Flow_Sensor a owl:Class ;
     rdfs:label "Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air ) ],
         brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -9075,19 +9693,21 @@ brick:Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air ) ],
         brick:Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -9096,6 +9716,7 @@ brick:Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Level a owl:Class,
@@ -9105,31 +9726,34 @@ brick:Level a owl:Class,
 
 brick:Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water ) ],
         brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] [ a owl:Restriction ;
                         owl:hasValue brick:Water ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Temperature,
         tag:Water .
 
@@ -9156,7 +9780,7 @@ tag:Unit a brick:Tag ;
 
 brick:Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air ) ],
         brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -9164,24 +9788,27 @@ brick:Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Enable_Command a owl:Class ;
     rdfs:label "Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Enable .
+        tag:Enable,
+        tag:Point .
 
 brick:On_Off_Status a owl:Class ;
     rdfs:label "On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:On_Status,
         brick:Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Outside_Air a owl:Class,
@@ -9231,19 +9858,21 @@ tag:Usage a brick:Tag ;
 
 brick:Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Max_Limit a owl:Class ;
     rdfs:label "Max Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 tag:Disable a brick:Tag ;
     rdfs:label "Disable" .
@@ -9264,17 +9893,16 @@ brick:Humidity a owl:Class,
 
 brick:Min_Limit a owl:Class ;
     rdfs:label "Min Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Point a owl:Class ;
     rdfs:label "Point" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:hasValue tag:Point ;
-            owl:onProperty brick:hasTag ],
+    rdfs:subClassOf _:has_Point,
         brick:Class ;
     brick:hasAssociatedTag tag:Point .
 
@@ -9298,10 +9926,11 @@ tag:Step a brick:Tag ;
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Limit ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Limit ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Location a owl:Class ;
     rdfs:label "Location" ;
@@ -9311,14 +9940,15 @@ brick:Location a owl:Class ;
 
 brick:Parameter a owl:Class ;
     rdfs:label "Parameter" ;
-    rdfs:subClassOf _:has_Parameter,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Parameter .
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point .
 
 tag:CO2 a brick:Tag ;
     rdfs:label "CO2" .
@@ -9337,9 +9967,10 @@ brick:Equipment a owl:Class ;
 
 brick:Temperature_Parameter a owl:Class ;
     rdfs:label "Temperature Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
 tag:Mode a brick:Tag ;
@@ -9416,14 +10047,15 @@ tag:Location a brick:Tag ;
 
 brick:Setpoint a owl:Class ;
     rdfs:label "Setpoint" ;
-    rdfs:subClassOf _:has_Setpoint,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Status ;
-    brick:hasAssociatedTag tag:Setpoint .
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint .
 
 brick:Temperature a owl:Class,
         brick:Temperature ;
@@ -9444,14 +10076,15 @@ tag:Shed a brick:Tag ;
 
 brick:Alarm a owl:Class ;
     rdfs:label "Alarm" ;
-    rdfs:subClassOf _:has_Alarm,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm ) ],
         brick:Point ;
     owl:disjointWith brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Alarm .
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point .
 
 tag:Liquid a brick:Tag ;
     rdfs:label "Liquid" .
@@ -9496,14 +10129,15 @@ tag:Outside a brick:Tag ;
 
 brick:Command a owl:Class ;
     rdfs:label "Command" ;
-    rdfs:subClassOf _:has_Command,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Command ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Command .
+    brick:hasAssociatedTag tag:Command,
+        tag:Point .
 
 tag:Max a brick:Tag ;
     rdfs:label "Max" .
@@ -9520,14 +10154,15 @@ brick:Quantity a owl:Class ;
 
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
-    rdfs:subClassOf _:has_Status,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Status ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Status .
+    brick:hasAssociatedTag tag:Point,
+        tag:Status .
 
 tag:Cooling a brick:Tag ;
     rdfs:label "Cooling" .
@@ -9543,14 +10178,15 @@ tag:Static a brick:Tag ;
 
 brick:Sensor a owl:Class ;
     rdfs:label "Sensor" ;
-    rdfs:subClassOf _:has_Sensor,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Sensor .
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor .
 
 tag:PID a brick:Tag ;
     rdfs:label "PID" .
@@ -9624,6 +10260,9 @@ brick:hasTag a owl:AsymmetricProperty,
 brick:Tag a owl:AllDifferent,
         owl:Class ;
     owl:distinctMembers ( tag:Coil tag:Valve tag:Heat tag:Cool tag:Equipment tag:Location tag:Point tag:Lighting tag:HVAC tag:Air tag:Steam tag:Ice tag:Chilled ) .
+
+tag:Point a brick:Tag ;
+    rdfs:label "Point" .
 
 [] a owl:Restriction ;
     owl:hasValue tag:Pir ;
@@ -10351,5 +10990,9 @@ _:has_Setpoint a owl:Restriction ;
 
 _:has_Air a owl:Restriction ;
     owl:hasValue tag:Air ;
+    owl:onProperty brick:hasTag .
+
+_:has_Point a owl:Restriction ;
+    owl:hasValue tag:Point ;
     owl:onProperty brick:hasTag .
 

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -72,6 +72,16 @@ brick:Air_Differential_Pressure_Sensor a owl:Class ;
         tag:Pressure,
         tag:Sensor .
 
+brick:Air_Flow_Loss_Alarm a owl:Class ;
+    rdfs:label "Air Flow Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm _:has_Flow _:has_Loss ) ],
+        brick:Air_Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Flow,
+        tag:Loss,
+        tag:Point .
+
 brick:Air_Handler_Unit a owl:Class ;
     rdfs:label "Air Handler Unit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Air [ a owl:Restriction ;
@@ -1510,7 +1520,9 @@ brick:Emergency_Power_Off_Activated_By_High_Temperature_Status a owl:Class ;
 
 brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By Leak Detection System Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak [ a owl:Restriction ;
+                        owl:hasValue tag:Detection ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
     brick:hasAssociatedTag tag:Detection,
         tag:Emergency,
@@ -1522,11 +1534,10 @@ brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status a owl:Class 
 
 brick:Emergency_Power_Off_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
         brick:Emergency_Power_Off_Status ;
-    brick:hasAssociatedTag tag:Detection,
-        tag:Emergency,
-        tag:Leak,
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Enable,
         tag:Off,
         tag:Point,
         tag:Power,
@@ -7005,14 +7016,6 @@ brick:Adjust_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Air_Alarm a owl:Class ;
-    rdfs:label "Air Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm ) ],
-        brick:Alarm ;
-    brick:hasAssociatedTag tag:Air,
-        tag:Alarm,
-        tag:Point .
-
 brick:Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Air Enthalpy Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Enthalpy _:has_Sensor ) ],
@@ -8092,6 +8095,9 @@ tag:Deceleration a brick:Tag ;
 tag:Dehumidification a brick:Tag ;
     rdfs:label "Dehumidification" .
 
+tag:Detection a brick:Tag ;
+    rdfs:label "Detection" .
+
 tag:Dimmer a brick:Tag ;
     rdfs:label "Dimmer" .
 
@@ -8359,6 +8365,14 @@ brick:AHU a owl:Class ;
         brick:HVAC ;
     brick:hasAssociatedTag tag:AHU,
         tag:Equipment .
+
+brick:Air_Alarm a owl:Class ;
+    rdfs:label "Air Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm ) ],
+        brick:Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point .
 
 brick:Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Air Temperature Alarm" ;
@@ -8851,9 +8865,6 @@ tag:Delay a brick:Tag ;
 tag:Derivative a brick:Tag ;
     rdfs:label "Derivative" .
 
-tag:Detection a brick:Tag ;
-    rdfs:label "Detection" .
-
 tag:Drive a brick:Tag ;
     rdfs:label "Drive" .
 
@@ -9321,6 +9332,9 @@ tag:Ice a brick:Tag ;
 tag:Lead a brick:Tag ;
     rdfs:label "Lead" .
 
+tag:Leak a brick:Tag ;
+    rdfs:label "Leak" .
+
 tag:Level a brick:Tag ;
     rdfs:label "Level" .
 
@@ -9513,14 +9527,8 @@ tag:Fixed a brick:Tag ;
 tag:Interface a brick:Tag ;
     rdfs:label "Interface" .
 
-tag:Leak a brick:Tag ;
-    rdfs:label "Leak" .
-
 tag:Leaving a brick:Tag ;
     rdfs:label "Leaving" .
-
-tag:Loss a brick:Tag ;
-    rdfs:label "Loss" .
 
 tag:Luminance a brick:Tag ;
     rdfs:label "Luminance" .
@@ -9657,6 +9665,9 @@ tag:Laboratory a brick:Tag ;
 
 tag:Lockout a brick:Tag ;
     rdfs:label "Lockout" .
+
+tag:Loss a brick:Tag ;
+    rdfs:label "Loss" .
 
 tag:Motor a brick:Tag ;
     rdfs:label "Motor" .
@@ -10036,9 +10047,6 @@ tag:Integral a brick:Tag ;
 tag:On a brick:Tag ;
     rdfs:label "On" .
 
-tag:Enable a brick:Tag ;
-    rdfs:label "Enable" .
-
 tag:Fan a brick:Tag ;
     rdfs:label "Fan" .
 
@@ -10064,6 +10072,9 @@ brick:Temperature a owl:Class,
 
 tag:Band a brick:Tag ;
     rdfs:label "Band" .
+
+tag:Enable a brick:Tag ;
+    rdfs:label "Enable" .
 
 tag:High a brick:Tag ;
     rdfs:label "High" .
@@ -10209,11 +10220,11 @@ tag:Differential a brick:Tag ;
 tag:Status a brick:Tag ;
     rdfs:label "Status" .
 
-tag:Flow a brick:Tag ;
-    rdfs:label "Flow" .
-
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
+
+tag:Flow a brick:Tag ;
+    rdfs:label "Flow" .
 
 tag:Supply a brick:Tag ;
     rdfs:label "Supply" .
@@ -10310,10 +10321,6 @@ _:has_Delay a owl:Restriction ;
 
 _:has_Derivative a owl:Restriction ;
     owl:hasValue tag:Derivative ;
-    owl:onProperty brick:hasTag .
-
-_:has_Detection a owl:Restriction ;
-    owl:hasValue tag:Detection ;
     owl:onProperty brick:hasTag .
 
 _:has_Drive a owl:Restriction ;
@@ -10512,6 +10519,10 @@ _:has_Lead a owl:Restriction ;
     owl:hasValue tag:Lead ;
     owl:onProperty brick:hasTag .
 
+_:has_Leak a owl:Restriction ;
+    owl:hasValue tag:Leak ;
+    owl:onProperty brick:hasTag .
+
 _:has_Level a owl:Restriction ;
     owl:hasValue tag:Level ;
     owl:onProperty brick:hasTag .
@@ -10564,16 +10575,8 @@ _:has_Interface a owl:Restriction ;
     owl:hasValue tag:Interface ;
     owl:onProperty brick:hasTag .
 
-_:has_Leak a owl:Restriction ;
-    owl:hasValue tag:Leak ;
-    owl:onProperty brick:hasTag .
-
 _:has_Leaving a owl:Restriction ;
     owl:hasValue tag:Leaving ;
-    owl:onProperty brick:hasTag .
-
-_:has_Loss a owl:Restriction ;
-    owl:hasValue tag:Loss ;
     owl:onProperty brick:hasTag .
 
 _:has_Luminance a owl:Restriction ;
@@ -10638,6 +10641,10 @@ _:has_Laboratory a owl:Restriction ;
 
 _:has_Lockout a owl:Restriction ;
     owl:hasValue tag:Lockout ;
+    owl:onProperty brick:hasTag .
+
+_:has_Loss a owl:Restriction ;
+    owl:hasValue tag:Loss ;
     owl:onProperty brick:hasTag .
 
 _:has_Motor a owl:Restriction ;
@@ -10828,16 +10835,16 @@ _:has_On a owl:Restriction ;
     owl:hasValue tag:On ;
     owl:onProperty brick:hasTag .
 
-_:has_Enable a owl:Restriction ;
-    owl:hasValue tag:Enable ;
-    owl:onProperty brick:hasTag .
-
 _:has_Fan a owl:Restriction ;
     owl:hasValue tag:Fan ;
     owl:onProperty brick:hasTag .
 
 _:has_Band a owl:Restriction ;
     owl:hasValue tag:Band ;
+    owl:onProperty brick:hasTag .
+
+_:has_Enable a owl:Restriction ;
+    owl:hasValue tag:Enable ;
     owl:onProperty brick:hasTag .
 
 _:has_High a owl:Restriction ;
@@ -10948,12 +10955,12 @@ _:has_Status a owl:Restriction ;
     owl:hasValue tag:Status ;
     owl:onProperty brick:hasTag .
 
-_:has_Flow a owl:Restriction ;
-    owl:hasValue tag:Flow ;
-    owl:onProperty brick:hasTag .
-
 _:has_Discharge a owl:Restriction ;
     owl:hasValue tag:Discharge ;
+    owl:onProperty brick:hasTag .
+
+_:has_Flow a owl:Restriction ;
+    owl:hasValue tag:Flow ;
     owl:onProperty brick:hasTag .
 
 _:has_Supply a owl:Restriction ;

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -878,8 +878,17 @@ brick:Disable_Fixed_Temperature_Command a owl:Class ;
 
 brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Disable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Outside_Air_Temperature_Setpoint ;
-    skos:definition "Disables hot water system when outside air temperature reaches the indicated value" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Disables hot water system when outside air temperature reaches the indicated value" ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Disable,
+        tag:Hot,
+        tag:Outside,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
 
 brick:Disable_Status a owl:Class ;
     rdfs:label "Disable Status" ;
@@ -911,11 +920,25 @@ brick:Discharge_Air_Flow_Demand_Setpoint a owl:Class ;
 
 brick:Discharge_Air_Flow_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset High Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Flow_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:High,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Flow_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Flow_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Low,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Discharge Air Humidity Sensor" ;
@@ -1008,11 +1031,27 @@ brick:Discharge_Air_Static_Pressure_Step_Parameter a owl:Class ;
 
 brick:Discharge_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:High,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Low,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Discharge Air Temperature Step Parameter" ;
@@ -1352,8 +1391,17 @@ brick:Enable_Fixed_Temperature_Command a owl:Class ;
 
 brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Enable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Outside_Air_Temperature_Setpoint ;
-    skos:definition "Enables hot water system when outside air temperature reaches the indicated value" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Enables hot water system when outside air temperature reaches the indicated value" ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enable,
+        tag:Hot,
+        tag:Outside,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
 
 brick:Entering_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Entering Water Temperature Sensor" ;
@@ -2684,7 +2732,17 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status 
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Setpoint" ;
-    rdfs:subClassOf brick:Load_Shed_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Sensor" ;
@@ -2692,12 +2750,29 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint,
-        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Return Temperature Sensor" ;
@@ -2705,12 +2780,30 @@ brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint,
-        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Setpoint" ;
-    rdfs:subClassOf brick:Load_Shed_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Status" ;
@@ -2718,13 +2811,20 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Cla
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Medium ;
-                        owl:onProperty brick:hasTag ] _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
         tag:Medium,
@@ -3292,11 +3392,25 @@ brick:Outside_Air_Lockout_Temperature_Setpoint a owl:Class ;
 
 brick:Outside_Air_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Outside,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Outside_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Outside,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Outside_Damper a owl:Class ;
     rdfs:label "Outside Damper" ;
@@ -4006,13 +4120,38 @@ brick:Supply_Air_Temperature_Alarm a owl:Class ;
         tag:Supply,
         tag:Temperature .
 
+brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
 brick:Supply_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf brick:Supply_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
 
 brick:Supply_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Supply_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
 
 brick:Supply_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Supply Air Temperature Step Parameter" ;
@@ -4267,7 +4406,14 @@ brick:Unoccupied_Air_Temperature_Heating_Setpoint a owl:Class ;
 
 brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf brick:Cooling_Discharge_Air_Flow_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Cooling_Discharge_Air_Flow_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cooling,
+        tag:Discharge,
+        tag:Flow,
+        tag:Setpoint,
+        tag:Unoccupied .
 
 brick:Unoccupied_Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Unoccupied Hot Water Shutdown Command" ;
@@ -4765,7 +4911,7 @@ brick:Discharge_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Cooling _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Discharge_Air_Temperature_Setpoint ;
-    owl:equivalentClass brick:Maximum_Discharge_Air_Temperature_Setpoint ;
+    owl:equivalentClass brick:Max_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
@@ -4777,7 +4923,7 @@ brick:Discharge_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Heating _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint,
         brick:Heating_Temperature_Setpoint ;
-    owl:equivalentClass brick:Minimum_Discharge_Air_Temperature_Setpoint ;
+    owl:equivalentClass brick:Min_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Heating,
@@ -5298,6 +5444,16 @@ brick:Makeup_Water a owl:Class,
         tag:Makeup,
         tag:Water .
 
+brick:Max_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Max Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Max _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Max,
+        tag:Setpoint,
+        tag:Temperature .
+
 brick:Max_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Temperature Setpoint Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
@@ -5308,13 +5464,19 @@ brick:Max_Temperature_Setpoint_Limit a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Maximum_Discharge_Air_Temperature_Setpoint a owl:Class ;
-    rdfs:label "Maximum Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Setpoint .
-
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Status" ;
     rdfs:subClassOf brick:Differential_Pressure_Load_Shed_Status .
+
+brick:Min_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Min Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Min _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Min,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Min_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Temperature Setpoint Limit" ;
@@ -5325,10 +5487,6 @@ brick:Min_Temperature_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Setpoint,
         tag:Temperature .
-
-brick:Minimum_Discharge_Air_Temperature_Setpoint a owl:Class ;
-    rdfs:label "Minimum Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Setpoint .
 
 brick:Motion_Sensor a owl:Class ;
     rdfs:label "Motion Sensor" ;
@@ -5694,10 +5852,6 @@ brick:TVOC_Level a owl:Class,
     rdfs:subClassOf brick:Air_Quality,
         brick:Level .
 
-brick:Temperature_High_Reset_Setpoint a owl:Class ;
-    rdfs:label "Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
-
 brick:Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Temperature Step Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Step _:has_Parameter ) ],
@@ -6057,8 +6211,13 @@ brick:Dewpoint_Sensor a owl:Class ;
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint ;
-    skos:definition "Setpoints used in Reset strategies" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Deadband Setpoint" ;
@@ -6086,7 +6245,14 @@ brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
 
 brick:Discharge_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Differential_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint Limit" ;
@@ -6214,7 +6380,27 @@ brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_High_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Humidity_Alarm a owl:Class ;
     rdfs:label "Humidity Alarm" ;
@@ -6646,10 +6832,6 @@ brick:Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
         tag:Supply,
         tag:Temperature .
 
-brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
-    rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Differential_Reset_Setpoint .
-
 brick:Supply_Hot_Water a owl:Class,
         brick:Supply_Hot_Water ;
     rdfs:label "Supply Hot Water" ;
@@ -6681,11 +6863,12 @@ brick:System_Enable_Command a owl:Class ;
 
 brick:Temperature_Differential_Reset_Setpoint a owl:Class ;
     rdfs:label "Temperature Differential Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
-
-brick:Temperature_Low_Reset_Setpoint a owl:Class ;
-    rdfs:label "Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
@@ -6921,9 +7104,6 @@ tag:Makeup a brick:Tag ;
 
 tag:Manual a brick:Tag ;
     rdfs:label "Manual" .
-
-tag:Medium a brick:Tag ;
-    rdfs:label "Medium" .
 
 tag:Month a brick:Tag ;
     rdfs:label "Month" .
@@ -7392,6 +7572,24 @@ brick:System_Status a owl:Class ;
     brick:hasAssociatedTag tag:Status,
         tag:System .
 
+brick:Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Low,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
 brick:Time a owl:Class,
         brick:Time ;
     rdfs:label "Time" ;
@@ -7744,10 +7942,6 @@ brick:Heating_Valve a owl:Class ;
         tag:Heat,
         tag:Valve .
 
-brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
-    rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Low_Reset_Setpoint .
-
 brick:Laboratory a owl:Class ;
     rdfs:label "Laboratory" ;
     rdfs:subClassOf brick:Room .
@@ -7798,6 +7992,14 @@ brick:Reset_Command a owl:Class ;
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Reset .
+
+brick:Reset_Setpoint a owl:Class ;
+    rdfs:label "Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Setpoints used in Reset strategies" ;
+    brick:hasAssociatedTag tag:Reset,
+        tag:Setpoint .
 
 brick:Solid a owl:Class,
         brick:Solid ;
@@ -8018,13 +8220,6 @@ brick:Power a owl:Class,
     rdfs:label "Power" ;
     rdfs:subClassOf brick:Quantity .
 
-brick:Reset_Setpoint a owl:Class ;
-    rdfs:label "Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Setpoint ) ],
-        brick:Setpoint ;
-    brick:hasAssociatedTag tag:Reset,
-        tag:Setpoint .
-
 brick:Static_Pressure a owl:Class,
         brick:Static_Pressure ;
     rdfs:label "Static Pressure" ;
@@ -8114,9 +8309,6 @@ tag:Output a brick:Tag ;
 
 tag:Preheat a brick:Tag ;
     rdfs:label "Preheat" .
-
-tag:Reset a brick:Tag ;
-    rdfs:label "Reset" .
 
 tag:Solar a brick:Tag ;
     rdfs:label "Solar" .
@@ -8374,11 +8566,11 @@ brick:Return_Air a owl:Class,
         tag:Gas,
         tag:Return .
 
-tag:Disable a brick:Tag ;
-    rdfs:label "Disable" .
-
 tag:Domestic a brick:Tag ;
     rdfs:label "Domestic" .
+
+tag:Medium a brick:Tag ;
+    rdfs:label "Medium" .
 
 tag:Request a brick:Tag ;
     rdfs:label "Request" .
@@ -8408,17 +8600,14 @@ brick:Max_Limit a owl:Class ;
         tag:Max,
         tag:Parameter .
 
+tag:Disable a brick:Tag ;
+    rdfs:label "Disable" .
+
 tag:Emergency a brick:Tag ;
     rdfs:label "Emergency" .
 
-tag:Low a brick:Tag ;
-    rdfs:label "Low" .
-
 tag:Meter a brick:Tag ;
     rdfs:label "Meter" .
-
-tag:System a brick:Tag ;
-    rdfs:label "System" .
 
 brick:Humidity a owl:Class,
         brick:Humidity ;
@@ -8453,14 +8642,14 @@ tag:Enthalpy a brick:Tag ;
 tag:Position a brick:Tag ;
     rdfs:label "Position" .
 
-tag:High a brick:Tag ;
-    rdfs:label "High" .
-
 tag:Mode a brick:Tag ;
     rdfs:label "Mode" .
 
 tag:Step a brick:Tag ;
     rdfs:label "Step" .
+
+tag:System a brick:Tag ;
+    rdfs:label "System" .
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
@@ -8489,17 +8678,11 @@ brick:Parameter a owl:Class ;
 tag:Heat a brick:Tag ;
     rdfs:label "Heat" .
 
-tag:Shed a brick:Tag ;
-    rdfs:label "Shed" .
-
 tag:Zone a brick:Tag ;
     rdfs:label "Zone" .
 
 tag:CO2 a brick:Tag ;
     rdfs:label "CO2" .
-
-tag:Unoccupied a brick:Tag ;
-    rdfs:label "Unoccupied" .
 
 brick:Equipment a owl:Class ;
     rdfs:label "Equipment" ;
@@ -8519,6 +8702,12 @@ tag:Location a brick:Tag ;
 
 tag:On a brick:Tag ;
     rdfs:label "On" .
+
+tag:Shed a brick:Tag ;
+    rdfs:label "Shed" .
+
+tag:Unoccupied a brick:Tag ;
+    rdfs:label "Unoccupied" .
 
 tag:Valve a brick:Tag ;
     rdfs:label "Valve" .
@@ -8550,8 +8739,8 @@ tag:Fan a brick:Tag ;
 tag:Gas a brick:Tag ;
     rdfs:label "Gas" .
 
-tag:Load a brick:Tag ;
-    rdfs:label "Load" .
+tag:Low a brick:Tag ;
+    rdfs:label "Low" .
 
 tag:Power a brick:Tag ;
     rdfs:label "Power" .
@@ -8568,11 +8757,17 @@ brick:Air a owl:Class,
 tag:Humidity a brick:Tag ;
     rdfs:label "Humidity" .
 
-tag:Enable a brick:Tag ;
-    rdfs:label "Enable" .
+tag:Load a brick:Tag ;
+    rdfs:label "Load" .
+
+tag:High a brick:Tag ;
+    rdfs:label "High" .
 
 tag:Occupied a brick:Tag ;
     rdfs:label "Occupied" .
+
+tag:Enable a brick:Tag ;
+    rdfs:label "Enable" .
 
 tag:Integral a brick:Tag ;
     rdfs:label "Integral" .
@@ -8616,9 +8811,6 @@ tag:Exhaust a brick:Tag ;
 tag:Liquid a brick:Tag ;
     rdfs:label "Liquid" .
 
-tag:Outside a brick:Tag ;
-    rdfs:label "Outside" .
-
 tag:Proportional a brick:Tag ;
     rdfs:label "Proportional" .
 
@@ -8633,11 +8825,14 @@ brick:HVAC a owl:Class ;
 tag:Deadband a brick:Tag ;
     rdfs:label "Deadband" .
 
+tag:Reset a brick:Tag ;
+    rdfs:label "Reset" .
+
 tag:Min a brick:Tag ;
     rdfs:label "Min" .
 
-tag:Max a brick:Tag ;
-    rdfs:label "Max" .
+tag:Outside a brick:Tag ;
+    rdfs:label "Outside" .
 
 brick:Command a owl:Class ;
     rdfs:label "Command" ;
@@ -8653,8 +8848,8 @@ brick:Command a owl:Class ;
 tag:Chilled a brick:Tag ;
     rdfs:label "Chilled" .
 
-tag:Hot a brick:Tag ;
-    rdfs:label "Hot" .
+tag:Max a brick:Tag ;
+    rdfs:label "Max" .
 
 brick:Quantity a owl:Class ;
     rdfs:subClassOf sosa:ObservableProperty,
@@ -8683,6 +8878,9 @@ tag:Fluid a brick:Tag ;
 tag:Static a brick:Tag ;
     rdfs:label "Static" .
 
+tag:Hot a brick:Tag ;
+    rdfs:label "Hot" .
+
 brick:Sensor a owl:Class ;
     rdfs:label "Sensor" ;
     rdfs:subClassOf _:has_Sensor,
@@ -8706,32 +8904,32 @@ tag:Alarm a brick:Tag ;
 tag:Equipment a brick:Tag ;
     rdfs:label "Equipment" .
 
-tag:Differential a brick:Tag ;
-    rdfs:label "Differential" .
-
 tag:Limit a brick:Tag ;
     rdfs:label "Limit" .
 
-tag:Discharge a brick:Tag ;
-    rdfs:label "Discharge" .
+tag:Differential a brick:Tag ;
+    rdfs:label "Differential" .
 
 tag:Status a brick:Tag ;
     rdfs:label "Status" .
 
+tag:Flow a brick:Tag ;
+    rdfs:label "Flow" .
+
 tag:Supply a brick:Tag ;
     rdfs:label "Supply" .
 
-tag:Flow a brick:Tag ;
-    rdfs:label "Flow" .
+tag:Discharge a brick:Tag ;
+    rdfs:label "Discharge" .
 
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .
 
-tag:Water a brick:Tag ;
-    rdfs:label "Water" .
-
 tag:Parameter a brick:Tag ;
     rdfs:label "Parameter" .
+
+tag:Water a brick:Tag ;
+    rdfs:label "Water" .
 
 tag:Temperature a brick:Tag ;
     rdfs:label "Temperature" .
@@ -9028,10 +9226,6 @@ _:has_Preheat a owl:Restriction ;
     owl:hasValue tag:Preheat ;
     owl:onProperty brick:hasTag .
 
-_:has_Reset a owl:Restriction ;
-    owl:hasValue tag:Reset ;
-    owl:onProperty brick:hasTag .
-
 _:has_Solar a owl:Restriction ;
     owl:hasValue tag:Solar ;
     owl:onProperty brick:hasTag .
@@ -9096,12 +9290,12 @@ _:has_Steam a owl:Restriction ;
     owl:hasValue tag:Steam ;
     owl:onProperty brick:hasTag .
 
-_:has_Disable a owl:Restriction ;
-    owl:hasValue tag:Disable ;
-    owl:onProperty brick:hasTag .
-
 _:has_Domestic a owl:Restriction ;
     owl:hasValue tag:Domestic ;
+    owl:onProperty brick:hasTag .
+
+_:has_Medium a owl:Restriction ;
+    owl:hasValue tag:Medium ;
     owl:onProperty brick:hasTag .
 
 _:has_Request a owl:Restriction ;
@@ -9116,20 +9310,16 @@ _:has_Usage a owl:Restriction ;
     owl:hasValue tag:Usage ;
     owl:onProperty brick:hasTag .
 
+_:has_Disable a owl:Restriction ;
+    owl:hasValue tag:Disable ;
+    owl:onProperty brick:hasTag .
+
 _:has_Emergency a owl:Restriction ;
     owl:hasValue tag:Emergency ;
     owl:onProperty brick:hasTag .
 
-_:has_Low a owl:Restriction ;
-    owl:hasValue tag:Low ;
-    owl:onProperty brick:hasTag .
-
 _:has_Meter a owl:Restriction ;
     owl:hasValue tag:Meter ;
-    owl:onProperty brick:hasTag .
-
-_:has_System a owl:Restriction ;
-    owl:hasValue tag:System ;
     owl:onProperty brick:hasTag .
 
 _:has_Damper a owl:Restriction ;
@@ -9152,10 +9342,6 @@ _:has_Heat a owl:Restriction ;
     owl:hasValue tag:Heat ;
     owl:onProperty brick:hasTag .
 
-_:has_High a owl:Restriction ;
-    owl:hasValue tag:High ;
-    owl:onProperty brick:hasTag .
-
 _:has_Mode a owl:Restriction ;
     owl:hasValue tag:Mode ;
     owl:onProperty brick:hasTag .
@@ -9164,8 +9350,8 @@ _:has_Step a owl:Restriction ;
     owl:hasValue tag:Step ;
     owl:onProperty brick:hasTag .
 
-_:has_Shed a owl:Restriction ;
-    owl:hasValue tag:Shed ;
+_:has_System a owl:Restriction ;
+    owl:hasValue tag:System ;
     owl:onProperty brick:hasTag .
 
 _:has_Zone a owl:Restriction ;
@@ -9180,16 +9366,20 @@ _:has_Location a owl:Restriction ;
     owl:hasValue tag:Location ;
     owl:onProperty brick:hasTag .
 
-_:has_Unoccupied a owl:Restriction ;
-    owl:hasValue tag:Unoccupied ;
-    owl:onProperty brick:hasTag .
-
 _:has_Valve a owl:Restriction ;
     owl:hasValue tag:Valve ;
     owl:onProperty brick:hasTag .
 
 _:has_On a owl:Restriction ;
     owl:hasValue tag:On ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shed a owl:Restriction ;
+    owl:hasValue tag:Shed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Unoccupied a owl:Restriction ;
+    owl:hasValue tag:Unoccupied ;
     owl:onProperty brick:hasTag .
 
 _:has_Off a owl:Restriction ;
@@ -9208,8 +9398,8 @@ _:has_Gas a owl:Restriction ;
     owl:hasValue tag:Gas ;
     owl:onProperty brick:hasTag .
 
-_:has_Load a owl:Restriction ;
-    owl:hasValue tag:Load ;
+_:has_Low a owl:Restriction ;
+    owl:hasValue tag:Low ;
     owl:onProperty brick:hasTag .
 
 _:has_Power a owl:Restriction ;
@@ -9220,12 +9410,20 @@ _:has_Humidity a owl:Restriction ;
     owl:hasValue tag:Humidity ;
     owl:onProperty brick:hasTag .
 
-_:has_Enable a owl:Restriction ;
-    owl:hasValue tag:Enable ;
+_:has_Load a owl:Restriction ;
+    owl:hasValue tag:Load ;
+    owl:onProperty brick:hasTag .
+
+_:has_High a owl:Restriction ;
+    owl:hasValue tag:High ;
     owl:onProperty brick:hasTag .
 
 _:has_Occupied a owl:Restriction ;
     owl:hasValue tag:Occupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Enable a owl:Restriction ;
+    owl:hasValue tag:Enable ;
     owl:onProperty brick:hasTag .
 
 _:has_Integral a owl:Restriction ;
@@ -9248,10 +9446,6 @@ _:has_Liquid a owl:Restriction ;
     owl:hasValue tag:Liquid ;
     owl:onProperty brick:hasTag .
 
-_:has_Outside a owl:Restriction ;
-    owl:hasValue tag:Outside ;
-    owl:onProperty brick:hasTag .
-
 _:has_Proportional a owl:Restriction ;
     owl:hasValue tag:Proportional ;
     owl:onProperty brick:hasTag .
@@ -9264,20 +9458,24 @@ _:has_Deadband a owl:Restriction ;
     owl:hasValue tag:Deadband ;
     owl:onProperty brick:hasTag .
 
-_:has_Min a owl:Restriction ;
-    owl:hasValue tag:Min ;
+_:has_Reset a owl:Restriction ;
+    owl:hasValue tag:Reset ;
     owl:onProperty brick:hasTag .
 
 _:has_Chilled a owl:Restriction ;
     owl:hasValue tag:Chilled ;
     owl:onProperty brick:hasTag .
 
-_:has_Max a owl:Restriction ;
-    owl:hasValue tag:Max ;
+_:has_Min a owl:Restriction ;
+    owl:hasValue tag:Min ;
     owl:onProperty brick:hasTag .
 
-_:has_Hot a owl:Restriction ;
-    owl:hasValue tag:Hot ;
+_:has_Outside a owl:Restriction ;
+    owl:hasValue tag:Outside ;
+    owl:onProperty brick:hasTag .
+
+_:has_Max a owl:Restriction ;
+    owl:hasValue tag:Max ;
     owl:onProperty brick:hasTag .
 
 _:has_Cooling a owl:Restriction ;
@@ -9296,6 +9494,10 @@ _:has_Static a owl:Restriction ;
     owl:hasValue tag:Static ;
     owl:onProperty brick:hasTag .
 
+_:has_Hot a owl:Restriction ;
+    owl:hasValue tag:Hot ;
+    owl:onProperty brick:hasTag .
+
 _:has_Command a owl:Restriction ;
     owl:hasValue tag:Command ;
     owl:onProperty brick:hasTag .
@@ -9312,40 +9514,40 @@ _:has_Equipment a owl:Restriction ;
     owl:hasValue tag:Equipment ;
     owl:onProperty brick:hasTag .
 
-_:has_Differential a owl:Restriction ;
-    owl:hasValue tag:Differential ;
-    owl:onProperty brick:hasTag .
-
 _:has_Limit a owl:Restriction ;
     owl:hasValue tag:Limit ;
     owl:onProperty brick:hasTag .
 
-_:has_Discharge a owl:Restriction ;
-    owl:hasValue tag:Discharge ;
+_:has_Differential a owl:Restriction ;
+    owl:hasValue tag:Differential ;
     owl:onProperty brick:hasTag .
 
 _:has_Status a owl:Restriction ;
     owl:hasValue tag:Status ;
     owl:onProperty brick:hasTag .
 
+_:has_Flow a owl:Restriction ;
+    owl:hasValue tag:Flow ;
+    owl:onProperty brick:hasTag .
+
 _:has_Supply a owl:Restriction ;
     owl:hasValue tag:Supply ;
     owl:onProperty brick:hasTag .
 
-_:has_Flow a owl:Restriction ;
-    owl:hasValue tag:Flow ;
+_:has_Discharge a owl:Restriction ;
+    owl:hasValue tag:Discharge ;
     owl:onProperty brick:hasTag .
 
 _:has_Pressure a owl:Restriction ;
     owl:hasValue tag:Pressure ;
     owl:onProperty brick:hasTag .
 
-_:has_Water a owl:Restriction ;
-    owl:hasValue tag:Water ;
-    owl:onProperty brick:hasTag .
-
 _:has_Parameter a owl:Restriction ;
     owl:hasValue tag:Parameter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Water a owl:Restriction ;
+    owl:hasValue tag:Water ;
     owl:onProperty brick:hasTag .
 
 _:has_Temperature a owl:Restriction ;

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -23,7 +23,13 @@
 
 brick:Absorption_Chiller a owl:Class ;
     rdfs:label "Absorption Chiller" ;
-    rdfs:subClassOf brick:Chiller .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Absorption ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    brick:hasAssociatedTag tag:Absorption,
+        tag:Chiller,
+        tag:Equipment .
 
 brick:Acceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Acceleration Time Setpoint" ;
@@ -65,9 +71,16 @@ brick:Air_Differential_Pressure_Sensor a owl:Class ;
 
 brick:Air_Handler_Unit a owl:Class ;
     rdfs:label "Air Handler Unit" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Handler ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:AHU ;
-    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system." .
+    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system." ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Handler,
+        tag:Unit .
 
 brick:Alarm_Delay_Parameter a owl:Class ;
     rdfs:label "Alarm Delay Parameter" ;
@@ -79,7 +92,13 @@ brick:Alarm_Delay_Parameter a owl:Class ;
 
 brick:Automatic_Mode_Command a owl:Class ;
     rdfs:label "Automatic Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Automatic ;
+                        owl:onProperty brick:hasTag ] _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Automatic,
+        tag:Command,
+        tag:Mode .
 
 brick:Average_Discharge_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Average Discharge Air Flow Sensor" ;
@@ -150,8 +169,13 @@ brick:Battery_Voltage_Sensor a owl:Class ;
 
 brick:Boiler a owl:Class ;
     rdfs:label "Boiler" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Boiler ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications." ;
+    brick:hasAssociatedTag tag:Boiler,
+        tag:Equipment .
 
 brick:Booster_Fan a owl:Class ;
     rdfs:label "Booster Fan" ;
@@ -165,7 +189,11 @@ brick:Booster_Fan a owl:Class ;
 
 brick:Box_Mode_Command a owl:Class ;
     rdfs:label "Box Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Box _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Command,
+        tag:Mode .
 
 brick:Building a owl:Class ;
     rdfs:label "Building" ;
@@ -259,7 +287,13 @@ brick:Capacity_Sensor a owl:Class ;
 
 brick:Centrifugal_Chiller a owl:Class ;
     rdfs:label "Centrifugal Chiller" ;
-    rdfs:subClassOf brick:Chiller .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Centrifugal ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    brick:hasAssociatedTag tag:Centrifugal,
+        tag:Chiller,
+        tag:Equipment .
 
 brick:Change_Filter_Alarm a owl:Class ;
     rdfs:label "Change Filter Alarm" ;
@@ -386,7 +420,12 @@ brick:Chilled_Water_Meter a owl:Class ;
 
 brick:Chilled_Water_Pump a owl:Class ;
     rdfs:label "Chilled Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Chilled _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Pump Differential Pressure Deadband Setpoint" ;
@@ -492,7 +531,15 @@ brick:Close_Limit a owl:Class ;
 
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Cold ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Cold,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Communication_Loss_Alarm a owl:Class ;
     rdfs:label "Communication Loss Alarm" ;
@@ -506,8 +553,13 @@ brick:Communication_Loss_Alarm a owl:Class ;
 
 brick:Compressor a owl:Class ;
     rdfs:label "Compressor" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Compressor ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor." ;
+    brick:hasAssociatedTag tag:Compressor,
+        tag:Equipment .
 
 brick:Condensate_Leak_Alarm a owl:Class ;
     rdfs:label "Condensate Leak Alarm" ;
@@ -521,16 +573,29 @@ brick:Condensate_Leak_Alarm a owl:Class ;
 
 brick:Condenser a owl:Class ;
     rdfs:label "Condenser" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Condenser ) ],
+        brick:HVAC ;
+    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase." ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment .
 
 brick:Condenser_Heat_Exchanger a owl:Class ;
     rdfs:label "Condenser Heat Exchanger" ;
-    rdfs:subClassOf brick:Heat_Exchanger .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:Condenser_Water_Pump a owl:Class ;
     rdfs:label "Condenser Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Condenser _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Contact_Sensor a owl:Class ;
     rdfs:label "Contact Sensor" ;
@@ -664,7 +729,14 @@ brick:Cooling_Thermal_Power_Meter a owl:Class ;
 
 brick:Cooling_Tower_Fan a owl:Class ;
     rdfs:label "Cooling Tower Fan" ;
-    rdfs:subClassOf brick:Fan .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling [ a owl:Restriction ;
+                        owl:hasValue tag:Tower ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment _:has_Fan ) ],
+        brick:Fan ;
+    brick:hasAssociatedTag tag:Cooling,
+        tag:Equipment,
+        tag:Fan,
+        tag:Tower .
 
 brick:Cooling_Valve a owl:Class ;
     rdfs:label "Cooling Valve" ;
@@ -831,7 +903,14 @@ brick:Differential_Speed_Sensor a owl:Class ;
 
 brick:Dimmer a owl:Class ;
     rdfs:label "Dimmer" ;
-    rdfs:subClassOf brick:Switch .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch [ a owl:Restriction ;
+                        owl:hasValue tag:Dimmer ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Switch ;
+    brick:hasAssociatedTag tag:Dimmer,
+        tag:Equipment,
+        tag:Interface,
+        tag:Switch .
 
 brick:Direction_Command a owl:Class ;
     rdfs:label "Direction Command" ;
@@ -1188,10 +1267,6 @@ brick:Domestic_Hot_Water_System_Enable_Command a owl:Class ;
         tag:System,
         tag:Water .
 
-brick:Domestic_Hot_Water_System_Start_Stop_Command a owl:Class ;
-    rdfs:label "Domestic Hot Water System Start Stop Command" ;
-    rdfs:subClassOf brick:Start_Stop_Command .
-
 brick:Domestic_Hot_Water_Valve a owl:Class ;
     rdfs:label "Domestic Hot Water Valve" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Water _:has_Hot _:has_Valve _:has_Heat _:has_Equipment ) ],
@@ -1207,9 +1282,7 @@ brick:Domestic_Hot_Water_Valve a owl:Class ;
 
 brick:Drive_Ready_Status a owl:Class ;
     rdfs:label "Drive Ready Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Drive ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Drive [ a owl:Restriction ;
                         owl:hasValue tag:Ready ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
@@ -1241,14 +1314,15 @@ brick:EconCycle_On_Off_Status a owl:Class ;
 
 brick:Economizer a owl:Class ;
     rdfs:label "Economizer" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Economizer ) ],
+        brick:HVAC ;
+    skos:definition "Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement." ;
+    brick:hasAssociatedTag tag:Economizer,
+        tag:Equipment .
 
 brick:Economizer_Damper a owl:Class ;
     rdfs:label "Economizer Damper" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper [ a owl:Restriction ;
-                        owl:hasValue tag:Economizer ;
-                        owl:onProperty brick:hasTag ] ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Economizer ) ],
         brick:Damper ;
     brick:hasAssociatedTag tag:Damper,
         tag:Economizer,
@@ -1278,7 +1352,12 @@ brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
 
 brick:Elevator a owl:Class ;
     rdfs:label "Elevator" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Elevator ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Elevator,
+        tag:Equipment .
 
 brick:Emergency_Air_Flow_Status a owl:Class ;
     rdfs:label "Emergency Air Flow Status" ;
@@ -1317,15 +1396,36 @@ brick:Emergency_Power_Loss_Alarm a owl:Class ;
 
 brick:Emergency_Power_Off_Activated_By_High_Temperature_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By High Temperature Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_High _:has_Temperature _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:High,
+        tag:Off,
+        tag:Power,
+        tag:Status,
+        tag:Temperature .
 
 brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By Leak Detection System Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Detection,
+        tag:Emergency,
+        tag:Leak,
+        tag:Off,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Power_Off_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off Enable Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Leak _:has_Detection _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Detection,
+        tag:Emergency,
+        tag:Leak,
+        tag:Off,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Power_Off_System a owl:Class ;
     rdfs:label "Emergency Power Off System" ;
@@ -1338,7 +1438,13 @@ brick:Emergency_Power_Off_System a owl:Class ;
 
 brick:Emergency_Power_Off_System_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off System Enable Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Enable,
+        tag:Off,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Push_Button_Status a owl:Class ;
     rdfs:label "Emergency Push Button Status" ;
@@ -1435,11 +1541,26 @@ brick:Enthalpy_Setpoint a owl:Class ;
 
 brick:Environment_Box a owl:Class ;
     rdfs:label "Environment Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Environment ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Environment,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Evaporative_Heat_Exchanger a owl:Class ;
     rdfs:label "Evaporative Heat Exchanger" ;
-    rdfs:subClassOf brick:Heat_Exchanger .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Evaporative ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Evaporative,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:Even_Month_Status a owl:Class ;
     rdfs:label "Even Month Status" ;
@@ -1603,11 +1724,27 @@ brick:Exhaust_Fan_Enable_Command a owl:Class ;
 
 brick:Exhaust_Fan_Fire_Control_Panel_Off_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel Off Command" ;
-    rdfs:subClassOf brick:Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_Off _:has_Command ) ],
+        brick:Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Control,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Fire,
+        tag:Off,
+        tag:Panel .
 
 brick:Exhaust_Fan_Fire_Control_Panel_On_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel On Command" ;
-    rdfs:subClassOf brick:On_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_On _:has_Command ) ],
+        brick:On_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Control,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Fire,
+        tag:On,
+        tag:Panel .
 
 brick:Fan_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Fan Air Flow Setpoint" ;
@@ -1620,12 +1757,22 @@ brick:Fan_Air_Flow_Setpoint a owl:Class ;
 
 brick:Fan_Coil_Unit a owl:Class ;
     rdfs:label "Fan Coil Unit" ;
-    rdfs:subClassOf brick:Terminal_Unit ;
-    owl:equivalentClass brick:FCU .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Coil _:has_Unit ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:FCU ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment,
+        tag:Fan,
+        tag:Unit .
 
 brick:Fan_Speed_Reset_Command a owl:Class ;
     rdfs:label "Fan Speed Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Speed_Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fan,
+        tag:Reset,
+        tag:Speed .
 
 brick:Fan_Start_Stop_Status a owl:Class ;
     rdfs:label "Fan Start Stop Status" ;
@@ -1649,7 +1796,11 @@ brick:Fault_Indicator_Status a owl:Class ;
 
 brick:Fault_Reset_Command a owl:Class ;
     rdfs:label "Fault Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fault _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fault,
+        tag:Reset .
 
 brick:Filter_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Filter Differential Pressure Sensor" ;
@@ -1662,12 +1813,21 @@ brick:Filter_Differential_Pressure_Sensor a owl:Class ;
 
 brick:Filter_Reset_Command a owl:Class ;
     rdfs:label "Filter Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Filter _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Filter,
+        tag:Reset .
 
 brick:Fire_Control_Panel a owl:Class ;
     rdfs:label "Fire Control Panel" ;
-    rdfs:subClassOf brick:Fire_Safety_System ;
-    owl:equivalentClass brick:FCP .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety _:has_Panel ) ],
+        brick:Fire_Safety_System ;
+    owl:equivalentClass brick:FCP ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Panel,
+        tag:Safety .
 
 brick:Fire_Sensor a owl:Class ;
     rdfs:label "Fire Sensor" ;
@@ -1696,16 +1856,21 @@ brick:Floor a owl:Class ;
 
 brick:Freeze_Status a owl:Class ;
     rdfs:label "Freeze Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Freeze ;
-                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Freeze _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Freeze,
         tag:Status .
 
 brick:Freezer a owl:Class ;
     rdfs:label "Freezer" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Freezer ;
+                        owl:onProperty brick:hasTag ] _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Freezer,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Frost_Sensor a owl:Class ;
     rdfs:label "Frost Sensor" ;
@@ -1719,16 +1884,16 @@ brick:Frost_Sensor a owl:Class ;
 
 brick:Fume_Hood a owl:Class ;
     rdfs:label "Fume Hood" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fume _:has_Hood ) ],
+        brick:HVAC ;
+    skos:definition "A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fume,
+        tag:Hood .
 
 brick:Fume_Hood_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Fume Hood Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Fume ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Hood ;
-                        owl:onProperty brick:hasTag ] _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fume _:has_Hood _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -1738,7 +1903,12 @@ brick:Fume_Hood_Air_Flow_Sensor a owl:Class ;
 
 brick:Furniture a owl:Class ;
     rdfs:label "Furniture" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Furniture ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Furniture .
 
 brick:Gas_Sensor a owl:Class ;
     rdfs:label "Gas Sensor" ;
@@ -1750,9 +1920,7 @@ brick:Gas_Sensor a owl:Class ;
 
 brick:HVAC_Zone a owl:Class ;
     rdfs:label "HVAC Zone" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:HVAC ;
-                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Location ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_HVAC _:has_Zone _:has_Location ) ],
         brick:Zone ;
     brick:hasAssociatedTag tag:HVAC,
         tag:Location,
@@ -1802,7 +1970,14 @@ brick:Heat_Exchanger_System_Enable_Status a owl:Class ;
 
 brick:Heat_Wheel_VFD a owl:Class ;
     rdfs:label "Heat Wheel VFD" ;
-    rdfs:subClassOf brick:VFD .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat [ a owl:Restriction ;
+                        owl:hasValue tag:Wheel ;
+                        owl:onProperty brick:hasTag ] _:has_VFD ) ],
+        brick:VFD ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:VFD,
+        tag:Wheel .
 
 brick:Heating_Coil a owl:Class ;
     rdfs:label "Heating Coil" ;
@@ -1961,7 +2136,14 @@ brick:High_Discharge_Air_Temperature_Alarm a owl:Class ;
 
 brick:High_Head_Pressure_Alarm a owl:Class ;
     rdfs:label "High Head Pressure Alarm" ;
-    rdfs:subClassOf brick:Pressure_Alarm .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_High [ a owl:Restriction ;
+                        owl:hasValue tag:Head ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Head,
+        tag:High,
+        tag:Pressure .
 
 brick:High_Humidity_Alarm a owl:Class ;
     rdfs:label "High Humidity Alarm" ;
@@ -2027,7 +2209,14 @@ brick:High_Temperature_Alarm_Parameter a owl:Class ;
 
 brick:High_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Return_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Supply Temperature Sensor" ;
@@ -2042,9 +2231,7 @@ brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Highest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Highest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone [ a owl:Restriction ;
-                        owl:hasValue tag:Highest ;
-                        owl:onProperty brick:hasTag ] _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Highest _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     owl:equivalentClass brick:Warmest_Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
@@ -2055,7 +2242,12 @@ brick:Highest_Zone_Air_Temperature_Sensor a owl:Class ;
 
 brick:Highest_Zone_Cooling_Command a owl:Class ;
     rdfs:label "Highest Zone Cooling Command" ;
-    rdfs:subClassOf brick:Cooling_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Highest _:has_Zone _:has_Cool _:has_Command ) ],
+        brick:Cooling_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Cool,
+        tag:Highest,
+        tag:Zone .
 
 brick:Hold_Status a owl:Class ;
     rdfs:label "Hold Status" ;
@@ -2068,7 +2260,13 @@ brick:Hold_Status a owl:Class ;
 
 brick:Hot_Box a owl:Class ;
     rdfs:label "Hot Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Hot,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Hot_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Deadband Setpoint" ;
@@ -2144,7 +2342,12 @@ brick:Hot_Water_Flow_Sensor a owl:Class ;
 
 brick:Hot_Water_Pump a owl:Class ;
     rdfs:label "Hot Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Hot _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Pump,
+        tag:Water .
 
 brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Hot Water Static Pressure Setpoint" ;
@@ -2178,13 +2381,14 @@ brick:Humidification_On_Off_Status a owl:Class ;
 
 brick:Humidifier a owl:Class ;
     rdfs:label "Humidifier" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Humidifier ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Humidifier .
 
 brick:Humidifier_Fault_Status a owl:Class ;
     rdfs:label "Humidifier Fault Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Humidifier ;
-                        owl:onProperty brick:hasTag ] _:has_Fault _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidifier _:has_Fault _:has_Status ) ],
         brick:Fault_Status ;
     brick:hasAssociatedTag tag:Fault,
         tag:Humidifier,
@@ -2278,7 +2482,12 @@ brick:Lead_Lag_Status a owl:Class ;
 
 brick:Lead_On_Off_Command a owl:Class ;
     rdfs:label "Lead On Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Lead,
+        tag:Off,
+        tag:On .
 
 brick:Leaving_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Leaving Water Temperature Setpoint" ;
@@ -2333,7 +2542,15 @@ brick:Lockout_Command a owl:Class ;
 
 brick:Low_Freeze_Protect_Temperature_Parameter a owl:Class ;
     rdfs:label "Low Freeze Protect Temperature Parameter" ;
-    rdfs:subClassOf brick:Temperature_Parameter .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Freeze [ a owl:Restriction ;
+                        owl:hasValue tag:Protect ;
+                        owl:onProperty brick:hasTag ] _:has_Temperature _:has_Parameter ) ],
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Freeze,
+        tag:Low,
+        tag:Parameter,
+        tag:Protect,
+        tag:Temperature .
 
 brick:Low_Humidity_Alarm a owl:Class ;
     rdfs:label "Low Humidity Alarm" ;
@@ -2400,7 +2617,14 @@ brick:Low_Return_Air_Temperature_Alarm a owl:Class ;
 
 brick:Low_Suction_Pressure_Alarm a owl:Class ;
     rdfs:label "Low Suction Pressure Alarm" ;
-    rdfs:subClassOf brick:Pressure_Alarm .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low [ a owl:Restriction ;
+                        owl:hasValue tag:Suction ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Low,
+        tag:Pressure,
+        tag:Suction .
 
 brick:Low_Temperature_Alarm_Parameter a owl:Class ;
     rdfs:label "Low Temperature Alarm Parameter" ;
@@ -2435,11 +2659,20 @@ brick:Lowest_Zone_Air_Temperature_Sensor a owl:Class ;
 
 brick:Luminaire a owl:Class ;
     rdfs:label "Luminaire" ;
-    rdfs:subClassOf brick:Lighting .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire _:has_Equipment ) ],
+        brick:Lighting ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Luminaire .
 
 brick:Luminaire_Driver a owl:Class ;
     rdfs:label "Luminaire Driver" ;
-    rdfs:subClassOf brick:Lighting .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire [ a owl:Restriction ;
+                        owl:hasValue tag:Driver ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Lighting ;
+    brick:hasAssociatedTag tag:Driver,
+        tag:Equipment,
+        tag:Luminaire .
 
 brick:Luminance_Alarm a owl:Class ;
     rdfs:label "Luminance Alarm" ;
@@ -2474,13 +2707,15 @@ brick:Luminance_Setpoint a owl:Class ;
 
 brick:Maintenance_Mode_Command a owl:Class ;
     rdfs:label "Maintenance Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Maintenance _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Maintenance,
+        tag:Mode .
 
 brick:Maintenance_Required_Alarm a owl:Class ;
     rdfs:label "Maintenance Required Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Maintenance ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Maintenance [ a owl:Restriction ;
                         owl:hasValue tag:Required ;
                         owl:onProperty brick:hasTag ] _:has_Alarm ) ],
         brick:Alarm ;
@@ -2728,7 +2963,16 @@ brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+        brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Pressure,
+        tag:Reset,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Setpoint" ;
@@ -2746,7 +2990,15 @@ brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a ow
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Differential_Pressure_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+        brick:Hot_Water_Differential_Pressure_Sensor ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Medium,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature High Reset Setpoint" ;
@@ -2776,7 +3028,14 @@ brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a ow
 
 brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Return_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Medium,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature High Reset Setpoint" ;
@@ -2807,7 +3066,16 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:C
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Status" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Hot_Water_Supply_Temperature_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Shed,
+        tag:Status,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Low Reset Setpoint" ;
@@ -3059,7 +3327,12 @@ brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
 
 brick:Mixed_Air_Filter a owl:Class ;
     rdfs:label "Mixed Air Filter" ;
-    rdfs:subClassOf brick:Filter .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Mixed _:has_Air _:has_Filter ) ],
+        brick:Filter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Filter,
+        tag:Mixed .
 
 brick:Mixed_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Mixed Air Temperature Sensor" ;
@@ -3468,9 +3741,7 @@ brick:PIR_Sensor a owl:Class ;
 
 brick:Peak_Power_Demand_Sensor a owl:Class ;
     rdfs:label "Peak Power Demand Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Peak ;
-                        owl:onProperty brick:hasTag ] _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Peak _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
         brick:Demand_Sensor,
         brick:Electrical_Power_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -3565,7 +3836,11 @@ brick:Preheat_Supply_Air_Temperature_Sensor a owl:Class ;
 
 brick:Preheat_Valve_VFD a owl:Class ;
     rdfs:label "Preheat Valve VFD" ;
-    rdfs:subClassOf brick:VFD .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Preheat _:has_VFD ) ],
+        brick:VFD ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Preheat,
+        tag:VFD .
 
 brick:Pump_Command a owl:Class ;
     rdfs:label "Pump Command" ;
@@ -3618,9 +3893,7 @@ brick:Reactive_Power_Sensor a owl:Class ;
 
 brick:Reheat_Valve a owl:Class ;
     rdfs:label "Reheat Valve" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve [ a owl:Restriction ;
-                        owl:hasValue tag:Reheat ;
-                        owl:onProperty brick:hasTag ] _:has_Heat _:has_Equipment ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Reheat _:has_Heat _:has_Equipment ) ],
         brick:Heating_Valve ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Heat,
@@ -3799,9 +4072,7 @@ brick:Roof a owl:Class ;
 
 brick:Room_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Room Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Room ;
-                        owl:onProperty brick:hasTag ] _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Room _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Room,
@@ -3872,7 +4143,13 @@ brick:Schedule_Temperature_Setpoint a owl:Class ;
 
 brick:Server_Room a owl:Class ;
     rdfs:label "Server Room" ;
-    rdfs:subClassOf brick:Room .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Server ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Location ) ],
+        brick:Room ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Server .
 
 brick:Shading_System a owl:Class ;
     rdfs:label "Shading System" ;
@@ -3937,21 +4214,21 @@ brick:Solar_Zenith_Angle_Sensor a owl:Class ;
 
 brick:Space a owl:Class ;
     rdfs:label "Space" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Space ;
-                        owl:onProperty brick:hasTag ] _:has_Location ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Space _:has_Location ) ],
         brick:Location ;
     brick:hasAssociatedTag tag:Location,
         tag:Space .
 
 brick:Space_Heater a owl:Class ;
     rdfs:label "Space Heater" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A heater used to warm the air in an enclosed area, such as a room or office" .
-
-brick:Speed_Reset_Command a owl:Class ;
-    rdfs:label "Speed Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Space [ a owl:Restriction ;
+                        owl:hasValue tag:Heater ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "A heater used to warm the air in an enclosed area, such as a room or office" ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heater,
+        tag:Space .
 
 brick:Speed_Status a owl:Class ;
     rdfs:label "Speed Status" ;
@@ -3990,9 +4267,22 @@ brick:Standby_Glycool_Unit_On_Off_Status a owl:Class ;
         tag:Status,
         tag:Unit .
 
+brick:Start_Stop_Command a owl:Class ;
+    rdfs:label "Start Stop Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Start _:has_Stop _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Start,
+        tag:Stop .
+
 brick:Steam_On_Off_Command a owl:Class ;
     rdfs:label "Steam On Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Steam _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:On,
+        tag:Steam .
 
 brick:Steam_System a owl:Class ;
     rdfs:label "Steam System" ;
@@ -4323,18 +4613,26 @@ brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoin
 
 brick:Thermostat a owl:Class ;
     rdfs:label "Thermostat" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "An automatic control device used to maintain temperature at a fixed or adjustable setpoint." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Thermostat ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "An automatic control device used to maintain temperature at a fixed or adjustable setpoint." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Thermostat .
 
 brick:Today_Peak_Energy_Sensor a owl:Class ;
     rdfs:label "Today Peak Energy Sensor" ;
-    rdfs:subClassOf brick:Energy_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Energy _:has_Today _:has_Peak ) ],
+        brick:Energy_Sensor ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Peak,
+        tag:Sensor,
+        tag:Today .
 
 brick:Today_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Today Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Today ;
-                        owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Today _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
     brick:hasAssociatedTag tag:Sensor,
         tag:Steam,
@@ -4343,7 +4641,13 @@ brick:Today_Steam_Usage_Sensor a owl:Class ;
 
 brick:Touchpanel a owl:Class ;
     rdfs:label "Touchpanel" ;
-    rdfs:subClassOf brick:Interface .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface [ a owl:Restriction ;
+                        owl:hasValue tag:Touchpanel ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Interface ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Touchpanel .
 
 brick:Trace_Heat_Sensor a owl:Class ;
     rdfs:label "Trace Heat Sensor" ;
@@ -4357,11 +4661,19 @@ brick:Trace_Heat_Sensor a owl:Class ;
 
 brick:Turn_Off_Status a owl:Class ;
     rdfs:label "Turn Off Status" ;
-    rdfs:subClassOf brick:Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Turn _:has_Off _:has_Status ) ],
+        brick:Off_Status ;
+    brick:hasAssociatedTag tag:Off,
+        tag:Status,
+        tag:Turn .
 
 brick:Turn_On_Status a owl:Class ;
     rdfs:label "Turn On Status" ;
-    rdfs:subClassOf brick:On_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Turn _:has_On _:has_Status ) ],
+        brick:On_Status ;
+    brick:hasAssociatedTag tag:On,
+        tag:Status,
+        tag:Turn .
 
 brick:Underfloor_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Underfloor Air Temperature Sensor" ;
@@ -4417,7 +4729,13 @@ brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
 
 brick:Unoccupied_Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Unoccupied Hot Water Shutdown Command" ;
-    rdfs:subClassOf brick:Hot_Water_Shutdown_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
+        brick:Hot_Water_Shutdown_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Hot,
+        tag:Shutdown,
+        tag:Unoccupied,
+        tag:Water .
 
 brick:Unoccupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Mode Setpoint" ;
@@ -4429,9 +4747,7 @@ brick:Unoccupied_Mode_Setpoint a owl:Class ;
 
 brick:VFD_Enable_Command a owl:Class ;
     rdfs:label "VFD Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command [ a owl:Restriction ;
-                        owl:hasValue tag:VFD ;
-                        owl:onProperty brick:hasTag ] ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_VFD ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
@@ -4446,14 +4762,25 @@ brick:Valve_Command a owl:Class ;
 
 brick:Variable_Air_Volume_Box_With_Reheat a owl:Class ;
     rdfs:label "Variable Air Volume Box With Reheat" ;
-    rdfs:subClassOf brick:Variable_Air_Volume_Box ;
-    owl:equivalentClass brick:RVAV .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box _:has_Reheat ) ],
+        brick:Variable_Air_Volume_Box ;
+    owl:equivalentClass brick:RVAV ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Reheat,
+        tag:Variable,
+        tag:Volume .
 
 brick:Variable_Frequency_Drive a owl:Class ;
     rdfs:label "Variable Frequency Drive" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Frequency _:has_Drive ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:VFD ;
-    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure." .
+    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure." ;
+    brick:hasAssociatedTag tag:Drive,
+        tag:Equipment,
+        tag:Frequency,
+        tag:Variable .
 
 brick:Velocity_Pressure_Setpoint a owl:Class ;
     rdfs:label "Velocity Pressure Setpoint" ;
@@ -4476,7 +4803,14 @@ brick:Vent_Operating_Mode_Status a owl:Class ;
 
 brick:Ventilation_Air_Flow_Ratio_Limit a owl:Class ;
     rdfs:label "Ventilation Air Flow Ratio Limit" ;
-    rdfs:subClassOf brick:Limit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Ventilation _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Ratio ;
+                        owl:onProperty brick:hasTag ] _:has_Limit ) ],
+        brick:Limit ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Ratio,
+        tag:Ventilation .
 
 brick:Warm_Cool_Adjust_Sensor a owl:Class ;
     rdfs:label "Warm Cool Adjust Sensor" ;
@@ -4572,11 +4906,23 @@ brick:Zone_Air_Temperature_Setpoint a owl:Class ;
 
 brick:Zone_Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Standby Load Shed Command" ;
-    rdfs:subClassOf brick:Standby_Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Standby_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Shed,
+        tag:Standby,
+        tag:Zone .
 
 brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Unoccupied Load Shed Command" ;
-    rdfs:subClassOf brick:Unoccupied_Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Unoccupied_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Shed,
+        tag:Unoccupied,
+        tag:Zone .
 
 brick:feedsAir a owl:ObjectProperty ;
     rdfs:subPropertyOf brick:feeds ;
@@ -4688,13 +5034,22 @@ brick:CO2_Setpoint a owl:Class ;
 
 brick:CRAC a owl:Class ;
     rdfs:label "CRAC" ;
-    rdfs:subClassOf brick:HVAC ;
-    owl:equivalentClass brick:Computer_Room_Air_Conditioning .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:CRAC ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    owl:equivalentClass brick:Computer_Room_Air_Conditioning ;
+    brick:hasAssociatedTag tag:CRAC,
+        tag:Equipment .
 
 brick:CWS a owl:Class ;
     rdfs:label "CWS" ;
-    rdfs:subClassOf brick:Water_System ;
-    owl:equivalentClass brick:Chilled_Water_System .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:CWS ;
+            owl:onProperty brick:hasTag ],
+        brick:Water_System ;
+    owl:equivalentClass brick:Chilled_Water_System ;
+    brick:hasAssociatedTag tag:CWS .
 
 brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
@@ -4727,7 +5082,15 @@ brick:Cloudage a owl:Class,
 
 brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Coldest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf brick:Zone_Air_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Coldest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Coldest,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Zone .
 
 brick:Complex_Power a owl:Class,
         brick:Complex_Power ;
@@ -4736,16 +5099,22 @@ brick:Complex_Power a owl:Class,
 
 brick:Computer_Room_Air_Conditioning a owl:Class ;
     rdfs:label "Computer Room Air Conditioning" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Computer ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Air _:has_Conditioning ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:CRAC ;
-    skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " .
+    skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Computer,
+        tag:Conditioning,
+        tag:Equipment,
+        tag:Room .
 
 brick:Condenser_Water a owl:Class,
         brick:Condenser_Water ;
     rdfs:label "Condenser Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
-                        owl:hasValue tag:Condenser ;
-                        owl:onProperty brick:hasTag ] ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Condenser ) ],
         brick:Water ;
     skos:definition "Water used used to remove heat through condensation" ;
     brick:hasAssociatedTag tag:Condenser,
@@ -5111,11 +5480,20 @@ brick:Exhaust_Air_Stack_Flow_Setpoint a owl:Class ;
 
 brick:FCP a owl:Class ;
     rdfs:label "FCP" ;
-    rdfs:subClassOf brick:Fire_Safety_System .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:FCP ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Fire_Safety_System ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:FCP .
 
 brick:FCU a owl:Class ;
     rdfs:label "FCU" ;
-    rdfs:subClassOf brick:Terminal_Unit .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:FCU ;
+            owl:onProperty brick:hasTag ],
+        brick:Terminal_Unit ;
+    brick:hasAssociatedTag tag:FCU .
 
 brick:Failure_Alarm a owl:Class ;
     rdfs:label "Failure Alarm" ;
@@ -5133,8 +5511,11 @@ brick:Fan_Status a owl:Class ;
 
 brick:Filter a owl:Class ;
     rdfs:label "Filter" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Device to remove gases from a mixture of gases" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Filter ) ],
+        brick:HVAC ;
+    skos:definition "Device to remove gases from a mixture of gases" ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Filter .
 
 brick:Filter_Status a owl:Class ;
     rdfs:label "Filter Status" ;
@@ -5207,16 +5588,28 @@ brick:Gasoline a owl:Class,
 
 brick:HWS a owl:Class ;
     rdfs:label "HWS" ;
-    rdfs:subClassOf brick:Water_System ;
-    owl:equivalentClass brick:Hot_Water_System .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:HWS ;
+            owl:onProperty brick:hasTag ],
+        brick:Water_System ;
+    owl:equivalentClass brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:HWS .
 
 brick:HX a owl:Class ;
     rdfs:label "HX" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:HX ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:HX .
 
 brick:Heat_Sensor a owl:Class ;
     rdfs:label "Heat Sensor" ;
-    rdfs:subClassOf brick:Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Heat ) ],
+        brick:Sensor ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Sensor .
 
 brick:Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Heating Discharge Air Flow Setpoint" ;
@@ -5248,8 +5641,10 @@ brick:Heating_Supply_Air_Flow_Setpoint a owl:Class ;
 
 brick:Heating_Ventilation_Air_Conditioning_System a owl:Class ;
     rdfs:label "Heating Ventilation Air Conditioning System" ;
-    rdfs:subClassOf brick:Equipment ;
-    owl:equivalentClass brick:HVAC .
+    rdfs:subClassOf _:has_HVAC,
+        brick:Equipment ;
+    owl:equivalentClass brick:HVAC ;
+    brick:hasAssociatedTag tag:HVAC .
 
 brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Load Shed Status" ;
@@ -5466,7 +5861,15 @@ brick:Max_Temperature_Setpoint_Limit a owl:Class ;
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf brick:Differential_Pressure_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
 
 brick:Min_Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Min Discharge Air Temperature Setpoint" ;
@@ -5538,11 +5941,17 @@ brick:Occupancy_Status a owl:Class ;
 
 brick:Off_Command a owl:Class ;
     rdfs:label "Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off .
 
 brick:On_Command a owl:Class ;
     rdfs:label "On Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:On .
 
 brick:Operating_Mode_Status a owl:Class ;
     rdfs:label "Operating Mode Status" ;
@@ -5589,7 +5998,14 @@ brick:PM25_Level a owl:Class,
 
 brick:PV_Current_Output_Sensor a owl:Class ;
     rdfs:label "PV Current Output Sensor" ;
-    rdfs:subClassOf brick:Current_Output_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:PV ;
+                        owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
+        brick:Current_Output_Sensor ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Output,
+        tag:PV,
+        tag:Sensor .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
@@ -5650,17 +6066,30 @@ brick:Proportional_Gain_Parameter a owl:Class ;
 
 brick:Pump a owl:Class ;
     rdfs:label "Pump" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump ) ],
+        brick:HVAC ;
+    skos:definition "Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump .
 
 brick:RTU a owl:Class ;
     rdfs:label "RTU" ;
-    rdfs:subClassOf brick:AHU ;
-    owl:equivalentClass brick:Rooftop_Unit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RTU ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:AHU ;
+    owl:equivalentClass brick:Rooftop_Unit ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RTU .
 
 brick:RVAV a owl:Class ;
     rdfs:label "RVAV" ;
-    rdfs:subClassOf brick:Variable_Air_Volume_Box .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RVAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Variable_Air_Volume_Box ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RVAV .
 
 brick:Radiant_Temperature a owl:Class,
         brick:Radiant_Temperature ;
@@ -5721,9 +6150,22 @@ brick:Solar_Irradiance a owl:Class,
     rdfs:label "Solar Irradiance" ;
     rdfs:subClassOf brick:Irradiance .
 
+brick:Speed_Reset_Command a owl:Class ;
+    rdfs:label "Speed Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Reset,
+        tag:Speed .
+
 brick:Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Standby Load Shed Command" ;
-    rdfs:subClassOf brick:Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Shed,
+        tag:Standby .
 
 brick:Standby_Unit_On_Off_Status a owl:Class ;
     rdfs:label "Standby Unit On Off Status" ;
@@ -5734,10 +6176,6 @@ brick:Standby_Unit_On_Off_Status a owl:Class ;
         tag:Standby,
         tag:Status,
         tag:Unit .
-
-brick:Start_Stop_Command a owl:Class ;
-    rdfs:label "Start Stop Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
 
 brick:Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Static Pressure Step Parameter" ;
@@ -5844,7 +6282,11 @@ brick:Supply_Water_Flow_Sensor a owl:Class ;
 
 brick:Switch a owl:Class ;
     rdfs:label "Switch" ;
-    rdfs:subClassOf brick:Interface .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch ) ],
+        brick:Interface ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Switch .
 
 brick:TVOC_Level a owl:Class,
         brick:TVOC_Level ;
@@ -5891,11 +6333,21 @@ brick:Torque_Sensor a owl:Class ;
 
 brick:Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Unoccupied Load Shed Command" ;
-    rdfs:subClassOf brick:Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Shed,
+        tag:Unoccupied .
 
 brick:VAV a owl:Class ;
     rdfs:label "VAV" ;
-    rdfs:subClassOf brick:Terminal_Unit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:VAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Terminal_Unit ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VAV .
 
 brick:Voltage_Angle a owl:Class,
         brick:Voltage_Angle ;
@@ -5914,7 +6366,15 @@ brick:Voltage_Magnitude a owl:Class,
 
 brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Warmest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf brick:Zone_Air_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Warmest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Warmest,
+        tag:Zone .
 
 brick:Water_Level_Sensor a owl:Class ;
     rdfs:label "Water Level Sensor" ;
@@ -6171,7 +6631,10 @@ brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
 
 brick:Chiller a owl:Class ;
     rdfs:label "Chiller" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Chiller,
+        tag:Equipment .
 
 brick:Coil a owl:Class ;
     rdfs:label "Coil" ;
@@ -6326,7 +6789,12 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
 
 brick:Fire_Safety_System a owl:Class ;
     rdfs:label "Fire Safety System" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety _:has_System ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Safety,
+        tag:System .
 
 brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
@@ -6357,8 +6825,12 @@ brick:Hail a owl:Class,
 
 brick:Heat_Exchanger a owl:Class ;
     rdfs:label "Heat Exchanger" ;
-    rdfs:subClassOf brick:HVAC ;
-    owl:equivalentClass brick:HX .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:HVAC ;
+    owl:equivalentClass brick:HX ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:High_Temperature_Alarm a owl:Class ;
     rdfs:label "High Temperature Alarm" ;
@@ -6416,7 +6888,10 @@ brick:Illuminance a owl:Class,
 
 brick:Interface a owl:Class ;
     rdfs:label "Interface" ;
-    rdfs:subClassOf brick:Lighting_System .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface ) ],
+        brick:Lighting_System ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface .
 
 brick:Irradiance a owl:Class,
         brick:Irradiance ;
@@ -6446,12 +6921,11 @@ brick:Lighting_System a owl:Class ;
 
 brick:Load_Shed_Command a owl:Class ;
     rdfs:label "Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Load_Shed ;
-                        owl:onProperty brick:hasTag ] _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Load_Shed .
+        tag:Load,
+        tag:Shed .
 
 brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Cooling Discharge Air Flow Setpoint Limit" ;
@@ -6683,10 +7157,13 @@ brick:Position_Sensor a owl:Class ;
 
 brick:Power_Sensor a owl:Class ;
     rdfs:label "Power Sensor" ;
-    rdfs:subClassOf brick:Sensor ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power ) ],
+        brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Power ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Power,
+        tag:Sensor .
 
 brick:Pressure_Alarm a owl:Class ;
     rdfs:label "Pressure Alarm" ;
@@ -6757,7 +7234,10 @@ brick:Return_Water_Temperature_Sensor a owl:Class ;
 
 brick:Room a owl:Class ;
     rdfs:label "Room" ;
-    rdfs:subClassOf brick:Location .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Room _:has_Location ) ],
+        brick:Location ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room .
 
 brick:Run_Status a owl:Class ;
     rdfs:label "Run Status" ;
@@ -6933,8 +7413,13 @@ brick:Usage_Sensor a owl:Class ;
 
 brick:Variable_Air_Volume_Box a owl:Class ;
     rdfs:label "Variable Air Volume Box" ;
-    rdfs:subClassOf brick:Terminal_Unit ;
-    owl:equivalentClass brick:VAV .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:VAV ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Variable,
+        tag:Volume .
 
 brick:Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Water Temperature Alarm" ;
@@ -6961,8 +7446,14 @@ brick:feeds a owl:AsymmetricProperty,
     owl:inverseOf brick:isFedBy ;
     skos:definition "The subject is upstream of the object in the context of some sequential process; some media is passed between them" .
 
+tag:Absorption a brick:Tag ;
+    rdfs:label "Absorption" .
+
 tag:Acceleration a brick:Tag ;
     rdfs:label "Acceleration" .
+
+tag:Automatic a brick:Tag ;
+    rdfs:label "Automatic" .
 
 tag:Azimuth a brick:Tag ;
     rdfs:label "Azimuth" .
@@ -6973,6 +7464,9 @@ tag:Basement a brick:Tag ;
 tag:Blowdown a brick:Tag ;
     rdfs:label "Blowdown" .
 
+tag:Boiler a brick:Tag ;
+    rdfs:label "Boiler" .
+
 tag:Booster a brick:Tag ;
     rdfs:label "Booster" .
 
@@ -6982,8 +7476,17 @@ tag:Bus a brick:Tag ;
 tag:Button a brick:Tag ;
     rdfs:label "Button" .
 
+tag:CRAC a brick:Tag ;
+    rdfs:label "CRAC" .
+
+tag:CWS a brick:Tag ;
+    rdfs:label "CWS" .
+
 tag:Capacity a brick:Tag ;
     rdfs:label "Capacity" .
+
+tag:Centrifugal a brick:Tag ;
+    rdfs:label "Centrifugal" .
 
 tag:Change a brick:Tag ;
     rdfs:label "Change" .
@@ -6997,14 +7500,23 @@ tag:Close a brick:Tag ;
 tag:Code a brick:Tag ;
     rdfs:label "Code" .
 
+tag:Cold a brick:Tag ;
+    rdfs:label "Cold" .
+
+tag:Coldest a brick:Tag ;
+    rdfs:label "Coldest" .
+
 tag:Communication a brick:Tag ;
     rdfs:label "Communication" .
 
+tag:Compressor a brick:Tag ;
+    rdfs:label "Compressor" .
+
+tag:Computer a brick:Tag ;
+    rdfs:label "Computer" .
+
 tag:Condensate a brick:Tag ;
     rdfs:label "Condensate" .
-
-tag:Condenser a brick:Tag ;
-    rdfs:label "Condenser" .
 
 tag:Contact a brick:Tag ;
     rdfs:label "Contact" .
@@ -7024,8 +7536,11 @@ tag:Deceleration a brick:Tag ;
 tag:Dehumidification a brick:Tag ;
     rdfs:label "Dehumidification" .
 
-tag:Drive a brick:Tag ;
-    rdfs:label "Drive" .
+tag:Dimmer a brick:Tag ;
+    rdfs:label "Dimmer" .
+
+tag:Driver a brick:Tag ;
+    rdfs:label "Driver" .
 
 tag:Dual a brick:Tag ;
     rdfs:label "Dual" .
@@ -7033,23 +7548,35 @@ tag:Dual a brick:Tag ;
 tag:Econcycle a brick:Tag ;
     rdfs:label "Econcycle" .
 
-tag:Economizer a brick:Tag ;
-    rdfs:label "Economizer" .
+tag:Elevator a brick:Tag ;
+    rdfs:label "Elevator" .
+
+tag:Environment a brick:Tag ;
+    rdfs:label "Environment" .
+
+tag:Evaporative a brick:Tag ;
+    rdfs:label "Evaporative" .
 
 tag:Even a brick:Tag ;
     rdfs:label "Even" .
 
+tag:FCP a brick:Tag ;
+    rdfs:label "FCP" .
+
+tag:FCU a brick:Tag ;
+    rdfs:label "FCU" .
+
 tag:Floor a brick:Tag ;
     rdfs:label "Floor" .
 
-tag:Freeze a brick:Tag ;
-    rdfs:label "Freeze" .
+tag:Freezer a brick:Tag ;
+    rdfs:label "Freezer" .
 
 tag:Fuel a brick:Tag ;
     rdfs:label "Fuel" .
 
-tag:Fume a brick:Tag ;
-    rdfs:label "Fume" .
+tag:Furniture a brick:Tag ;
+    rdfs:label "Furniture" .
 
 tag:Gasoline a brick:Tag ;
     rdfs:label "Gasoline" .
@@ -7057,23 +7584,29 @@ tag:Gasoline a brick:Tag ;
 tag:Glycool a brick:Tag ;
     rdfs:label "Glycool" .
 
+tag:HWS a brick:Tag ;
+    rdfs:label "HWS" .
+
+tag:HX a brick:Tag ;
+    rdfs:label "HX" .
+
 tag:Hand a brick:Tag ;
     rdfs:label "Hand" .
 
-tag:Highest a brick:Tag ;
-    rdfs:label "Highest" .
+tag:Handler a brick:Tag ;
+    rdfs:label "Handler" .
+
+tag:Head a brick:Tag ;
+    rdfs:label "Head" .
+
+tag:Heater a brick:Tag ;
+    rdfs:label "Heater" .
 
 tag:Hold a brick:Tag ;
     rdfs:label "Hold" .
 
-tag:Hood a brick:Tag ;
-    rdfs:label "Hood" .
-
 tag:Humidification a brick:Tag ;
     rdfs:label "Humidification" .
-
-tag:Humidifier a brick:Tag ;
-    rdfs:label "Humidifier" .
 
 tag:Humidify a brick:Tag ;
     rdfs:label "Humidify" .
@@ -7090,14 +7623,8 @@ tag:Isolation a brick:Tag ;
 tag:Last a brick:Tag ;
     rdfs:label "Last" .
 
-tag:Load_Shed a brick:Tag ;
-    rdfs:label "Load_Shed" .
-
 tag:Locally a brick:Tag ;
     rdfs:label "Locally" .
-
-tag:Maintenance a brick:Tag ;
-    rdfs:label "Maintenance" .
 
 tag:Makeup a brick:Tag ;
     rdfs:label "Makeup" .
@@ -7120,9 +7647,6 @@ tag:Natural a brick:Tag ;
 tag:No a brick:Tag ;
     rdfs:label "No" .
 
-tag:OnOff a brick:Tag ;
-    rdfs:label "OnOff" .
-
 tag:Open a brick:Tag ;
     rdfs:label "Open" .
 
@@ -7132,8 +7656,8 @@ tag:Overload a brick:Tag ;
 tag:PIR a brick:Tag ;
     rdfs:label "PIR" .
 
-tag:Peak a brick:Tag ;
-    rdfs:label "Peak" .
+tag:PV a brick:Tag ;
+    rdfs:label "PV" .
 
 tag:Photovoltaic a brick:Tag ;
     rdfs:label "Photovoltaic" .
@@ -7150,14 +7674,26 @@ tag:PlugStrip a brick:Tag ;
 tag:Pre a brick:Tag ;
     rdfs:label "Pre" .
 
+tag:Protect a brick:Tag ;
+    rdfs:label "Protect" .
+
 tag:Push a brick:Tag ;
     rdfs:label "Push" .
+
+tag:RTU a brick:Tag ;
+    rdfs:label "RTU" .
+
+tag:RVAV a brick:Tag ;
+    rdfs:label "RVAV" .
 
 tag:Radiance a brick:Tag ;
     rdfs:label "Radiance" .
 
 tag:Rated a brick:Tag ;
     rdfs:label "Rated" .
+
+tag:Ratio a brick:Tag ;
+    rdfs:label "Ratio" .
 
 tag:Reactive a brick:Tag ;
     rdfs:label "Reactive" .
@@ -7167,9 +7703,6 @@ tag:Ready a brick:Tag ;
 
 tag:Real a brick:Tag ;
     rdfs:label "Real" .
-
-tag:Reheat a brick:Tag ;
-    rdfs:label "Reheat" .
 
 tag:Relative a brick:Tag ;
     rdfs:label "Relative" .
@@ -7186,14 +7719,14 @@ tag:Roof a brick:Tag ;
 tag:Rooftop a brick:Tag ;
     rdfs:label "Rooftop" .
 
-tag:Room a brick:Tag ;
-    rdfs:label "Room" .
-
 tag:Sash a brick:Tag ;
     rdfs:label "Sash" .
 
 tag:Schedule a brick:Tag ;
     rdfs:label "Schedule" .
+
+tag:Server a brick:Tag ;
+    rdfs:label "Server" .
 
 tag:Shade a brick:Tag ;
     rdfs:label "Shade" .
@@ -7204,11 +7737,11 @@ tag:Short a brick:Tag ;
 tag:Site a brick:Tag ;
     rdfs:label "Site" .
 
-tag:Space a brick:Tag ;
-    rdfs:label "Space" .
-
 tag:Stages a brick:Tag ;
     rdfs:label "Stages" .
+
+tag:Suction a brick:Tag ;
+    rdfs:label "Suction" .
 
 tag:Tank a brick:Tag ;
     rdfs:label "Tank" .
@@ -7216,11 +7749,20 @@ tag:Tank a brick:Tag ;
 tag:Temporary a brick:Tag ;
     rdfs:label "Temporary" .
 
+tag:Terminal a brick:Tag ;
+    rdfs:label "Terminal" .
+
+tag:Thermostat a brick:Tag ;
+    rdfs:label "Thermostat" .
+
 tag:Timer a brick:Tag ;
     rdfs:label "Timer" .
 
-tag:Today a brick:Tag ;
-    rdfs:label "Today" .
+tag:Touchpanel a brick:Tag ;
+    rdfs:label "Touchpanel" .
+
+tag:Tower a brick:Tag ;
+    rdfs:label "Tower" .
 
 tag:Trace a brick:Tag ;
     rdfs:label "Trace" .
@@ -7228,8 +7770,8 @@ tag:Trace a brick:Tag ;
 tag:Underfloor a brick:Tag ;
     rdfs:label "Underfloor" .
 
-tag:VFD a brick:Tag ;
-    rdfs:label "VFD" .
+tag:VAV a brick:Tag ;
+    rdfs:label "VAV" .
 
 tag:Vent a brick:Tag ;
     rdfs:label "Vent" .
@@ -7237,8 +7779,14 @@ tag:Vent a brick:Tag ;
 tag:Warm a brick:Tag ;
     rdfs:label "Warm" .
 
+tag:Warmest a brick:Tag ;
+    rdfs:label "Warmest" .
+
 tag:Weather a brick:Tag ;
     rdfs:label "Weather" .
+
+tag:Wheel a brick:Tag ;
+    rdfs:label "Wheel" .
 
 tag:Wing a brick:Tag ;
     rdfs:label "Wing" .
@@ -7502,6 +8050,13 @@ brick:Pressure_Status a owl:Class ;
     brick:hasAssociatedTag tag:Pressure,
         tag:Status .
 
+brick:Reset_Command a owl:Class ;
+    rdfs:label "Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Command ) ],
+        brick:Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Reset .
+
 brick:Speed a owl:Class,
         brick:Speed ;
     rdfs:label "Speed" ;
@@ -7597,7 +8152,10 @@ brick:Time a owl:Class,
 
 brick:VFD a owl:Class ;
     rdfs:label "VFD" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_VFD ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VFD .
 
 brick:Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Velocity Pressure Sensor" ;
@@ -7640,7 +8198,11 @@ brick:Water_Flow_Sensor a owl:Class ;
 
 brick:Water_Pump a owl:Class ;
     rdfs:label "Water Pump" ;
-    rdfs:subClassOf brick:Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Water ) ],
+        brick:Pump ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Water_Valve a owl:Class ;
     rdfs:label "Water Valve" ;
@@ -7677,8 +8239,14 @@ tag:Auto a brick:Tag ;
 tag:Battery a brick:Tag ;
     rdfs:label "Battery" .
 
+tag:Conditioning a brick:Tag ;
+    rdfs:label "Conditioning" .
+
 tag:Conductivity a brick:Tag ;
     rdfs:label "Conductivity" .
+
+tag:Control a brick:Tag ;
+    rdfs:label "Control" .
 
 tag:Cycle a brick:Tag ;
     rdfs:label "Cycle" .
@@ -7695,14 +8263,20 @@ tag:Delay a brick:Tag ;
 tag:Derivative a brick:Tag ;
     rdfs:label "Derivative" .
 
+tag:Detection a brick:Tag ;
+    rdfs:label "Detection" .
+
+tag:Drive a brick:Tag ;
+    rdfs:label "Drive" .
+
 tag:Duct a brick:Tag ;
     rdfs:label "Duct" .
 
 tag:Duration a brick:Tag ;
     rdfs:label "Duration" .
 
-tag:Exchanger a brick:Tag ;
-    rdfs:label "Exchanger" .
+tag:Economizer a brick:Tag ;
+    rdfs:label "Economizer" .
 
 tag:Failure a brick:Tag ;
     rdfs:label "Failure" .
@@ -7710,11 +8284,8 @@ tag:Failure a brick:Tag ;
 tag:Fequency a brick:Tag ;
     rdfs:label "Fequency" .
 
-tag:Fire a brick:Tag ;
-    rdfs:label "Fire" .
-
-tag:Frequency a brick:Tag ;
-    rdfs:label "Frequency" .
+tag:Freeze a brick:Tag ;
+    rdfs:label "Freeze" .
 
 tag:Fresh a brick:Tag ;
     rdfs:label "Fresh" .
@@ -7722,14 +8293,23 @@ tag:Fresh a brick:Tag ;
 tag:Frost a brick:Tag ;
     rdfs:label "Frost" .
 
+tag:Fume a brick:Tag ;
+    rdfs:label "Fume" .
+
 tag:Generator a brick:Tag ;
     rdfs:label "Generator" .
 
-tag:HVAC a brick:Tag ;
-    rdfs:label "HVAC" .
-
 tag:Hail a brick:Tag ;
     rdfs:label "Hail" .
+
+tag:Highest a brick:Tag ;
+    rdfs:label "Highest" .
+
+tag:Hood a brick:Tag ;
+    rdfs:label "Hood" .
+
+tag:Humidifier a brick:Tag ;
+    rdfs:label "Humidifier" .
 
 tag:Illuminance a brick:Tag ;
     rdfs:label "Illuminance" .
@@ -7737,14 +8317,14 @@ tag:Illuminance a brick:Tag ;
 tag:Lag a brick:Tag ;
     rdfs:label "Lag" .
 
-tag:Lead a brick:Tag ;
-    rdfs:label "Lead" .
-
-tag:Leak a brick:Tag ;
-    rdfs:label "Leak" .
-
 tag:Lowest a brick:Tag ;
     rdfs:label "Lowest" .
+
+tag:Luminaire a brick:Tag ;
+    rdfs:label "Luminaire" .
+
+tag:Maintenance a brick:Tag ;
+    rdfs:label "Maintenance" .
 
 tag:Oil a brick:Tag ;
     rdfs:label "Oil" .
@@ -7755,6 +8335,9 @@ tag:Operating a brick:Tag ;
 tag:Override a brick:Tag ;
     rdfs:label "Override" .
 
+tag:Peak a brick:Tag ;
+    rdfs:label "Peak" .
+
 tag:Percent a brick:Tag ;
     rdfs:label "Percent" .
 
@@ -7764,8 +8347,32 @@ tag:Point a brick:Tag ;
 tag:Rain a brick:Tag ;
     rdfs:label "Rain" .
 
+tag:Reheat a brick:Tag ;
+    rdfs:label "Reheat" .
+
+tag:Safety a brick:Tag ;
+    rdfs:label "Safety" .
+
+tag:Space a brick:Tag ;
+    rdfs:label "Space" .
+
+tag:Switch a brick:Tag ;
+    rdfs:label "Switch" .
+
+tag:Today a brick:Tag ;
+    rdfs:label "Today" .
+
 tag:Torque a brick:Tag ;
     rdfs:label "Torque" .
+
+tag:Turn a brick:Tag ;
+    rdfs:label "Turn" .
+
+tag:Ventilation a brick:Tag ;
+    rdfs:label "Ventilation" .
+
+tag:Volume a brick:Tag ;
+    rdfs:label "Volume" .
 
 tag:Wind a brick:Tag ;
     rdfs:label "Wind" .
@@ -7944,7 +8551,11 @@ brick:Heating_Valve a owl:Class ;
 
 brick:Laboratory a owl:Class ;
     rdfs:label "Laboratory" ;
-    rdfs:subClassOf brick:Room .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Room ;
+    brick:hasAssociatedTag tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Luminance a owl:Class,
         brick:Luminance ;
@@ -7985,13 +8596,6 @@ brick:PID_Parameter a owl:Class ;
         brick:Parameter ;
     brick:hasAssociatedTag tag:PID,
         tag:Parameter .
-
-brick:Reset_Command a owl:Class ;
-    rdfs:label "Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Command ) ],
-        brick:Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Reset .
 
 brick:Reset_Setpoint a owl:Class ;
     rdfs:label "Reset Setpoint" ;
@@ -8052,8 +8656,14 @@ brick:Temperature_Alarm a owl:Class ;
 
 brick:Terminal_Unit a owl:Class ;
     rdfs:label "Terminal Unit" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Terminal ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC ;
+    skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Terminal,
+        tag:Unit .
 
 brick:Valve a owl:Class ;
     rdfs:label "Valve" ;
@@ -8078,6 +8688,9 @@ tag:Angle a brick:Tag ;
 tag:Bypass a brick:Tag ;
     rdfs:label "Bypass" .
 
+tag:Chiller a brick:Tag ;
+    rdfs:label "Chiller" .
+
 tag:Detected a brick:Tag ;
     rdfs:label "Detected" .
 
@@ -8087,11 +8700,20 @@ tag:Effective a brick:Tag ;
 tag:Entering a brick:Tag ;
     rdfs:label "Entering" .
 
+tag:Frequency a brick:Tag ;
+    rdfs:label "Frequency" .
+
 tag:Grains a brick:Tag ;
     rdfs:label "Grains" .
 
+tag:HVAC a brick:Tag ;
+    rdfs:label "HVAC" .
+
 tag:Ice a brick:Tag ;
     rdfs:label "Ice" .
+
+tag:Lead a brick:Tag ;
+    rdfs:label "Lead" .
 
 tag:Level a brick:Tag ;
     rdfs:label "Level" .
@@ -8099,29 +8721,20 @@ tag:Level a brick:Tag ;
 tag:Lighting a brick:Tag ;
     rdfs:label "Lighting" .
 
-tag:Mixed a brick:Tag ;
-    rdfs:label "Mixed" .
-
 tag:Overridden a brick:Tag ;
     rdfs:label "Overridden" .
 
-tag:Pump a brick:Tag ;
-    rdfs:label "Pump" .
-
-tag:Shutdown a brick:Tag ;
-    rdfs:label "Shutdown" .
+tag:Panel a brick:Tag ;
+    rdfs:label "Panel" .
 
 tag:Smoke a brick:Tag ;
     rdfs:label "Smoke" .
 
-tag:Standby a brick:Tag ;
-    rdfs:label "Standby" .
-
 tag:Tolerance a brick:Tag ;
     rdfs:label "Tolerance" .
 
-tag:Unit a brick:Tag ;
-    rdfs:label "Unit" .
+tag:Variable a brick:Tag ;
+    rdfs:label "Variable" .
 
 brick:Air_Quality a owl:Class,
         brick:Air_Quality ;
@@ -8199,12 +8812,11 @@ brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
 
 brick:On_Off_Command a owl:Class ;
     rdfs:label "On Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:OnOff ;
-                        owl:onProperty brick:hasTag ] _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Off _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:OnOff .
+        tag:Off,
+        tag:On .
 
 brick:Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Setpoint" ;
@@ -8274,23 +8886,20 @@ tag:Average a brick:Tag ;
 tag:Building a brick:Tag ;
     rdfs:label "Building" .
 
-tag:Coil a brick:Tag ;
-    rdfs:label "Coil" .
+tag:Condenser a brick:Tag ;
+    rdfs:label "Condenser" .
 
 tag:Dewpoint a brick:Tag ;
     rdfs:label "Dewpoint" .
 
-tag:Electrical a brick:Tag ;
-    rdfs:label "Electrical" .
-
-tag:Fault a brick:Tag ;
-    rdfs:label "Fault" .
-
-tag:Filter a brick:Tag ;
-    rdfs:label "Filter" .
-
 tag:Fixed a brick:Tag ;
     rdfs:label "Fixed" .
+
+tag:Interface a brick:Tag ;
+    rdfs:label "Interface" .
+
+tag:Leak a brick:Tag ;
+    rdfs:label "Leak" .
 
 tag:Leaving a brick:Tag ;
     rdfs:label "Leaving" .
@@ -8301,14 +8910,14 @@ tag:Loss a brick:Tag ;
 tag:Luminance a brick:Tag ;
     rdfs:label "Luminance" .
 
+tag:Mixed a brick:Tag ;
+    rdfs:label "Mixed" .
+
 tag:Occupancy a brick:Tag ;
     rdfs:label "Occupancy" .
 
-tag:Output a brick:Tag ;
-    rdfs:label "Output" .
-
-tag:Preheat a brick:Tag ;
-    rdfs:label "Preheat" .
+tag:Shutdown a brick:Tag ;
+    rdfs:label "Shutdown" .
 
 tag:Solar a brick:Tag ;
     rdfs:label "Solar" .
@@ -8316,14 +8925,11 @@ tag:Solar a brick:Tag ;
 tag:Solid a brick:Tag ;
     rdfs:label "Solid" .
 
-tag:Start a brick:Tag ;
-    rdfs:label "Start" .
-
-tag:Stop a brick:Tag ;
-    rdfs:label "Stop" .
-
 tag:Storage a brick:Tag ;
     rdfs:label "Storage" .
+
+tag:VFD a brick:Tag ;
+    rdfs:label "VFD" .
 
 tag:Voltage a brick:Tag ;
     rdfs:label "Voltage" .
@@ -8350,7 +8956,10 @@ brick:Electric_Power a owl:Class,
 
 brick:Electrical_System a owl:Class ;
     rdfs:label "Electrical System" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:System .
 
 brick:Exhaust_Air a owl:Class,
         brick:Exhaust_Air ;
@@ -8410,14 +9019,23 @@ brick:Temperature_Setpoint a owl:Class ;
     brick:hasAssociatedTag tag:Setpoint,
         tag:Temperature .
 
-tag:Cool a brick:Tag ;
-    rdfs:label "Cool" .
+tag:Coil a brick:Tag ;
+    rdfs:label "Coil" .
 
 tag:Direction a brick:Tag ;
     rdfs:label "Direction" .
 
-tag:Energy a brick:Tag ;
-    rdfs:label "Energy" .
+tag:Electrical a brick:Tag ;
+    rdfs:label "Electrical" .
+
+tag:Exchanger a brick:Tag ;
+    rdfs:label "Exchanger" .
+
+tag:Fault a brick:Tag ;
+    rdfs:label "Fault" .
+
+tag:Laboratory a brick:Tag ;
+    rdfs:label "Laboratory" .
 
 tag:Lockout a brick:Tag ;
     rdfs:label "Lockout" .
@@ -8425,8 +9043,23 @@ tag:Lockout a brick:Tag ;
 tag:Motor a brick:Tag ;
     rdfs:label "Motor" .
 
+tag:Output a brick:Tag ;
+    rdfs:label "Output" .
+
+tag:Preheat a brick:Tag ;
+    rdfs:label "Preheat" .
+
 tag:Stack a brick:Tag ;
     rdfs:label "Stack" .
+
+tag:Standby a brick:Tag ;
+    rdfs:label "Standby" .
+
+tag:Start a brick:Tag ;
+    rdfs:label "Start" .
+
+tag:Stop a brick:Tag ;
+    rdfs:label "Stop" .
 
 tag:Velocity a brick:Tag ;
     rdfs:label "Velocity" .
@@ -8500,14 +9133,26 @@ brick:Water_Temperature_Sensor a owl:Class ;
         tag:Temperature,
         tag:Water .
 
-tag:Current a brick:Tag ;
-    rdfs:label "Current" .
+tag:Box a brick:Tag ;
+    rdfs:label "Box" .
+
+tag:Cool a brick:Tag ;
+    rdfs:label "Cool" .
+
+tag:Energy a brick:Tag ;
+    rdfs:label "Energy" .
+
+tag:Fire a brick:Tag ;
+    rdfs:label "Fire" .
 
 tag:Gain a brick:Tag ;
     rdfs:label "Gain" .
 
 tag:Run a brick:Tag ;
     rdfs:label "Run" .
+
+tag:Unit a brick:Tag ;
+    rdfs:label "Unit" .
 
 brick:Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Air Temperature Sensor" ;
@@ -8566,17 +9211,17 @@ brick:Return_Air a owl:Class,
         tag:Gas,
         tag:Return .
 
+tag:Current a brick:Tag ;
+    rdfs:label "Current" .
+
 tag:Domestic a brick:Tag ;
     rdfs:label "Domestic" .
 
-tag:Medium a brick:Tag ;
-    rdfs:label "Medium" .
+tag:Filter a brick:Tag ;
+    rdfs:label "Filter" .
 
 tag:Request a brick:Tag ;
     rdfs:label "Request" .
-
-tag:Steam a brick:Tag ;
-    rdfs:label "Steam" .
 
 tag:Thermal a brick:Tag ;
     rdfs:label "Thermal" .
@@ -8603,11 +9248,14 @@ brick:Max_Limit a owl:Class ;
 tag:Disable a brick:Tag ;
     rdfs:label "Disable" .
 
-tag:Emergency a brick:Tag ;
-    rdfs:label "Emergency" .
-
 tag:Meter a brick:Tag ;
     rdfs:label "Meter" .
+
+tag:Pump a brick:Tag ;
+    rdfs:label "Pump" .
+
+tag:Steam a brick:Tag ;
+    rdfs:label "Steam" .
 
 brick:Humidity a owl:Class,
         brick:Humidity ;
@@ -8642,14 +9290,11 @@ tag:Enthalpy a brick:Tag ;
 tag:Position a brick:Tag ;
     rdfs:label "Position" .
 
-tag:Mode a brick:Tag ;
-    rdfs:label "Mode" .
+tag:Room a brick:Tag ;
+    rdfs:label "Room" .
 
 tag:Step a brick:Tag ;
     rdfs:label "Step" .
-
-tag:System a brick:Tag ;
-    rdfs:label "System" .
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
@@ -8675,14 +9320,14 @@ brick:Parameter a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Parameter .
 
-tag:Heat a brick:Tag ;
-    rdfs:label "Heat" .
-
-tag:Zone a brick:Tag ;
-    rdfs:label "Zone" .
-
 tag:CO2 a brick:Tag ;
     rdfs:label "CO2" .
+
+tag:Emergency a brick:Tag ;
+    rdfs:label "Emergency" .
+
+tag:Medium a brick:Tag ;
+    rdfs:label "Medium" .
 
 brick:Equipment a owl:Class ;
     rdfs:label "Equipment" ;
@@ -8697,17 +9342,11 @@ brick:Temperature_Parameter a owl:Class ;
     brick:hasAssociatedTag tag:Parameter,
         tag:Temperature .
 
-tag:Location a brick:Tag ;
-    rdfs:label "Location" .
+tag:Mode a brick:Tag ;
+    rdfs:label "Mode" .
 
-tag:On a brick:Tag ;
-    rdfs:label "On" .
-
-tag:Shed a brick:Tag ;
-    rdfs:label "Shed" .
-
-tag:Unoccupied a brick:Tag ;
-    rdfs:label "Unoccupied" .
+tag:System a brick:Tag ;
+    rdfs:label "System" .
 
 tag:Valve a brick:Tag ;
     rdfs:label "Valve" .
@@ -8716,12 +9355,6 @@ brick:Flow a owl:Class,
         brick:Flow ;
     rdfs:label "Flow" ;
     rdfs:subClassOf brick:Quantity .
-
-tag:Off a brick:Tag ;
-    rdfs:label "Off" .
-
-tag:Speed a brick:Tag ;
-    rdfs:label "Speed" .
 
 brick:Water a owl:Class,
         brick:Water ;
@@ -8733,17 +9366,20 @@ brick:Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
-tag:Fan a brick:Tag ;
-    rdfs:label "Fan" .
-
 tag:Gas a brick:Tag ;
     rdfs:label "Gas" .
 
-tag:Low a brick:Tag ;
-    rdfs:label "Low" .
+tag:Heat a brick:Tag ;
+    rdfs:label "Heat" .
 
-tag:Power a brick:Tag ;
-    rdfs:label "Power" .
+tag:Speed a brick:Tag ;
+    rdfs:label "Speed" .
+
+tag:Unoccupied a brick:Tag ;
+    rdfs:label "Unoccupied" .
+
+tag:Zone a brick:Tag ;
+    rdfs:label "Zone" .
 
 brick:Air a owl:Class,
         brick:Air ;
@@ -8757,20 +9393,26 @@ brick:Air a owl:Class,
 tag:Humidity a brick:Tag ;
     rdfs:label "Humidity" .
 
-tag:Load a brick:Tag ;
-    rdfs:label "Load" .
-
-tag:High a brick:Tag ;
-    rdfs:label "High" .
+tag:Low a brick:Tag ;
+    rdfs:label "Low" .
 
 tag:Occupied a brick:Tag ;
     rdfs:label "Occupied" .
 
+tag:Integral a brick:Tag ;
+    rdfs:label "Integral" .
+
+tag:On a brick:Tag ;
+    rdfs:label "On" .
+
 tag:Enable a brick:Tag ;
     rdfs:label "Enable" .
 
-tag:Integral a brick:Tag ;
-    rdfs:label "Integral" .
+tag:Fan a brick:Tag ;
+    rdfs:label "Fan" .
+
+tag:Location a brick:Tag ;
+    rdfs:label "Location" .
 
 brick:Setpoint a owl:Class ;
     rdfs:label "Setpoint" ;
@@ -8791,8 +9433,14 @@ brick:Temperature a owl:Class,
 tag:Band a brick:Tag ;
     rdfs:label "Band" .
 
-tag:Return a brick:Tag ;
-    rdfs:label "Return" .
+tag:High a brick:Tag ;
+    rdfs:label "High" .
+
+tag:Power a brick:Tag ;
+    rdfs:label "Power" .
+
+tag:Shed a brick:Tag ;
+    rdfs:label "Shed" .
 
 brick:Alarm a owl:Class ;
     rdfs:label "Alarm" ;
@@ -8805,28 +9453,40 @@ brick:Alarm a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Alarm .
 
-tag:Exhaust a brick:Tag ;
-    rdfs:label "Exhaust" .
-
 tag:Liquid a brick:Tag ;
     rdfs:label "Liquid" .
 
 tag:Proportional a brick:Tag ;
     rdfs:label "Proportional" .
 
+tag:Return a brick:Tag ;
+    rdfs:label "Return" .
+
 tag:Time a brick:Tag ;
     rdfs:label "Time" .
 
 brick:HVAC a owl:Class ;
     rdfs:label "HVAC" ;
-    rdfs:subClassOf brick:Equipment ;
-    owl:equivalentClass brick:Heating_Ventilation_Air_Conditioning_System .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Ventilation _:has_Air _:has_Conditioning _:has_System ) ],
+        brick:Equipment ;
+    owl:equivalentClass brick:Heating_Ventilation_Air_Conditioning_System ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Conditioning,
+        tag:Heating,
+        tag:System,
+        tag:Ventilation .
 
 tag:Deadband a brick:Tag ;
     rdfs:label "Deadband" .
 
-tag:Reset a brick:Tag ;
-    rdfs:label "Reset" .
+tag:Exhaust a brick:Tag ;
+    rdfs:label "Exhaust" .
+
+tag:Off a brick:Tag ;
+    rdfs:label "Off" .
+
+tag:Load a brick:Tag ;
+    rdfs:label "Load" .
 
 tag:Min a brick:Tag ;
     rdfs:label "Min" .
@@ -8845,18 +9505,18 @@ brick:Command a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Command .
 
+tag:Max a brick:Tag ;
+    rdfs:label "Max" .
+
 tag:Chilled a brick:Tag ;
     rdfs:label "Chilled" .
 
-tag:Max a brick:Tag ;
-    rdfs:label "Max" .
+tag:Reset a brick:Tag ;
+    rdfs:label "Reset" .
 
 brick:Quantity a owl:Class ;
     rdfs:subClassOf sosa:ObservableProperty,
         brick:Measurable .
-
-tag:Cooling a brick:Tag ;
-    rdfs:label "Cooling" .
 
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
@@ -8869,17 +9529,17 @@ brick:Status a owl:Class ;
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Status .
 
-tag:Heating a brick:Tag ;
-    rdfs:label "Heating" .
+tag:Cooling a brick:Tag ;
+    rdfs:label "Cooling" .
 
 tag:Fluid a brick:Tag ;
     rdfs:label "Fluid" .
 
+tag:Heating a brick:Tag ;
+    rdfs:label "Heating" .
+
 tag:Static a brick:Tag ;
     rdfs:label "Static" .
-
-tag:Hot a brick:Tag ;
-    rdfs:label "Hot" .
 
 brick:Sensor a owl:Class ;
     rdfs:label "Sensor" ;
@@ -8892,20 +9552,20 @@ brick:Sensor a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Sensor .
 
-tag:Command a brick:Tag ;
-    rdfs:label "Command" .
-
 tag:PID a brick:Tag ;
     rdfs:label "PID" .
+
+tag:Hot a brick:Tag ;
+    rdfs:label "Hot" .
 
 tag:Alarm a brick:Tag ;
     rdfs:label "Alarm" .
 
-tag:Equipment a brick:Tag ;
-    rdfs:label "Equipment" .
-
 tag:Limit a brick:Tag ;
     rdfs:label "Limit" .
+
+tag:Command a brick:Tag ;
+    rdfs:label "Command" .
 
 tag:Differential a brick:Tag ;
     rdfs:label "Differential" .
@@ -8916,23 +9576,23 @@ tag:Status a brick:Tag ;
 tag:Flow a brick:Tag ;
     rdfs:label "Flow" .
 
-tag:Supply a brick:Tag ;
-    rdfs:label "Supply" .
-
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
 
+tag:Supply a brick:Tag ;
+    rdfs:label "Supply" .
+
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .
+
+tag:Equipment a brick:Tag ;
+    rdfs:label "Equipment" .
 
 tag:Parameter a brick:Tag ;
     rdfs:label "Parameter" .
 
 tag:Water a brick:Tag ;
     rdfs:label "Water" .
-
-tag:Temperature a brick:Tag ;
-    rdfs:label "Temperature" .
 
 brick:measures a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -8941,6 +9601,9 @@ brick:measures a owl:AsymmetricProperty,
     rdfs:range brick:Measurable ;
     owl:inverseOf brick:isMeasuredBy ;
     skos:definition "The subject measures a quantity or substance given by the object" .
+
+tag:Temperature a brick:Tag ;
+    rdfs:label "Temperature" .
 
 tag:Sensor a brick:Tag ;
     rdfs:label "Sensor" .
@@ -8978,8 +9641,16 @@ _:has_Battery a owl:Restriction ;
     owl:hasValue tag:Battery ;
     owl:onProperty brick:hasTag .
 
+_:has_Conditioning a owl:Restriction ;
+    owl:hasValue tag:Conditioning ;
+    owl:onProperty brick:hasTag .
+
 _:has_Conductivity a owl:Restriction ;
     owl:hasValue tag:Conductivity ;
+    owl:onProperty brick:hasTag .
+
+_:has_Control a owl:Restriction ;
+    owl:hasValue tag:Control ;
     owl:onProperty brick:hasTag .
 
 _:has_Cycle a owl:Restriction ;
@@ -9002,6 +9673,14 @@ _:has_Derivative a owl:Restriction ;
     owl:hasValue tag:Derivative ;
     owl:onProperty brick:hasTag .
 
+_:has_Detection a owl:Restriction ;
+    owl:hasValue tag:Detection ;
+    owl:onProperty brick:hasTag .
+
+_:has_Drive a owl:Restriction ;
+    owl:hasValue tag:Drive ;
+    owl:onProperty brick:hasTag .
+
 _:has_Duct a owl:Restriction ;
     owl:hasValue tag:Duct ;
     owl:onProperty brick:hasTag .
@@ -9010,8 +9689,8 @@ _:has_Duration a owl:Restriction ;
     owl:hasValue tag:Duration ;
     owl:onProperty brick:hasTag .
 
-_:has_Exchanger a owl:Restriction ;
-    owl:hasValue tag:Exchanger ;
+_:has_Economizer a owl:Restriction ;
+    owl:hasValue tag:Economizer ;
     owl:onProperty brick:hasTag .
 
 _:has_Failure a owl:Restriction ;
@@ -9022,12 +9701,8 @@ _:has_Fequency a owl:Restriction ;
     owl:hasValue tag:Fequency ;
     owl:onProperty brick:hasTag .
 
-_:has_Fire a owl:Restriction ;
-    owl:hasValue tag:Fire ;
-    owl:onProperty brick:hasTag .
-
-_:has_Frequency a owl:Restriction ;
-    owl:hasValue tag:Frequency ;
+_:has_Freeze a owl:Restriction ;
+    owl:hasValue tag:Freeze ;
     owl:onProperty brick:hasTag .
 
 _:has_Fresh a owl:Restriction ;
@@ -9038,12 +9713,32 @@ _:has_Frost a owl:Restriction ;
     owl:hasValue tag:Frost ;
     owl:onProperty brick:hasTag .
 
+_:has_Fume a owl:Restriction ;
+    owl:hasValue tag:Fume ;
+    owl:onProperty brick:hasTag .
+
 _:has_Generator a owl:Restriction ;
     owl:hasValue tag:Generator ;
     owl:onProperty brick:hasTag .
 
+_:has_HVAC a owl:Restriction ;
+    owl:hasValue tag:HVAC ;
+    owl:onProperty brick:hasTag .
+
 _:has_Hail a owl:Restriction ;
     owl:hasValue tag:Hail ;
+    owl:onProperty brick:hasTag .
+
+_:has_Highest a owl:Restriction ;
+    owl:hasValue tag:Highest ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hood a owl:Restriction ;
+    owl:hasValue tag:Hood ;
+    owl:onProperty brick:hasTag .
+
+_:has_Humidifier a owl:Restriction ;
+    owl:hasValue tag:Humidifier ;
     owl:onProperty brick:hasTag .
 
 _:has_Ice a owl:Restriction ;
@@ -9058,20 +9753,20 @@ _:has_Lag a owl:Restriction ;
     owl:hasValue tag:Lag ;
     owl:onProperty brick:hasTag .
 
-_:has_Lead a owl:Restriction ;
-    owl:hasValue tag:Lead ;
-    owl:onProperty brick:hasTag .
-
-_:has_Leak a owl:Restriction ;
-    owl:hasValue tag:Leak ;
-    owl:onProperty brick:hasTag .
-
 _:has_Lighting a owl:Restriction ;
     owl:hasValue tag:Lighting ;
     owl:onProperty brick:hasTag .
 
 _:has_Lowest a owl:Restriction ;
     owl:hasValue tag:Lowest ;
+    owl:onProperty brick:hasTag .
+
+_:has_Luminaire a owl:Restriction ;
+    owl:hasValue tag:Luminaire ;
+    owl:onProperty brick:hasTag .
+
+_:has_Maintenance a owl:Restriction ;
+    owl:hasValue tag:Maintenance ;
     owl:onProperty brick:hasTag .
 
 _:has_Oil a owl:Restriction ;
@@ -9086,6 +9781,10 @@ _:has_Override a owl:Restriction ;
     owl:hasValue tag:Override ;
     owl:onProperty brick:hasTag .
 
+_:has_Peak a owl:Restriction ;
+    owl:hasValue tag:Peak ;
+    owl:onProperty brick:hasTag .
+
 _:has_Percent a owl:Restriction ;
     owl:hasValue tag:Percent ;
     owl:onProperty brick:hasTag .
@@ -9094,8 +9793,40 @@ _:has_Rain a owl:Restriction ;
     owl:hasValue tag:Rain ;
     owl:onProperty brick:hasTag .
 
+_:has_Reheat a owl:Restriction ;
+    owl:hasValue tag:Reheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Safety a owl:Restriction ;
+    owl:hasValue tag:Safety ;
+    owl:onProperty brick:hasTag .
+
+_:has_Space a owl:Restriction ;
+    owl:hasValue tag:Space ;
+    owl:onProperty brick:hasTag .
+
+_:has_Switch a owl:Restriction ;
+    owl:hasValue tag:Switch ;
+    owl:onProperty brick:hasTag .
+
+_:has_Today a owl:Restriction ;
+    owl:hasValue tag:Today ;
+    owl:onProperty brick:hasTag .
+
 _:has_Torque a owl:Restriction ;
     owl:hasValue tag:Torque ;
+    owl:onProperty brick:hasTag .
+
+_:has_Turn a owl:Restriction ;
+    owl:hasValue tag:Turn ;
+    owl:onProperty brick:hasTag .
+
+_:has_Ventilation a owl:Restriction ;
+    owl:hasValue tag:Ventilation ;
+    owl:onProperty brick:hasTag .
+
+_:has_Volume a owl:Restriction ;
+    owl:hasValue tag:Volume ;
     owl:onProperty brick:hasTag .
 
 _:has_Wind a owl:Restriction ;
@@ -9114,8 +9845,8 @@ _:has_Bypass a owl:Restriction ;
     owl:hasValue tag:Bypass ;
     owl:onProperty brick:hasTag .
 
-_:has_Coil a owl:Restriction ;
-    owl:hasValue tag:Coil ;
+_:has_Chiller a owl:Restriction ;
+    owl:hasValue tag:Chiller ;
     owl:onProperty brick:hasTag .
 
 _:has_Detected a owl:Restriction ;
@@ -9130,44 +9861,40 @@ _:has_Entering a owl:Restriction ;
     owl:hasValue tag:Entering ;
     owl:onProperty brick:hasTag .
 
+_:has_Frequency a owl:Restriction ;
+    owl:hasValue tag:Frequency ;
+    owl:onProperty brick:hasTag .
+
 _:has_Grains a owl:Restriction ;
     owl:hasValue tag:Grains ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lead a owl:Restriction ;
+    owl:hasValue tag:Lead ;
     owl:onProperty brick:hasTag .
 
 _:has_Level a owl:Restriction ;
     owl:hasValue tag:Level ;
     owl:onProperty brick:hasTag .
 
-_:has_Mixed a owl:Restriction ;
-    owl:hasValue tag:Mixed ;
-    owl:onProperty brick:hasTag .
-
 _:has_Overridden a owl:Restriction ;
     owl:hasValue tag:Overridden ;
     owl:onProperty brick:hasTag .
 
-_:has_Pump a owl:Restriction ;
-    owl:hasValue tag:Pump ;
-    owl:onProperty brick:hasTag .
-
-_:has_Shutdown a owl:Restriction ;
-    owl:hasValue tag:Shutdown ;
+_:has_Panel a owl:Restriction ;
+    owl:hasValue tag:Panel ;
     owl:onProperty brick:hasTag .
 
 _:has_Smoke a owl:Restriction ;
     owl:hasValue tag:Smoke ;
     owl:onProperty brick:hasTag .
 
-_:has_Standby a owl:Restriction ;
-    owl:hasValue tag:Standby ;
-    owl:onProperty brick:hasTag .
-
 _:has_Tolerance a owl:Restriction ;
     owl:hasValue tag:Tolerance ;
     owl:onProperty brick:hasTag .
 
-_:has_Unit a owl:Restriction ;
-    owl:hasValue tag:Unit ;
+_:has_Variable a owl:Restriction ;
+    owl:hasValue tag:Variable ;
     owl:onProperty brick:hasTag .
 
 _:has_Average a owl:Restriction ;
@@ -9178,28 +9905,28 @@ _:has_Building a owl:Restriction ;
     owl:hasValue tag:Building ;
     owl:onProperty brick:hasTag .
 
-_:has_Cool a owl:Restriction ;
-    owl:hasValue tag:Cool ;
+_:has_Coil a owl:Restriction ;
+    owl:hasValue tag:Coil ;
+    owl:onProperty brick:hasTag .
+
+_:has_Condenser a owl:Restriction ;
+    owl:hasValue tag:Condenser ;
     owl:onProperty brick:hasTag .
 
 _:has_Dewpoint a owl:Restriction ;
     owl:hasValue tag:Dewpoint ;
     owl:onProperty brick:hasTag .
 
-_:has_Electrical a owl:Restriction ;
-    owl:hasValue tag:Electrical ;
-    owl:onProperty brick:hasTag .
-
-_:has_Fault a owl:Restriction ;
-    owl:hasValue tag:Fault ;
-    owl:onProperty brick:hasTag .
-
-_:has_Filter a owl:Restriction ;
-    owl:hasValue tag:Filter ;
-    owl:onProperty brick:hasTag .
-
 _:has_Fixed a owl:Restriction ;
     owl:hasValue tag:Fixed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Interface a owl:Restriction ;
+    owl:hasValue tag:Interface ;
+    owl:onProperty brick:hasTag .
+
+_:has_Leak a owl:Restriction ;
+    owl:hasValue tag:Leak ;
     owl:onProperty brick:hasTag .
 
 _:has_Leaving a owl:Restriction ;
@@ -9214,16 +9941,16 @@ _:has_Luminance a owl:Restriction ;
     owl:hasValue tag:Luminance ;
     owl:onProperty brick:hasTag .
 
+_:has_Mixed a owl:Restriction ;
+    owl:hasValue tag:Mixed ;
+    owl:onProperty brick:hasTag .
+
 _:has_Occupancy a owl:Restriction ;
     owl:hasValue tag:Occupancy ;
     owl:onProperty brick:hasTag .
 
-_:has_Output a owl:Restriction ;
-    owl:hasValue tag:Output ;
-    owl:onProperty brick:hasTag .
-
-_:has_Preheat a owl:Restriction ;
-    owl:hasValue tag:Preheat ;
+_:has_Shutdown a owl:Restriction ;
+    owl:hasValue tag:Shutdown ;
     owl:onProperty brick:hasTag .
 
 _:has_Solar a owl:Restriction ;
@@ -9234,28 +9961,40 @@ _:has_Solid a owl:Restriction ;
     owl:hasValue tag:Solid ;
     owl:onProperty brick:hasTag .
 
-_:has_Start a owl:Restriction ;
-    owl:hasValue tag:Start ;
-    owl:onProperty brick:hasTag .
-
-_:has_Stop a owl:Restriction ;
-    owl:hasValue tag:Stop ;
-    owl:onProperty brick:hasTag .
-
 _:has_Storage a owl:Restriction ;
     owl:hasValue tag:Storage ;
+    owl:onProperty brick:hasTag .
+
+_:has_VFD a owl:Restriction ;
+    owl:hasValue tag:VFD ;
     owl:onProperty brick:hasTag .
 
 _:has_Voltage a owl:Restriction ;
     owl:hasValue tag:Voltage ;
     owl:onProperty brick:hasTag .
 
+_:has_Cool a owl:Restriction ;
+    owl:hasValue tag:Cool ;
+    owl:onProperty brick:hasTag .
+
 _:has_Direction a owl:Restriction ;
     owl:hasValue tag:Direction ;
     owl:onProperty brick:hasTag .
 
-_:has_Energy a owl:Restriction ;
-    owl:hasValue tag:Energy ;
+_:has_Electrical a owl:Restriction ;
+    owl:hasValue tag:Electrical ;
+    owl:onProperty brick:hasTag .
+
+_:has_Exchanger a owl:Restriction ;
+    owl:hasValue tag:Exchanger ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fault a owl:Restriction ;
+    owl:hasValue tag:Fault ;
+    owl:onProperty brick:hasTag .
+
+_:has_Laboratory a owl:Restriction ;
+    owl:hasValue tag:Laboratory ;
     owl:onProperty brick:hasTag .
 
 _:has_Lockout a owl:Restriction ;
@@ -9266,16 +10005,44 @@ _:has_Motor a owl:Restriction ;
     owl:hasValue tag:Motor ;
     owl:onProperty brick:hasTag .
 
+_:has_Output a owl:Restriction ;
+    owl:hasValue tag:Output ;
+    owl:onProperty brick:hasTag .
+
+_:has_Preheat a owl:Restriction ;
+    owl:hasValue tag:Preheat ;
+    owl:onProperty brick:hasTag .
+
 _:has_Stack a owl:Restriction ;
     owl:hasValue tag:Stack ;
+    owl:onProperty brick:hasTag .
+
+_:has_Standby a owl:Restriction ;
+    owl:hasValue tag:Standby ;
+    owl:onProperty brick:hasTag .
+
+_:has_Start a owl:Restriction ;
+    owl:hasValue tag:Start ;
+    owl:onProperty brick:hasTag .
+
+_:has_Stop a owl:Restriction ;
+    owl:hasValue tag:Stop ;
     owl:onProperty brick:hasTag .
 
 _:has_Velocity a owl:Restriction ;
     owl:hasValue tag:Velocity ;
     owl:onProperty brick:hasTag .
 
-_:has_Current a owl:Restriction ;
-    owl:hasValue tag:Current ;
+_:has_Box a owl:Restriction ;
+    owl:hasValue tag:Box ;
+    owl:onProperty brick:hasTag .
+
+_:has_Energy a owl:Restriction ;
+    owl:hasValue tag:Energy ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fire a owl:Restriction ;
+    owl:hasValue tag:Fire ;
     owl:onProperty brick:hasTag .
 
 _:has_Gain a owl:Restriction ;
@@ -9286,20 +10053,28 @@ _:has_Run a owl:Restriction ;
     owl:hasValue tag:Run ;
     owl:onProperty brick:hasTag .
 
-_:has_Steam a owl:Restriction ;
-    owl:hasValue tag:Steam ;
+_:has_Unit a owl:Restriction ;
+    owl:hasValue tag:Unit ;
+    owl:onProperty brick:hasTag .
+
+_:has_Current a owl:Restriction ;
+    owl:hasValue tag:Current ;
     owl:onProperty brick:hasTag .
 
 _:has_Domestic a owl:Restriction ;
     owl:hasValue tag:Domestic ;
     owl:onProperty brick:hasTag .
 
-_:has_Medium a owl:Restriction ;
-    owl:hasValue tag:Medium ;
+_:has_Filter a owl:Restriction ;
+    owl:hasValue tag:Filter ;
     owl:onProperty brick:hasTag .
 
 _:has_Request a owl:Restriction ;
     owl:hasValue tag:Request ;
+    owl:onProperty brick:hasTag .
+
+_:has_Steam a owl:Restriction ;
+    owl:hasValue tag:Steam ;
     owl:onProperty brick:hasTag .
 
 _:has_Thermal a owl:Restriction ;
@@ -9314,12 +10089,12 @@ _:has_Disable a owl:Restriction ;
     owl:hasValue tag:Disable ;
     owl:onProperty brick:hasTag .
 
-_:has_Emergency a owl:Restriction ;
-    owl:hasValue tag:Emergency ;
-    owl:onProperty brick:hasTag .
-
 _:has_Meter a owl:Restriction ;
     owl:hasValue tag:Meter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Pump a owl:Restriction ;
+    owl:hasValue tag:Pump ;
     owl:onProperty brick:hasTag .
 
 _:has_Damper a owl:Restriction ;
@@ -9338,108 +10113,104 @@ _:has_Position a owl:Restriction ;
     owl:hasValue tag:Position ;
     owl:onProperty brick:hasTag .
 
-_:has_Heat a owl:Restriction ;
-    owl:hasValue tag:Heat ;
-    owl:onProperty brick:hasTag .
-
-_:has_Mode a owl:Restriction ;
-    owl:hasValue tag:Mode ;
+_:has_Room a owl:Restriction ;
+    owl:hasValue tag:Room ;
     owl:onProperty brick:hasTag .
 
 _:has_Step a owl:Restriction ;
     owl:hasValue tag:Step ;
     owl:onProperty brick:hasTag .
 
-_:has_System a owl:Restriction ;
-    owl:hasValue tag:System ;
-    owl:onProperty brick:hasTag .
-
-_:has_Zone a owl:Restriction ;
-    owl:hasValue tag:Zone ;
-    owl:onProperty brick:hasTag .
-
 _:has_CO2 a owl:Restriction ;
     owl:hasValue tag:CO2 ;
     owl:onProperty brick:hasTag .
 
-_:has_Location a owl:Restriction ;
-    owl:hasValue tag:Location ;
+_:has_Emergency a owl:Restriction ;
+    owl:hasValue tag:Emergency ;
+    owl:onProperty brick:hasTag .
+
+_:has_Medium a owl:Restriction ;
+    owl:hasValue tag:Medium ;
     owl:onProperty brick:hasTag .
 
 _:has_Valve a owl:Restriction ;
     owl:hasValue tag:Valve ;
     owl:onProperty brick:hasTag .
 
-_:has_On a owl:Restriction ;
-    owl:hasValue tag:On ;
+_:has_Mode a owl:Restriction ;
+    owl:hasValue tag:Mode ;
     owl:onProperty brick:hasTag .
 
-_:has_Shed a owl:Restriction ;
-    owl:hasValue tag:Shed ;
-    owl:onProperty brick:hasTag .
-
-_:has_Unoccupied a owl:Restriction ;
-    owl:hasValue tag:Unoccupied ;
-    owl:onProperty brick:hasTag .
-
-_:has_Off a owl:Restriction ;
-    owl:hasValue tag:Off ;
-    owl:onProperty brick:hasTag .
-
-_:has_Speed a owl:Restriction ;
-    owl:hasValue tag:Speed ;
-    owl:onProperty brick:hasTag .
-
-_:has_Fan a owl:Restriction ;
-    owl:hasValue tag:Fan ;
+_:has_System a owl:Restriction ;
+    owl:hasValue tag:System ;
     owl:onProperty brick:hasTag .
 
 _:has_Gas a owl:Restriction ;
     owl:hasValue tag:Gas ;
     owl:onProperty brick:hasTag .
 
-_:has_Low a owl:Restriction ;
-    owl:hasValue tag:Low ;
+_:has_Heat a owl:Restriction ;
+    owl:hasValue tag:Heat ;
     owl:onProperty brick:hasTag .
 
-_:has_Power a owl:Restriction ;
-    owl:hasValue tag:Power ;
+_:has_Speed a owl:Restriction ;
+    owl:hasValue tag:Speed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Unoccupied a owl:Restriction ;
+    owl:hasValue tag:Unoccupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Zone a owl:Restriction ;
+    owl:hasValue tag:Zone ;
     owl:onProperty brick:hasTag .
 
 _:has_Humidity a owl:Restriction ;
     owl:hasValue tag:Humidity ;
     owl:onProperty brick:hasTag .
 
-_:has_Load a owl:Restriction ;
-    owl:hasValue tag:Load ;
-    owl:onProperty brick:hasTag .
-
-_:has_High a owl:Restriction ;
-    owl:hasValue tag:High ;
+_:has_Low a owl:Restriction ;
+    owl:hasValue tag:Low ;
     owl:onProperty brick:hasTag .
 
 _:has_Occupied a owl:Restriction ;
     owl:hasValue tag:Occupied ;
     owl:onProperty brick:hasTag .
 
+_:has_Integral a owl:Restriction ;
+    owl:hasValue tag:Integral ;
+    owl:onProperty brick:hasTag .
+
+_:has_Location a owl:Restriction ;
+    owl:hasValue tag:Location ;
+    owl:onProperty brick:hasTag .
+
+_:has_On a owl:Restriction ;
+    owl:hasValue tag:On ;
+    owl:onProperty brick:hasTag .
+
 _:has_Enable a owl:Restriction ;
     owl:hasValue tag:Enable ;
     owl:onProperty brick:hasTag .
 
-_:has_Integral a owl:Restriction ;
-    owl:hasValue tag:Integral ;
+_:has_Fan a owl:Restriction ;
+    owl:hasValue tag:Fan ;
     owl:onProperty brick:hasTag .
 
 _:has_Band a owl:Restriction ;
     owl:hasValue tag:Band ;
     owl:onProperty brick:hasTag .
 
-_:has_Return a owl:Restriction ;
-    owl:hasValue tag:Return ;
+_:has_High a owl:Restriction ;
+    owl:hasValue tag:High ;
     owl:onProperty brick:hasTag .
 
-_:has_Exhaust a owl:Restriction ;
-    owl:hasValue tag:Exhaust ;
+_:has_Power a owl:Restriction ;
+    owl:hasValue tag:Power ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shed a owl:Restriction ;
+    owl:hasValue tag:Shed ;
     owl:onProperty brick:hasTag .
 
 _:has_Liquid a owl:Restriction ;
@@ -9450,6 +10221,10 @@ _:has_Proportional a owl:Restriction ;
     owl:hasValue tag:Proportional ;
     owl:onProperty brick:hasTag .
 
+_:has_Return a owl:Restriction ;
+    owl:hasValue tag:Return ;
+    owl:onProperty brick:hasTag .
+
 _:has_Time a owl:Restriction ;
     owl:hasValue tag:Time ;
     owl:onProperty brick:hasTag .
@@ -9458,12 +10233,16 @@ _:has_Deadband a owl:Restriction ;
     owl:hasValue tag:Deadband ;
     owl:onProperty brick:hasTag .
 
-_:has_Reset a owl:Restriction ;
-    owl:hasValue tag:Reset ;
+_:has_Exhaust a owl:Restriction ;
+    owl:hasValue tag:Exhaust ;
     owl:onProperty brick:hasTag .
 
-_:has_Chilled a owl:Restriction ;
-    owl:hasValue tag:Chilled ;
+_:has_Off a owl:Restriction ;
+    owl:hasValue tag:Off ;
+    owl:onProperty brick:hasTag .
+
+_:has_Load a owl:Restriction ;
+    owl:hasValue tag:Load ;
     owl:onProperty brick:hasTag .
 
 _:has_Min a owl:Restriction ;
@@ -9474,48 +10253,52 @@ _:has_Outside a owl:Restriction ;
     owl:hasValue tag:Outside ;
     owl:onProperty brick:hasTag .
 
+_:has_Chilled a owl:Restriction ;
+    owl:hasValue tag:Chilled ;
+    owl:onProperty brick:hasTag .
+
 _:has_Max a owl:Restriction ;
     owl:hasValue tag:Max ;
+    owl:onProperty brick:hasTag .
+
+_:has_Reset a owl:Restriction ;
+    owl:hasValue tag:Reset ;
     owl:onProperty brick:hasTag .
 
 _:has_Cooling a owl:Restriction ;
     owl:hasValue tag:Cooling ;
     owl:onProperty brick:hasTag .
 
-_:has_Heating a owl:Restriction ;
-    owl:hasValue tag:Heating ;
-    owl:onProperty brick:hasTag .
-
 _:has_Fluid a owl:Restriction ;
     owl:hasValue tag:Fluid ;
+    owl:onProperty brick:hasTag .
+
+_:has_Heating a owl:Restriction ;
+    owl:hasValue tag:Heating ;
     owl:onProperty brick:hasTag .
 
 _:has_Static a owl:Restriction ;
     owl:hasValue tag:Static ;
     owl:onProperty brick:hasTag .
 
-_:has_Hot a owl:Restriction ;
-    owl:hasValue tag:Hot ;
-    owl:onProperty brick:hasTag .
-
-_:has_Command a owl:Restriction ;
-    owl:hasValue tag:Command ;
-    owl:onProperty brick:hasTag .
-
 _:has_PID a owl:Restriction ;
     owl:hasValue tag:PID ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hot a owl:Restriction ;
+    owl:hasValue tag:Hot ;
     owl:onProperty brick:hasTag .
 
 _:has_Alarm a owl:Restriction ;
     owl:hasValue tag:Alarm ;
     owl:onProperty brick:hasTag .
 
-_:has_Equipment a owl:Restriction ;
-    owl:hasValue tag:Equipment ;
-    owl:onProperty brick:hasTag .
-
 _:has_Limit a owl:Restriction ;
     owl:hasValue tag:Limit ;
+    owl:onProperty brick:hasTag .
+
+_:has_Command a owl:Restriction ;
+    owl:hasValue tag:Command ;
     owl:onProperty brick:hasTag .
 
 _:has_Differential a owl:Restriction ;
@@ -9530,16 +10313,20 @@ _:has_Flow a owl:Restriction ;
     owl:hasValue tag:Flow ;
     owl:onProperty brick:hasTag .
 
-_:has_Supply a owl:Restriction ;
-    owl:hasValue tag:Supply ;
-    owl:onProperty brick:hasTag .
-
 _:has_Discharge a owl:Restriction ;
     owl:hasValue tag:Discharge ;
     owl:onProperty brick:hasTag .
 
+_:has_Supply a owl:Restriction ;
+    owl:hasValue tag:Supply ;
+    owl:onProperty brick:hasTag .
+
 _:has_Pressure a owl:Restriction ;
     owl:hasValue tag:Pressure ;
+    owl:onProperty brick:hasTag .
+
+_:has_Equipment a owl:Restriction ;
+    owl:hasValue tag:Equipment ;
     owl:onProperty brick:hasTag .
 
 _:has_Parameter a owl:Restriction ;

--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -6,6 +6,11 @@ alarm_definitions = {
         "subclasses": {
             "Air_Alarm": {
                 "tags": [TAG.Point, TAG.Air, TAG.Alarm],
+                "subclasses": {
+                    "Air_Flow_Loss_Alarm": {
+                        "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Loss],
+                    }
+                }
             },
             "CO2_Alarm": {
                 "tags": [TAG.Point, TAG.CO2, TAG.Alarm],

--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -2,132 +2,136 @@ from .namespaces import TAG, BRICK
 
 alarm_definitions = {
     "Alarm": {
-        "tags": [TAG.Alarm],
+        "tags": [TAG.Point, TAG.Alarm],
         "subclasses": {
             "Air_Alarm": {
-                "tags": [TAG.Air, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Air, TAG.Alarm],
             },
             "CO2_Alarm": {
-                "tags": [TAG.CO2, TAG.Alarm],
+                "tags": [TAG.Point, TAG.CO2, TAG.Alarm],
                 "subclasses": {
                     "High_CO2_Alarm": {
-                        "tags": [TAG.High, TAG.CO2, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.High, TAG.CO2, TAG.Alarm],
                     },
                 },
             },
             "Change_Filter_Alarm": {
-                "tags": [TAG.Change, TAG.Filter, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Change, TAG.Filter, TAG.Alarm],
             },
             "Communication_Loss_Alarm": {
-                "tags": [TAG.Communication, TAG.Loss, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Communication, TAG.Loss, TAG.Alarm],
             },
             "Cycle_Alarm": {
-                "tags": [TAG.Cycle, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Cycle, TAG.Alarm],
                 "subclasses": {
                     "Short_Cycle_Alarm": {
-                        "tags": [TAG.Short, TAG.Cycle, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Short, TAG.Cycle, TAG.Alarm],
                     },
                 },
             },
             "Emergency_Alarm": {
-                "tags": [TAG.Emergency, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Emergency, TAG.Alarm],
                 "subclasses": {
                     "Emergency_Generator_Alarm": {
-                        "tags": [TAG.Generator, TAG.Emergency, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Generator, TAG.Emergency, TAG.Alarm],
                     },
                     "Emergency_Power_Loss_Alarm": {
-                        "tags": [TAG.Power, TAG.Loss, TAG.Emergency, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Power, TAG.Loss, TAG.Emergency, TAG.Alarm],
                         "parents": [BRICK.Power_Loss_Alarm],
                     },
                 },
             },
             "Failure_Alarm": {
-                "tags": [TAG.Failure, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Failure, TAG.Alarm],
                 "subclasses": {
                     "Unit_Failure_Alarm": {
-                        "tags": [TAG.Unit, TAG.Failure, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Unit, TAG.Failure, TAG.Alarm],
                     },
                 },
             },
             "Humidity_Alarm": {
-                "tags": [TAG.Humidity, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Humidity, TAG.Alarm],
                 "subclasses": {
                     "High_Humidity_Alarm": {
-                        "tags": [TAG.High, TAG.Humidity, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.High, TAG.Humidity, TAG.Alarm],
                     },
                     "Low_Humidity_Alarm": {
-                        "tags": [TAG.Low, TAG.Humidity, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Low, TAG.Humidity, TAG.Alarm],
                     },
                 },
             },
             "Leak_Alarm": {
-                "tags": [TAG.Leak, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Leak, TAG.Alarm],
                 "subclasses": {
                     "Condensate_Leak_Alarm": {
-                        "tags": [TAG.Condensate, TAG.Leak, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Condensate, TAG.Leak, TAG.Alarm],
                     },
                 },
             },
             "Liquid_Detected_Alarm": {
-                "tags": [TAG.Liquid, TAG.Detected, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Liquid, TAG.Detected, TAG.Alarm],
             },
             "Luminance_Alarm": {
-                "tags": [TAG.Luminance, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Luminance, TAG.Alarm],
             },
             "Maintenance_Required_Alarm": {
-                "tags": [TAG.Maintenance, TAG.Required, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Maintenance, TAG.Required, TAG.Alarm],
             },
             "Overload_Alarm": {
-                "tags": [TAG.Overload, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Overload, TAG.Alarm],
             },
             "Power_Alarm": {
-                "tags": [TAG.Power, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Power, TAG.Alarm],
                 "subclasses": {
                     "Power_Loss_Alarm": {
-                        "tags": [TAG.Power, TAG.Loss, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Power, TAG.Loss, TAG.Alarm],
                     },
                 },
             },
             "Pressure_Alarm": {
-                "tags": [TAG.Pressure, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Pressure, TAG.Alarm],
                 "subclasses": {
-                    "High_Head_Pressure_Alarm": {},
-                    "Low_Suction_Pressure_Alarm": {},
+                    "High_Head_Pressure_Alarm": {
+                        "tags": [TAG.Point, TAG.High, TAG.Head, TAG.Pressure, TAG.Alarm],
+                    },
+                    "Low_Suction_Pressure_Alarm": {
+                        "tags": [TAG.Point, TAG.Low, TAG.Suction, TAG.Pressure, TAG.Alarm],
+                    },
                 },
             },
             "Temperature_Alarm": {
-                "tags": [TAG.Temperature, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Temperature, TAG.Alarm],
                 "subclasses": {
                     "High_Temperature_Alarm": {
-                        "tags": [TAG.High, TAG.Temperature, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.High, TAG.Temperature, TAG.Alarm],
                     },
                     "Low_Temperature_Alarm": {
-                        "tags": [TAG.Low, TAG.Temperature, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Low, TAG.Temperature, TAG.Alarm],
                     },
                     "Water_Temperature_Alarm": {
-                        "tags": [TAG.Water, TAG.Temperature, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Water, TAG.Temperature, TAG.Alarm],
                         "parents": [BRICK.Water_Alarm],
                         "subclasses": {
                             "Discharge_Water_Temperature_Alarm": {
-                                "tags": [TAG.Discharge, TAG.Water,
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Water,
                                          TAG.Temperature, TAG.Alarm],
                             },
                             "Supply_Water_Temperature_Alarm": {
-                                "tags": [TAG.Supply, TAG.Water,
+                                "tags": [TAG.Point, TAG.Supply, TAG.Water,
                                          TAG.Temperature, TAG.Alarm],
                             },
                         },
                     },
                     "Air_Temperature_Alarm": {
-                        "tags": [TAG.Air, TAG.Temperature, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Alarm],
                         "parents": [BRICK.Air_Alarm],
                         "subclasses": {
                             "Discharge_Air_Temperature_Alarm": {
-                                "tags": [TAG.Discharge, TAG.Air,
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air,
                                          TAG.Temperature, TAG.Alarm],
                                 "subclasses": {
                                     "High_Discharge_Air_Temperature_Alarm": {
-                                        "tags": [TAG.High, TAG.Discharge,
+                                        "tags": [TAG.Point, TAG.High, TAG.Discharge,
                                                  TAG.Air, TAG.Temperature,
                                                  TAG.Alarm],
                                         "parents": [BRICK.High_Temperature_Alarm],
@@ -135,18 +139,18 @@ alarm_definitions = {
                                 },
                             },
                             "Supply_Air_Temperature_Alarm": {
-                                "tags": [TAG.Supply, TAG.Air,
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air,
                                          TAG.Temperature, TAG.Alarm],
                             },
                             "Return_Air_Temperature_Alarm": {
-                                "tags": [TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
+                                "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
                                 "subclasses": {
                                     "High_Return_Air_Temperature_Alarm": {
-                                        "tags": [TAG.High, TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
+                                        "tags": [TAG.Point, TAG.High, TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
                                         "parents": [BRICK.High_Temperature_Alarm],
                                     },
                                     "Low_Return_Air_Temperature_Alarm": {
-                                        "tags": [TAG.Low, TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
+                                        "tags": [TAG.Point, TAG.Low, TAG.Return, TAG.Air, TAG.Temperature, TAG.Alarm],
                                         "parents": [BRICK.Low_Temperature_Alarm],
                                     },
                                 },
@@ -156,13 +160,13 @@ alarm_definitions = {
                 }
             },
             "Smoke_Alarm": {
-                "tags": [TAG.Smoke, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Smoke, TAG.Alarm],
                 "subclasses": {
                     "Smoke_Detected_Alarm": {
-                        "tags": [TAG.Smoke, TAG.Detected, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Smoke, TAG.Detected, TAG.Alarm],
                         "subclasses": {
                             "Discharge_Air_Smoke_Detected_Alarm": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Smoke, TAG.Detected, TAG.Alarm],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Smoke, TAG.Detected, TAG.Alarm],
                                 "parents": [BRICK.Air_Alarm],
                             },
                         },
@@ -170,16 +174,16 @@ alarm_definitions = {
                 },
             },
             "Water_Alarm": {
-                "tags": [TAG.Water, TAG.Alarm],
+                "tags": [TAG.Point, TAG.Water, TAG.Alarm],
                 "subclasses": {
                     "Deionized_Water_Alarm": {
-                        "tags": [TAG.Deionized, TAG.Water, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Deionized, TAG.Water, TAG.Alarm],
                     },
                     "No_Water_Alarm": {
-                        "tags": [TAG.No, TAG.Water, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.No, TAG.Water, TAG.Alarm],
                     },
                     "Water_Loss_Alarm": {
-                        "tags": [TAG.Loss, TAG.Water, TAG.Alarm],
+                        "tags": [TAG.Point, TAG.Loss, TAG.Water, TAG.Alarm],
                     },
                 },
             },

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -144,7 +144,7 @@ command_definitions = {
                 "tags": [TAG.Lead, TAG.Lag, TAG.Command],
             },
             "Load_Shed_Command": {
-                "tags": [TAG.Load_Shed, TAG.Command],
+                "tags": [TAG.Load, TAG.Shed, TAG.Command],
                 "subclasses": {
                     "Standby_Load_Shed_Command": {
                         "subclasses": {

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -73,6 +73,7 @@ command_definitions = {
                         "tags": [TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
                         "subclasses": {
                             "Unoccupied_Hot_Water_Shutdown_Command": {
+                                "tags": [TAG.Unoccupied, TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
                             },
                         },
                     },
@@ -147,13 +148,19 @@ command_definitions = {
                 "tags": [TAG.Load, TAG.Shed, TAG.Command],
                 "subclasses": {
                     "Standby_Load_Shed_Command": {
+                        "tags": [TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
                         "subclasses": {
-                            "Zone_Standby_Load_Shed_Command": {},
+                            "Zone_Standby_Load_Shed_Command": {
+                                "tags": [TAG.Zone, TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
+                            },
                         },
                     },
                     "Unoccupied_Load_Shed_Command": {
+                        "tags": [TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
                         "subclasses": {
-                            "Zone_Unoccupied_Load_Shed_Command": {},
+                            "Zone_Unoccupied_Load_Shed_Command": {
+                                "tags": [TAG.Zone, TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
+                            },
                         },
                     },
                 },
@@ -161,9 +168,15 @@ command_definitions = {
             "Mode_Command": {
                 "tags": [TAG.Mode, TAG.Command],
                 "subclasses": {
-                    "Automatic_Mode_Command": {},
-                    "Maintenance_Mode_Command": {},
-                    "Box_Mode_Command": {},
+                    "Automatic_Mode_Command": {
+                        "tags": [TAG.Automatic, TAG.Mode, TAG.Command],
+                    },
+                    "Maintenance_Mode_Command": {
+                        "tags": [TAG.Maintenance, TAG.Mode, TAG.Command],
+                    },
+                    "Box_Mode_Command": {
+                        "tags": [TAG.Box, TAG.Mode, TAG.Command],
+                    },
                 },
             },
             "Frequency_Command": {

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -217,9 +217,6 @@ command_definitions = {
                     },
                     "Start_Stop_Command": {
                         "tags": [TAG.Start, TAG.Stop, TAG.Command],
-                        "subclasses": {
-                            "Domestic_Hot_Water_System_Start_Stop_Command": {},
-                        },
                     },
                 },
             },

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -7,7 +7,9 @@ command_definitions = {
             "Cooling_Command": {
                 "tags": [TAG.Cool, TAG.Command],
                 "subclasses": {
-                    "Highest_Zone_Cooling_Command": {},
+                    "Highest_Zone_Cooling_Command": {
+                        "tags": [TAG.Highest, TAG.Zone, TAG.Cool, TAG.Command],
+                    },
                 },
             },
             "Heating_Command": {
@@ -48,10 +50,20 @@ command_definitions = {
             "Reset_Command": {
                 "tags": [TAG.Reset, TAG.Command],
                 "subclasses": {
-                    "Fault_Reset_Command": {},
-                    "Filter_Reset_Command": {},
-                    "Speed_Reset_Command": {},
-                    "Fan_Speed_Reset_Command": {},
+                    "Fault_Reset_Command": {
+                        "tags": [TAG.Fault, TAG.Reset, TAG.Command],
+                    },
+                    "Filter_Reset_Command": {
+                        "tags": [TAG.Filter, TAG.Reset, TAG.Command],
+                    },
+                    "Speed_Reset_Command": {
+                        "tags": [TAG.Speed, TAG.Reset, TAG.Command],
+                        "subclasses": {
+                            "Fan_Speed_Reset_Command": {
+                                "tags": [TAG.Fan, TAG.Speed, TAG.Reset, TAG.Command],
+                            },
+                        }
+                    },
                 },
             },
             "Shutdown_Command": {

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -191,7 +191,7 @@ command_definitions = {
                 "tags": [TAG.Occupancy, TAG.Command],
             },
             "On_Off_Command": {
-                "tags": [TAG.OnOff, TAG.Command],
+                "tags": [TAG.On, TAG.Off, TAG.Command],
                 "subclasses": {
                     "Off_Command": {
                         "subclasses": {

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -2,237 +2,237 @@ from .namespaces import TAG, BRICK
 
 command_definitions = {
     "Command": {
-        "tags": [TAG.Command],
+        "tags": [TAG.Point, TAG.Command],
         "subclasses": {
             "Cooling_Command": {
-                "tags": [TAG.Cool, TAG.Command],
+                "tags": [TAG.Point, TAG.Cool, TAG.Command],
                 "subclasses": {
                     "Highest_Zone_Cooling_Command": {
-                        "tags": [TAG.Highest, TAG.Zone, TAG.Cool, TAG.Command],
+                        "tags": [TAG.Point, TAG.Highest, TAG.Zone, TAG.Cool, TAG.Command],
                     },
                 },
             },
             "Heating_Command": {
-                "tags": [TAG.Heat, TAG.Command],
+                "tags": [TAG.Point, TAG.Heat, TAG.Command],
             },
             "Luminance_Command": {
-                "tags": [TAG.Luminance, TAG.Command],
+                "tags": [TAG.Point, TAG.Luminance, TAG.Command],
             },
             "Bypass_Command": {
-                "tags": [TAG.Bypass, TAG.Command],
+                "tags": [TAG.Point, TAG.Bypass, TAG.Command],
             },
             "Damper_Command": {
-                "tags": [TAG.Damper, TAG.Command],
+                "tags": [TAG.Point, TAG.Damper, TAG.Command],
                 "subclasses": {
                     "Damper_Position_Command": {
-                        "tags": [TAG.Damper, TAG.Position, TAG.Command],
+                        "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Command],
                         "parents": [BRICK.Position_Command],
                     },
                 },
             },
             "Humidify_Command": {
-                "tags": [TAG.Humidify, TAG.Command],
+                "tags": [TAG.Point, TAG.Humidify, TAG.Command],
             },
             "Position_Command": {
-                "tags": [TAG.Position, TAG.Command],
+                "tags": [TAG.Point, TAG.Position, TAG.Command],
             },
             "Direction_Command": {
-                "tags": [TAG.Direction, TAG.Command],
+                "tags": [TAG.Point, TAG.Direction, TAG.Command],
             },
             "Pump_Command": {
                 # TODO: position?
-                "tags": [TAG.Pump, TAG.Command],
+                "tags": [TAG.Point, TAG.Pump, TAG.Command],
             },
             "Valve_Command": {
                 # TODO: position?
-                "tags": [TAG.Valve, TAG.Command],
+                "tags": [TAG.Point, TAG.Valve, TAG.Command],
             },
             "Reset_Command": {
-                "tags": [TAG.Reset, TAG.Command],
+                "tags": [TAG.Point, TAG.Reset, TAG.Command],
                 "subclasses": {
                     "Fault_Reset_Command": {
-                        "tags": [TAG.Fault, TAG.Reset, TAG.Command],
+                        "tags": [TAG.Point, TAG.Fault, TAG.Reset, TAG.Command],
                     },
                     "Filter_Reset_Command": {
-                        "tags": [TAG.Filter, TAG.Reset, TAG.Command],
+                        "tags": [TAG.Point, TAG.Filter, TAG.Reset, TAG.Command],
                     },
                     "Speed_Reset_Command": {
-                        "tags": [TAG.Speed, TAG.Reset, TAG.Command],
+                        "tags": [TAG.Point, TAG.Speed, TAG.Reset, TAG.Command],
                         "subclasses": {
                             "Fan_Speed_Reset_Command": {
-                                "tags": [TAG.Fan, TAG.Speed, TAG.Reset, TAG.Command],
+                                "tags": [TAG.Point, TAG.Fan, TAG.Speed, TAG.Reset, TAG.Command],
                             },
                         }
                     },
                 },
             },
             "Shutdown_Command": {
-                "tags": [TAG.Shutdown, TAG.Command],
+                "tags": [TAG.Point, TAG.Shutdown, TAG.Command],
                 "subclasses": {
                     "Hot_Water_Shutdown_Command": {
-                        "tags": [TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
+                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
                         "subclasses": {
                             "Unoccupied_Hot_Water_Shutdown_Command": {
-                                "tags": [TAG.Unoccupied, TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
+                                "tags": [TAG.Point, TAG.Unoccupied, TAG.Hot, TAG.Water, TAG.Shutdown, TAG.Command],
                             },
                         },
                     },
                 },
             },
             "Enable_Command": {
-                "tags": [TAG.Enable, TAG.Command],
+                "tags": [TAG.Point, TAG.Enable, TAG.Command],
                 "subclasses": {
                     "VFD_Enable_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.VFD],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.VFD],
                     },
                     "System_Enable_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.System],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.System],
                         "subclasses": {
                             "Chilled_Water_System_Enable_Command": {
-                                "tags": [TAG.Enable, TAG.Command, TAG.Chilled, TAG.Water, TAG.System],
+                                "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Chilled, TAG.Water, TAG.System],
                             },
                             "Hot_Water_System_Enable_Command": {
-                                "tags": [TAG.Enable, TAG.Command, TAG.Hot, TAG.Water, TAG.System],
+                                "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Hot, TAG.Water, TAG.System],
                                 "subclasses": {
                                     "Domestic_Hot_Water_System_Enable_Command": {
-                                        "tags": [TAG.Enable, TAG.Command, TAG.Domestic, TAG.Hot, TAG.Water, TAG.System],
+                                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Domestic, TAG.Hot, TAG.Water, TAG.System],
                                     },
                                 },
                             },
                         },
                     },
                     "Exhaust_Fan_Enable_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Fan, TAG.Exhaust],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Fan, TAG.Exhaust],
                     },
                     "Run_Enable_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Run],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Run],
                     },
                     "Enable_Differential_Enthalpy_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Differential, TAG.Enthalpy],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Differential, TAG.Enthalpy],
                     },
                     "Enable_Differential_Temperature_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Differential, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Differential, TAG.Temperature],
                     },
                     "Enable_Fixed_Enthalpy_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Fixed, TAG.Enthalpy],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Fixed, TAG.Enthalpy],
                     },
                     "Enable_Fixed_Temperature_Command": {
-                        "tags": [TAG.Enable, TAG.Command, TAG.Fixed, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Enable, TAG.Command, TAG.Fixed, TAG.Temperature],
                     },
                 },
             },
             "Disable_Command": {
-                "tags": [TAG.Disable, TAG.Command],
+                "tags": [TAG.Point, TAG.Disable, TAG.Command],
                 "subclasses": {
                     "Exhaust_Fan_Disable_Command": {
-                        "tags": [TAG.Disable, TAG.Command, TAG.Fan, TAG.Exhaust],
+                        "tags": [TAG.Point, TAG.Disable, TAG.Command, TAG.Fan, TAG.Exhaust],
                     },
                     "Disable_Differential_Enthalpy_Command": {
-                        "tags": [TAG.Disable, TAG.Command, TAG.Differential, TAG.Enthalpy],
+                        "tags": [TAG.Point, TAG.Disable, TAG.Command, TAG.Differential, TAG.Enthalpy],
                     },
                     "Disable_Differential_Temperature_Command": {
-                        "tags": [TAG.Disable, TAG.Command, TAG.Differential, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Disable, TAG.Command, TAG.Differential, TAG.Temperature],
                     },
                     "Disable_Fixed_Enthalpy_Command": {
-                        "tags": [TAG.Disable, TAG.Command, TAG.Fixed, TAG.Enthalpy],
+                        "tags": [TAG.Point, TAG.Disable, TAG.Command, TAG.Fixed, TAG.Enthalpy],
                     },
                     "Disable_Fixed_Temperature_Command": {
-                        "tags": [TAG.Disable, TAG.Command, TAG.Fixed, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Disable, TAG.Command, TAG.Fixed, TAG.Temperature],
                     },
                 },
             },
             "Lead_Lag_Command": {
-                "tags": [TAG.Lead, TAG.Lag, TAG.Command],
+                "tags": [TAG.Point, TAG.Lead, TAG.Lag, TAG.Command],
             },
             "Load_Shed_Command": {
-                "tags": [TAG.Load, TAG.Shed, TAG.Command],
+                "tags": [TAG.Point, TAG.Load, TAG.Shed, TAG.Command],
                 "subclasses": {
                     "Standby_Load_Shed_Command": {
-                        "tags": [TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
+                        "tags": [TAG.Point, TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
                         "subclasses": {
                             "Zone_Standby_Load_Shed_Command": {
-                                "tags": [TAG.Zone, TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
+                                "tags": [TAG.Point, TAG.Zone, TAG.Standby, TAG.Load, TAG.Shed, TAG.Command],
                             },
                         },
                     },
                     "Unoccupied_Load_Shed_Command": {
-                        "tags": [TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
+                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
                         "subclasses": {
                             "Zone_Unoccupied_Load_Shed_Command": {
-                                "tags": [TAG.Zone, TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
+                                "tags": [TAG.Point, TAG.Zone, TAG.Unoccupied, TAG.Load, TAG.Shed, TAG.Command],
                             },
                         },
                     },
                 },
             },
             "Mode_Command": {
-                "tags": [TAG.Mode, TAG.Command],
+                "tags": [TAG.Point, TAG.Mode, TAG.Command],
                 "subclasses": {
                     "Automatic_Mode_Command": {
-                        "tags": [TAG.Automatic, TAG.Mode, TAG.Command],
+                        "tags": [TAG.Point, TAG.Automatic, TAG.Mode, TAG.Command],
                     },
                     "Maintenance_Mode_Command": {
-                        "tags": [TAG.Maintenance, TAG.Mode, TAG.Command],
+                        "tags": [TAG.Point, TAG.Maintenance, TAG.Mode, TAG.Command],
                     },
                     "Box_Mode_Command": {
-                        "tags": [TAG.Box, TAG.Mode, TAG.Command],
+                        "tags": [TAG.Point, TAG.Box, TAG.Mode, TAG.Command],
                     },
                 },
             },
             "Frequency_Command": {
-                "tags": [TAG.Fequency, TAG.Command],
+                "tags": [TAG.Point, TAG.Fequency, TAG.Command],
                 "subclasses": {
                     "Max_Frequency_Command": {
-                        "tags": [TAG.Max, TAG.Fequency, TAG.Command],
+                        "tags": [TAG.Point, TAG.Max, TAG.Fequency, TAG.Command],
                     },
                 },
             },
             "Occupancy_Command": {
-                "tags": [TAG.Occupancy, TAG.Command],
+                "tags": [TAG.Point, TAG.Occupancy, TAG.Command],
             },
             "On_Off_Command": {
-                "tags": [TAG.On, TAG.Off, TAG.Command],
+                "tags": [TAG.Point, TAG.On, TAG.Off, TAG.Command],
                 "subclasses": {
                     "Off_Command": {
-                        "tags": [TAG.Off, TAG.Command],
+                        "tags": [TAG.Point, TAG.Off, TAG.Command],
                         "subclasses": {
                             "Exhaust_Fan_Fire_Control_Panel_Off_Command": {
-                                "tags": [TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.Off, TAG.Command],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.Off, TAG.Command],
                             }
                         },
                     },
                     "On_Command": {
-                        "tags": [TAG.On, TAG.Command],
+                        "tags": [TAG.Point, TAG.On, TAG.Command],
                         "subclasses": {
                             "Exhaust_Fan_Fire_Control_Panel_On_Command": {
-                                "tags": [TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.On, TAG.Command],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.On, TAG.Command],
                             }
                         },
                     },
                     "Lead_On_Off_Command": {
-                        "tags": [TAG.Lead, TAG.On, TAG.Off, TAG.Command],
+                        "tags": [TAG.Point, TAG.Lead, TAG.On, TAG.Off, TAG.Command],
                     },
                     "Steam_On_Off_Command": {
-                        "tags": [TAG.Steam, TAG.On, TAG.Off, TAG.Command],
+                        "tags": [TAG.Point, TAG.Steam, TAG.On, TAG.Off, TAG.Command],
                     },
                     "Start_Stop_Command": {
-                        "tags": [TAG.Start, TAG.Stop, TAG.Command],
+                        "tags": [TAG.Point, TAG.Start, TAG.Stop, TAG.Command],
                     },
                 },
             },
             "Override_Command": {
-                "tags": [TAG.Override, TAG.Command],
+                "tags": [TAG.Point, TAG.Override, TAG.Command],
                 "subclasses": {
                     "Curtailment_Override_Command": {
-                        "tags": [TAG.Curtailment, TAG.Override, TAG.Command],
+                        "tags": [TAG.Point, TAG.Curtailment, TAG.Override, TAG.Command],
                     },
                 },
             },
             "Lockout_Command": {
-                "tags": [TAG.Lockout, TAG.Command],
+                "tags": [TAG.Point, TAG.Lockout, TAG.Command],
             },
             "Run_Request_Command": {
-                "tags": [TAG.Run, TAG.Request, TAG.Command],
+                "tags": [TAG.Point, TAG.Run, TAG.Request, TAG.Command],
             },
         },
     }

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -194,18 +194,29 @@ command_definitions = {
                 "tags": [TAG.On, TAG.Off, TAG.Command],
                 "subclasses": {
                     "Off_Command": {
+                        "tags": [TAG.Off, TAG.Command],
                         "subclasses": {
-                            "Exhaust_Fan_Fire_Control_Panel_Off_Command": {}
+                            "Exhaust_Fan_Fire_Control_Panel_Off_Command": {
+                                "tags": [TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.Off, TAG.Command],
+                            }
                         },
                     },
                     "On_Command": {
+                        "tags": [TAG.On, TAG.Command],
                         "subclasses": {
-                            "Exhaust_Fan_Fire_Control_Panel_On_Command": {}
+                            "Exhaust_Fan_Fire_Control_Panel_On_Command": {
+                                "tags": [TAG.Exhaust, TAG.Fan, TAG.Fire, TAG.Control, TAG.Panel, TAG.On, TAG.Command],
+                            }
                         },
                     },
-                    "Lead_On_Off_Command": {},
-                    "Steam_On_Off_Command": {},
+                    "Lead_On_Off_Command": {
+                        "tags": [TAG.Lead, TAG.On, TAG.Off, TAG.Command],
+                    },
+                    "Steam_On_Off_Command": {
+                        "tags": [TAG.Steam, TAG.On, TAG.Off, TAG.Command],
+                    },
                     "Start_Stop_Command": {
+                        "tags": [TAG.Start, TAG.Stop, TAG.Command],
                         "subclasses": {
                             "Domestic_Hot_Water_System_Start_Stop_Command": {},
                         },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -7,14 +7,17 @@ Set up subclasses of the equipment superclass
 equipment_subclasses = {
     "HVAC": {
         OWL.equivalentClass: BRICK["Heating_Ventilation_Air_Conditioning_System"],
+        "tags": [TAG.Heating, TAG.Ventilation, TAG.Air, TAG.Conditioning, TAG.System],
     },
     "Heating_Ventilation_Air_Conditioning_System": {
         OWL.equivalentClass: BRICK["HVAC"],
+        "tags": [TAG.HVAC],
     },
     "Weather": {
         "tags": [TAG.Weather],
     },
     "Electrical_System": {
+        "tags": [TAG.Electrical, TAG.System],
         "subclasses": {
             "Emergency_Power_Off_System": {
                 "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Equipment],
@@ -92,9 +95,11 @@ equipment_subclasses = {
             },
             "CWS": {
                 OWL.equivalentClass: BRICK["Chilled_Water_System"],
+                "tags": [TAG.CWS],
             },
             "HWS": {
                 OWL.equivalentClass: BRICK["Hot_Water_System"],
+                "tags": [TAG.HWS],
             }
         }
     },
@@ -112,33 +117,49 @@ equipment_subclasses = {
         "subclasses": {
             "Lighting": {
                 "subclasses": {
-                    "Luminaire": {},
-                    "Luminaire_Driver": {},
+                    "Luminaire": {
+                        "tags": [TAG.Luminaire, TAG.Equipment],
+                    },
+                    "Luminaire_Driver": {
+                        "tags": [TAG.Luminaire, TAG.Driver, TAG.Equipment],
+                    },
                 },
             },
             "Interface": {
+                "tags": [TAG.Equipment, TAG.Interface],
                 "subclasses": {
                     "Switch": {
+                        "tags": [TAG.Equipment, TAG.Interface, TAG.Switch],
                         "subclasses": {
-                            "Dimmer": {},
+                            "Dimmer": {
+                                "tags": [TAG.Equipment, TAG.Interface, TAG.Switch, TAG.Dimmer],
+                            },
                         },
                     },
-                    "Touchpanel": {},
+                    "Touchpanel": {
+                        "tags": [TAG.Equipment, TAG.Interface, TAG.Touchpanel],
+                    },
                 },
             },
         },
     },
     "Furniture": {
+        "tags": [TAG.Equipment, TAG.Furniture],
     },
     "Fire_Safety_System": {
+        "tags": [TAG.Equipment, TAG.Fire, TAG.Safety, TAG.System],
         "subclasses": {
             "Fire_Control_Panel": {
+                "tags": [TAG.Equipment, TAG.Fire, TAG.Safety, TAG.Panel],
                 OWL.equivalentClass: BRICK["FCP"],
             },
-            "FCP": {},
+            "FCP": {
+                "tags": [TAG.FCP, TAG.Equipment],
+            },
         },
     },
     "Elevator": {
+        "tags": [TAG.Elevator, TAG.Equipment],
     },
 }
 
@@ -148,6 +169,7 @@ Define classes of HVAC equipment
 """
 hvac_subclasses = {
     "Variable_Frequency_Drive": {
+        "tags": [TAG.Equipment, TAG.Variable, TAG.Frequency, TAG.Drive],
         OWL.equivalentClass: BRICK["VFD"],
         SKOS.definition: Literal("Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure."),
     },
@@ -156,63 +178,99 @@ hvac_subclasses = {
         # subclasses defined in 'valve_subclasses'
     },
     "VFD": {
+        "tags": [TAG.Equipment, TAG.VFD],
         "subclasses": {
-            "Heat_Wheel_VFD": {},
-            "Preheat_Valve_VFD": {},
+            "Heat_Wheel_VFD": {
+                "tags": [TAG.Equipment, TAG.Heat, TAG.Wheel, TAG.VFD],
+            },
+            "Preheat_Valve_VFD": {
+                "tags": [TAG.Equipment, TAG.Preheat, TAG.VFD],
+            },
         },
     },
     "Thermostat": {
+        "tags": [TAG.Equipment, TAG.Thermostat],
         SKOS.definition: Literal("An automatic control device used to maintain temperature at a fixed or adjustable setpoint."),
     },
     "Terminal_Unit": {
+        "tags": [TAG.Equipment, TAG.Terminal, TAG.Unit],
         SKOS.definition: Literal("A device that regulates the volumetric flow rate and/or the temperature of the controlled medium."),
         "subclasses": {
             "Fan_Coil_Unit": {
+                "tags": [TAG.Equipment, TAG.Fan, TAG.Coil, TAG.Unit],
                 OWL.equivalentClass: BRICK["FCU"],
             },
-            "FCU": {},
+            "FCU": {
+                "tags": [TAG.FCU],
+            },
             "Variable_Air_Volume_Box": {
+                "tags": [TAG.Equipment, TAG.Variable, TAG.Volume, TAG.Box],
                 OWL.equivalentClass: BRICK["VAV"],
                 "subclasses": {
                     "Variable_Air_Volume_Box_With_Reheat": {
+                        "tags": [TAG.Equipment, TAG.Variable, TAG.Volume, TAG.Box, TAG.Reheat],
                         OWL.equivalentClass: BRICK["RVAV"],
                     },
-                    "RVAV": {},
+                    "RVAV": {
+                        "tags": [TAG.Equipment, TAG.RVAV],
+                    },
                 },
             },
-            "VAV": {},
+            "VAV": {
+                "tags": [TAG.Equipment, TAG.VAV],
+            },
         },
     },
     "Space_Heater": {
+        "tags": [TAG.Equipment, TAG.Space, TAG.Heater],
         SKOS.definition: Literal("A heater used to warm the air in an enclosed area, such as a room or office"),
     },
     "Pump": {
+        "tags": [TAG.Equipment, TAG.Pump],
         SKOS.definition: Literal("Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port."),
         "subclasses": {
             "Water_Pump": {
+                "tags": [TAG.Equipment, TAG.Pump, TAG.Water],
                 "subclasses": {
-                    "Chilled_Water_Pump": {},
-                    "Condenser_Water_Pump": {},
-                    "Hot_Water_Pump": {},
+                    "Chilled_Water_Pump": {
+                        "tags": [TAG.Equipment, TAG.Pump, TAG.Chilled, TAG.Water],
+                    },
+                    "Condenser_Water_Pump": {
+                        "tags": [TAG.Equipment, TAG.Pump, TAG.Condenser, TAG.Water],
+                    },
+                    "Hot_Water_Pump": {
+                        "tags": [TAG.Equipment, TAG.Pump, TAG.Hot, TAG.Water],
+                    },
                 },
             },
         },
     },
     "Heat_Exchanger": {
+        "tags": [TAG.Equipment, TAG.Heat, TAG.Exchanger],
         OWL.equivalentClass: BRICK["HX"],
         "subclasses": {
-            "Evaporative_Heat_Exchanger": {},
-            "Condenser_Heat_Exchanger": {},
+            "Evaporative_Heat_Exchanger": {
+                "tags": [TAG.Evaporative, TAG.Equipment, TAG.Heat, TAG.Exchanger],
+            },
+            "Condenser_Heat_Exchanger": {
+                "tags": [TAG.Condenser, TAG.Equipment, TAG.Heat, TAG.Exchanger],
+            },
         },
     },
-    "HX": {},
+    "HX": {
+        "tags": [TAG.Equipment, TAG.HX],
+    },
     "Fume_Hood": {
+        "tags": [TAG.Equipment, TAG.Fume, TAG.Hood],
         SKOS.definition: Literal("A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed."),
     },
     "Filter": {
+        "tags": [TAG.Equipment, TAG.Filter],
         SKOS.definition: Literal("Device to remove gases from a mixture of gases"),
         "subclasses": {
-            "Mixed_Air_Filter": {},
+            "Mixed_Air_Filter": {
+                "tags": [TAG.Equipment, TAG.Mixed, TAG.Air, TAG.Filter],
+            },
         },
     },
     "Fan": {
@@ -220,6 +278,7 @@ hvac_subclasses = {
         "tags": [TAG.Equipment, TAG.Fan],
         "subclasses": {
             "Cooling_Tower_Fan": {
+                "tags": [TAG.Cooling, TAG.Tower, TAG.Equipment, TAG.Fan],
             },
             "Exhaust_Fan": {
                 "tags": [TAG.Equipment, TAG.Fan, TAG.Exhaust],
@@ -244,6 +303,7 @@ hvac_subclasses = {
         },
     },
     "Economizer": {
+        "tags": [TAG.Equipment, TAG.Economizer],
         SKOS.definition: Literal("Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement."),
     },
     "Damper": {
@@ -265,16 +325,20 @@ hvac_subclasses = {
         },
     },
     "Condenser": {
+        "tags": [TAG.Equipment, TAG.Condenser],
         SKOS.definition: Literal("A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase."),
     },
     "Computer_Room_Air_Conditioning": {
+        "tags": [TAG.Equipment, TAG.Computer, TAG.Room, TAG.Air, TAG.Conditioning],
         SKOS.definition: Literal("A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. "),
         OWL.equivalentClass: BRICK["CRAC"],
     },
     "CRAC": {
+        "tags": [TAG.Equipment, TAG.CRAC],
         OWL.equivalentClass: BRICK["Computer_Room_Air_Conditioning"],
     },
     "Compressor": {
+        "tags": [TAG.Equipment, TAG.Compressor],
         SKOS.definition: Literal("(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor."),
     },
     "Coil": {
@@ -290,16 +354,25 @@ hvac_subclasses = {
         },
     },
     "Chiller": {
+        "tags": [TAG.Equipment, TAG.Chiller],
         "subclasses": {
-            "Absorption_Chiller": {},
-            "Centrifugal_Chiller": {},
+            "Absorption_Chiller": {
+                "tags": [TAG.Equipment, TAG.Chiller, TAG.Absorption],
+            },
+            "Centrifugal_Chiller": {
+                "tags": [TAG.Equipment, TAG.Chiller, TAG.Centrifugal],
+            },
         },
     },
-    "Humidifier": {},
+    "Humidifier": {
+        "tags": [TAG.Equipment, TAG.Humidifier],
+    },
     "Boiler": {
+        "tags": [TAG.Equipment, TAG.Boiler],
         SKOS.definition: Literal("A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications."),
     },
     "Air_Handler_Unit": {
+        "tags": [TAG.Equipment, TAG.Air, TAG.Handler, TAG.Unit],
         SKOS.definition: Literal("Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system."),
         OWL.equivalentClass: BRICK["AHU"],
     },
@@ -311,6 +384,7 @@ hvac_subclasses = {
                 "tags": [TAG.Equipment, TAG.Rooftop, TAG.AHU],
             },
             "RTU": {
+                "tags": [TAG.Equipment, TAG.RTU],
                 OWL.equivalentClass: BRICK["Rooftop_Unit"],
             },
         },

--- a/bricksrc/location.py
+++ b/bricksrc/location.py
@@ -43,16 +43,28 @@ location_subclasses = {
         },
     },
     "Room": {
+        "tags": [TAG.Room, TAG.Location],
         "subclasses": {
             "Laboratory": {
+                "tags": [TAG.Laboratory, TAG.Room, TAG.Location],
                 "subclasses": {
-                    "Freezer": {},
-                    "Cold_Box": {},
-                    "Hot_Box": {},
-                    "Environment_Box": {},
+                    "Freezer": {
+                        "tags": [TAG.Freezer, TAG.Laboratory, TAG.Room, TAG.Location],
+                    },
+                    "Cold_Box": {
+                        "tags": [TAG.Cold, TAG.Box, TAG.Laboratory, TAG.Room, TAG.Location],
+                    },
+                    "Hot_Box": {
+                        "tags": [TAG.Hot, TAG.Box, TAG.Laboratory, TAG.Room, TAG.Location],
+                    },
+                    "Environment_Box": {
+                        "tags": [TAG.Environment, TAG.Box, TAG.Laboratory, TAG.Room, TAG.Location],
+                    },
                 },
             },
-            "Server_Room": {},
+            "Server_Room": {
+                "tags": [TAG.Server, TAG.Room, TAG.Location],
+            },
         },
     },
 }

--- a/bricksrc/location.py
+++ b/bricksrc/location.py
@@ -17,28 +17,28 @@ location_subclasses = {
         "tags": [TAG.Basement, TAG.Location],
     },
     "Outside": {
-        "tags": [ TAG.Outside, TAG.Location ],
+        "tags": [TAG.Outside, TAG.Location],
     },
     "City": {
-        "tags": [ TAG.City, TAG.Location ],
+        "tags": [TAG.City, TAG.Location],
     },
     "Wing": {
-        "tags": [ TAG.Wing, TAG.Location ],
+        "tags": [TAG.Wing, TAG.Location],
     },
     "Space": {
-        "tags": [ TAG.Space, TAG.Location ],
+        "tags": [TAG.Space, TAG.Location],
     },
     "Zone": {
-        "tags": [ TAG.Zone, TAG.Location ],
+        "tags": [TAG.Zone, TAG.Location],
         "subclasses": {
             "HVAC_Zone": {
-                "tags": [ TAG.HVAC, TAG.Zone, TAG.Location ],
+                "tags": [TAG.HVAC, TAG.Zone, TAG.Location],
             },
             "Lighting_Zone": {
-                "tags": [ TAG.Lighting, TAG.Zone, TAG.Location ],
+                "tags": [TAG.Lighting, TAG.Zone, TAG.Location],
             },
             "Fire_Zone": {
-                "tags": [ TAG.Fire, TAG.Zone, TAG.Location ],
+                "tags": [TAG.Fire, TAG.Zone, TAG.Location],
             },
         },
     },

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -2,326 +2,326 @@ from .namespaces import TAG, BRICK
 
 parameter_definitions = {
     "Parameter": {
-        "tags": [TAG.Parameter],
+        "tags": [TAG.Point, TAG.Parameter],
         "subclasses": {
             "Delay_Parameter": {
-                "tags": [TAG.Delay, TAG.Parameter],
+                "tags": [TAG.Point, TAG.Delay, TAG.Parameter],
                 "subclasses": {
                     "Alarm_Delay_Parameter": {
-                        "tags": [TAG.Alarm, TAG.Delay, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Alarm, TAG.Delay, TAG.Parameter],
                     },
                 },
             },
             "Humidity_Parameter": {
-                "tags": [TAG.Humidity, TAG.Parameter],
+                "tags": [TAG.Point, TAG.Humidity, TAG.Parameter],
                 "subclasses": {
                     "High_Humidity_Alarm_Parameter": {
-                        "tags": [TAG.High, TAG.Humidity, TAG.Alarm, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.High, TAG.Humidity, TAG.Alarm, TAG.Parameter],
                     },
                     "Low_Humidity_Alarm_Parameter": {
-                        "tags": [TAG.Low, TAG.Humidity, TAG.Alarm, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Low, TAG.Humidity, TAG.Alarm, TAG.Parameter],
                     }
                 },
             },
             "Load_Parameter": {
-                "tags": [TAG.Load, TAG.Parameter],
+                "tags": [TAG.Point, TAG.Load, TAG.Parameter],
                 "subclasses": {
                     "Max_Load_Setpoint": {
-                        "tags": [TAG.Max, TAG.Load, TAG.Parameter, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Max, TAG.Load, TAG.Parameter, TAG.Setpoint],
                     },
                 },
             },
             "Temperature_Parameter": {
-                "tags": [TAG.Temperature, TAG.Parameter],
+                "tags": [TAG.Point, TAG.Temperature, TAG.Parameter],
                 "subclasses": {
                     "High_Temperature_Alarm_Parameter": {
-                        "tags": [TAG.High, TAG.Temperature, TAG.Alarm, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.High, TAG.Temperature, TAG.Alarm, TAG.Parameter],
                     },
                     "Low_Temperature_Alarm_Parameter": {
-                        "tags": [TAG.Low, TAG.Temperature, TAG.Alarm, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Low, TAG.Temperature, TAG.Alarm, TAG.Parameter],
                     },
                     "Low_Freeze_Protect_Temperature_Parameter": {
-                        "tags": [TAG.Low, TAG.Freeze, TAG.Protect, TAG.Temperature, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Low, TAG.Freeze, TAG.Protect, TAG.Temperature, TAG.Parameter],
                     },
                 },
             },
             "PID_Parameter": {
-                "tags": [TAG.Parameter, TAG.PID],
+                "tags": [TAG.Point, TAG.Parameter, TAG.PID],
                 "subclasses": {
                     "Gain_Parameter": {
-                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain],
+                        "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Gain],
                         "subclasses": {
                             "Integral_Gain_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Integral],
+                                "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Gain, TAG.Integral],
                                 "subclasses": {
                                     "Supply_Air_Integral_Gain_Parameter": {
-                                        "tags": [TAG.Supply, TAG.Air, TAG.Integral, TAG.Gain, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Integral, TAG.Gain, TAG.Parameter, TAG.PID],
                                     }
                                 }
                             },
                             "Proportional_Gain_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional],
+                                "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional],
                                 "subclasses": {
                                     "Supply_Air_Proportional_Gain_Parameter": {
-                                        "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional, TAG.Supply, TAG.Air],
+                                        "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Gain, TAG.Proportional, TAG.Supply, TAG.Air],
                                     },
                                 }
                             },
                             "Derivative_Gain_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Gain, TAG.Derivative],
+                                "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Gain, TAG.Derivative],
                             },
                         }
                     },
                     "Step_Parameter": {
-                        "tags": [TAG.Parameter, TAG.Step],
+                        "tags": [TAG.Point, TAG.Parameter, TAG.Step],
                         "subclasses": {
                             "Differential_Pressure_Step_Parameter": {
                                 "subclasses": {
                                     "Chilled_Water_Differential_Pressure_Step_Parameter": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter],
                                     }
                                 },
-                                "tags": [TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter],
+                                "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Step, TAG.Parameter],
                             },
                             "Static_Pressure_Step_Parameter": {
                                 "subclasses": {
                                     "Air_Static_Pressure_Step_Parameter": {
-                                        "tags": [TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
+                                        "tags": [TAG.Point, TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
                                         "subclasses": {
                                             "Discharge_Air_Static_Pressure_Step_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
                                             },
                                         },
                                     }
                                 },
-                                "tags": [TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
+                                "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Step, TAG.Parameter],
                             },
                             "Temperature_Step_Parameter": {
                                 "subclasses": {
                                     "Air_Temperature_Step_Parameter": {
-                                        "tags": [TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
+                                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
                                         "subclasses": {
                                             "Discharge_Air_Temperature_Step_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
                                             },
                                             "Supply_Air_Temperature_Step_Parameter": {
-                                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
+                                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Step, TAG.Parameter],
                                             },
                                         }
                                     }
                                 },
                                 "parents": [BRICK.Temperature_Parameter],
-                                "tags": [TAG.Temperature, TAG.Step, TAG.Parameter],
+                                "tags": [TAG.Point, TAG.Temperature, TAG.Step, TAG.Parameter],
                             }
                         },
                     },
                     "Time_Parameter": {
-                        "tags": [TAG.Parameter, TAG.Time],
+                        "tags": [TAG.Point, TAG.Parameter, TAG.Time],
                         "subclasses": {
                             "Integral_Time_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
+                                "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
                                 "subclasses": {
                                     "Air_Temperature_Integral_Time_Parameter": {
-                                        "tags": [TAG.Air, TAG.Temperature, TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
+                                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Parameter, TAG.PID, TAG.Time, TAG.Integral],
                                         "parents": [BRICK.Temperature_Parameter],
                                         "subclasses": {
                                             "Cooling_Discharge_Air_Temperature_Integral_Time_Parameter": {
-                                                "tags": [TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Cooling_Supply_Air_Temperature_Integral_Time_Parameter": {
-                                                "tags": [TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Heating_Discharge_Air_Temperature_Integral_Time_Parameter": {
-                                                "tags": [TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Heating_Supply_Air_Temperature_Integral_Time_Parameter": {
-                                                "tags": [TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                         }
                                     },
                                     "Differential_Pressure_Integral_Time_Parameter": {
-                                        "tags": [TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                         "subclasses": {
                                             "Hot_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Chilled_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Discharge_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             }
                                         },
                                     },
                                     "Exhaust_Air_Flow_Integral_Time_Parameter": {
                                         "subclasses": {
                                             "Exhaust_Air_Stack_Flow_Integral_Time_Parameter": {
-                                                "tags": [TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             }
                                         },
-                                        "tags": [TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                     },
                                     "Static_Pressure_Integral_Time_Parameter": {
-                                        "tags": [TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                         "subclasses": {
                                             "Discharge_Air_Static_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                             "Supply_Air_Static_Pressure_Integral_Time_Parameter": {
-                                                "tags": [TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                             },
                                         },
                                     },
                                     "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
-                                        "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                     },
                                     "Supply_Water_Temperature_Integral_Time_Parameter": {
                                         "parents": [BRICK.Temperature_Parameter],
-                                        "tags": [TAG.Supply, TAG.Water, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Integral, TAG.Time, TAG.Parameter, TAG.PID],
                                     }
                                 },
                             },
                             "Derivative_Time_Parameter": {
-                                "tags": [TAG.Parameter, TAG.PID, TAG.Time, TAG.Derivative],
+                                "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Time, TAG.Derivative],
                             },
                         },
                     },
                     "Proportional_Band_Parameter": {
-                        "tags": [TAG.Parameter, TAG.PID, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                        "tags": [TAG.Point, TAG.Parameter, TAG.PID, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                         "subclasses": {
                             "Differential_Pressure_Proportional_Band": {
-                                "tags": [TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.PID],
+                                "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.PID],
                                 "subclasses": {
                                     "Hot_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Chilled_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
                                         "subclasses": {
                                             "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                             },
                                         },
-                                        "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
                                         "subclasses": {
                                             "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                             },
                                         },
-                                        "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                 }
                             },
                             "Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                 "parents": [BRICK.Temperature_Parameter],
                                 "subclasses": {
                                     "Heating_Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                 },
                             },
                             "Supply_Air_Temperature_Proportional_Band_Parameter": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                 "parents": [BRICK.Temperature_Parameter],
                                 "subclasses": {
                                     "Cooling_Supply_Air_Temperature_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Heating_Supply_Air_Temperature_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                 }
                             },
                             "Exhaust_Air_Flow_Proportional_Band_Parameter": {
-                                "tags": [TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                 "subclasses": {
                                     "Exhaust_Air_Stack_Flow_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                 },
                             },
                             "Static_Pressure_Proportional_Band_Parameter": {
                                 "subclasses": {
                                     "Discharge_Air_Static_Pressure_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Exhaust_Air_Static_Pressure_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                     "Supply_Air_Static_Pressure_Proportional_Band_Parameter": {
-                                        "tags": [TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                                     },
                                 },
-                                "tags": [TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                             },
                             "Supply_Water_Temperature_Proportional_Band_Parameter": {
                                 "parents": [BRICK.Temperature_Parameter],
-                                "tags": [TAG.Supply, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                             },
                             "Discharge_Water_Temperature_Proportional_Band_Parameter": {
                                 "parents": [BRICK.Temperature_Parameter],
-                                "tags": [TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Proportional, TAG.Band, TAG.Parameter, TAG.PID],
                             },
                         },
                     },
                 }
             },
             "Tolerance_Parameter": {
-                "tags": [TAG.Tolerance, TAG.Parameter],
+                "tags": [TAG.Point, TAG.Tolerance, TAG.Parameter],
                 "subclasses": {
                     "Humidity_Tolerance_Parameter": {
-                        "tags": [TAG.Tolerance, TAG.Parameter, TAG.Humidity],
+                        "tags": [TAG.Point, TAG.Tolerance, TAG.Parameter, TAG.Humidity],
                         "parents": [BRICK.Humidity_Parameter],
                     },
                     "Temperature_Tolerance_Parameter": {
                         "parents": [BRICK.Temperature_Parameter],
-                        "tags": [TAG.Tolerance, TAG.Parameter, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Tolerance, TAG.Parameter, TAG.Temperature],
                     },
                 },
             },
             "Limit": {
-                "tags": [TAG.Parameter, TAG.Limit],
+                "tags": [TAG.Point, TAG.Parameter, TAG.Limit],
                 "subclasses": {
                     "Close_Limit": {
-                        "tags": [TAG.Close, TAG.Parameter, TAG.Limit],
+                        "tags": [TAG.Point, TAG.Close, TAG.Parameter, TAG.Limit],
                     },
                     "Speed_Setpoint_Limit": {
-                        "tags": [TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "parents": [BRICK.Max_Limit],
                             },
                             "Min_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "parents": [BRICK.Min_Limit],
                             },
                         },
                     },
                     "Air_Temperature_Setpoint_Limit": {
-                        "tags": [TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                         "parents": [BRICK.Temperature_Parameter],
                         "subclasses": {
                             "Discharge_Air_Temperature_Setpoint_Limit": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                                 "subclasses": {
                                     "Max_Discharge_Air_Temperature_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                                         "parents": [BRICK.Max_Temperature_Setpoint_Limit],
                                     },
                                     "Min_Discharge_Air_Temperature_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                                         "parents": [BRICK.Min_Temperature_Setpoint_Limit],
                                     },
                                 }
@@ -329,152 +329,152 @@ parameter_definitions = {
                         },
                     },
                     "Air_Flow_Setpoint_Limit": {
-                        "tags": [TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                         "subclasses": {
                             "Max_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                         },
                     },
                     "Current_Limit": {
-                        "tags": [TAG.Current, TAG.Limit, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Current, TAG.Limit, TAG.Parameter],
                     },
                     "Position_Limit": {
-                        "tags": [TAG.Position, TAG.Limit],
+                        "tags": [TAG.Point, TAG.Position, TAG.Limit],
                         "subclasses": {
                             "Max_Position_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Position, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Position, TAG.Limit, TAG.Setpoint],
                                 "parents": [BRICK.Max_Limit],
                             },
                             "Min_Position_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Position, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Position, TAG.Limit, TAG.Setpoint],
                                 "parents": [BRICK.Min_Limit],
                             },
                         },
                     },
                     "Differential_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                         "subclasses": {
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                         },
                     },
                     "Fresh_Air_Setpoint_Limit": {
-                        "tags": [TAG.Fresh, TAG.Air, TAG.Limit, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Fresh, TAG.Air, TAG.Limit, TAG.Setpoint],
                         "subclasses": {
                             "Min_Fresh_Air_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Fresh, TAG.Air, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Fresh, TAG.Air, TAG.Limit, TAG.Setpoint],
                                 "parents": [BRICK.Min_Limit],
                             },
                         },
                     },
                     "Ventilation_Air_Flow_Ratio_Limit": {
-                        "tags": [TAG.Ventilation, TAG.Air, TAG.Ratio, TAG.Limit],
+                        "tags": [TAG.Point, TAG.Ventilation, TAG.Air, TAG.Ratio, TAG.Limit],
                     },
                     "Static_Pressure_Setpoint_Limit": {
-                        "tags": [TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                         "subclasses": {
                             "Min_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "High_Static_Pressure_Cutout_Setpoint_Limit": {
-                                "tags": [TAG.High, TAG.Static, TAG.Pressure, TAG.Cutout, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.High, TAG.Static, TAG.Pressure, TAG.Cutout, TAG.Limit, TAG.Setpoint],
                             },
                         },
                     },
                     "Max_Limit": {
-                        "tags": [TAG.Max, TAG.Limit, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Max, TAG.Limit, TAG.Parameter],
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "subclasses": {
                                     "Max_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                     },
                                     "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                     },
                                 },
                             },
                             "Max_Temperature_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                                 "parents": [BRICK.Temperature_Parameter],
                             },
                             "Max_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Max, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "subclasses": {
                                     "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Max_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Max_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Max, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Max, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
@@ -483,85 +483,85 @@ parameter_definitions = {
                         },
                     },
                     "Min_Limit": {
-                        "tags": [TAG.Min, TAG.Limit, TAG.Parameter],
+                        "tags": [TAG.Point, TAG.Min, TAG.Limit, TAG.Parameter],
                         "subclasses": {
                             "Min_Speed_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Speed, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                             },
                             "Min_Temperature_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Temperature, TAG.Limit, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Temperature, TAG.Limit, TAG.Setpoint],
                                 "parents": [BRICK.Temperature_Parameter],
                             },
                             "Min_Static_Pressure_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "subclasses": {
                                     "Min_Discharge_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                     },
                                     "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                     },
                                 },
                             },
                             "Min_Air_Flow_Setpoint_Limit": {
-                                "tags": [TAG.Min, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Min, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                 "subclasses": {
                                     "Min_Outside_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Outside, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                     },
                                     "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Min_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Min_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Min_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                        "tags": [TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Min, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                         "subclasses": {
                                             "Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                             "Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit": {
-                                                "tags": [TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Min, TAG.Unoccupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                                             },
                                         },
                                     },

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -40,7 +40,9 @@ parameter_definitions = {
                     "Low_Temperature_Alarm_Parameter": {
                         "tags": [TAG.Low, TAG.Temperature, TAG.Alarm, TAG.Parameter],
                     },
-                    "Low_Freeze_Protect_Temperature_Parameter": {},
+                    "Low_Freeze_Protect_Temperature_Parameter": {
+                        "tags": [TAG.Low, TAG.Freeze, TAG.Protect, TAG.Temperature, TAG.Parameter],
+                    },
                 },
             },
             "PID_Parameter": {
@@ -379,7 +381,9 @@ parameter_definitions = {
                             },
                         },
                     },
-                    "Ventilation_Air_Flow_Ratio_Limit": {},
+                    "Ventilation_Air_Flow_Ratio_Limit": {
+                        "tags": [TAG.Ventilation, TAG.Air, TAG.Ratio, TAG.Limit],
+                    },
                     "Static_Pressure_Setpoint_Limit": {
                         "tags": [TAG.Static, TAG.Pressure, TAG.Limit, TAG.Parameter, TAG.Setpoint],
                         "subclasses": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -106,7 +106,9 @@ sensor_definitions = {
                                 OWL.equivalentClass: BRICK["PV_Current_Output_Sensor"],
                                 "tags": [TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor],
                             },
-                            "PV_Current_Output_Sensor": {},
+                            "PV_Current_Output_Sensor": {
+                                "tags": [TAG.PV, TAG.Current, TAG.Output, TAG.Sensor],
+                            },
                         },
                     },
                 }
@@ -154,7 +156,9 @@ sensor_definitions = {
                 "tags": [TAG.Sensor, TAG.Energy],
                 "substances": [[BRICK.measures, BRICK.Energy]],
                 "subclasses": {
-                    "Today_Peak_Energy_Sensor": {},
+                    "Today_Peak_Energy_Sensor": {
+                        "tags": [TAG.Sensor, TAG.Energy, TAG.Today, TAG.Peak],
+                    },
                 },
             },
             "Enthalpy_Sensor": {
@@ -287,6 +291,7 @@ sensor_definitions = {
                 "substances": [[BRICK.measures, BRICK.Hail]],
             },
             "Heat_Sensor": {
+                "tags": [TAG.Sensor, TAG.Heat],
                 "subclasses": {
                     "Trace_Heat_Sensor": {
                         #TODO: substance
@@ -389,7 +394,9 @@ sensor_definitions = {
                                 "tags": [TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
                                 "substances": [[BRICK.measures, BRICK.Pressure], [BRICK.measures, BRICK.Hot_Water]],
                                 "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {},
+                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
+                                    },
                                 },
                             }
                         }
@@ -444,6 +451,7 @@ sensor_definitions = {
                 }
             },
             "Power_Sensor": {
+                "tags": [TAG.Sensor, TAG.Power],
                 "substances": [[BRICK.measures, BRICK.Power]],
                 "subclasses": {
                     "Thermal_Power_Sensor": {
@@ -623,8 +631,12 @@ sensor_definitions = {
                                         "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Lowest, TAG.Air],
                                         OWL.equivalentClass: BRICK["Coldest_Zone_Air_Temperature_Sensor"],
                                     },
-                                    "Coldest_Zone_Air_Temperature_Sensor": {},
-                                    "Warmest_Zone_Air_Temperature_Sensor": {},
+                                    "Coldest_Zone_Air_Temperature_Sensor": {
+                                        "tags": [TAG.Coldest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                    },
+                                    "Warmest_Zone_Air_Temperature_Sensor": {
+                                        "tags": [TAG.Warmest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                    },
                                 }
                             },
                             "Exhaust_Air_Temperature_Sensor": {
@@ -725,8 +737,12 @@ sensor_definitions = {
                                     "Hot_Water_Return_Temperature_Sensor": {
                                         "tags": [TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
                                         "subclasses": {
-                                            "Medium_Temperature_Hot_Water_Return_Temperature_Sensor": {},
-                                            "High_Temperature_Hot_Water_Return_Temperature_Sensor": {},
+                                            "Medium_Temperature_Hot_Water_Return_Temperature_Sensor": {
+                                                "tags": [TAG.Medium, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                            },
+                                            "High_Temperature_Hot_Water_Return_Temperature_Sensor": {
+                                                "tags": [TAG.High, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                            },
                                         },
                                     },
                                     "Chilled_Water_Return_Temperature_Sensor": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -3,31 +3,31 @@ from .namespaces import BRICK, TAG, OWL, SKOS
 
 sensor_definitions = {
     "Sensor": {
-        "tags": [TAG.Sensor],
+        "tags": [TAG.Point, TAG.Sensor],
         "subclasses": {
             "Adjust_Sensor": {
-                "tags": [TAG.Sensor, TAG.Adjust],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Adjust],
                 "subclasses": {
                     "Temperature_Adjust_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Adjust, TAG.Temperature],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Adjust, TAG.Temperature],
                     },
                     "Warm_Cool_Adjust_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Adjust, TAG.Warm, TAG.Cool],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Adjust, TAG.Warm, TAG.Cool],
                     },
                 },
             },
             "Air_Grains_Sensor": {
-                "tags": [TAG.Sensor, TAG.Air, TAG.Grains],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Air, TAG.Grains],
                 "substances": [[BRICK.measures, BRICK.Air],
                                [BRICK.measures, BRICK.Grains]],
                 "subclasses": {
                     "Outside_Air_Grains_Sensor": {
-                        "tags": [TAG.Outside, TAG.Air, TAG.Grains, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Grains, TAG.Sensor],
                         "substances": [[BRICK.measures, BRICK.Outside_Air],
                                        [BRICK.measures, BRICK.Grains]],
                     },
                     "Return_Air_Grains_Sensor": {
-                        "tags": [TAG.Return, TAG.Air, TAG.Grains, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.Grains, TAG.Sensor],
                         "substances": [[BRICK.measures, BRICK.Return_Air],
                                        [BRICK.measures, BRICK.Grains]],
                     }
@@ -37,77 +37,77 @@ sensor_definitions = {
                 "substances": [[BRICK.measures, BRICK.Angle]],
                 "subclasses": {
                     "Solar_Azimuth_Angle_Sensor": {
-                        "tags": [TAG.Solar, TAG.Azimuth, TAG.Angle,
+                        "tags": [TAG.Point, TAG.Solar, TAG.Azimuth, TAG.Angle,
                                  TAG.Sensor],
                     },
                     "Solar_Zenith_Angle_Sensor": {
-                        "tags": [TAG.Solar, TAG.Zenith, TAG.Angle, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Solar, TAG.Zenith, TAG.Angle, TAG.Sensor],
                     }
                 },
-                "tags": [TAG.Angle, TAG.Sensor],
+                "tags": [TAG.Point, TAG.Angle, TAG.Sensor],
             },
             "CO2_Sensor": {
-                "tags": [TAG.Sensor, TAG.CO2],
+                "tags": [TAG.Point, TAG.Sensor, TAG.CO2],
                 "substances": [[BRICK.measures, BRICK.Air],
                                [BRICK.measures, BRICK.CO2]],
                 "subclasses": {
                     "CO2_Differential_Sensor": {
-                        "tags": [TAG.CO2, TAG.Differential, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.CO2, TAG.Differential, TAG.Sensor],
                     },
                     "CO2_Level_Sensor": {
-                        "tags": [TAG.CO2, TAG.Level, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.CO2, TAG.Level, TAG.Sensor],
                     },
                     "Outside_Air_CO2_Sensor": {
-                        "tags": [TAG.Outside, TAG.Air, TAG.CO2, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.CO2, TAG.Sensor],
                         "substances": [[BRICK.measures, BRICK.Outside_Air], [BRICK.measures, BRICK.CO2]],
                     },
                     "Return_Air_CO2_Sensor": {
-                        "tags": [TAG.Return, TAG.Air, TAG.CO2, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.CO2, TAG.Sensor],
                         "substances": [[BRICK.measures, BRICK.Return_Air], [BRICK.measures, BRICK.CO2]],
                     }
                 }
             },
             "Capacity_Sensor": {
-                "tags": [TAG.Sensor, TAG.Capacity],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Capacity],
                 "substances": [[BRICK.measures, BRICK.Capacity]],
             },
             "Contact_Sensor": {
                 SKOS.definition: Literal('Senses or detects contact, such as for detecting if a door is closed.'),
-                "tags": [TAG.Sensor, TAG.Contact],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Contact],
             },
             "Conductivity_Sensor": {
                 # IFC ConductanceSensor
                 # TODO: pull from
                 # https://technical.buildingsmart.org/standards/ifc/ifc-schema-specifications/
                 SKOS.definition: Literal("senses or detects electrical conductance"),
-                "tags": [TAG.Sensor, TAG.Conductivity],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Conductivity],
                 "substances": [[BRICK.measures, BRICK.Conductivity]],
                 "subclasses": {
                     "Deionised_Water_Conductivity_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Conductivity, TAG.Water, TAG.Deionised],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Conductivity, TAG.Water, TAG.Deionised],
                         "substances": [[BRICK.measures, BRICK.Conductivity], [BRICK.measures, BRICK.Deionized_Water]],
                     }
                 }
             },
             "Current_Sensor": {
-                "tags": [TAG.Sensor, TAG.Current],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Current],
                 "substances": [[BRICK.measures, BRICK.Current]],
                 "subclasses": {
                     "Load_Current_Sensor": {
-                        "tags": [TAG.Load, TAG.Current, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Load, TAG.Current, TAG.Sensor],
                     },
                     "Motor_Current_Sensor": {
-                        "tags": [TAG.Motor, TAG.Current, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Motor, TAG.Current, TAG.Sensor],
                     },
                     "Current_Output_Sensor": {
-                        "tags": [TAG.Current, TAG.Output, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Current, TAG.Output, TAG.Sensor],
                         "subclasses": {
                             "Photovoltaic_Current_Output_Sensor": {
                                 OWL.equivalentClass: BRICK["PV_Current_Output_Sensor"],
-                                "tags": [TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Photovoltaic, TAG.Current, TAG.Output, TAG.Sensor],
                             },
                             "PV_Current_Output_Sensor": {
-                                "tags": [TAG.PV, TAG.Current, TAG.Output, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.PV, TAG.Current, TAG.Output, TAG.Sensor],
                             },
                         },
                     },
@@ -115,152 +115,152 @@ sensor_definitions = {
             },
             "Position_Sensor": {
                 "substances": [[BRICK.measures, BRICK.Position]],
-                "tags": [TAG.Position, TAG.Sensor],
+                "tags": [TAG.Point, TAG.Position, TAG.Sensor],
                 "subclasses": {
                     "Sash_Position_Sensor": {
-                        "tags": [TAG.Sash, TAG.Position, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Sash, TAG.Position, TAG.Sensor],
                     },
                     "Damper_Position_Sensor": {
-                        "tags": [TAG.Damper, TAG.Position, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Sensor],
                     },
                 },
             },
             "Demand_Sensor": {
-                "tags": [TAG.Sensor, TAG.Demand],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Demand],
             },
             "Dewpoint_Sensor": {
-                "tags": [TAG.Sensor, TAG.Dewpoint],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Dewpoint],
                 "substances": [[BRICK.measures, BRICK.Dewpoint]],
                 "subclasses": {
                     "Outside_Air_Dewpoint_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Outside],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Outside],
                         "substances": [[BRICK.measures, BRICK.Dewpoint], [BRICK.measures, BRICK.Outside_Air]],
                     },
                     "Return_Air_Dewpoint_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Return],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Dewpoint, TAG.Air, TAG.Return],
                         "substances": [[BRICK.measures, BRICK.Dewpoint], [BRICK.measures, BRICK.Return_Air]],
                     }
                 }
             },
             "Direction_Sensor": {
-                "tags": [TAG.Sensor, TAG.Direction],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Direction],
                 "substances": [[BRICK.measures, BRICK.Direction]],
                 "subclasses": {
                     "Wind_Direction_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Direction, TAG.Wind],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Direction, TAG.Wind],
                         "substances": [[BRICK.measures, BRICK.Wind_Direction]],
                     }
                 }
             },
             "Energy_Sensor": {
-                "tags": [TAG.Sensor, TAG.Energy],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Energy],
                 "substances": [[BRICK.measures, BRICK.Energy]],
                 "subclasses": {
                     "Today_Peak_Energy_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Energy, TAG.Today, TAG.Peak],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Energy, TAG.Today, TAG.Peak],
                     },
                 },
             },
             "Enthalpy_Sensor": {
-                "tags": [TAG.Sensor, TAG.Enthalpy],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Enthalpy],
                 "substances": [[BRICK.measures, BRICK.Enthalpy]],
                 "subclasses": {
                     "Air_Enthalpy_Sensor": {
                         "substances": [[BRICK.measures, BRICK.Enthalpy], [BRICK.measures, BRICK.Air]],
                         "subclasses": {
                             "Outside_Air_Enthalpy_Sensor": {
-                                "tags": [TAG.Outside, TAG.Air, TAG.Enthalpy, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Enthalpy, TAG.Sensor],
                                 "substances": [[BRICK.measures, BRICK.Enthalpy], [BRICK.measures, BRICK.Outside_Air]],
                             },
                             "Return_Air_Enthalpy_Sensor": {
-                                "tags": [TAG.Return, TAG.Air, TAG.Enthalpy, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.Enthalpy, TAG.Sensor],
                                 "substances": [[BRICK.measures, BRICK.Enthalpy], [BRICK.measures, BRICK.Return_Air]],
                             }
                         },
-                        "tags": [TAG.Air, TAG.Enthalpy, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Air, TAG.Enthalpy, TAG.Sensor],
                     }
                 }
             },
             "Fire_Sensor": {
                 SKOS.definition: Literal("senses or detects fire"),
-                "tags": [TAG.Sensor, TAG.Fire],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Fire],
             },
             "Flow_Sensor": {
                 SKOS.definition: Literal("senses or detects flow in a fluid"),
-                "tags": [TAG.Sensor, TAG.Flow],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Flow],
                 "substances": [[BRICK.measures, BRICK.Flow]],
                 "subclasses": {
                     "Air_Flow_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Flow, TAG.Air],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air],
                         "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Air]],
                         "subclasses": {
                             "Bypass_Air_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Bypass],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Bypass],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Bypass_Air]],
                             },
                             "Discharge_Air_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Discharge_Air]],
                                 "subclasses": {
                                     "Average_Discharge_Air_Flow_Sensor": {
-                                        "tags": [TAG.Average, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Average, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Sensor],
                                     }
                                 }
                             },
                             "Exhaust_Air_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Exhaust],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Exhaust],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Exhaust_Air]],
                                 "subclasses": {
                                     "Exhaust_Air_Stack_Flow_Sensor": {
-                                        "tags": [TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Sensor],
                                     }
                                 }
                             },
                             "Fume_Hood_Air_Flow_Sensor": {
-                                "tags": [TAG.Fume, TAG.Hood, TAG.Air, TAG.Flow, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Fume, TAG.Hood, TAG.Air, TAG.Flow, TAG.Sensor],
                             },
                             "Outside_Air_Flow_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Outside_Air]],
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Outside],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Outside],
                             },
                             "Return_Air_Flow_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Return_Air]],
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Return],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Return],
                             },
                             "Supply_Air_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Air, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Air, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Supply_Air]],
                                 "subclasses": {
                                     "Average_Supply_Air_Flow_Sensor": {
-                                        "tags": [TAG.Average, TAG.Supply, TAG.Air, TAG.Flow, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Average, TAG.Supply, TAG.Air, TAG.Flow, TAG.Sensor],
                                     }
                                 }
                             }
                         }
                     },
                     "Water_Flow_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Flow, TAG.Water],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water],
                         "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Water]],
                         "subclasses": {
                             "Hot_Water_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Water, TAG.Hot],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water, TAG.Hot],
                             },
                             "Supply_Water_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Supply_Water]],
                                 "subclasses": {
                                     "Chilled_Water_Supply_Flow_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply, TAG.Chilled],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water, TAG.Supply, TAG.Chilled],
                                         "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Supply_Chilled_Water]],
                                     }
                                 }
                             },
                             "Discharge_Water_Flow_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Flow, TAG.Water, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Discharge_Water]],
                                 "subclasses": {
                                     "Chilled_Water_Discharge_Flow_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Flow, TAG.Water, TAG.Discharge, TAG.Chilled],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Flow, TAG.Water, TAG.Discharge, TAG.Chilled],
                                         "substances": [[BRICK.measures, BRICK.Flow], [BRICK.measures, BRICK.Discharge_Chilled_Water]],
                                     }
                                 }
@@ -271,68 +271,68 @@ sensor_definitions = {
             },
             "Frequency_Sensor": {
                 "substances": [[BRICK.measures, BRICK.Frequency]],
-                "tags": [TAG.Sensor, TAG.Frequency],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Frequency],
                 "subclasses": {
                     "Output_Frequency_Sensor": {
-                        "tags": [TAG.Output, TAG.Frequency, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Output, TAG.Frequency, TAG.Sensor],
                     }
                 }
             },
             "Frost_Sensor": {
-                "tags": [TAG.Sensor, TAG.Frost],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Frost],
                 "substances": [[BRICK.measures, BRICK.Frost]],
             },
             "Gas_Sensor": {
                 SKOS.definition: Literal("senses or detects gas concentration (other than CO2)"),
-                "tags": [TAG.Sensor, TAG.Gas],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Gas],
             },
             "Hail_Sensor": {
-                "tags": [TAG.Sensor, TAG.Hail],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Hail],
                 "substances": [[BRICK.measures, BRICK.Hail]],
             },
             "Heat_Sensor": {
-                "tags": [TAG.Sensor, TAG.Heat],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Heat],
                 "subclasses": {
                     "Trace_Heat_Sensor": {
                         #TODO: substance
-                        "tags": [TAG.Trace, TAG.Heat, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Trace, TAG.Heat, TAG.Sensor],
                     },
                 },
             },
             "Humidity_Sensor": {
-                "tags": [TAG.Sensor, TAG.Humidity],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity],
                 "substances": [[BRICK.measures, BRICK.Humidity]],
                 "subclasses": {
                     "Air_Humidity_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Humidity, TAG.Air],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air],
                         "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Air]],
                         "subclasses": {
                             "Discharge_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Discharge_Air]],
                             },
                             "Exhaust_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Exhaust],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Exhaust],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Exhaust_Air]],
                             },
                             "Outside_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Outside],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Outside],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Outside_Air]],
                             },
                             "Relative_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Relative],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Relative],
                                 "substances": [[BRICK.measures, BRICK.Relative_Humidity], [BRICK.measures, BRICK.Air]],
                             },
                             "Return_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Return],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Return],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Return_Air]],
                             },
                             "Supply_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Supply_Air]],
                             },
                             "Zone_Air_Humidity_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Zone],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air, TAG.Zone],
                                 "substances": [[BRICK.measures, BRICK.Humidity], [BRICK.measures, BRICK.Zone_Air]],
                             }
                         }
@@ -340,110 +340,110 @@ sensor_definitions = {
                 }
             },
             "Illuminance_Sensor": {
-                "tags": [TAG.Sensor, TAG.Illuminance],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Illuminance],
                 "substances": [[BRICK.measures, BRICK.Illuminance]],
                 "subclasses": {
                     "Outside_Illuminance_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Illuminance, TAG.Outside],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Illuminance, TAG.Outside],
                     }
                 }
             },
             "Luminance_Sensor": {
-                "tags": [TAG.Sensor, TAG.Luminance],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Luminance],
                 "substances": [[BRICK.measures, BRICK.Luminance]],
             },
             "Motion_Sensor": {
-                "tags": [TAG.Sensor, TAG.Motion],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Motion],
                 "subclasses": {
                     "PIR_Sensor": {
-                        "tags": [TAG.Sensor, TAG.PIR],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.PIR],
                     }
                 }
             },
             "Occupancy_Sensor": {
-                "tags": [TAG.Sensor, TAG.Occupancy],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Occupancy],
                 "substances": [[BRICK.measures, BRICK.Occupancy]],
                 "subclasses": {
                     "PIR_Sensor": {
-                        "tags": [TAG.Pir, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Pir, TAG.Sensor],
                     }
                 }
             },
             "Piezoelectric_Sensor": {
-                "tags": [TAG.Sensor, TAG.Piezoelectric],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Piezoelectric],
             },
             "Pressure_Sensor": {
-                "tags": [TAG.Sensor, TAG.Pressure],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure],
                 "substances": [[BRICK.measures, BRICK.Pressure]],
                 "subclasses": {
                     "Differential_Pressure_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Pressure, TAG.Differential],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Differential],
                         "subclasses": {
                             "Air_Differential_Pressure_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Pressure], [BRICK.measures, BRICK.Air]],
-                                "tags": [TAG.Air, TAG.Sensor, TAG.Pressure, TAG.Differential],
+                                "tags": [TAG.Point, TAG.Air, TAG.Sensor, TAG.Pressure, TAG.Differential],
                             },
                             "Chilled_Water_Differential_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Chilled],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Chilled],
                                 "substances": [[BRICK.measures, BRICK.Pressure], [BRICK.measures, BRICK.Chilled_Water]],
                             },
                             "Filter_Differential_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Filter],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Filter],
                             },
                             "Hot_Water_Differential_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
                                 "substances": [[BRICK.measures, BRICK.Pressure], [BRICK.measures, BRICK.Hot_Water]],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Sensor, TAG.Pressure, TAG.Differential, TAG.Water, TAG.Hot],
                                     },
                                 },
                             }
                         }
                     },
                     "Static_Pressure_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Pressure, TAG.Static],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Static],
                         "subclasses": {
                             "Building_Air_Static_Pressure_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Static_Pressure], [BRICK.measures, BRICK.Building_Air]],
-                                "tags": [TAG.Building, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Building, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
                             },
                             "Discharge_Air_Static_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Static_Pressure], [BRICK.measures, BRICK.Discharge_Air]],
                             },
                             "Supply_Air_Static_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Static_Pressure], [BRICK.measures, BRICK.Supply_Air]],
                             },
                             "Exhaust_Air_Static_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Exhaust],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Static, TAG.Air, TAG.Exhaust],
                                 "substances": [[BRICK.measures, BRICK.Static_Pressure], [BRICK.measures, BRICK.Exhaust_Air]],
                                 "subclasses": {
                                     "Average_Exhaust_Air_Static_Pressure_Sensor": {
-                                        "tags": [TAG.Average, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Average, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
                                     },
                                     "Lowest_Exhaust_Air_Static_Pressure_Sensor": {
-                                        "tags": [TAG.Lowest, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Lowest, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Sensor],
                                     }
                                 }
                             }
                         }
                     },
                     "Velocity_Pressure_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Pressure, TAG.Velocity],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Velocity],
                         "substances": [[BRICK.measures, BRICK.Velocity_Pressure]],
                         "subclasses": {
                             "Discharge_Air_Velocity_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Discharge, TAG.Air],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Discharge, TAG.Air],
                                 "substances": [[BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Discharge_Air]],
                             },
                             "Exhaust_Air_Velocity_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Exhaust, TAG.Air],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Exhaust, TAG.Air],
                                 "substances": [[BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Exhaust_Air]],
                             },
                             "Supply_Air_Velocity_Pressure_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Supply, TAG.Air],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Pressure, TAG.Velocity, TAG.Supply, TAG.Air],
                                 "substances": [[BRICK.measures, BRICK.Velocity_Pressure], [BRICK.measures, BRICK.Supply_Air]],
                             }
                         }
@@ -451,30 +451,30 @@ sensor_definitions = {
                 }
             },
             "Power_Sensor": {
-                "tags": [TAG.Sensor, TAG.Power],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Power],
                 "substances": [[BRICK.measures, BRICK.Power]],
                 "subclasses": {
                     "Thermal_Power_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Power, TAG.Thermal],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Power, TAG.Thermal],
                         "subclasses": {
                             "Heating_Thermal_Power_Sensor": {
-                                "tags": [TAG.Heating, TAG.Sensor, TAG.Power, TAG.Thermal],
+                                "tags": [TAG.Point, TAG.Heating, TAG.Sensor, TAG.Power, TAG.Thermal],
                             }
                         },
                     },
                     "Electrical_Power_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Power, TAG.Electrical],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Power, TAG.Electrical],
                         "subclasses": {
                             "Reactive_Power_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Power, TAG.Reactive, TAG.Electrical],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Power, TAG.Reactive, TAG.Electrical],
                                 "substances": [[BRICK.measures, BRICK.Reactive_Power]],
                             },
                             "Active_Power_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Power, TAG.Real, TAG.Electrical],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Power, TAG.Real, TAG.Electrical],
                                 "substances": [[BRICK.measures, BRICK.Active_Power]],
                             },
                             "Peak_Power_Demand_Sensor": {
-                                "tags": [TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor, TAG.Electrical],
+                                "tags": [TAG.Point, TAG.Peak, TAG.Power, TAG.Demand, TAG.Sensor, TAG.Electrical],
                                 "substances": [[BRICK.measures, BRICK.Peak_Power]],
                                 "parents": [BRICK.Demand_Sensor],
                             }
@@ -483,194 +483,194 @@ sensor_definitions = {
                 }
             },
             "Rain_Sensor": {
-                "tags": [TAG.Sensor, TAG.Rain],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Rain],
                 #TODO: substances
                 "subclasses": {
                     "Rain_Duration_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Rain, TAG.Duration],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Rain, TAG.Duration],
                     }
                 }
             },
             "Duration_Sensor": {
-                "tags": [TAG.Sensor, TAG.Duration],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Duration],
                 #TODO: substances
                 "subclasses": {
                     "Rain_Duration_Sensor": {
-                        "tags": [TAG.Rain, TAG.Duration, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Rain, TAG.Duration, TAG.Sensor],
                     },
                     "Run_Time_Sensor": {
-                        "tags": [TAG.Run, TAG.Time, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Run, TAG.Time, TAG.Sensor],
                     },
                     "On_Timer_Sensor": {
-                        "tags": [TAG.On, TAG.Timer, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.On, TAG.Timer, TAG.Sensor],
                     }
                 }
             },
             "Solar_Radiance_Sensor": {
-                "tags": [TAG.Sensor, TAG.Radiance, TAG.Solar],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Radiance, TAG.Solar],
                 "substances": [[BRICK.measures, BRICK.Solar_Radiance]],
             },
             "Speed_Sensor": {
-                "tags": [TAG.Sensor, TAG.Speed],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Speed],
                 "substances": [[BRICK.measures, BRICK.Speed]],
                 "subclasses": {
                     "Differential_Speed_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Speed, TAG.Differential],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Speed, TAG.Differential],
                     },
                     "Motor_Speed_Sensor": {
-                        "tags": [TAG.Motor, TAG.Speed, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Motor, TAG.Speed, TAG.Sensor],
                     },
                     "Wind_Speed_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Speed, TAG.Wind],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Speed, TAG.Wind],
                         "substances": [[BRICK.measures, BRICK.Wind_Speed]],
                     }
                 }
             },
             "Torque_Sensor": {
-                "tags": [TAG.Sensor, TAG.Torque],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Torque],
                 "substances": [[BRICK.measures, BRICK.Torque]],
                 "subclasses": {
                     "Motor_Torque_Sensor": {
-                        "tags": [TAG.Motor, TAG.Torque, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Motor, TAG.Torque, TAG.Sensor],
                     }
                 }
             },
             "Voltage_Sensor": {
-                "tags": [TAG.Sensor, TAG.Voltage],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Voltage],
                 "substances": [[BRICK.measures, BRICK.Voltage]],
                 "subclasses": {
                     "Battery_Voltage_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Voltage, TAG.Battery],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Voltage, TAG.Battery],
                     },
                     "DC_Bus_Voltage_Sensor": {
-                        "tags": [TAG.Dc, TAG.Bus, TAG.Voltage, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Dc, TAG.Bus, TAG.Voltage, TAG.Sensor],
                     },
                     "Output_Voltage_Sensor": {
-                        "tags": [TAG.Output, TAG.Voltage, TAG.Sensor],
+                        "tags": [TAG.Point, TAG.Output, TAG.Voltage, TAG.Sensor],
                     }
                 }
             },
             "Water_Level_Sensor": {
-                "tags": [TAG.Sensor, TAG.Water, TAG.Level],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Water, TAG.Level],
                 "substances": [[BRICK.measures, BRICK.Water], [BRICK.measures, BRICK.Level]],
                 "subclasses": {
                     "Deionised_Water_Level_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Water, TAG.Level, TAG.Deionised],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Water, TAG.Level, TAG.Deionised],
                         "substances": [[BRICK.measures, BRICK.Deionized_Water], [BRICK.measures, BRICK.Level]],
                     }
                 }
             },
             "Usage_Sensor": {
-                "tags": [TAG.Sensor, TAG.Usage],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Usage],
                 "subclasses": {
                     "Steam_Usage_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Usage, TAG.Steam],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Usage, TAG.Steam],
                         "subclasses": {
                             "Today_Steam_Usage_Sensor": {
-                                "tags": [TAG.Today, TAG.Sensor, TAG.Usage, TAG.Steam],
+                                "tags": [TAG.Point, TAG.Today, TAG.Sensor, TAG.Usage, TAG.Steam],
                             },
                             "Monthly_Steam_Usage_Sensor": {
-                                "tags": [TAG.Monthly, TAG.Sensor, TAG.Usage, TAG.Steam],
+                                "tags": [TAG.Point, TAG.Monthly, TAG.Sensor, TAG.Usage, TAG.Steam],
                             },
                             "Yearly_Steam_Usage_Sensor": {
-                                "tags": [TAG.Yearly, TAG.Sensor, TAG.Usage, TAG.Steam],
+                                "tags": [TAG.Point, TAG.Yearly, TAG.Sensor, TAG.Usage, TAG.Steam],
                             },
                         },
                     },
                     "Water_Usage_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Usage, TAG.Water],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Usage, TAG.Water],
                         "subclasses": {
                             "Hot_Water_Usage_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Usage, TAG.Hot, TAG.Water],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Usage, TAG.Hot, TAG.Water],
                             },
                         },
                     },
                 },
             },
             "Temperature_Sensor": {
-                "tags": [TAG.Sensor, TAG.Temperature],
+                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature],
                 "substances": [[BRICK.measures, BRICK.Temperature]],
                 "subclasses": {
                     "Air_Temperature_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Air],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air],
                         "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Air]],
                         "subclasses": {
                             "Discharge_Air_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Discharge_Air]],
                                 "subclasses": {
                                     "Preheat_Discharge_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Preheat, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Preheat, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Sensor],
                                     }
                                 }
                             },
                             "Supply_Air_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Supply_Air]],
                                 "subclasses": {
                                     "Preheat_Supply_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Preheat, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Preheat, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Sensor],
                                     }
                                 }
                             },
                             "Underfloor_Air_Temperature_Sensor": {
-                                "tags": [TAG.Underfloor, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Underfloor, TAG.Air, TAG.Temperature, TAG.Sensor],
                             },
                             "Zone_Air_Temperature_Sensor": {
-                                "tags": [TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Zone_Air]],
                                 "subclasses": {
                                     "Average_Zone_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Average, TAG.Air],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Average, TAG.Air],
                                     },
                                     "Highest_Zone_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Highest, TAG.Air],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Highest, TAG.Air],
                                         OWL.equivalentClass: BRICK["Warmest_Zone_Air_Temperature_Sensor"],
                                     },
                                     "Lowest_Zone_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Lowest, TAG.Air],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Zone, TAG.Lowest, TAG.Air],
                                         OWL.equivalentClass: BRICK["Coldest_Zone_Air_Temperature_Sensor"],
                                     },
                                     "Coldest_Zone_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Coldest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Coldest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
                                     },
                                     "Warmest_Zone_Air_Temperature_Sensor": {
-                                        "tags": [TAG.Warmest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Warmest, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Sensor],
                                     },
                                 }
                             },
                             "Exhaust_Air_Temperature_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Exhaust_Air]],
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Exhaust],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Exhaust],
                             },
                             "Mixed_Air_Temperature_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Mixed_Air]],
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Mixed],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Mixed],
                             },
                             "Return_Air_Temperature_Sensor": {
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Return_Air]],
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Return],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Return],
                             },
                             "Outside_Air_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Outside],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Air, TAG.Outside],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Outside_Air]],
                                 "subclasses": {
                                     "Outside_Air_Temperature_Enable_Differential_Sensor": {
-                                        "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Differential, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Differential, TAG.Sensor],
                                         "subclasses": {
                                             "Low_Outside_Air_Temperature_Enable_Differential_Sensor": {
-                                                "tags": [TAG.Low, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Differential, TAG.Sensor],
+                                                "tags": [TAG.Point, TAG.Low, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Differential, TAG.Sensor],
                                             },
                                         },
                                     },
                                     "Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                        "tags": [TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
                                         "subclasses": {
                                             "Low_Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                                "tags": [TAG.Low, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
+                                                "tags": [TAG.Point, TAG.Low, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
                                             },
                                             "High_Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                                "tags": [TAG.High, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
+                                                "tags": [TAG.Point, TAG.High, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Differential, TAG.Sensor],
                                             }
                                         },
                                     }
@@ -679,74 +679,74 @@ sensor_definitions = {
                         }
                     },
                     "Water_Temperature_Sensor": {
-                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Water],
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water],
                         "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Water]],
                         "subclasses": {
                             "Heat_Exchanger_Supply_Water_Temperature_Sensor": {
-                                "tags": [TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Sensor],
+                                "tags": [TAG.Point, TAG.Heat, TAG.Exchanger, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Sensor],
                             },
                             "Hot_Water_Supply_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Hot, TAG.Supply],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Hot, TAG.Supply],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Supply_Hot_Water]],
                                 "subclasses": {
                                     "Domestic_Hot_Water_Supply_Temperature_Sensor": {
-                                        "tags": [TAG.Domestic, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Domestic, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
                                     },
                                     "High_Temperature_Hot_Water_Supply_Temperature_Sensor": {
-                                        "tags": [TAG.High, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.High, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
                                     },
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_Sensor": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Sensor],
                                     }
                                 }
                             },
                             "Chilled_Water_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Chilled_Water]],
                                 "subclasses": {
                                     "Chilled_Water_Differential_Temperature_Sensor": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Temperature, TAG.Sensor],
                                     },
                                     "Chilled_Water_Supply_Temperature_Sensor": {
-                                        "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled, TAG.Supply],
+                                        "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Chilled, TAG.Supply],
                                         "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Supply_Chilled_Water]],
                                     }
                                 }
                             },
                             "Discharge_Water_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Discharge],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Discharge],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Discharge_Water]],
                             },
                             "Entering_Water_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Entering],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Entering],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Entering_Water]],
                             },
                             "Leaving_Water_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Leaving],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Leaving],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Leaving_Water]],
                                 "subclasses": {
                                     "Ice_Tank_Leaving_Water_Temperature_Sensor": {
-                                        "tags": [TAG.Ice, TAG.Tank, TAG.Leaving, TAG.Water, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Ice, TAG.Tank, TAG.Leaving, TAG.Water, TAG.Temperature, TAG.Sensor],
                                     },
                                 }
                             },
                             "Return_Water_Temperature_Sensor": {
-                                "tags": [TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Return],
+                                "tags": [TAG.Point, TAG.Sensor, TAG.Temperature, TAG.Water, TAG.Return],
                                 "substances": [[BRICK.measures, BRICK.Temperature], [BRICK.measures, BRICK.Return_Water]],
                                 "subclasses": {
                                     "Hot_Water_Return_Temperature_Sensor": {
-                                        "tags": [TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
                                         "subclasses": {
                                             "Medium_Temperature_Hot_Water_Return_Temperature_Sensor": {
-                                                "tags": [TAG.Medium, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                                "tags": [TAG.Point, TAG.Medium, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
                                             },
                                             "High_Temperature_Hot_Water_Return_Temperature_Sensor": {
-                                                "tags": [TAG.High, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                                "tags": [TAG.Point, TAG.High, TAG.Hot, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
                                             },
                                         },
                                     },
                                     "Chilled_Water_Return_Temperature_Sensor": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Return, TAG.Temperature, TAG.Sensor],
                                         "parents": [BRICK.Chilled_Water_Temperature_Sensor],
                                     }
                                 }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -3,146 +3,146 @@ from rdflib import Literal
 
 setpoint_definitions = {
     "Setpoint": {
-        "tags": [TAG.Setpoint],
+        "tags": [TAG.Point, TAG.Setpoint],
         "subclasses": {
             "Enthalpy_Setpoint": {
-                "tags": [TAG.Setpoint, TAG.Enthalpy],
+                "tags": [TAG.Point, TAG.Setpoint, TAG.Enthalpy],
             },
             "Dew_Point_Setpoint": {
-                "tags": [TAG.Dewpoint, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Dewpoint, TAG.Setpoint],
             },
             "Demand_Setpoint": {
-                "tags": [TAG.Demand, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Demand, TAG.Setpoint],
                 "subclasses": {
                     "Cooling_Demand_Setpoint": {
-                        "tags": [TAG.Cooling, TAG.Demand, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Cooling, TAG.Demand, TAG.Setpoint],
                     },
                     "Heating_Demand_Setpoint": {
-                        "tags": [TAG.Heating, TAG.Demand, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Heating, TAG.Demand, TAG.Setpoint],
                     },
                     "Preheat_Demand_Setpoint": {
-                        "tags": [TAG.Preheat, TAG.Demand, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Preheat, TAG.Demand, TAG.Setpoint],
                     },
                     "Air_Flow_Demand_Setpoint": {
-                        "tags": [TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Flow_Demand_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                             },
                             "Supply_Air_Flow_Demand_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                             }
                         }
                     }
                 }
             },
             "Damper_Position_Setpoint": {
-                "tags": [TAG.Damper, TAG.Position, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Setpoint],
             },
             "Deadband_Setpoint": {
-                "tags": [TAG.Deadband, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Deadband, TAG.Setpoint],
                 "subclasses": {
                     "Differential_Pressure_Deadband_Setpoint": {
-                        "tags": [TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                         "parents": [BRICK.Differential_Pressure_Setpoint],
                         "subclasses": {
                             "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Hot_Water_Differential_Pressure_Setpoint],
                             },
                             "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
-                                "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Chilled_Water_Differential_Pressure_Setpoint],
                                 "subclasses": {
                                     "Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Pump, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                     },
                                 },
                             },
                             "Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
                                 "subclasses": {
                                     "Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                             },
                             "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
                                 "subclasses": {
                                     "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Thermal, TAG.Energy, TAG.Storage, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                             },
                         },
                     },
                     "Temperature_Deadband_Setpoint": {
                         "subclasses": {
                             "Occupied_Cooling_Temperature_Deadband_Setpoint": {
-                                "tags": [TAG.Occupied, TAG.Cooling, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Occupied, TAG.Cooling, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Cooling_Temperature_Setpoint],
                             },
                             "Occupied_Heating_Temperature_Deadband_Setpoint": {
-                                "tags": [TAG.Occupied, TAG.Heating, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Occupied, TAG.Heating, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Heating_Temperature_Setpoint],
                             },
                             "Discharge_Air_Temperature_Deadband_Setpoint": {
                                 "subclasses": {
                                     "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {
-                                        "tags": [TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                         "parents": [BRICK.Discharge_Air_Temperature_Heating_Setpoint],
                                     },
                                     "Cooling_Discharge_Air_Temperature_Deadband_Setpoint": {
-                                        "tags": [TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                         "parents": [BRICK.Discharge_Air_Temperature_Cooling_Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Discharge_Air_Temperature_Setpoint],
                             },
                             "Supply_Air_Temperature_Deadband_Setpoint": {
                                 "subclasses": {
                                     "Heating_Supply_Air_Temperature_Deadband_Setpoint": {
-                                        "tags": [TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                     },
                                     "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
-                                        "tags": [TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Air_Temperature_Setpoint],
                             },
                             "Supply_Water_Temperature_Deadband_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Supply_Water_Temperature_Setpoint],
                             }
                         },
-                        "tags": [TAG.Temperature, TAG.Deadband, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Deadband, TAG.Setpoint],
                         "parents": [BRICK.Temperature_Setpoint],
                     },
                     "Air_Flow_Deadband_Setpoint": {
                         "subclasses": {
                             "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {
-                                "tags": [TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Exhaust_Air_Stack_Flow_Setpoint],
                             }
                         },
-                        "tags": [TAG.Air, TAG.Flow, TAG.Deadband, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Deadband, TAG.Setpoint],
                         "parents": [BRICK.Air_Flow_Setpoint],
                     },
                     "Static_Pressure_Deadband_Setpoint": {
-                        "tags": [TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                         "parents": [BRICK.Static_Pressure_Setpoint],
                         "subclasses": {
                             "Discharge_Air_Static_Pressure_Deadband_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Discharge_Air_Static_Pressure_Setpoint],
                             },
                             "Supply_Air_Static_Pressure_Deadband_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Deadband, TAG.Setpoint],
                                 "parents": [BRICK.Supply_Air_Static_Pressure_Setpoint],
                             },
                         },
@@ -150,386 +150,386 @@ setpoint_definitions = {
                 },
             },
             "Flow_Setpoint": {
-                "tags": [TAG.Flow, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Flow, TAG.Setpoint],
                 "subclasses": {
                     "Air_Flow_Setpoint": {
-                        "tags": [TAG.Air, TAG.Flow, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Setpoint],
                         "subclasses": {
                             "Air_Flow_Demand_Setpoint": {
-                                "tags": [TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                             },
                             "Discharge_Air_Flow_Setpoint": {
                                 "subclasses": {
                                     "Discharge_Air_Flow_Demand_Setpoint": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                                     },
                                     "Cooling_Discharge_Air_Flow_Setpoint": {
-                                        "tags": [TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                         "subclasses": {
                                             "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {
-                                                "tags": [TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                             },
                                         },
                                     },
                                     "Heating_Discharge_Air_Flow_Setpoint": {
-                                        "tags": [TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                     },
                                     "Occupied_Discharge_Air_Flow_Setpoint": {
                                         "subclasses": {
                                             "Occupied_Cooling_Discharge_Air_Flow_Setpoint": {
-                                                "tags": [TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Occupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                                 "parents": [BRICK.Cooling_Discharge_Air_Flow_Setpoint],
                                             },
                                             "Occupied_Heating_Discharge_Air_Flow_Setpoint": {
-                                                "tags": [TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Occupied, TAG.Heating, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                                 "parents": [BRICK.Heating_Discharge_Air_Flow_Setpoint],
                                             }
                                         },
-                                        "tags": [TAG.Occupied, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Occupied, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                     },
                                 },
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                             },
                             "Exhaust_Air_Flow_Setpoint": {
                                 "subclasses": {
                                     "Exhaust_Air_Stack_Flow_Setpoint": {
-                                        "tags": [TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Stack, TAG.Flow, TAG.Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Flow, TAG.Setpoint],
                             },
                             "Fan_Air_Flow_Setpoint": {
-                                "tags": [TAG.Fan, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Fan, TAG.Air, TAG.Flow, TAG.Setpoint],
                             },
                             "Outside_Air_Flow_Setpoint": {
-                                "tags": [TAG.Outside, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Flow, TAG.Setpoint],
                             },
                             "Supply_Air_Flow_Setpoint": {
                                 "subclasses": {
                                     "Supply_Air_Flow_Demand_Setpoint": {
-                                        "tags": [TAG.Supply, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Flow, TAG.Demand, TAG.Setpoint],
                                     },
                                     "Occupied_Supply_Air_Flow_Setpoint": {
                                         "subclasses": {
                                             "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                "tags": [TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Occupied, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                                                 "parents": [BRICK.Cooling_Supply_Air_Flow_Setpoint],
                                             },
                                             "Occupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                "tags": [TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                                "tags": [TAG.Point, TAG.Occupied, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                                                 "parents": [BRICK.Heating_Supply_Air_Flow_Setpoint],
                                             }
                                         },
-                                        "tags": [TAG.Occupied, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Occupied, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                                     },
                                     "Cooling_Supply_Air_Flow_Setpoint": {
-                                        "tags": [TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Cooling, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                                     },
                                     "Heating_Supply_Air_Flow_Setpoint": {
-                                        "tags": [TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Heating, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Flow, TAG.Setpoint],
                             }
                         },
                     }
                 },
             },
             "Humidity_Setpoint": {
-                "tags": [TAG.Humidity, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Humidity, TAG.Setpoint],
             },
             "Load_Setpoint": {
                 "subclasses": {
                     "Load_Shed_Setpoint": {
-                        "tags": [TAG.Shed, TAG.Load, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Shed, TAG.Load, TAG.Setpoint],
                         "subclasses": {
                             "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
                             },
                             "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint": {
-                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
                             },
                         },
                     }
                 },
-                "tags": [TAG.Load, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Load, TAG.Setpoint],
             },
             "Luminance_Setpoint": {
-                "tags": [TAG.Luminance, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Luminance, TAG.Setpoint],
             },
             "Mode_Setpoint": {
                 "subclasses": {
                     "Dual_Band_Mode_Setpoint": {
-                        "tags": [TAG.Dual, TAG.Band, TAG.Mode, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Dual, TAG.Band, TAG.Mode, TAG.Setpoint],
                     },
                     "Unoccupied_Mode_Setpoint": {
-                        "tags": [TAG.Unoccupied, TAG.Mode, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Mode, TAG.Setpoint],
                     },
                     "Occupied_Mode_Setpoint": {
-                        "tags": [TAG.Occupied, TAG.Mode, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Occupied, TAG.Mode, TAG.Setpoint],
                     }
                 },
-                "tags": [TAG.Mode, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Mode, TAG.Setpoint],
             },
             "Pressure_Setpoint": {
                 "subclasses": {
                     "Differential_Pressure_Setpoint": {
                         "subclasses": {
                             "Chilled_Water_Differential_Pressure_Setpoint": {
-                                "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint],
                             },
                             "Hot_Water_Differential_Pressure_Setpoint": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Setpoint],
                             },
                             "Load_Shed_Differential_Pressure_Setpoint": {
                                 "parents": [BRICK.Load_Shed_Setpoint],
                                 "subclasses": {
                                     "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Setpoint],
                                         "parents": [BRICK.Chilled_Water_Differential_Pressure_Setpoint],
                                     },
                                 },
-                                "tags": [TAG.Load, TAG.Shed, TAG.Differential, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Load, TAG.Shed, TAG.Differential, TAG.Pressure, TAG.Setpoint],
                             }
                         },
-                        "tags": [TAG.Differential, TAG.Pressure, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Setpoint],
                     },
                     "Static_Pressure_Setpoint": {
                         "subclasses": {
                             "Building_Air_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Building, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Building, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             },
                             "Chilled_Water_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Chilled, TAG.Water, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             },
                             "Discharge_Air_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             },
                             "Exhaust_Air_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Exhaust, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             },
                             "Hot_Water_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             },
                             "Supply_Air_Static_Pressure_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Static, TAG.Pressure, TAG.Setpoint],
                             }
                         },
-                        "tags": [TAG.Static, TAG.Pressure, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Setpoint],
                     },
                     "Velocity_Pressure_Setpoint": {
-                        "tags": [TAG.Velocity, TAG.Pressure, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Velocity, TAG.Pressure, TAG.Setpoint],
                     }
                 },
-                "tags": [TAG.Pressure, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Pressure, TAG.Setpoint],
             },
             "Request_Setpoint": {
-                "tags": [TAG.Request, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Request, TAG.Setpoint],
                 "subclasses": {
                     "Cooling_Request_Setpoint": {
-                        "tags": [TAG.Cooling, TAG.Request, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Cooling, TAG.Request, TAG.Setpoint],
                         "subclasses": {
                             "Cooling_Request_Percent_Setpoint": {
-                                "tags": [TAG.Cooling, TAG.Request, TAG.Percent, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Cooling, TAG.Request, TAG.Percent, TAG.Setpoint],
                             },
                         },
                     },
                     "Heating_Request_Setpoint": {
-                        "tags": [TAG.Heating, TAG.Request, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Heating, TAG.Request, TAG.Setpoint],
                         "subclasses": {
                             "Heating_Request_Percent_Setpoint": {
-                                "tags": [TAG.Heating, TAG.Request, TAG.Percent, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Heating, TAG.Request, TAG.Percent, TAG.Setpoint],
                             },
                         }
                     },
                 },
             },
             "Reset_Setpoint": {
-                "tags": [TAG.Reset, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Reset, TAG.Setpoint],
                 SKOS.definition: Literal("Setpoints used in Reset strategies"),
                 "subclasses": {
                     "Discharge_Air_Flow_Reset_Setpoint": {
-                        "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Flow_Reset_High_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.High],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.High],
                             },
                             "Discharge_Air_Flow_Reset_Low_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.Low],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.Low],
                             }
                         }
                     },
                     "Temperature_Differential_Reset_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Temperature_Reset_Differential_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
                                     "Discharge_Air_Temperature_Reset_High_Setpoint": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.High],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.High],
                                     },
                                     "Discharge_Air_Temperature_Reset_Low_Setpoint": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.Low],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.Low],
                                     },
                                 }
                             },
                             "Supply_Air_Temperature_Reset_Differential_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                             },
                         }
                     },
                     "Temperature_High_Reset_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                                     },
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                                     },
                                 }
                             },
                             "Supply_Air_Temperature_Reset_High_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                             },
                             "Outside_Air_Temperature_High_Reset_Setpoint": {
-                                "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                             },
                         }
                     },
                     "Temperature_Low_Reset_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Supply_Air_Temperature_Reset_Low_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                             },
                             "Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                     },
                                     "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                     },
                                 }
                             },
                             "Outside_Air_Temperature_Low_Reset_Setpoint": {
-                                "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                             }
                         }
                     },
                 }
             },
             "Speed_Setpoint": {
-                "tags": [TAG.Speed, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Speed, TAG.Setpoint],
                 "subclasses": {
                     "Rated_Speed_Setpoint": {
-                        "tags": [TAG.Rated, TAG.Speed, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Rated, TAG.Speed, TAG.Setpoint],
                     },
                     "Differential_Speed_Setpoint": {
-                        "tags": [TAG.Differential, TAG.Speed, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Differential, TAG.Speed, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Fan_Differential_Speed_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
                             },
                             "Return_Fan_Differential_Speed_Setpoint": {
-                                "tags": [TAG.Return, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Return, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
                             },
                             "Supply_Fan_Differential_Speed_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Fan, TAG.Differential, TAG.Speed, TAG.Setpoint],
                             }
                         },
                     }
                 },
             },
             "Temperature_Setpoint": {
-                "tags": [TAG.Temperature, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint],
                 "subclasses": {
                     "Air_Temperature_Setpoint": {
-                        "tags": [TAG.Air, TAG.Temperature, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Setpoint],
                         "subclasses": {
                             "Differential_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Differential, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Differential, TAG.Air, TAG.Temperature, TAG.Setpoint],
                             },
                             "Discharge_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Discharge_Air_Temperature_Heating_Setpoint": {
                                         OWL.equivalentClass: BRICK["Min_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint],
                                     },
                                     "Min_Discharge_Air_Temperature_Setpoint": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Min, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Min, TAG.Setpoint],
                                     },
                                     "Max_Discharge_Air_Temperature_Setpoint": {
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Max, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Max, TAG.Setpoint],
                                     },
                                     "Discharge_Air_Temperature_Cooling_Setpoint": {
                                         OWL.equivalentClass: BRICK["Max_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
-                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Cooling, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Cooling, TAG.Setpoint],
                                     }
                                 },
                             },
                             "Effective_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Effective, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Effective, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Effective_Air_Temperature_Cooling_Setpoint": {
-                                        "tags": [TAG.Effective, TAG.Air, TAG.Cooling, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Effective, TAG.Air, TAG.Cooling, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
                                     },
                                     "Effective_Air_Temperature_Heating_Setpoint": {
-                                        "tags": [TAG.Effective, TAG.Air, TAG.Heating, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Effective, TAG.Air, TAG.Heating, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                     },
                                 }
                             },
                             "Mixed_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Mixed, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Mixed, TAG.Air, TAG.Temperature, TAG.Setpoint],
                             },
                             "Room_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Room, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Room, TAG.Air, TAG.Temperature, TAG.Setpoint],
                             },
                             "Zone_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Zone, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Zone, TAG.Air, TAG.Temperature, TAG.Setpoint],
                             },
                             "Outside_Air_Temperature_Setpoint": {
                                 "subclasses": {
                                     "Low_Outside_Air_Temperature_Enable_Setpoint": {
-                                        "tags": [TAG.Low, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Low, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Setpoint],
                                     },
                                     "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [TAG.Disable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Disable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         SKOS.definition: Literal("Disables hot water system when outside air temperature reaches the indicated value"),
                                     },
                                     "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [TAG.Enable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Enable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         SKOS.definition: Literal("Enables hot water system when outside air temperature reaches the indicated value"),
                                     },
                                     "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [TAG.Open, TAG.Heating, TAG.Valve, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Open, TAG.Heating, TAG.Valve, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                     },
                                     "Outside_Air_Lockout_Temperature_Setpoint": {
-                                        "tags": [TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Lockout, TAG.Temperature, TAG.Setpoint],
                                     }
                                 },
-                                "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                             },
                             "Unoccupied_Air_Temperature_Setpoint": {
-                                "tags": [TAG.Unoccupied, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Unoccupied, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Unoccupied_Air_Temperature_Cooling_Setpoint": {
-                                        "tags": [TAG.Unoccupied, TAG.Cooling, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Cooling, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
                                     },
                                     "Unoccupied_Air_Temperature_Heating_Setpoint": {
-                                        "tags": [TAG.Unoccupied, TAG.Heating, TAG.Air, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Heating, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                     },
                                 },
@@ -537,40 +537,40 @@ setpoint_definitions = {
                         },
                     },
                     "Cooling_Temperature_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.Setpoint, TAG.Cooling],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Cooling],
                     },
                     "Heating_Temperature_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.Setpoint, TAG.Heating],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Heating],
                     },
                     "Schedule_Temperature_Setpoint": {
-                        "tags": [TAG.Temperature, TAG.Setpoint, TAG.Schedule],
+                        "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Schedule],
                         SKOS.definition: Literal("The current setpoint as indicated by the schedule"),
                     },
                     "Water_Temperature_Setpoint": {
                         "subclasses": {
                             "Domestic_Hot_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Domestic, TAG.Hot, TAG.Water, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Domestic, TAG.Hot, TAG.Water, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Domestic_Hot_Water_Supply_Temperature_Setpoint": {
-                                        "tags": [TAG.Domestic, TAG.Hot, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Setpoint],
+                                        "tags": [TAG.Point, TAG.Domestic, TAG.Hot, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Setpoint],
                                         "parents": [BRICK.Supply_Water_Temperature_Setpoint],
                                     }
                                 }
                             },
                             "Discharge_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Discharge, TAG.Water, TAG.Temperature, TAG.Setpoint],
                             },
                             "Supply_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Supply, TAG.Water, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Supply, TAG.Water, TAG.Temperature, TAG.Setpoint],
                             },
                             "Entering_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Entering, TAG.Water, TAG.Temperature, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Entering, TAG.Water, TAG.Temperature, TAG.Setpoint],
                             },
                             "Leaving_Water_Temperature_Setpoint": {
-                                "tags": [TAG.Leaving, TAG.Setpoint, TAG.Temperature, TAG.Water],
+                                "tags": [TAG.Point, TAG.Leaving, TAG.Setpoint, TAG.Temperature, TAG.Water],
                             }
                         },
-                        "tags": [TAG.Water, TAG.Temperature, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Water, TAG.Temperature, TAG.Setpoint],
                     }
                 },
             },
@@ -579,22 +579,22 @@ setpoint_definitions = {
                     "Return_Air_CO2_Setpoint": {
                         "subclasses": {
                             "Max_Return_Air_CO2_Setpoint": {
-                                "tags": [TAG.Max, TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
+                                "tags": [TAG.Point, TAG.Max, TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
                             }
                         },
-                        "tags": [TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
+                        "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
                     }
                 },
-                "tags": [TAG.CO2, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.CO2, TAG.Setpoint],
             },
             "Time_Setpoint": {
-                "tags": [TAG.Time, TAG.Setpoint],
+                "tags": [TAG.Point, TAG.Time, TAG.Setpoint],
                 "subclasses": {
                     "Deceleration_Time_Setpoint": {
-                        "tags": [TAG.Time, TAG.Setpoint, TAG.Deceleration],
+                        "tags": [TAG.Point, TAG.Time, TAG.Setpoint, TAG.Deceleration],
                     },
                     "Acceleration_Time_Setpoint": {
-                        "tags": [TAG.Time, TAG.Setpoint, TAG.Acceleration],
+                        "tags": [TAG.Point, TAG.Time, TAG.Setpoint, TAG.Acceleration],
                     },
                 },
             },

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -346,9 +346,9 @@ setpoint_definitions = {
             },
             "Reset_Setpoint": {
                 "tags": [TAG.Reset, TAG.Setpoint],
+                SKOS.definition: Literal("Setpoints used in Reset strategies"),
                 "subclasses": {
                     "Discharge_Air_Flow_Reset_Setpoint": {
-                        SKOS.definition: Literal("Setpoints used in Reset strategies"),
                         "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Flow_Reset_High_Setpoint": {},

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -388,6 +388,7 @@ setpoint_definitions = {
                                 }
                             },
                             "Supply_Air_Temperature_Reset_High_Setpoint": {
+                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                             },
                         }
                     },
@@ -395,13 +396,20 @@ setpoint_definitions = {
                     "Temperature_Low_Reset_Setpoint": {
                         "subclasses": {
                             "Supply_Air_Temperature_Reset_Low_Setpoint": {
+                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                             },
                             "Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
                                 "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {},
-                                    "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {},
-                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {},
-                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {},
+                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                    },
+                                    "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                                    },
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {
+                                    },
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {
+                                    },
                                 }
                             },
                             "Outside_Air_Temperature_Low_Reset_Setpoint": {}

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -351,22 +351,35 @@ setpoint_definitions = {
                     "Discharge_Air_Flow_Reset_Setpoint": {
                         "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
-                            "Discharge_Air_Flow_Reset_High_Setpoint": {},
-                            "Discharge_Air_Flow_Reset_Low_Setpoint": {}
+                            "Discharge_Air_Flow_Reset_High_Setpoint": {
+                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.High],
+                            },
+                            "Discharge_Air_Flow_Reset_Low_Setpoint": {
+                                "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint, TAG.Low],
+                            }
                         }
                     },
                     "Temperature_Differential_Reset_Setpoint": {
+                        "tags": [TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Temperature_Reset_Differential_Setpoint": {
+                                "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
-                                    "Discharge_Air_Temperature_Reset_High_Setpoint": {},
-                                    "Discharge_Air_Temperature_Reset_Low_Setpoint": {},
+                                    "Discharge_Air_Temperature_Reset_High_Setpoint": {
+                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.High],
+                                    },
+                                    "Discharge_Air_Temperature_Reset_Low_Setpoint": {
+                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint, TAG.Low],
+                                    },
                                 }
                             },
                             "Supply_Air_Temperature_Reset_Differential_Setpoint": {
+                                "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
-                                    "Supply_Air_Temperature_Reset_High_Setpoint": {},
-                                    "Supply_Air_Temperature_Reset_Low_Setpoint": {},
+                                    "Supply_Air_Temperature_Reset_High_Setpoint": {
+                                    },
+                                    "Supply_Air_Temperature_Reset_Low_Setpoint": {
+                                    },
                                 }
                             }
                         }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -166,7 +166,9 @@ setpoint_definitions = {
                                     "Cooling_Discharge_Air_Flow_Setpoint": {
                                         "tags": [TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
                                         "subclasses": {
-                                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {},
+                                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {
+                                                "tags": [TAG.Unoccupied, TAG.Cooling, TAG.Discharge, TAG.Air, TAG.Flow, TAG.Setpoint],
+                                            },
                                         },
                                     },
                                     "Heating_Discharge_Air_Flow_Setpoint": {
@@ -241,8 +243,12 @@ setpoint_definitions = {
                     "Load_Shed_Setpoint": {
                         "tags": [TAG.Shed, TAG.Load, TAG.Setpoint],
                         "subclasses": {
-                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {},
-                            "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint": {},
+                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
+                            },
+                            "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint": {
+                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Pressure, TAG.Shed, TAG.Load, TAG.Setpoint],
+                            },
                         },
                     }
                 },
@@ -343,6 +349,7 @@ setpoint_definitions = {
                 "subclasses": {
                     "Discharge_Air_Flow_Reset_Setpoint": {
                         SKOS.definition: Literal("Setpoints used in Reset strategies"),
+                        "tags": [TAG.Discharge, TAG.Air, TAG.Flow, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Discharge_Air_Flow_Reset_High_Setpoint": {},
                             "Discharge_Air_Flow_Reset_Low_Setpoint": {}

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -459,14 +459,14 @@ setpoint_definitions = {
                                 "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                 "subclasses": {
                                     "Discharge_Air_Temperature_Heating_Setpoint": {
-                                        OWL.equivalentClass: BRICK["Minimum_Discharge_Air_Temperature_Setpoint"],
+                                        OWL.equivalentClass: BRICK["Min_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                         "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint],
                                     },
-                                    "Minimum_Discharge_Air_Temperature_Setpoint": {},
-                                    "Maximum_Discharge_Air_Temperature_Setpoint": {},
+                                    "Min_Discharge_Air_Temperature_Setpoint": {},
+                                    "Max_Discharge_Air_Temperature_Setpoint": {},
                                     "Discharge_Air_Temperature_Cooling_Setpoint": {
-                                        OWL.equivalentClass: BRICK["Maximum_Discharge_Air_Temperature_Setpoint"],
+                                        OWL.equivalentClass: BRICK["Max_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
                                         "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Cooling, TAG.Setpoint],
                                     }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -463,8 +463,12 @@ setpoint_definitions = {
                                         "parents": [BRICK.Heating_Temperature_Setpoint],
                                         "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Heating, TAG.Setpoint],
                                     },
-                                    "Min_Discharge_Air_Temperature_Setpoint": {},
-                                    "Max_Discharge_Air_Temperature_Setpoint": {},
+                                    "Min_Discharge_Air_Temperature_Setpoint": {
+                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Min, TAG.Setpoint],
+                                    },
+                                    "Max_Discharge_Air_Temperature_Setpoint": {
+                                        "tags": [TAG.Discharge, TAG.Air, TAG.Temperature, TAG.Max, TAG.Setpoint],
+                                    },
                                     "Discharge_Air_Temperature_Cooling_Setpoint": {
                                         OWL.equivalentClass: BRICK["Max_Discharge_Air_Temperature_Setpoint"],
                                         "parents": [BRICK.Cooling_Temperature_Setpoint],
@@ -500,9 +504,11 @@ setpoint_definitions = {
                                         "tags": [TAG.Low, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Enable, TAG.Setpoint],
                                     },
                                     "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
+                                        "tags": [TAG.Disable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         SKOS.definition: Literal("Disables hot water system when outside air temperature reaches the indicated value"),
                                     },
                                     "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
+                                        "tags": [TAG.Enable, TAG.Hot, TAG.Water, TAG.System, TAG.Outside, TAG.Air, TAG.Temperature, TAG.Setpoint],
                                         SKOS.definition: Literal("Enables hot water system when outside air temperature reaches the indicated value"),
                                     },
                                     "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -382,37 +382,44 @@ setpoint_definitions = {
                         "tags": [TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {},
-                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {}
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                    },
+                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                                    },
                                 }
                             },
                             "Supply_Air_Temperature_Reset_High_Setpoint": {
                                 "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                             },
+                            "Outside_Air_Temperature_High_Reset_Setpoint": {
+                                "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
+                            },
                         }
                     },
-                    "Outside_Air_Temperature_High_Reset_Setpoint": {},
                     "Temperature_Low_Reset_Setpoint": {
+                        "tags": [TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Supply_Air_Temperature_Reset_Low_Setpoint": {
                                 "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                             },
                             "Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
+                                "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                 "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
-                                    },
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
                                         "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                     },
                                     "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {
-                                    },
-                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
                                     },
                                 }
                             },
-                            "Outside_Air_Temperature_Low_Reset_Setpoint": {}
+                            "Outside_Air_Temperature_Low_Reset_Setpoint": {
+                                "tags": [TAG.Outside, TAG.Air, TAG.Temperature, TAG.Low, TAG.Reset, TAG.Setpoint],
+                            }
                         }
                     },
                 }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -375,28 +375,27 @@ setpoint_definitions = {
                             },
                             "Supply_Air_Temperature_Reset_Differential_Setpoint": {
                                 "tags": [TAG.Supply, TAG.Air, TAG.Temperature, TAG.Differential, TAG.Reset, TAG.Setpoint],
-                                "subclasses": {
-                                    "Supply_Air_Temperature_Reset_High_Setpoint": {
-                                    },
-                                    "Supply_Air_Temperature_Reset_Low_Setpoint": {
-                                    },
-                                }
-                            }
+                            },
                         }
                     },
                     "Temperature_High_Reset_Setpoint": {
+                        "tags": [TAG.Temperature, TAG.High, TAG.Reset, TAG.Setpoint],
                         "subclasses": {
                             "Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {},
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {}
                                 }
-                            }
+                            },
+                            "Supply_Air_Temperature_Reset_High_Setpoint": {
+                            },
                         }
                     },
                     "Outside_Air_Temperature_High_Reset_Setpoint": {},
                     "Temperature_Low_Reset_Setpoint": {
                         "subclasses": {
+                            "Supply_Air_Temperature_Reset_Low_Setpoint": {
+                            },
                             "Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {},

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -28,10 +28,18 @@ status_definitions = {
                 "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Status],
                 "parents": [BRICK.Off_Status],
                 "subclasses": {
-                    "Emergency_Power_Off_Activated_By_High_Temperature_Status": {},
-                    "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {},
-                    "Emergency_Power_Off_Enable_Status": {},
-                    "Emergency_Power_Off_System_Enable_Status": {}
+                    "Emergency_Power_Off_Activated_By_High_Temperature_Status": {
+                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.High, TAG.Temperature, TAG.Status],
+                    },
+                    "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {
+                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
+                    },
+                    "Emergency_Power_Off_Enable_Status": {
+                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
+                    },
+                    "Emergency_Power_Off_System_Enable_Status": {
+                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status],
+                    }
                 },
             },
             "Emergency_Push_Button_Status": {
@@ -95,14 +103,19 @@ status_definitions = {
                     "Hot_Water_Supply_Temperature_Load_Shed_Status": {
                         "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
                         "subclasses": {
-                            "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status": {},
+                            "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status": {
+                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
+                            },
                         },
                     },
                     "Differential_Pressure_Load_Shed_Status": {
                         "subclasses": {
                             "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status": {
+                                "tags": [TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
                                 "subclasses": {
-                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {},
+                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {
+                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
+                                    },
                                 }
                             },
                             "Chilled_Water_Differential_Pressure_Load_Shed_Status": {
@@ -197,13 +210,17 @@ status_definitions = {
             "Off_Status": {
                 "tags": [TAG.Off, TAG.Status],
                 "subclasses": {
-                    "Turn_Off_Status": {},
+                    "Turn_Off_Status": {
+                        "tags": [TAG.Turn, TAG.Off, TAG.Status],
+                    },
                 }
             },
             "On_Status": {
                 "tags": [TAG.On, TAG.Status],
                 "subclasses": {
-                    "Turn_On_Status": {},
+                    "Turn_On_Status": {
+                        "tags": [TAG.Turn, TAG.On, TAG.Status],
+                    },
                 }
             },
             "Overridden_Status": {

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -2,289 +2,289 @@ from .namespaces import TAG, BRICK
 
 status_definitions = {
     "Status": {
-        "tags": [TAG.Status],
+        "tags": [TAG.Point, TAG.Status],
         "subclasses": {
             "Direction_Status": {
                 "subclasses": {
                     "Motor_Direction_Status": {
-                        "tags": [TAG.Motor, TAG.Direction, TAG.Status],
+                        "tags": [TAG.Point, TAG.Motor, TAG.Direction, TAG.Status],
                     },
                 },
-                "tags": [TAG.Direction, TAG.Status],
+                "tags": [TAG.Point, TAG.Direction, TAG.Status],
             },
             "Disable_Status": {
-                "tags": [TAG.Disable, TAG.Status],
+                "tags": [TAG.Point, TAG.Disable, TAG.Status],
             },
             "Drive_Ready_Status": {
-                "tags": [TAG.Drive, TAG.Ready, TAG.Status],
+                "tags": [TAG.Point, TAG.Drive, TAG.Ready, TAG.Status],
             },
             "Emergency_Air_Flow_Status": {
-                "tags": [TAG.Emergency, TAG.Air, TAG.Flow, TAG.Status],
+                "tags": [TAG.Point, TAG.Emergency, TAG.Air, TAG.Flow, TAG.Status],
             },
             "Emergency_Generator_Status": {
-                "tags": [TAG.Emergency, TAG.Generator, TAG.Status],
+                "tags": [TAG.Point, TAG.Emergency, TAG.Generator, TAG.Status],
             },
             "Emergency_Power_Off_Status": {
-                "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Status],
+                "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Status],
                 "parents": [BRICK.Off_Status],
                 "subclasses": {
                     "Emergency_Power_Off_Activated_By_High_Temperature_Status": {
-                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.High, TAG.Temperature, TAG.Status],
+                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.High, TAG.Temperature, TAG.Status],
                     },
                     "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {
-                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
+                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
                     },
                     "Emergency_Power_Off_Enable_Status": {
-                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
+                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
                     },
                     "Emergency_Power_Off_System_Enable_Status": {
-                        "tags": [TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status],
+                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status],
                     }
                 },
             },
             "Emergency_Push_Button_Status": {
-                "tags": [TAG.Emergency, TAG.Push, TAG.Button, TAG.Status],
+                "tags": [TAG.Point, TAG.Emergency, TAG.Push, TAG.Button, TAG.Status],
             },
             "Enable_Status": {
                 "subclasses": {
                     "Heat_Exchanger_System_Enable_Status": {
-                        "tags": [TAG.Heat, TAG.Exchanger, TAG.System, TAG.Enable, TAG.Status],
+                        "tags": [TAG.Point, TAG.Heat, TAG.Exchanger, TAG.System, TAG.Enable, TAG.Status],
                         "parents": [BRICK.System_Status],
                     },
                     "Run_Enable_Status": {
-                        "tags": [TAG.Run, TAG.Enable, TAG.Status],
+                        "tags": [TAG.Point, TAG.Run, TAG.Enable, TAG.Status],
                         "parents": [BRICK.Run_Status],
                     }
                 },
-                "tags": [TAG.Enable, TAG.Status],
+                "tags": [TAG.Point, TAG.Enable, TAG.Status],
             },
             "Even_Month_Status": {
-                "tags": [TAG.Even, TAG.Month, TAG.Status],
+                "tags": [TAG.Point, TAG.Even, TAG.Month, TAG.Status],
             },
             "Fan_Status": {
-                "tags": [TAG.Fan, TAG.Status],
+                "tags": [TAG.Point, TAG.Fan, TAG.Status],
             },
             "Fault_Status": {
                 "subclasses": {
                     "Fault_Indicator_Status": {
-                        "tags": [TAG.Indicator, TAG.Fault, TAG.Status],
+                        "tags": [TAG.Point, TAG.Indicator, TAG.Fault, TAG.Status],
                     },
                     "Humidifier_Fault_Status": {
-                        "tags": [TAG.Humidifier, TAG.Fault, TAG.Status],
+                        "tags": [TAG.Point, TAG.Humidifier, TAG.Fault, TAG.Status],
                     },
                     "Last_Fault_Code_Status": {
-                        "tags": [TAG.Last, TAG.Fault, TAG.Code, TAG.Status],
+                        "tags": [TAG.Point, TAG.Last, TAG.Fault, TAG.Code, TAG.Status],
                     },
                 },
-                "tags": [TAG.Fault, TAG.Status],
+                "tags": [TAG.Point, TAG.Fault, TAG.Status],
             },
             "Filter_Status": {
                 "subclasses": {
                     "Pre_Filter_Status": {
-                        "tags": [TAG.Pre, TAG.Filter, TAG.Status],
+                        "tags": [TAG.Point, TAG.Pre, TAG.Filter, TAG.Status],
                     }
                 },
-                "tags": [TAG.Filter, TAG.Status],
+                "tags": [TAG.Point, TAG.Filter, TAG.Status],
             },
             "Freeze_Status": {
-                "tags": [TAG.Freeze, TAG.Status],
+                "tags": [TAG.Point, TAG.Freeze, TAG.Status],
             },
             "Hand_Auto_Status": {
-                "tags": [TAG.Hand, TAG.Auto, TAG.Status],
+                "tags": [TAG.Point, TAG.Hand, TAG.Auto, TAG.Status],
             },
             "Hold_Status": {
-                "tags": [TAG.Hold, TAG.Status],
+                "tags": [TAG.Point, TAG.Hold, TAG.Status],
             },
             "Load_Shed_Status": {
                 "subclasses": {
                     "Hot_Water_Discharge_Temperature_Load_Shed_Status": {
-                        "tags": [TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
+                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Discharge, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
                     },
                     "Hot_Water_Supply_Temperature_Load_Shed_Status": {
-                        "tags": [TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
+                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
                         "subclasses": {
                             "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status": {
-                                "tags": [TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
+                                "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Hot, TAG.Water, TAG.Supply, TAG.Temperature, TAG.Load, TAG.Shed, TAG.Status],
                             },
                         },
                     },
                     "Differential_Pressure_Load_Shed_Status": {
                         "subclasses": {
                             "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status": {
-                                "tags": [TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
+                                "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {
-                                        "tags": [TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
+                                        "tags": [TAG.Point, TAG.Medium, TAG.Temperature, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
                                     },
                                 }
                             },
                             "Chilled_Water_Differential_Pressure_Load_Shed_Status": {
-                                "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
+                                "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
                                 "subclasses": {
                                     "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status": {
-                                        "tags": [TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
+                                        "tags": [TAG.Point, TAG.Chilled, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
                                     },
                                 }
                             },
                             "Hot_Water_Differential_Pressure_Load_Shed_Status": {
-                                "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
+                                "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
                                 "subclasses": {
                                     "Hot_Water_Differential_Pressure_Load_Shed_Reset_Status": {
-                                        "tags": [TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
+                                        "tags": [TAG.Point, TAG.Hot, TAG.Water, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Reset, TAG.Status],
                                     },
                                 }
                             },
                         },
-                        "tags": [TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
+                        "tags": [TAG.Point, TAG.Differential, TAG.Pressure, TAG.Load, TAG.Shed, TAG.Status],
                         "parents": [BRICK.Pressure_Status],
                     }
                 },
-                "tags": [TAG.Load, TAG.Shed, TAG.Status],
+                "tags": [TAG.Point, TAG.Load, TAG.Shed, TAG.Status],
             },
             "Manual_Auto_Status": {
-                "tags": [TAG.Manual, TAG.Auto, TAG.Status],
+                "tags": [TAG.Point, TAG.Manual, TAG.Auto, TAG.Status],
             },
             "Mode_Status": {
                 "subclasses": {
                     "Occupied_Mode_Status": {
-                        "tags": [TAG.Occupied, TAG.Mode, TAG.Status],
+                        "tags": [TAG.Point, TAG.Occupied, TAG.Mode, TAG.Status],
                     },
                     "System_Mode_Status": {
-                        "tags": [TAG.System, TAG.Mode, TAG.Status],
+                        "tags": [TAG.Point, TAG.System, TAG.Mode, TAG.Status],
                         "parents": [BRICK.System_Status],
                     },
                     "Operating_Mode_Status": {
                         "subclasses": {
                             "Vent_Operating_Mode_Status": {
-                                "tags": [TAG.Vent, TAG.Operating, TAG.Mode, TAG.Status],
+                                "tags": [TAG.Point, TAG.Vent, TAG.Operating, TAG.Mode, TAG.Status],
                             }
                         },
-                        "tags": [TAG.Operating, TAG.Mode, TAG.Status],
+                        "tags": [TAG.Point, TAG.Operating, TAG.Mode, TAG.Status],
                     }
                 },
-                "tags": [TAG.Mode, TAG.Status],
+                "tags": [TAG.Point, TAG.Mode, TAG.Status],
             },
             "Occupancy_Status": {
                 "subclasses": {
                     "Temporary_Occupancy_Status": {
-                        "tags": [TAG.Temporary, TAG.Occupancy, TAG.Status],
+                        "tags": [TAG.Point, TAG.Temporary, TAG.Occupancy, TAG.Status],
                     }
                 },
-                "tags": [TAG.Occupancy, TAG.Status],
+                "tags": [TAG.Point, TAG.Occupancy, TAG.Status],
             },
             "On_Off_Status": {
                 "subclasses": {
                     "Cooling_On_Off_Status": {
-                        "tags": [TAG.Cooling, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Cooling, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Dehumidification_On_Off_Status": {
-                        "tags": [TAG.Dehumidification, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Dehumidification, TAG.On, TAG.Off, TAG.Status],
                     },
                     "EconCycle_On_Off_Status": {
-                        "tags": [TAG.Econcycle, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Econcycle, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Heating_On_Off_Status": {
-                        "tags": [TAG.Heating, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Heating, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Humidification_On_Off_Status": {
-                        "tags": [TAG.Humidification, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Humidification, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Locally_On_Off_Status": {
-                        "tags": [TAG.Locally, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Locally, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Remotely_On_Off_Status": {
-                        "tags": [TAG.Remotely, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Remotely, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Standby_Unit_On_Off_Status": {
-                        "tags": [TAG.Standby, TAG.Unit, TAG.On, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Standby, TAG.Unit, TAG.On, TAG.Off, TAG.Status],
                         "subclasses": {
                             "Standby_Glycool_Unit_On_Off_Status": {
-                                "tags": [TAG.Standby, TAG.Glycool, TAG.Unit, TAG.On, TAG.Off, TAG.Status],
+                                "tags": [TAG.Point, TAG.Standby, TAG.Glycool, TAG.Unit, TAG.On, TAG.Off, TAG.Status],
                             },
                         },
                     },
                 },
-                "tags": [TAG.On, TAG.Off, TAG.Status],
+                "tags": [TAG.Point, TAG.On, TAG.Off, TAG.Status],
                 "parents": [BRICK.On_Status, BRICK.Off_Status],
             },
             "Off_Status": {
-                "tags": [TAG.Off, TAG.Status],
+                "tags": [TAG.Point, TAG.Off, TAG.Status],
                 "subclasses": {
                     "Turn_Off_Status": {
-                        "tags": [TAG.Turn, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Turn, TAG.Off, TAG.Status],
                     },
                 }
             },
             "On_Status": {
-                "tags": [TAG.On, TAG.Status],
+                "tags": [TAG.Point, TAG.On, TAG.Status],
                 "subclasses": {
                     "Turn_On_Status": {
-                        "tags": [TAG.Turn, TAG.On, TAG.Status],
+                        "tags": [TAG.Point, TAG.Turn, TAG.On, TAG.Status],
                     },
                 }
             },
             "Overridden_Status": {
                 "subclasses": {
                     "Overridden_Off_Status": {
-                        "tags": [TAG.Overridden, TAG.Off, TAG.Status],
+                        "tags": [TAG.Point, TAG.Overridden, TAG.Off, TAG.Status],
                         "parents": [BRICK.Off_Status],
                     },
                     "Overridden_On_Status": {
-                        "tags": [TAG.Overridden, TAG.On, TAG.Status],
+                        "tags": [TAG.Point, TAG.Overridden, TAG.On, TAG.Status],
                         "parents": [BRICK.On_Status],
                     }
                 },
-                "tags": [TAG.Overridden, TAG.Status],
+                "tags": [TAG.Point, TAG.Overridden, TAG.Status],
             },
             "Pressure_Status": {
                 "subclasses": {
                     "Discharge_Air_Duct_Pressure_Status": {
-                        "tags": [TAG.Discharge, TAG.Air, TAG.Duct, TAG.Pressure, TAG.Status],
+                        "tags": [TAG.Point, TAG.Discharge, TAG.Air, TAG.Duct, TAG.Pressure, TAG.Status],
                     },
                     "Supply_Air_Duct_Pressure_Status": {
-                        "tags": [TAG.Supply, TAG.Air, TAG.Duct, TAG.Pressure, TAG.Status],
+                        "tags": [TAG.Point, TAG.Supply, TAG.Air, TAG.Duct, TAG.Pressure, TAG.Status],
                     }
                 },
-                "tags": [TAG.Pressure, TAG.Status],
+                "tags": [TAG.Point, TAG.Pressure, TAG.Status],
             },
             "Lead_Lag_Status": {
-                "tags": [TAG.Lead, TAG.Lag, TAG.Status],
+                "tags": [TAG.Point, TAG.Lead, TAG.Lag, TAG.Status],
             },
             "Stages_Status": {
-                "tags": [TAG.Stages, TAG.Status],
+                "tags": [TAG.Point, TAG.Stages, TAG.Status],
             },
             "Start_Stop_Status": {
                 "subclasses": {
                     "Fan_Start_Stop_Status": {
-                        "tags": [TAG.Fan, TAG.Start, TAG.Stop, TAG.Status],
+                        "tags": [TAG.Point, TAG.Fan, TAG.Start, TAG.Stop, TAG.Status],
                         "parents": [BRICK.Fan_Status],
                     },
                     "Motor_Start_Stop_Status": {
-                        "tags": [TAG.Motor, TAG.Start, TAG.Stop, TAG.Status],
+                        "tags": [TAG.Point, TAG.Motor, TAG.Start, TAG.Stop, TAG.Status],
                     },
                     "Pump_Start_Stop_Status": {
-                        "tags": [TAG.Pump, TAG.Start, TAG.Stop, TAG.Status],
+                        "tags": [TAG.Point, TAG.Pump, TAG.Start, TAG.Stop, TAG.Status],
                     },
                     "Run_Status": {
-                        "tags": [TAG.Run, TAG.Status],
+                        "tags": [TAG.Point, TAG.Run, TAG.Status],
                         "subclasses": {
                             "Run_Request_Status": {
-                                "tags": [TAG.Request, TAG.Run, TAG.Status],
+                                "tags": [TAG.Point, TAG.Request, TAG.Run, TAG.Status],
                             },
                         },
                     }
                 },
-                "tags": [TAG.Start, TAG.Stop, TAG.Status],
+                "tags": [TAG.Point, TAG.Start, TAG.Stop, TAG.Status],
             },
             "System_Shutdown_Status": {
-                "tags": [TAG.System, TAG.Shutdown, TAG.Status],
+                "tags": [TAG.Point, TAG.System, TAG.Shutdown, TAG.Status],
                 "parents": [BRICK.System_Status],
             },
             "System_Status": {
-                "tags": [TAG.System, TAG.Status],
+                "tags": [TAG.Point, TAG.System, TAG.Status],
             },
             "Speed_Status": {
-                "tags": [TAG.Speed, TAG.Status],
+                "tags": [TAG.Point, TAG.Speed, TAG.Status],
             }
         },
     }

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -35,7 +35,7 @@ status_definitions = {
                         "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
                     },
                     "Emergency_Power_Off_Enable_Status": {
-                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Leak, TAG.Detection, TAG.Status],
+                        "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status],
                     },
                     "Emergency_Power_Off_System_Enable_Status": {
                         "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Enable, TAG.Status],


### PR DESCRIPTION
I add missing tags for certain classes. Some bugs are fixed during the work such as incorrect hierarchy.

### Progress
- [x] Setpoint
- [x] Sensor
- [x] Status
- [x] Parameter
- [x] Command
- [x] Equipment
- ~~Substance~~
- ~~Quantity~~
- [x] Add `Point` to all point classes

I'd skip for substance/quantity in this PR if it's fine.


### Issues
- It is hard to define `Lighting` because it shares the same tags with `Lighting_System`. We need to address this in a separate PR.