### PR TITLE
Fix parameter subclasses

### DIFF
--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -542,21 +542,6 @@ parameter_definitions = {
                                         ],
                                     },
                                     "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                        "subclasses": {
-                                            "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Discharge,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Proportional,
-                                                    TAG.Band,
-                                                    TAG.Parameter,
-                                                    TAG.PID,
-                                                ],
-                                            },
-                                        },
                                         "tags": [
                                             TAG.Point,
                                             TAG.Discharge,
@@ -570,21 +555,6 @@ parameter_definitions = {
                                         ],
                                     },
                                     "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                        "subclasses": {
-                                            "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Discharge,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Proportional,
-                                                    TAG.Band,
-                                                    TAG.Parameter,
-                                                    TAG.PID,
-                                                ],
-                                            },
-                                        },
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,


### PR DESCRIPTION
Remove brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter as a subclass of:
- itself
- brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter
