### PR TITLE
Add 1.0.3 to 1.1 conversions

### DIFF
--- a/tools/convert/conversions/1.0.3-1.1.json
+++ b/tools/convert/conversions/1.0.3-1.1.json
@@ -1,0 +1,6003 @@
+{
+  "namespaces": {
+    "brick": "https://brickschema.org/schema/1.1/Brick#",
+    "tag": "https://brickschema.org/schema/1.1/BrickTag#",
+    "brick_v_1_0_3": "https://brickschema.org/schema/1.0.3/Brick#",
+    "brickframe": "https://brickschema.org/schema/1.0.3/BrickFrame#",
+    "btag": "https://brickschema.org/schema/1.0.3/BrickTag#"
+  },
+  "operations": [
+    {
+      "description": "controls => controls",
+      "query": "DELETE{ ?subject brickframe:controls ?object . } INSERT{ ?subject brick:controls ?object . } WHERE { ?subject brickframe:controls ?object . }"
+    },
+    {
+      "description": "feeds => feeds",
+      "query": "DELETE{ ?subject brickframe:feeds ?object . } INSERT{ ?subject brick:feeds ?object . } WHERE { ?subject brickframe:feeds ?object . }"
+    },
+    {
+      "description": "hasInput => hasInputSubstance",
+      "query": "DELETE{ ?subject brickframe:hasInput ?object . } INSERT{ ?subject brick:hasInputSubstance ?object . } WHERE { ?subject brickframe:hasInput ?object . }"
+    },
+    {
+      "description": "hasMeasurement => measures",
+      "query": "DELETE{ ?subject brickframe:hasMeasurement ?object . } INSERT{ ?subject brick:measures ?object . } WHERE { ?subject brickframe:hasMeasurement ?object . }"
+    },
+    {
+      "description": "hasOutput => hasOutputSubstance",
+      "query": "DELETE{ ?subject brickframe:hasOutput ?object . } INSERT{ ?subject brick:hasOutputSubstance ?object . } WHERE { ?subject brickframe:hasOutput ?object . }"
+    },
+    {
+      "description": "hasPart => hasPart",
+      "query": "DELETE{ ?subject brickframe:hasPart ?object . } INSERT{ ?subject brick:hasPart ?object . } WHERE { ?subject brickframe:hasPart ?object . }"
+    },
+    {
+      "description": "hasPoint => hasPoint",
+      "query": "DELETE{ ?subject brickframe:hasPoint ?object . } INSERT{ ?subject brick:hasPoint ?object . } WHERE { ?subject brickframe:hasPoint ?object . }"
+    },
+    {
+      "description": "hasTag => hasTag",
+      "query": "DELETE{ ?subject brickframe:hasTag ?object . } INSERT{ ?subject brick:hasTag ?object . } WHERE { ?subject brickframe:hasTag ?object . }"
+    },
+    {
+      "description": "hasTagSet => hasTag",
+      "query": "DELETE{ ?subject brickframe:hasTagSet ?object . } INSERT{ ?subject brick:hasTag ?object . } WHERE { ?subject brickframe:hasTagSet ?object . }"
+    },
+    {
+      "description": "isControlledBy => isControlledBy",
+      "query": "DELETE{ ?subject brickframe:isControlledBy ?object . } INSERT{ ?subject brick:isControlledBy ?object . } WHERE { ?subject brickframe:isControlledBy ?object . }"
+    },
+    {
+      "description": "isFedBy => isFedBy",
+      "query": "DELETE{ ?subject brickframe:isFedBy ?object . } INSERT{ ?subject brick:isFedBy ?object . } WHERE { ?subject brickframe:isFedBy ?object . }"
+    },
+    {
+      "description": "isLocationOf => hasLocation",
+      "query": "DELETE{ ?subject brickframe:isLocationOf ?object . } INSERT{ ?subject brick:hasLocation ?object . } WHERE { ?subject brickframe:isLocationOf ?object . }"
+    },
+    {
+      "description": "isMeasuredBy => isMeasuredBy",
+      "query": "DELETE{ ?subject brickframe:isMeasuredBy ?object . } INSERT{ ?subject brick:isMeasuredBy ?object . } WHERE { ?subject brickframe:isMeasuredBy ?object . }"
+    },
+    {
+      "description": "isPartOf => isPartOf",
+      "query": "DELETE{ ?subject brickframe:isPartOf ?object . } INSERT{ ?subject brick:isPartOf ?object . } WHERE { ?subject brickframe:isPartOf ?object . }"
+    },
+    {
+      "description": "isPointOf => isPointOf",
+      "query": "DELETE{ ?subject brickframe:isPointOf ?object . } INSERT{ ?subject brick:isPointOf ?object . } WHERE { ?subject brickframe:isPointOf ?object . }"
+    },
+    {
+      "description": "isTagOf => isTagOf",
+      "query": "DELETE{ ?subject brickframe:isTagOf ?object . } INSERT{ ?subject brick:isTagOf ?object . } WHERE { ?subject brickframe:isTagOf ?object . }"
+    },
+    {
+      "description": "usesTag => hasTag",
+      "query": "DELETE{ ?subject brickframe:usesTag ?object . } INSERT{ ?subject brick:hasTag ?object . } WHERE { ?subject brickframe:usesTag ?object . }"
+    },
+    {
+      "description": "hasLocation => hasLocation",
+      "query": "DELETE{ ?subject brickframe:hasLocation ?object . } INSERT{ ?subject brick:hasLocation ?object . } WHERE { ?subject brickframe:hasLocation ?object . }"
+    },
+    {
+      "description": "AHU => AHU",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU . } INSERT{ ?subject ?predicate brick:AHU . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU . }"
+    },
+    {
+      "description": "AHU_Automatic_Mode_Command => Automatic_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Automatic_Mode_Command . } INSERT{ ?subject ?predicate brick:Automatic_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Automatic_Mode_Command . }"
+    },
+    {
+      "description": "AHU_Average_Exhaust_Air_Static_Pressure_Sensor => Average_Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Average_Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Average_Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Average_Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Average_Zone_Temperature_Sensor => Average_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Average_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Average_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Average_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Building_Static_Pressure_Sensor => Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Building_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Building_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Building_Static_Pressure_Setpoint => Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Building_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Building_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Bypass_Air_Flow_Sensor => Bypass_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Bypass_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Bypass_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Bypass_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Bypass_Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Bypass_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Bypass_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "AHU_CO2_Differential_Sensor => CO2_Differential_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_CO2_Differential_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Differential_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_CO2_Differential_Sensor . }"
+    },
+    {
+      "description": "AHU_Coldest_Zone_Temperature_Sensor => Coldest_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Coldest_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Coldest_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Coldest_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Cooling_Coil_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Coil_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Coil_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Cooling_Coil_Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Coil_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Coil_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Cooling_Demand_Setpoint => Cooling_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Demand_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint => Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Request_Percent_Setpoint => Cooling_Request_Percent_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Request_Percent_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Request_Percent_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Request_Percent_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Request_Setpoint => Cooling_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Request_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Supply_Air_Temperature_Dead_Band_Setpoint => Cooling_Supply_Air_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Supply_Air_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Supply_Air_Temperature_Integral_Time_Setpoint => Cooling_Supply_Air_Temperature_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Supply_Air_Temperature_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint => Cooling_Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Cooling_Valve_Command => Cooling_Command + Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Cooling_Valve_Command . } INSERT{ ?subject ?predicate brick:Cooling_Command, brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Cooling_Valve_Command . }"
+    },
+    {
+      "description": "AHU_Current_Cooling_Setpoint => Discharge_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Current_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Current_Cooling_Setpoint . }"
+    },
+    {
+      "description": "AHU_Curtailment_Override_Command => Curtailment_Override_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Curtailment_Override_Command . } INSERT{ ?subject ?predicate brick:Curtailment_Override_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Curtailment_Override_Command . }"
+    },
+    {
+      "description": "AHU_Differential_Pressure_Sensor => Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Flow_Demand_Setpoint => Discharge_Air_Flow_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Flow_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Flow_Demand_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Humidity_Sensor => Discharge_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Static_Pressure_Proportional_Band_Setpoint => Discharge_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Static_Pressure_Sensor => Discharge_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Static_Pressure_Setpoint => Discharge_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Temperature_Cooling_Setpoint => Discharge_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Temperature_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Temperature_Cooling_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Temperature_Heating_Setpoint => Discharge_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Temperature_Heating_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Temperature_Heating_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Temperature_Reset_Low_Setpoint => Discharge_Air_Temperature_Reset_Low_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Temperature_Reset_Low_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Reset_Low_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Temperature_Reset_Low_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Air_Temperature_Setpoint => Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Command . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Piezoelectric_Sensor => Piezoelectric_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Piezoelectric_Sensor . } INSERT{ ?subject ?predicate brick:Piezoelectric_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Piezoelectric_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_Status . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_VFD_Speed_Command => Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Command . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_VFD_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Sensor . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "AHU_Discharge_Fan_VFD_Speed_Status => Speed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Status . } INSERT{ ?subject ?predicate brick:Speed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Discharge_Fan_VFD_Speed_Status . }"
+    },
+    {
+      "description": "AHU_Dual_Band_Mode_Setpoint => Dual_Band_Mode_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Dual_Band_Mode_Setpoint . } INSERT{ ?subject ?predicate brick:Dual_Band_Mode_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Dual_Band_Mode_Setpoint . }"
+    },
+    {
+      "description": "AHU_Economizer_Damper_Command => Damper_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Economizer_Damper_Command . } INSERT{ ?subject ?predicate brick:Damper_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Economizer_Damper_Command . }"
+    },
+    {
+      "description": "AHU_Economizer_Damper_Min_Position_Setpoint => Min_Position_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Economizer_Damper_Min_Position_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Position_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Economizer_Damper_Min_Position_Setpoint . }"
+    },
+    {
+      "description": "AHU_Economizer_Differential_Air_Temperature_Setpoint => Differential_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Economizer_Differential_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Differential_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Economizer_Differential_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Economizer_Mode_Status => Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Economizer_Mode_Status . } INSERT{ ?subject ?predicate brick:Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Economizer_Mode_Status . }"
+    },
+    {
+      "description": "AHU_Economizer_Outside_Air_Flow_Setpoint => Outside_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Economizer_Outside_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Economizer_Outside_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Flow_Sensor => Exhaust_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Humidity_Sensor => Exhaust_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Stack_Flow_Sensor => Exhaust_Air_Stack_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Stack_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Stack_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Stack_Flow_Setpoint => Exhaust_Air_Stack_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Stack_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Stack_Flow_Setpoint . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint => Exhaust_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Static_Pressure_Sensor => Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Static_Pressure_Setpoint => Exhaust_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Temperature_Sensor => Exhaust_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Air_Velocity_Pressure_Sensor => Exhaust_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Air_Flow_Setpoint => Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Disable_Command => Exhaust_Fan_Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Disable_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Disable_Command . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Disable_Status => Exhaust_Fan_Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Disable_Status . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Disable_Status . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Enable_Command => Exhaust_Fan_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Enable_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Enable_Command . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Overridden_Off_Status => Overridden_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Overridden_Off_Status . } INSERT{ ?subject ?predicate brick:Overridden_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Overridden_Off_Status . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Overridden_On_Status => Overridden_On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Overridden_On_Status . } INSERT{ ?subject ?predicate brick:Overridden_On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Overridden_On_Status . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_Status . }"
+    },
+    {
+      "description": "AHU_Exhaust_Fan_System_Enable_Command => System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Exhaust_Fan_System_Enable_Command . } INSERT{ ?subject ?predicate brick:System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Exhaust_Fan_System_Enable_Command . }"
+    },
+    {
+      "description": "AHU_Fan_Start_Stop_Status => Fan_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Fan_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "AHU_Filter_Status => Filter_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Filter_Status . } INSERT{ ?subject ?predicate brick:Filter_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Filter_Status . }"
+    },
+    {
+      "description": "AHU_Frost_Sensor => Frost_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Frost_Sensor . } INSERT{ ?subject ?predicate brick:Frost_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Frost_Sensor . }"
+    },
+    {
+      "description": "AHU_Heat_Exchanger_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heat_Exchanger_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heat_Exchanger_Start_Stop_Command . }"
+    },
+    {
+      "description": "AHU_Heat_Exchanger_System_Enable_Status => Heat_Exchanger_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heat_Exchanger_System_Enable_Status . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heat_Exchanger_System_Enable_Status . }"
+    },
+    {
+      "description": "AHU_Heat_Wheel_Differential_Pressure_Sensor => Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heat_Wheel_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heat_Wheel_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Heating_Demand_Setpoint => Heating_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Demand_Setpoint . }"
+    },
+    {
+      "description": "AHU_Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint => Heating_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Heating_Request_Percent_Setpoint => Heating_Request_Percent_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Request_Percent_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Request_Percent_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Request_Percent_Setpoint . }"
+    },
+    {
+      "description": "AHU_Heating_Request_Setpoint => Heating_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Request_Setpoint . }"
+    },
+    {
+      "description": "AHU_Heating_Supply_Air_Temperature_Proportional_Band_Setpoint => Heating_Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Supply_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Supply_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "AHU_Heating_Valve_Command => Heating_Command + Heating_Valve + Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Heating_Valve_Command . } INSERT{ ?subject ?predicate brick:Heating_Command, brick:Heating_Valve, brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Heating_Valve_Command . }"
+    },
+    {
+      "description": "AHU_Highest_Zone_Cooling_Command => Highest_Zone_Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Highest_Zone_Cooling_Command . } INSERT{ ?subject ?predicate brick:Highest_Zone_Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Highest_Zone_Cooling_Command . }"
+    },
+    {
+      "description": "AHU_Low_Outside_Air_Temperature_Enable_Setpoint => Low_Outside_Air_Temperature_Enable_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Low_Outside_Air_Temperature_Enable_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Outside_Air_Temperature_Enable_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Low_Outside_Air_Temperature_Enable_Setpoint . }"
+    },
+    {
+      "description": "AHU_Lowest_Exhaust_Air_Static_Pressure_Sensor => Lowest_Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Lowest_Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Lowest_Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Lowest_Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Max_Discharge_Air_Static_Pressure_Setpoint => Max_Discharge_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Max_Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Max_Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Max_Discharge_Air_Temperature_Setpoint => Max_Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Max_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Max_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Max_Return_Air_CO2_Setpoint => Max_Return_Air_CO2_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Max_Return_Air_CO2_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Return_Air_CO2_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Max_Return_Air_CO2_Setpoint . }"
+    },
+    {
+      "description": "AHU_Max_Supply_Air_Static_Pressure_Setpoint => Max_Supply_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Max_Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Max_Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Min_Discharge_Air_Static_Pressure_Setpoint => Min_Discharge_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Min_Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Min_Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Min_Discharge_Air_Temperature_Setpoint => Min_Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Min_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Min_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Min_Fresh_Air_Setpoint => Min_Fresh_Air_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Min_Fresh_Air_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Fresh_Air_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Min_Fresh_Air_Setpoint . }"
+    },
+    {
+      "description": "AHU_Min_Supply_Air_Static_Pressure_Setpoint => Min_Supply_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Min_Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Min_Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Mixed_Air_Temperature_Sensor => Mixed_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Mixed_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Mixed_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Mixed_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Mixed_Air_Temperature_Setpoint => Mixed_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Mixed_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Mixed_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Mixed_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Occupied_Mode_Status => Occupied_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Occupied_Mode_Status . } INSERT{ ?subject ?predicate brick:Occupied_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Occupied_Mode_Status . }"
+    },
+    {
+      "description": "AHU_Outside_Air_CO2_Sensor => Outside_Air_CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_CO2_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_CO2_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Damper_Position_Command => Damper_Position_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Damper_Position_Command . } INSERT{ ?subject ?predicate brick:Damper_Position_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Damper_Position_Command . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Dewpoint_Sensor => Outside_Air_Dewpoint_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Dewpoint_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Dewpoint_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Dewpoint_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Enthalpy_Sensor => Outside_Air_Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Flow_Sensor => Outside_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Grains_Sensor => Outside_Air_Grains_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Grains_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Grains_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Grains_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Humidity_Sensor => Outside_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Lockout_Temperature_Differential_Sensor => Outside_Air_Lockout_Temperature_Differential_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Lockout_Temperature_Differential_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Lockout_Temperature_Differential_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Lockout_Temperature_Differential_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Lockout_Temperature_Setpoint => Outside_Air_Lockout_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Lockout_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Lockout_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Lockout_Temperature_Setpoint . }"
+    },
+    {
+      "description": "AHU_Outside_Air_Temperature_Sensor => Outside_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Outside_Min_Air_Flow_Setpoint => Min_Outside_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Outside_Min_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Outside_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Outside_Min_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "AHU_Overridden_Off_Status => Overridden_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Overridden_Off_Status . } INSERT{ ?subject ?predicate brick:Overridden_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Overridden_Off_Status . }"
+    },
+    {
+      "description": "AHU_Overridden_On_Status => Overridden_On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Overridden_On_Status . } INSERT{ ?subject ?predicate brick:Overridden_On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Overridden_On_Status . }"
+    },
+    {
+      "description": "AHU_Pre_Filter_Status => Pre_Filter_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Pre_Filter_Status . } INSERT{ ?subject ?predicate brick:Pre_Filter_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Pre_Filter_Status . }"
+    },
+    {
+      "description": "AHU_Preheat_Demand_Setpoint => Preheat_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Preheat_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Preheat_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Preheat_Demand_Setpoint . }"
+    },
+    {
+      "description": "AHU_Preheat_Discharge_Air_Temperature_Sensor => Preheat_Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Preheat_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Preheat_Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Preheat_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Preheat_Supply_Air_Temperature_Sensor => Preheat_Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Preheat_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Preheat_Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Preheat_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_CO2_Sensor => Return_Air_CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_CO2_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_CO2_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Dewpoint_Sensor => Return_Air_Dewpoint_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Dewpoint_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Dewpoint_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Dewpoint_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Enthalpy_Sensor => Return_Air_Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Flow_Sensor => Return_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Grains_Sensor => Return_Air_Grains_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Grains_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Grains_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Grains_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Humidity_Sensor => Return_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Air_Temperature_Sensor => Return_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Return_Fan_Differential_Speed_Setpoint => Return_Fan_Differential_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Return_Fan_Differential_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Return_Fan_Differential_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Return_Fan_Differential_Speed_Setpoint . }"
+    },
+    {
+      "description": "AHU_Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Run_Time_Sensor . }"
+    },
+    {
+      "description": "AHU_Static_Pressure_Sensor => Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Steam_On_Off_Command => Steam_On_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Steam_On_Off_Command . } INSERT{ ?subject ?predicate brick:Steam_On_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Steam_On_Off_Command . }"
+    },
+    {
+      "description": "AHU_Supply_Air_Flow_Demand_Setpoint => Supply_Air_Flow_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Air_Flow_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Air_Flow_Demand_Setpoint . }"
+    },
+    {
+      "description": "AHU_Supply_Air_Humidity_Sensor => Supply_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Air_Static_Pressure_Sensor => Supply_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Air_Static_Pressure_Setpoint => Supply_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Command . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Piezoelectric_Sensor => Piezoelectric_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Piezoelectric_Sensor . } INSERT{ ?subject ?predicate brick:Piezoelectric_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Piezoelectric_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_Status . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_VFD_Speed_Command => Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Command . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_VFD_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Sensor . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "AHU_Supply_Fan_VFD_Speed_Status => Speed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Status . } INSERT{ ?subject ?predicate brick:Speed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Supply_Fan_VFD_Speed_Status . }"
+    },
+    {
+      "description": "AHU_System_Enable_Command => System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_System_Enable_Command . } INSERT{ ?subject ?predicate brick:System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_System_Enable_Command . }"
+    },
+    {
+      "description": "AHU_System_Shutdown_Status => System_Shutdown_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_System_Shutdown_Status . } INSERT{ ?subject ?predicate brick:System_Shutdown_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_System_Shutdown_Status . }"
+    },
+    {
+      "description": "AHU_System_Status => System_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_System_Status . } INSERT{ ?subject ?predicate brick:System_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_System_Status . }"
+    },
+    {
+      "description": "AHU_Trace_Heat_Sensor => Trace_Heat_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Trace_Heat_Sensor . } INSERT{ ?subject ?predicate brick:Trace_Heat_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Trace_Heat_Sensor . }"
+    },
+    {
+      "description": "AHU_Unoccupied_Mode_Setpoint => Unoccupied_Mode_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Unoccupied_Mode_Setpoint . } INSERT{ ?subject ?predicate brick:Unoccupied_Mode_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Unoccupied_Mode_Setpoint . }"
+    },
+    {
+      "description": "AHU_Velocity_Pressure_Setpoint => Velocity_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Velocity_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Velocity_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Velocity_Pressure_Setpoint . }"
+    },
+    {
+      "description": "AHU_VFD_Enable_Command => VFD_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_VFD_Enable_Command . } INSERT{ ?subject ?predicate brick:VFD_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_VFD_Enable_Command . }"
+    },
+    {
+      "description": "AHU_Zone_Air_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:AHU_Zone_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:AHU_Zone_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Air => Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air . } INSERT{ ?subject ?predicate brick:Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air . }"
+    },
+    {
+      "description": "Air_CO2 => CO2",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_CO2 . } INSERT{ ?subject ?predicate brick:CO2 . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_CO2 . }"
+    },
+    {
+      "description": "Air_Dewpoint => Dewpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Dewpoint . } INSERT{ ?subject ?predicate brick:Dewpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Dewpoint . }"
+    },
+    {
+      "description": "Air_Enthalpy => Enthalpy",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Enthalpy . } INSERT{ ?subject ?predicate brick:Enthalpy . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Enthalpy . }"
+    },
+    {
+      "description": "Air_Flow => Flow",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Flow . } INSERT{ ?subject ?predicate brick:Flow . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Flow . }"
+    },
+    {
+      "description": "Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Air_Flow_Setpoint => Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Air_Grains => Grains",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Grains . } INSERT{ ?subject ?predicate brick:Grains . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Grains . }"
+    },
+    {
+      "description": "Air_Grains_Sensor => Air_Grains_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Grains_Sensor . } INSERT{ ?subject ?predicate brick:Air_Grains_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Grains_Sensor . }"
+    },
+    {
+      "description": "Air_Handler_Unit => Air_Handler_Unit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Handler_Unit . } INSERT{ ?subject ?predicate brick:Air_Handler_Unit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Handler_Unit . }"
+    },
+    {
+      "description": "Air_Humidity => Humidity",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Humidity . } INSERT{ ?subject ?predicate brick:Humidity . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Humidity . }"
+    },
+    {
+      "description": "Air_Temperature => Temperature",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Air_Temperature . } INSERT{ ?subject ?predicate brick:Temperature . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Air_Temperature . }"
+    },
+    {
+      "description": "Angle => Angle",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Angle . } INSERT{ ?subject ?predicate brick:Angle . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Angle . }"
+    },
+    {
+      "description": "Angle_Sensor => Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Angle_Sensor . } INSERT{ ?subject ?predicate brick:Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Angle_Sensor . }"
+    },
+    {
+      "description": "Auto_Cooling_Temperature_Setpoint => Cooling_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Auto_Cooling_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Auto_Cooling_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Automatic_Mode => Automatic_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Automatic_Mode . } INSERT{ ?subject ?predicate brick:Automatic_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Automatic_Mode . }"
+    },
+    {
+      "description": "Automatic_Mode_Command => Automatic_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Automatic_Mode_Command . } INSERT{ ?subject ?predicate brick:Automatic_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Automatic_Mode_Command . }"
+    },
+    {
+      "description": "Average_Discharge_Air_Flow_Sensor => Average_Discharge_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Average_Discharge_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Average_Discharge_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Average_Discharge_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Average_Exhaust_Air_Static_Pressure_Sensor => Average_Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Average_Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Average_Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Average_Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Average_Supply_Air_Flow_Sensor => Average_Supply_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Average_Supply_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Average_Supply_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Average_Supply_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Average_Zone_Temperature_Sensor => Average_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Average_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Average_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Average_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Basement => Basement",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Basement . } INSERT{ ?subject ?predicate brick:Basement . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Basement . }"
+    },
+    {
+      "description": "Battery => Battery",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Battery . } INSERT{ ?subject ?predicate brick:Battery . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Battery . }"
+    },
+    {
+      "description": "Battery_Voltage => Voltage",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Battery_Voltage . } INSERT{ ?subject ?predicate brick:Voltage . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Battery_Voltage . }"
+    },
+    {
+      "description": "Battery_Voltage_Sensor => Battery_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Battery_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Battery_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Battery_Voltage_Sensor . }"
+    },
+    {
+      "description": "Boiler => Boiler",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Boiler . } INSERT{ ?subject ?predicate brick:Boiler . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Boiler . }"
+    },
+    {
+      "description": "Boiler_On_Off_Status => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Boiler_On_Off_Status . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Boiler_On_Off_Status . }"
+    },
+    {
+      "description": "Boiler_Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Boiler_Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Boiler_Run_Time_Sensor . }"
+    },
+    {
+      "description": "Boiler_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Boiler_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Boiler_Start_Stop_Status . }"
+    },
+    {
+      "description": "Booster_Fan => Booster_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan . } INSERT{ ?subject ?predicate brick:Booster_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan . }"
+    },
+    {
+      "description": "Booster_Fan_Air_Flow => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan_Air_Flow . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan_Air_Flow . }"
+    },
+    {
+      "description": "Booster_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Booster_Fan_Air_Flow_Setpoint => Fan_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Fan_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Booster_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan_Command . }"
+    },
+    {
+      "description": "Booster_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Booster_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Booster_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "Box_Mode => Box_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Box_Mode . } INSERT{ ?subject ?predicate brick:Box_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Box_Mode . }"
+    },
+    {
+      "description": "Box_Mode_Command => Box_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Box_Mode_Command . } INSERT{ ?subject ?predicate brick:Box_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Box_Mode_Command . }"
+    },
+    {
+      "description": "Building => Building",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Building . } INSERT{ ?subject ?predicate brick:Building . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Building . }"
+    },
+    {
+      "description": "Building_Static_Pressure_Sensor => Building_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Building_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Building_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Building_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Building_Static_Pressure_Setpoint => Building_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Building_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Building_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Building_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Bypass_Air_Flow_Sensor => Bypass_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Bypass_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Bypass_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Bypass_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Bypass_Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Bypass_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Bypass_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "Capacity_Sensor => Capacity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Capacity_Sensor . } INSERT{ ?subject ?predicate brick:Capacity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Capacity_Sensor . }"
+    },
+    {
+      "description": "Chilled_Valve_Pressure_Sensor => Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Valve_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Valve_Pressure_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water => Chilled_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water . } INSERT{ ?subject ?predicate brick:Chilled_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water . }"
+    },
+    {
+      "description": "Chilled_Water_Bypass_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Bypass_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Bypass_Valve_Command . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Dead_Band_Setpoint => Chilled_Water_Differential_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Increase_Decrease_Step_Setpoint => Chilled_Water_Differential_Pressure_Step_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Increase_Decrease_Step_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Step_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Increase_Decrease_Step_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Integral_Time_Setpoint => Chilled_Water_Differential_Pressure_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Load_Shed => Chilled_Water_Differential_Pressure_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Load_Shed_Reset => Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Reset . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Reset . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status => Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint => Chilled_Water_Differential_Pressure_Load_Shed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Load_Shed_Status => Chilled_Water_Differential_Pressure_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Load_Shed_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Proportional_Band => Chilled_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Proportional_Band_Setpoint => Chilled_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Sensor => Chilled_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_Differential_Pressure_Setpoint => Chilled_Water_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Discharge_Flow => Flow + Discharge_Chilled_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Discharge_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Discharge_Chilled_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Discharge_Flow . }"
+    },
+    {
+      "description": "Chilled_Water_Discharge_Flow_Sensor => Chilled_Water_Discharge_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Discharge_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Discharge_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Discharge_Flow_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_Discharge_Temperature => Temperature + Chilled_Discharge_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Discharge_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Chilled_Discharge_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Discharge_Temperature . }"
+    },
+    {
+      "description": "Chilled_Water_Pump => Chilled_Water_Pump",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump . } INSERT{ ?subject ?predicate brick:Chilled_Water_Pump . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Command . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Differential_Pressure_Dead_Band_Setpoint => Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Differential_Pressure_Proportional_Band => Differential_Pressure_Proportional_Band",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Proportional_Band . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Differential_Pressure_Proportional_Band_Setpoint => Chilled_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Enable_Status => Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Enable_Status . } INSERT{ ?subject ?predicate brick:Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Enable_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Lead_Lag_Status => Lead_Lag_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Lead_Lag_Status . } INSERT{ ?subject ?predicate brick:Lead_Lag_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Lead_Lag_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Start_Stop_Command . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Start_Stop_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_Status . }"
+    },
+    {
+      "description": "Chilled_Water_Pump_VFD_Speed_Command => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Pump_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Pump_VFD_Speed_Command . }"
+    },
+    {
+      "description": "Chilled_Water_Return_Temperature => Temperature + Chilled_Return_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Return_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Chilled_Return_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Return_Temperature . }"
+    },
+    {
+      "description": "Chilled_Water_Return_Temperature_Sensor => Chilled_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_Static_Pressure_Setpoint => Chilled_Water_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Chilled_Water_Supply_Flow => Flow + Chilled_Supply_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Supply_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Chilled_Supply_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Supply_Flow . }"
+    },
+    {
+      "description": "Chilled_Water_Supply_Flow_Sensor => Chilled_Water_Supply_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Supply_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Supply_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Supply_Flow_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_Supply_Temperature => Temperature + Chilled_Supply_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Supply_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Chilled_Supply_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Supply_Temperature . }"
+    },
+    {
+      "description": "Chilled_Water_Supply_Temperature_Sensor => Chilled_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_System => Chilled_Water_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_System . } INSERT{ ?subject ?predicate brick:Chilled_Water_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_System . }"
+    },
+    {
+      "description": "Chilled_Water_System_Enable => Chilled_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_System_Enable . } INSERT{ ?subject ?predicate brick:Chilled_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_System_Enable . }"
+    },
+    {
+      "description": "Chilled_Water_System_Enable_Command => Chilled_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Chilled_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "Chilled_Water_Temperature_Differential_Sensor => Chilled_Water_Differential_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Temperature_Differential_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Temperature_Differential_Sensor . }"
+    },
+    {
+      "description": "Chilled_Water_Valve => Chilled_Water_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chilled_Water_Valve . } INSERT{ ?subject ?predicate brick:Chilled_Water_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chilled_Water_Valve . }"
+    },
+    {
+      "description": "Chiller => Chiller",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller . } INSERT{ ?subject ?predicate brick:Chiller . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller . }"
+    },
+    {
+      "description": "Chiller_Max_Load_Setpoint => Max_Load_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller_Max_Load_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Load_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller_Max_Load_Setpoint . }"
+    },
+    {
+      "description": "Chiller_On_Off_Status => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller_On_Off_Status . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller_On_Off_Status . }"
+    },
+    {
+      "description": "Chiller_On_Timer_Sensor => On_Timer_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller_On_Timer_Sensor . } INSERT{ ?subject ?predicate brick:On_Timer_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller_On_Timer_Sensor . }"
+    },
+    {
+      "description": "Chiller_Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller_Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller_Run_Time_Sensor . }"
+    },
+    {
+      "description": "Chiller_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Chiller_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Chiller_Start_Stop_Status . }"
+    },
+    {
+      "description": "City => City",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:City . } INSERT{ ?subject ?predicate brick:City . } WHERE { ?subject  ?predicate  brick_v_1_0_3:City . }"
+    },
+    {
+      "description": "CO2 => CO2",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2 . } INSERT{ ?subject ?predicate brick:CO2 . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2 . }"
+    },
+    {
+      "description": "CO2_Differential_Sensor => CO2_Differential_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2_Differential_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Differential_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2_Differential_Sensor . }"
+    },
+    {
+      "description": "CO2_Level => CO2_Level",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2_Level . } INSERT{ ?subject ?predicate brick:CO2_Level . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2_Level . }"
+    },
+    {
+      "description": "CO2_Level_Sensor => CO2_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2_Level_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2_Level_Sensor . }"
+    },
+    {
+      "description": "CO2_Sensor => CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2_Sensor . }"
+    },
+    {
+      "description": "CO2_Setpoint => CO2_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CO2_Setpoint . } INSERT{ ?subject ?predicate brick:CO2_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CO2_Setpoint . }"
+    },
+    {
+      "description": "Coil => Coil",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Coil . } INSERT{ ?subject ?predicate brick:Coil . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Coil . }"
+    },
+    {
+      "description": "Cold_Box => Cold_Box",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cold_Box . } INSERT{ ?subject ?predicate brick:Cold_Box . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cold_Box . }"
+    },
+    {
+      "description": "Coldest_Zone_Temperature_Sensor => Coldest_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Coldest_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Coldest_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Coldest_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Command . }"
+    },
+    {
+      "description": "Compressor => Compressor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Compressor . } INSERT{ ?subject ?predicate brick:Compressor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Compressor . }"
+    },
+    {
+      "description": "Computer_Room_Air_Conditioning => Computer_Room_Air_Conditioning",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Computer_Room_Air_Conditioning . } INSERT{ ?subject ?predicate brick:Computer_Room_Air_Conditioning . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Computer_Room_Air_Conditioning . }"
+    },
+    {
+      "description": "Condenser => Condenser",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Condenser . } INSERT{ ?subject ?predicate brick:Condenser . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Condenser . }"
+    },
+    {
+      "description": "Condenser_Condensor_Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Condenser_Condensor_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Condenser_Condensor_Temperature_Sensor . }"
+    },
+    {
+      "description": "Condensor => Condenser",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Condensor . } INSERT{ ?subject ?predicate brick:Condenser . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Condensor . }"
+    },
+    {
+      "description": "Condensor_Temperature => Temperature",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Condensor_Temperature . } INSERT{ ?subject ?predicate brick:Temperature . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Condensor_Temperature . }"
+    },
+    {
+      "description": "Condensor_Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Condensor_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Condensor_Temperature_Sensor . }"
+    },
+    {
+      "description": "Conductivity => Conductivity",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Conductivity . } INSERT{ ?subject ?predicate brick:Conductivity . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Conductivity . }"
+    },
+    {
+      "description": "Conductivity_Sensor => Conductivity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Conductivity_Sensor . } INSERT{ ?subject ?predicate brick:Conductivity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Conductivity_Sensor . }"
+    },
+    {
+      "description": "Cooling => Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling . } INSERT{ ?subject ?predicate brick:Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling . }"
+    },
+    {
+      "description": "Cooling_Coil => Cooling_Coil",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Coil . } INSERT{ ?subject ?predicate brick:Cooling_Coil . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Coil . }"
+    },
+    {
+      "description": "Cooling_Coil_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Coil_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Coil_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Cooling_Coil_Valve_Pressure => Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Coil_Valve_Pressure . } INSERT{ ?subject ?predicate brick:Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Coil_Valve_Pressure . }"
+    },
+    {
+      "description": "Cooling_Coil_Valve_Pressure_Sensor => Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Coil_Valve_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Coil_Valve_Pressure_Sensor . }"
+    },
+    {
+      "description": "Cooling_Command => Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Command . } INSERT{ ?subject ?predicate brick:Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Command . }"
+    },
+    {
+      "description": "Cooling_Demand_Setpoint => Cooling_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Demand_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Discharge_Air_Flow_Setpoint => Cooling_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Discharge_Air_Temperature_Dead_Band_Setpoint => Cooling_Discharge_Air_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Discharge_Air_Temperature_Integral_Time_Setpoint => Cooling_Discharge_Air_Temperature_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Discharge_Air_Temperature_Proportional_Band => Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint => Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Discharge_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Max_Discharge_Air_Flow_Setpoint => Max_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Max_Supply_Air_Flow_Setpoint => Max_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Min_Discharge_Air_Flow_Setpoint => Min_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Min_Supply_Air_Flow_Setpoint => Min_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Cooling_On_Off => Cooling_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_On_Off . } INSERT{ ?subject ?predicate brick:Cooling_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_On_Off . }"
+    },
+    {
+      "description": "Cooling_On_Off_Status => Cooling_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_On_Off_Status . } INSERT{ ?subject ?predicate brick:Cooling_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_On_Off_Status . }"
+    },
+    {
+      "description": "Cooling_Request_Percent_Setpoint => Cooling_Request_Percent_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Request_Percent_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Request_Percent_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Request_Percent_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Request_Setpoint => Cooling_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Request_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Supply_Air_Temperature_Proportional_Band => Cooling_Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Supply_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Supply_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint => Cooling_Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Supply_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Temperature_Setpoint => Cooling_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Tower_Fan => Cooling_Tower_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Tower_Fan . } INSERT{ ?subject ?predicate brick:Cooling_Tower_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Tower_Fan . }"
+    },
+    {
+      "description": "Cooling_Tower_Fan_Speed => Speed",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Tower_Fan_Speed . } INSERT{ ?subject ?predicate brick:Speed . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Tower_Fan_Speed . }"
+    },
+    {
+      "description": "Cooling_Tower_Fan_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Tower_Fan_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Tower_Fan_Speed_Setpoint . }"
+    },
+    {
+      "description": "Cooling_Valve => Cooling_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Valve . } INSERT{ ?subject ?predicate brick:Cooling_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Valve . }"
+    },
+    {
+      "description": "Cooling_Valve_Command => Valve_Command + Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Cooling_Valve_Command . } INSERT{ ?subject ?predicate brick:Valve_Command, brick:Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Cooling_Valve_Command . }"
+    },
+    {
+      "description": "CRAC => CRAC",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC . } INSERT{ ?subject ?predicate brick:CRAC . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC . }"
+    },
+    {
+      "description": "CRAC_Capacity_Sensor => Capacity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Capacity_Sensor . } INSERT{ ?subject ?predicate brick:Capacity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Capacity_Sensor . }"
+    },
+    {
+      "description": "CRAC_Cooling_On_Off_Status => Cooling_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Cooling_On_Off_Status . } INSERT{ ?subject ?predicate brick:Cooling_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Cooling_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Dehumidification_On_Off_Status => Dehumidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Dehumidification_On_Off_Status . } INSERT{ ?subject ?predicate brick:Dehumidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Dehumidification_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Disable_Command => Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Disable_Command . } INSERT{ ?subject ?predicate brick:Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Disable_Command . }"
+    },
+    {
+      "description": "CRAC_EconCycle_On_Off_Status => EconCycle_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_EconCycle_On_Off_Status . } INSERT{ ?subject ?predicate brick:EconCycle_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_EconCycle_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Emergency_Power_Off_Activated_By_High_Temperature_Status => Emergency_Power_Off_Activated_By_High_Temperature_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Emergency_Power_Off_Activated_By_High_Temperature_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_High_Temperature_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Emergency_Power_Off_Activated_By_High_Temperature_Status . }"
+    },
+    {
+      "description": "CRAC_Emergency_Power_Off_Activated_By_Leak_Detection_System_Status => Emergency_Power_Off_Activated_By_Leak_Detection_System_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . }"
+    },
+    {
+      "description": "CRAC_Emergency_Power_Off_Enable_Status => Emergency_Power_Off_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Emergency_Power_Off_Enable_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Emergency_Power_Off_Enable_Status . }"
+    },
+    {
+      "description": "CRAC_Emergency_Power_Off_System_Enable_Status => Emergency_Power_Off_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Emergency_Power_Off_System_Enable_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Emergency_Power_Off_System_Enable_Status . }"
+    },
+    {
+      "description": "CRAC_Heating_On_Off_Status => Heating_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Heating_On_Off_Status . } INSERT{ ?subject ?predicate brick:Heating_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Heating_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_High_Humidity_Alarm_Setpoint => High_Humidity_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_High_Humidity_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:High_Humidity_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_High_Humidity_Alarm_Setpoint . }"
+    },
+    {
+      "description": "CRAC_Humidification_On_Off_Status => Humidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Humidification_On_Off_Status . } INSERT{ ?subject ?predicate brick:Humidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Humidification_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Humidifier_Fault_Status => Humidifier_Fault_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Humidifier_Fault_Status . } INSERT{ ?subject ?predicate brick:Humidifier_Fault_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Humidifier_Fault_Status . }"
+    },
+    {
+      "description": "CRAC_Locally_On_Off_Status => Locally_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Locally_On_Off_Status . } INSERT{ ?subject ?predicate brick:Locally_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Locally_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Low_Humidity_Alarm_Setpoint => Low_Humidity_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Low_Humidity_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Humidity_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Low_Humidity_Alarm_Setpoint . }"
+    },
+    {
+      "description": "CRAC_On_Off_Status => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_On_Off_Status . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Remotely_On_Off_Status => Remotely_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Remotely_On_Off_Status . } INSERT{ ?subject ?predicate brick:Remotely_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Remotely_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Run_Status => Run_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Run_Status . } INSERT{ ?subject ?predicate brick:Run_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Run_Status . }"
+    },
+    {
+      "description": "CRAC_Stages_Status => Stages_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Stages_Status . } INSERT{ ?subject ?predicate brick:Stages_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Stages_Status . }"
+    },
+    {
+      "description": "CRAC_Standby_Glycool_Unit_On_Off_Status => Standby_Glycool_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Standby_Glycool_Unit_On_Off_Status . } INSERT{ ?subject ?predicate brick:Standby_Glycool_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Standby_Glycool_Unit_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Standby_Unit_On_Off_Status => Standby_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Standby_Unit_On_Off_Status . } INSERT{ ?subject ?predicate brick:Standby_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Standby_Unit_On_Off_Status . }"
+    },
+    {
+      "description": "CRAC_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Start_Stop_Command . }"
+    },
+    {
+      "description": "CRAC_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Start_Stop_Status . }"
+    },
+    {
+      "description": "CRAC_System_Enable_Command => System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_System_Enable_Command . } INSERT{ ?subject ?predicate brick:System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_System_Enable_Command . }"
+    },
+    {
+      "description": "CRAC_Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Temperature_Sensor . }"
+    },
+    {
+      "description": "CRAC_Temperature_Setpoint => Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CRAC_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CRAC_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Current => Current",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Current . } INSERT{ ?subject ?predicate brick:Current . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Current . }"
+    },
+    {
+      "description": "Current_Cooling_Setpoint => Cooling_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Current_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Current_Cooling_Setpoint . }"
+    },
+    {
+      "description": "Current_Limit => Current_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Current_Limit . } INSERT{ ?subject ?predicate brick:Current_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Current_Limit . }"
+    },
+    {
+      "description": "Current_Limit_Setpoint => Current_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Current_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:Current_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Current_Limit_Setpoint . }"
+    },
+    {
+      "description": "Current_Sensor => Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Current_Sensor . } INSERT{ ?subject ?predicate brick:Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Current_Sensor . }"
+    },
+    {
+      "description": "Curtailment_Override => Curtailment_Override_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Curtailment_Override . } INSERT{ ?subject ?predicate brick:Curtailment_Override_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Curtailment_Override . }"
+    },
+    {
+      "description": "Curtailment_Override_Command => Curtailment_Override_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Curtailment_Override_Command . } INSERT{ ?subject ?predicate brick:Curtailment_Override_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Curtailment_Override_Command . }"
+    },
+    {
+      "description": "CWS => CWS",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS . } INSERT{ ?subject ?predicate brick:CWS . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Differential_Pressure_Sensor => Chilled_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Differential_Pressure_Setpoint => Chilled_Water_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Discharge_Flow_Sensor => Chilled_Water_Discharge_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Discharge_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Discharge_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Discharge_Flow_Sensor . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Return_Temperature_Sensor => Chilled_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Static_Pressure_Setpoint => Chilled_Water_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Supply_Flow_Sensor => Chilled_Water_Supply_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Supply_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Supply_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Supply_Flow_Sensor . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Supply_Temperature_Sensor => Chilled_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_System_Enable_Command => Chilled_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Chilled_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "CWS_Chilled_Water_Temperature_Differential_Sensor => Chilled_Water_Differential_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Chilled_Water_Temperature_Differential_Sensor . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Chilled_Water_Temperature_Differential_Sensor . }"
+    },
+    {
+      "description": "CWS_Max_Chilled_Water_Differential_Pressure_Setpoint => Max_Chilled_Water_Differential_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Max_Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Max_Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "CWS_Min_Chilled_Water_Differential_Pressure_Setpoint => Min_Chilled_Water_Differential_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:CWS_Min_Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:CWS_Min_Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Damper => Damper",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Damper . } INSERT{ ?subject ?predicate brick:Damper . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Damper . }"
+    },
+    {
+      "description": "Damper_Command => Damper_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Damper_Command . } INSERT{ ?subject ?predicate brick:Damper_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Damper_Command . }"
+    },
+    {
+      "description": "Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Damper_Position_Sensor . }"
+    },
+    {
+      "description": "Damper_Position_Setpoint => Damper_Position_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Damper_Position_Setpoint . } INSERT{ ?subject ?predicate brick:Damper_Position_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Damper_Position_Setpoint . }"
+    },
+    {
+      "description": "DC_Bus_Voltage_Sensor => DC_Bus_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DC_Bus_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:DC_Bus_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DC_Bus_Voltage_Sensor . }"
+    },
+    {
+      "description": "Deceleration_Time => Deceleration_Time",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Deceleration_Time . } INSERT{ ?subject ?predicate brick:Deceleration_Time . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Deceleration_Time . }"
+    },
+    {
+      "description": "Deceleration_Time_Setpoint => Deceleration_Time_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Deceleration_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Deceleration_Time_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Deceleration_Time_Setpoint . }"
+    },
+    {
+      "description": "Dehumidification_On_Off => Dehumidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Dehumidification_On_Off . } INSERT{ ?subject ?predicate brick:Dehumidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Dehumidification_On_Off . }"
+    },
+    {
+      "description": "Dehumidification_On_Off_Status => Dehumidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Dehumidification_On_Off_Status . } INSERT{ ?subject ?predicate brick:Dehumidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Dehumidification_On_Off_Status . }"
+    },
+    {
+      "description": "Deionised_Water_Alarm => Deionized_Water_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Deionised_Water_Alarm . } INSERT{ ?subject ?predicate brick:Deionized_Water_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Deionised_Water_Alarm . }"
+    },
+    {
+      "description": "Deionised_Water_Conductivity_Sensor => Deionised_Water_Conductivity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Deionised_Water_Conductivity_Sensor . } INSERT{ ?subject ?predicate brick:Deionised_Water_Conductivity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Deionised_Water_Conductivity_Sensor . }"
+    },
+    {
+      "description": "Deionised_Water_Level_Sensor => Deionised_Water_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Deionised_Water_Level_Sensor . } INSERT{ ?subject ?predicate brick:Deionised_Water_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Deionised_Water_Level_Sensor . }"
+    },
+    {
+      "description": "Demand_Sensor => Demand_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Demand_Sensor . } INSERT{ ?subject ?predicate brick:Demand_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Demand_Sensor . }"
+    },
+    {
+      "description": "Demand_Setpoint => Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Demand_Setpoint . }"
+    },
+    {
+      "description": "DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status => Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status . }"
+    },
+    {
+      "description": "DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Setpoint => Chilled_Water_Differential_Pressure_Load_Shed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Setpoint . }"
+    },
+    {
+      "description": "DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Status => Chilled_Water_Differential_Pressure_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Chilled_Water_Differential_Pressure_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Chilled_Water_Differential_Pressure_Load_Shed_Status . }"
+    },
+    {
+      "description": "DemandResponse_Load_Shed_Command => Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Load_Shed_Command . }"
+    },
+    {
+      "description": "DemandResponse_Load_Shed_Status => Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Load_Shed_Status . }"
+    },
+    {
+      "description": "DemandResponse_Standby_Load_Shed_Command => Standby_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Standby_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Standby_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Standby_Load_Shed_Command . }"
+    },
+    {
+      "description": "DemandResponse_Unoccupied_Load_Shed_Command => Unoccupied_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Unoccupied_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Unoccupied_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Unoccupied_Load_Shed_Command . }"
+    },
+    {
+      "description": "DemandResponse_Zone_Standby_Load_Shed_Command => Zone_Standby_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Zone_Standby_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Zone_Standby_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Zone_Standby_Load_Shed_Command . }"
+    },
+    {
+      "description": "DemandResponse_Zone_Unoccupied_Load_Shed_Command => Zone_Unoccupied_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DemandResponse_Zone_Unoccupied_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Zone_Unoccupied_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DemandResponse_Zone_Unoccupied_Load_Shed_Command . }"
+    },
+    {
+      "description": "Dewpoint => Dewpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Dewpoint . } INSERT{ ?subject ?predicate brick:Dewpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Dewpoint . }"
+    },
+    {
+      "description": "Dewpoint_Sensor => Dewpoint_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Dewpoint_Sensor . } INSERT{ ?subject ?predicate brick:Dewpoint_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Dewpoint_Sensor . }"
+    },
+    {
+      "description": "DHWS_Domestic_Hot_Water_Supply_Temperature_Sensor => Domestic_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DHWS_Domestic_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DHWS_Domestic_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "DHWS_Domestic_Hot_Water_System_Enable_Command => Domestic_Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DHWS_Domestic_Hot_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DHWS_Domestic_Hot_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "DI_Water => Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DI_Water . } INSERT{ ?subject ?predicate brick:Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DI_Water . }"
+    },
+    {
+      "description": "DI_Water_Alarm => Deionized_Water_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DI_Water_Alarm . } INSERT{ ?subject ?predicate brick:Deionized_Water_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DI_Water_Alarm . }"
+    },
+    {
+      "description": "DI_Water_Level_Sensor => Water_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:DI_Water_Level_Sensor . } INSERT{ ?subject ?predicate brick:Water_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:DI_Water_Level_Sensor . }"
+    },
+    {
+      "description": "Differential_Pressure => Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Pressure . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Pressure . }"
+    },
+    {
+      "description": "Differential_Pressure_Dead_Band_Setpoint => Differential_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Differential_Pressure_Load_Shed_Status => Differential_Pressure_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Pressure_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Pressure_Load_Shed_Status . }"
+    },
+    {
+      "description": "Differential_Pressure_Sensor => Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Differential_Pressure_Setpoint => Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Differential_Speed_Sensor => Differential_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Differential_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Speed_Sensor . }"
+    },
+    {
+      "description": "Differential_Speed_Setpoint => Differential_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Differential_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Differential_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Differential_Speed_Setpoint . }"
+    },
+    {
+      "description": "Direction => Direction",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Direction . } INSERT{ ?subject ?predicate brick:Direction . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Direction . }"
+    },
+    {
+      "description": "Direction_Command => Direction_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Direction_Command . } INSERT{ ?subject ?predicate brick:Direction_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Direction_Command . }"
+    },
+    {
+      "description": "Direction_Sensor => Direction_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Direction_Sensor . } INSERT{ ?subject ?predicate brick:Direction_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Direction_Sensor . }"
+    },
+    {
+      "description": "Direction_Status => Direction_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Direction_Status . } INSERT{ ?subject ?predicate brick:Direction_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Direction_Status . }"
+    },
+    {
+      "description": "Disable_Command => Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Disable_Command . } INSERT{ ?subject ?predicate brick:Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Disable_Command . }"
+    },
+    {
+      "description": "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint => Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Disable_Status => Disable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Disable_Status . } INSERT{ ?subject ?predicate brick:Disable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Disable_Status . }"
+    },
+    {
+      "description": "Discharge_Air => Discharge_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air . } INSERT{ ?subject ?predicate brick:Discharge_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air . }"
+    },
+    {
+      "description": "Discharge_Air_Duct_Pressure_Status => Discharge_Air_Duct_Pressure_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Duct_Pressure_Status . } INSERT{ ?subject ?predicate brick:Discharge_Air_Duct_Pressure_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Duct_Pressure_Status . }"
+    },
+    {
+      "description": "Discharge_Air_Flow => Flow + Discharge_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Discharge_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Command => Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Command . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Command . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Demand_Setpoint => Discharge_Air_Flow_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Demand_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Reset_High_Setpoint => Discharge_Air_Flow_Reset_High_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Reset_High_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Reset_High_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Reset_High_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Reset_Low_Setpoint => Discharge_Air_Flow_Reset_Low_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Reset_Low_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Reset_Low_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Reset_Low_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Reset_Setpoint => Discharge_Air_Flow_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Reset_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Sensor => Discharge_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Discharge_Air_Flow_Setpoint => Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Humidity_Sensor => Discharge_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "Discharge_Air_Smoke_Detected_Alarm => Discharge_Air_Smoke_Detected_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Smoke_Detected_Alarm . } INSERT{ ?subject ?predicate brick:Discharge_Air_Smoke_Detected_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Smoke_Detected_Alarm . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Dead_Band_Setpoint => Discharge_Air_Static_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Increase_Decrease_Step_Setpoint => Discharge_Air_Static_Pressure_Step_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Increase_Decrease_Step_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Step_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Increase_Decrease_Step_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Integral_Time_Setpoint => Discharge_Air_Static_Pressure_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Proportional_Band => Discharge_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Proportional_Band_Setpoint => Discharge_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Sensor => Discharge_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Discharge_Air_Static_Pressure_Setpoint => Discharge_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature => Temperature + Discharge_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Discharge_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Cooling_Setpoint => Discharge_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Cooling_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Heating_Setpoint => Discharge_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Heating_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Heating_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_High_Limit_Alarm => High_Discharge_Air_Temperature_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_High_Limit_Alarm . } INSERT{ ?subject ?predicate brick:High_Discharge_Air_Temperature_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_High_Limit_Alarm . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Reset_Differential_Setpoint => Discharge_Air_Temperature_Reset_Differential_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Reset_Differential_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Reset_Differential_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Reset_Differential_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Reset_High_Setpoint => Discharge_Air_Temperature_Reset_High_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Reset_High_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Reset_High_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Reset_High_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Reset_Low_Setpoint => Discharge_Air_Temperature_Reset_Low_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Reset_Low_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Reset_Low_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Reset_Low_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Setpoint => Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Air_Temperature_Setpoint_Increase_Decrease_Step => Discharge_Air_Temperature_Step_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Temperature_Setpoint_Increase_Decrease_Step . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Step_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Temperature_Setpoint_Increase_Decrease_Step . }"
+    },
+    {
+      "description": "Discharge_Air_Velocity_Pressure => Velocity_Pressure + Discharge_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Velocity_Pressure . } INSERT{ ?subject ?predicate brick:Velocity_Pressure, brick:Discharge_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Velocity_Pressure . }"
+    },
+    {
+      "description": "Discharge_Air_Velocity_Pressure_Sensor => Discharge_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "Discharge_Fan => Discharge_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Fan . } INSERT{ ?subject ?predicate brick:Discharge_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Fan . }"
+    },
+    {
+      "description": "Discharge_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Discharge_Fan_VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Fan_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Fan_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "Discharge_Water_Differential_Pressure_Proportional_Band => Discharge_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Water_Differential_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Water_Differential_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Discharge_Water_Temperature_Setpoint => Water_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Discharge_Water_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Water_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Discharge_Water_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Domestic_Hot_Water => Domestic_Water + Hot_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water . } INSERT{ ?subject ?predicate brick:Domestic_Water, brick:Hot_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Discharge_Temperature_Sensor => Domestic_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Discharge_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Discharge_Temperature_Sensor . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Supply_Temperature => Temperature + Domestic_Hot_Supply_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Domestic_Hot_Supply_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Supply_Temperature_Sensor => Domestic_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Supply_Temperature_Setpoint => Domestic_Hot_Water_Supply_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_Supply_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Supply_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_System => Domestic_Hot_Water_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_System . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_System . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_System_Enable => Domestic_Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_System_Enable . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_System_Enable . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_System_Enable_Command => Domestic_Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Valve => Domestic_Hot_Water_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Valve . } INSERT{ ?subject ?predicate brick:Domestic_Hot_Water_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Valve . }"
+    },
+    {
+      "description": "Domestic_Hot_Water_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Domestic_Hot_Water_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Domestic_Hot_Water_Valve_Command . }"
+    },
+    {
+      "description": "Drive_Ready_Status => Drive_Ready_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Drive_Ready_Status . } INSERT{ ?subject ?predicate brick:Drive_Ready_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Drive_Ready_Status . }"
+    },
+    {
+      "description": "Drive_Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Drive_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Drive_Temperature_Sensor . }"
+    },
+    {
+      "description": "Dual_Band_Mode_Setpoint => Dual_Band_Mode_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Dual_Band_Mode_Setpoint . } INSERT{ ?subject ?predicate brick:Dual_Band_Mode_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Dual_Band_Mode_Setpoint . }"
+    },
+    {
+      "description": "EconCycle_On_Off => EconCycle_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:EconCycle_On_Off . } INSERT{ ?subject ?predicate brick:EconCycle_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:EconCycle_On_Off . }"
+    },
+    {
+      "description": "EconCycle_On_Off_Status => EconCycle_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:EconCycle_On_Off_Status . } INSERT{ ?subject ?predicate brick:EconCycle_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:EconCycle_On_Off_Status . }"
+    },
+    {
+      "description": "Economizer => Economizer",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer . } INSERT{ ?subject ?predicate brick:Economizer . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer . }"
+    },
+    {
+      "description": "Economizer_Damper => Economizer_Damper",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Damper . } INSERT{ ?subject ?predicate brick:Economizer_Damper . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Damper . }"
+    },
+    {
+      "description": "Economizer_Damper_Command => Damper_Position_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Damper_Command . } INSERT{ ?subject ?predicate brick:Damper_Position_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Damper_Command . }"
+    },
+    {
+      "description": "Economizer_Damper_Min_Position_Setpoint => Min_Position_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Damper_Min_Position_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Position_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Damper_Min_Position_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Differential_Air_Temperature_Setpoint => Differential_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Differential_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Differential_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Differential_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Disable_Differential_Enthalpy => Disable_Differential_Enthalpy_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Disable_Differential_Enthalpy . } INSERT{ ?subject ?predicate brick:Disable_Differential_Enthalpy_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Disable_Differential_Enthalpy . }"
+    },
+    {
+      "description": "Economizer_Disable_Differential_Temperature => Disable_Differential_Temperature_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Disable_Differential_Temperature . } INSERT{ ?subject ?predicate brick:Disable_Differential_Temperature_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Disable_Differential_Temperature . }"
+    },
+    {
+      "description": "Economizer_Disable_Fixed_Enthalpy => Disable_Fixed_Enthalpy_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Disable_Fixed_Enthalpy . } INSERT{ ?subject ?predicate brick:Disable_Fixed_Enthalpy_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Disable_Fixed_Enthalpy . }"
+    },
+    {
+      "description": "Economizer_Disable_Fixed_Temperature => Disable_Fixed_Temperature_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Disable_Fixed_Temperature . } INSERT{ ?subject ?predicate brick:Disable_Fixed_Temperature_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Disable_Fixed_Temperature . }"
+    },
+    {
+      "description": "Economizer_Discharge_Air_Temperature_Dead_Band_Setpoint => Discharge_Air_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Discharge_Air_Temperature_Proportional_Band => Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Economizer_Discharge_Air_Temperature_Proportional_Band_Setpoint => Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Discharge_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Enable_Differential_Enthalpy => Enable_Differential_Enthalpy_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Enable_Differential_Enthalpy . } INSERT{ ?subject ?predicate brick:Enable_Differential_Enthalpy_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Enable_Differential_Enthalpy . }"
+    },
+    {
+      "description": "Economizer_Enable_Differential_Temperature => Enable_Differential_Temperature_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Enable_Differential_Temperature . } INSERT{ ?subject ?predicate brick:Enable_Differential_Temperature_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Enable_Differential_Temperature . }"
+    },
+    {
+      "description": "Economizer_Enable_Fixed_Enthalpy => Enable_Fixed_Enthalpy_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Enable_Fixed_Enthalpy . } INSERT{ ?subject ?predicate brick:Enable_Fixed_Enthalpy_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Enable_Fixed_Enthalpy . }"
+    },
+    {
+      "description": "Economizer_Enable_Fixed_Temperature => Enable_Fixed_Temperature_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Enable_Fixed_Temperature . } INSERT{ ?subject ?predicate brick:Enable_Fixed_Temperature_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Enable_Fixed_Temperature . }"
+    },
+    {
+      "description": "Economizer_Mode_Status => Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Mode_Status . } INSERT{ ?subject ?predicate brick:Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Mode_Status . }"
+    },
+    {
+      "description": "Economizer_Outside_Air_Flow_Setpoint => Outside_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Outside_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Outside_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Status . }"
+    },
+    {
+      "description": "Economizer_Supply_Air_Temperature_Dead_Band_Setpoint => Supply_Air_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Supply_Air_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Supply_Air_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Economizer_Supply_Air_Temperature_Proportional_Band => Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Supply_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Supply_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Economizer_Temperature_Setpoint => Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Economizer_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Economizer_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Effective_Cooling_Temperature_Setpoint => Effective_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Effective_Cooling_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Effective_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Effective_Cooling_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Effective_Heating_Temperature_Setpoint => Effective_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Effective_Heating_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Effective_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Effective_Heating_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Elevator => Elevator",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Elevator . } INSERT{ ?subject ?predicate brick:Elevator . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Elevator . }"
+    },
+    {
+      "description": "Emergency_Air_Flow => Emergency_Air_Flow_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Air_Flow . } INSERT{ ?subject ?predicate brick:Emergency_Air_Flow_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Air_Flow . }"
+    },
+    {
+      "description": "Emergency_Air_Flow_Status => Emergency_Air_Flow_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Air_Flow_Status . } INSERT{ ?subject ?predicate brick:Emergency_Air_Flow_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Air_Flow_Status . }"
+    },
+    {
+      "description": "Emergency_Generator_Alarm => Emergency_Generator_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Generator_Alarm . } INSERT{ ?subject ?predicate brick:Emergency_Generator_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Generator_Alarm . }"
+    },
+    {
+      "description": "Emergency_Generator_Status => Emergency_Generator_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Generator_Status . } INSERT{ ?subject ?predicate brick:Emergency_Generator_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Generator_Status . }"
+    },
+    {
+      "description": "Emergency_Power_Loss_Alarm => Emergency_Power_Loss_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Loss_Alarm . } INSERT{ ?subject ?predicate brick:Emergency_Power_Loss_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Loss_Alarm . }"
+    },
+    {
+      "description": "Emergency_Power_Off => Emergency_Power_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Activated_By_High_Temperature => Emergency_Power_Off_Activated_By_High_Temperature_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Activated_By_High_Temperature . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_High_Temperature_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Activated_By_High_Temperature . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Activated_By_High_Temperature_Status => Emergency_Power_Off_Activated_By_High_Temperature_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Activated_By_High_Temperature_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_High_Temperature_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Activated_By_High_Temperature_Status . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Activated_By_Leak_Detection_System => Emergency_Power_Off_Activated_By_Leak_Detection_System_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Activated_By_Leak_Detection_System . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Activated_By_Leak_Detection_System . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status => Emergency_Power_Off_Activated_By_Leak_Detection_System_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Command => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Command . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Command . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Enable => Emergency_Power_Off_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Enable . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Enable . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Enable_Status => Emergency_Power_Off_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Enable_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Enable_Status . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Status => Emergency_Power_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Status . }"
+    },
+    {
+      "description": "Emergency_Power_Off_Switch_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_Switch_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_Switch_Command . }"
+    },
+    {
+      "description": "Emergency_Power_Off_System => Emergency_Power_Off_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_System . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_System . }"
+    },
+    {
+      "description": "Emergency_Power_Off_System_Enable => Emergency_Power_Off_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_System_Enable . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_System_Enable . }"
+    },
+    {
+      "description": "Emergency_Power_Off_System_Enable_Status => Emergency_Power_Off_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Power_Off_System_Enable_Status . } INSERT{ ?subject ?predicate brick:Emergency_Power_Off_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Power_Off_System_Enable_Status . }"
+    },
+    {
+      "description": "Emergency_Push_Button => Emergency_Push_Button_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Push_Button . } INSERT{ ?subject ?predicate brick:Emergency_Push_Button_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Push_Button . }"
+    },
+    {
+      "description": "Emergency_Push_Button_Status => Emergency_Push_Button_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Emergency_Push_Button_Status . } INSERT{ ?subject ?predicate brick:Emergency_Push_Button_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Emergency_Push_Button_Status . }"
+    },
+    {
+      "description": "Enable_Command => Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enable_Command . } INSERT{ ?subject ?predicate brick:Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enable_Command . }"
+    },
+    {
+      "description": "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint => Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Enable_Status => Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enable_Status . } INSERT{ ?subject ?predicate brick:Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enable_Status . }"
+    },
+    {
+      "description": "Energy => Energy",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Energy . } INSERT{ ?subject ?predicate brick:Energy . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Energy . }"
+    },
+    {
+      "description": "Energy_Sensor => Energy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Energy_Sensor . } INSERT{ ?subject ?predicate brick:Energy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Energy_Sensor . }"
+    },
+    {
+      "description": "Energy_Storage => Energy_Storage",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Energy_Storage . } INSERT{ ?subject ?predicate brick:Energy_Storage . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Energy_Storage . }"
+    },
+    {
+      "description": "Entering_Water_Temperature_Sensor => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Entering_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Entering_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Enthalpy => Enthalpy",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enthalpy . } INSERT{ ?subject ?predicate brick:Enthalpy . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enthalpy . }"
+    },
+    {
+      "description": "Enthalpy_Sensor => Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enthalpy_Sensor . }"
+    },
+    {
+      "description": "Enthalpy_Setpoint => Enthalpy_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Enthalpy_Setpoint . } INSERT{ ?subject ?predicate brick:Enthalpy_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Enthalpy_Setpoint . }"
+    },
+    {
+      "description": "Environment_Box => Environment_Box",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Environment_Box . } INSERT{ ?subject ?predicate brick:Environment_Box . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Environment_Box . }"
+    },
+    {
+      "description": "Equipment => Equipment",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Equipment . } INSERT{ ?subject ?predicate brick:Equipment . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Equipment . }"
+    },
+    {
+      "description": "Even_Month_Status => Even_Month_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Even_Month_Status . } INSERT{ ?subject ?predicate brick:Even_Month_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Even_Month_Status . }"
+    },
+    {
+      "description": "Exhaust_Air => Exhaust_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air . } INSERT{ ?subject ?predicate brick:Exhaust_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air . }"
+    },
+    {
+      "description": "Exhaust_Air_Damper => Exhaust_Damper",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Damper . } INSERT{ ?subject ?predicate brick:Exhaust_Damper . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Damper . }"
+    },
+    {
+      "description": "Exhaust_Air_Flow => Flow + Exhaust_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Exhaust_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Flow . }"
+    },
+    {
+      "description": "Exhaust_Air_Flow_Proportional_Band_Setpoint => Exhaust_Air_Flow_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Flow_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Flow_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Flow_Sensor => Exhaust_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Air_Flow_Setpoint => Exhaust_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Humidity_Sensor => Exhaust_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow => Flow + Exhaust_Air_Stack",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Exhaust_Air_Stack . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Dead_Band_Setpoint => Exhaust_Air_Stack_Flow_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Integral_Time_Setpoint => Exhaust_Air_Flow_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Proportional_Band => Exhaust_Air_Flow_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Proportional_Band . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Flow_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Proportional_Band . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Proportional_Band_Setpoint => Exhaust_Air_Stack_Flow_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Sensor => Exhaust_Air_Stack_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Air_Stack_Flow_Setpoint => Exhaust_Air_Stack_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Stack_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Stack_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Stack_Flow_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Static_Pressure_Dead_Band_Setpoint => Exhaust_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Static_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Static_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Static_Pressure_Proportional_Band => Exhaust_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Static_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Static_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint => Exhaust_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Static_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Static_Pressure_Sensor => Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Air_Static_Pressure_Setpoint => Exhaust_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Air_Temperature => Temperature + Exhaust_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Exhaust_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Temperature . }"
+    },
+    {
+      "description": "Exhaust_Air_Temperature_Sensor => Exhaust_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Air_Velocity_Pressure => Velocity_Pressure + Exhaust_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Velocity_Pressure . } INSERT{ ?subject ?predicate brick:Velocity_Pressure, brick:Exhaust_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Velocity_Pressure . }"
+    },
+    {
+      "description": "Exhaust_Air_Velocity_Pressure_Sensor => Exhaust_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Exhaust_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Bypass_Damper_Command => Bypass_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Bypass_Damper_Command . } INSERT{ ?subject ?predicate brick:Bypass_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Bypass_Damper_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan => Exhaust_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan . } INSERT{ ?subject ?predicate brick:Exhaust_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan . }"
+    },
+    {
+      "description": "Exhaust_Fan_Air_Flow_Setpoint => Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Exhaust_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Disable => Exhaust_Fan_Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Disable . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Disable . }"
+    },
+    {
+      "description": "Exhaust_Fan_Disable_Command => Exhaust_Fan_Disable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Disable_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Disable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Disable_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Disable_Status => Disable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Disable_Status . } INSERT{ ?subject ?predicate brick:Disable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Disable_Status . }"
+    },
+    {
+      "description": "Exhaust_Fan_Enable => Exhaust_Fan_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Enable . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Enable . }"
+    },
+    {
+      "description": "Exhaust_Fan_Enable_Command => Exhaust_Fan_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Enable_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Enable_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Fire_Control_Panel_Off_Command => Exhaust_Fan_Fire_Control_Panel_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Fire_Control_Panel_Off_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Fire_Control_Panel_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Fire_Control_Panel_Off_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Fire_Control_Panel_On_Command => Exhaust_Fan_Fire_Control_Panel_On_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Fire_Control_Panel_On_Command . } INSERT{ ?subject ?predicate brick:Exhaust_Fan_Fire_Control_Panel_On_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Fire_Control_Panel_On_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Off_Status_LED => On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Off_Status_LED . } INSERT{ ?subject ?predicate brick:On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Off_Status_LED . }"
+    },
+    {
+      "description": "Exhaust_Fan_On_Status_LED => Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_On_Status_LED . } INSERT{ ?subject ?predicate brick:Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_On_Status_LED . }"
+    },
+    {
+      "description": "Exhaust_Fan_Overridden_Off_Status => Overridden_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Overridden_Off_Status . } INSERT{ ?subject ?predicate brick:Overridden_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Overridden_Off_Status . }"
+    },
+    {
+      "description": "Exhaust_Fan_Overridden_On_Status => Overridden_On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Overridden_On_Status . } INSERT{ ?subject ?predicate brick:Overridden_On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Overridden_On_Status . }"
+    },
+    {
+      "description": "Exhaust_Fan_Piezoelectric_Sensor => Piezoelectric_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Piezoelectric_Sensor . } INSERT{ ?subject ?predicate brick:Piezoelectric_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Piezoelectric_Sensor . }"
+    },
+    {
+      "description": "Exhaust_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "Exhaust_Fan_Start_Stop_Status => Fan_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Fan_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "Exhaust_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_Status . }"
+    },
+    {
+      "description": "Exhaust_Fan_System_Enable_Command => Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Exhaust_Fan_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Exhaust_Fan_System_Enable_Command . }"
+    },
+    {
+      "description": "Failure_Alarm => Failure_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Failure_Alarm . } INSERT{ ?subject ?predicate brick:Failure_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Failure_Alarm . }"
+    },
+    {
+      "description": "Fan => Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan . } INSERT{ ?subject ?predicate brick:Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan . }"
+    },
+    {
+      "description": "Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Fan_Air_Flow_Setpoint => Fan_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Fan_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Fan_Coil_Unit => Fan_Coil_Unit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Coil_Unit . } INSERT{ ?subject ?predicate brick:Fan_Coil_Unit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Coil_Unit . }"
+    },
+    {
+      "description": "Fan_Overload_Alarm => Overload_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Overload_Alarm . } INSERT{ ?subject ?predicate brick:Overload_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Overload_Alarm . }"
+    },
+    {
+      "description": "Fan_Run_Request_Status => Run_Request_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Run_Request_Status . } INSERT{ ?subject ?predicate brick:Run_Request_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Run_Request_Status . }"
+    },
+    {
+      "description": "Fan_Speed_Reset => Fan_Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Speed_Reset . } INSERT{ ?subject ?predicate brick:Fan_Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Speed_Reset . }"
+    },
+    {
+      "description": "Fan_Speed_Reset_Command => Fan_Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Speed_Reset_Command . } INSERT{ ?subject ?predicate brick:Fan_Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Speed_Reset_Command . }"
+    },
+    {
+      "description": "Fan_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Speed_Setpoint . }"
+    },
+    {
+      "description": "Fan_Start_Stop => Fan_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Start_Stop . } INSERT{ ?subject ?predicate brick:Fan_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Start_Stop . }"
+    },
+    {
+      "description": "Fan_Start_Stop_Status => Fan_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Fan_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "Fan_Status => Fan_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fan_Status . } INSERT{ ?subject ?predicate brick:Fan_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fan_Status . }"
+    },
+    {
+      "description": "Fault_Indicator_Status => Fault_Indicator_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fault_Indicator_Status . } INSERT{ ?subject ?predicate brick:Fault_Indicator_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fault_Indicator_Status . }"
+    },
+    {
+      "description": "Fault_Reset_Command => Fault_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fault_Reset_Command . } INSERT{ ?subject ?predicate brick:Fault_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fault_Reset_Command . }"
+    },
+    {
+      "description": "Fault_Status => Fault_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fault_Status . } INSERT{ ?subject ?predicate brick:Fault_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fault_Status . }"
+    },
+    {
+      "description": "FCP => Fire_Control_Panel",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCP . } INSERT{ ?subject ?predicate brick:Fire_Control_Panel . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCP . }"
+    },
+    {
+      "description": "FCU => FCU",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU . } INSERT{ ?subject ?predicate brick:FCU . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU . }"
+    },
+    {
+      "description": "FCU_Discharge_Air_Temperature_Cooling_Setpoint => Discharge_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Discharge_Air_Temperature_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Discharge_Air_Temperature_Cooling_Setpoint . }"
+    },
+    {
+      "description": "FCU_Discharge_Air_Temperature_Heating_Setpoint => Discharge_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Discharge_Air_Temperature_Heating_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Discharge_Air_Temperature_Heating_Setpoint . }"
+    },
+    {
+      "description": "FCU_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "FCU_Discharge_Air_Temperature_Setpoint => Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "FCU_Return_Air_CO2_Sensor => Return_Air_CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Return_Air_CO2_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Return_Air_CO2_Sensor . }"
+    },
+    {
+      "description": "FCU_Return_Air_Humidity_Sensor => Return_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Return_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Return_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "FCU_Return_Air_Temperature_Sensor => Return_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Return_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Return_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "FCU_Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Run_Time_Sensor . }"
+    },
+    {
+      "description": "FCU_Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "FCU_Zone_Air_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:FCU_Zone_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:FCU_Zone_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Filter => Filter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Filter . } INSERT{ ?subject ?predicate brick:Filter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Filter . }"
+    },
+    {
+      "description": "Filter_Differential_Pressure_Sensor => Filter_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Filter_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Filter_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Filter_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Filter_Reset_Command => Filter_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Filter_Reset_Command . } INSERT{ ?subject ?predicate brick:Filter_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Filter_Reset_Command . }"
+    },
+    {
+      "description": "Filter_Status => Filter_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Filter_Status . } INSERT{ ?subject ?predicate brick:Filter_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Filter_Status . }"
+    },
+    {
+      "description": "Fire_Control_Panel => Fire_Control_Panel",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fire_Control_Panel . } INSERT{ ?subject ?predicate brick:Fire_Control_Panel . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fire_Control_Panel . }"
+    },
+    {
+      "description": "Fire_Control_Panel_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fire_Control_Panel_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fire_Control_Panel_Command . }"
+    },
+    {
+      "description": "Fire_Control_Panel_Off_Command => Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fire_Control_Panel_Off_Command . } INSERT{ ?subject ?predicate brick:Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fire_Control_Panel_Off_Command . }"
+    },
+    {
+      "description": "Fire_Control_Panel_On_Command => On_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fire_Control_Panel_On_Command . } INSERT{ ?subject ?predicate brick:On_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fire_Control_Panel_On_Command . }"
+    },
+    {
+      "description": "Fire_Safety_System => Fire_Safety_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fire_Safety_System . } INSERT{ ?subject ?predicate brick:Fire_Safety_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fire_Safety_System . }"
+    },
+    {
+      "description": "Floor => Floor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Floor . } INSERT{ ?subject ?predicate brick:Floor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Floor . }"
+    },
+    {
+      "description": "Flow => Flow",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Flow . } INSERT{ ?subject ?predicate brick:Flow . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Flow . }"
+    },
+    {
+      "description": "Flow_Sensor => Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Flow_Sensor . } INSERT{ ?subject ?predicate brick:Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Flow_Sensor . }"
+    },
+    {
+      "description": "Flow_Setpoint => Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Flow_Setpoint . }"
+    },
+    {
+      "description": "Freeze_Protect_Temperature_Low_Limit_Setpoint => Low_Freeze_Protect_Temperature_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Freeze_Protect_Temperature_Low_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Freeze_Protect_Temperature_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Freeze_Protect_Temperature_Low_Limit_Setpoint . }"
+    },
+    {
+      "description": "Freeze_Status => Freeze_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Freeze_Status . } INSERT{ ?subject ?predicate brick:Freeze_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Freeze_Status . }"
+    },
+    {
+      "description": "Freezer => Freezer",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Freezer . } INSERT{ ?subject ?predicate brick:Freezer . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Freezer . }"
+    },
+    {
+      "description": "Frequency => Frequency",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Frequency . } INSERT{ ?subject ?predicate brick:Frequency . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Frequency . }"
+    },
+    {
+      "description": "Frequency_Command => Frequency_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Frequency_Command . } INSERT{ ?subject ?predicate brick:Frequency_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Frequency_Command . }"
+    },
+    {
+      "description": "Frequency_Sensor => Frequency_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Frequency_Sensor . } INSERT{ ?subject ?predicate brick:Frequency_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Frequency_Sensor . }"
+    },
+    {
+      "description": "Frost => Frost",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Frost . } INSERT{ ?subject ?predicate brick:Frost . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Frost . }"
+    },
+    {
+      "description": "Frost_Sensor => Frost_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Frost_Sensor . } INSERT{ ?subject ?predicate brick:Frost_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Frost_Sensor . }"
+    },
+    {
+      "description": "Fume_Hood => Fume_Hood",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fume_Hood . } INSERT{ ?subject ?predicate brick:Fume_Hood . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fume_Hood . }"
+    },
+    {
+      "description": "Fume_Hood_Air_Flow_Sensor => Fume_Hood_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fume_Hood_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Fume_Hood_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fume_Hood_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Fume_Hood_Alarm => Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fume_Hood_Alarm . } INSERT{ ?subject ?predicate brick:Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fume_Hood_Alarm . }"
+    },
+    {
+      "description": "Fume_Hood_Sash_Position_Sensor => Sash_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Fume_Hood_Sash_Position_Sensor . } INSERT{ ?subject ?predicate brick:Sash_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Fume_Hood_Sash_Position_Sensor . }"
+    },
+    {
+      "description": "Furniture => Furniture",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Furniture . } INSERT{ ?subject ?predicate brick:Furniture . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Furniture . }"
+    },
+    {
+      "description": "Grains => Grains",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Grains . } INSERT{ ?subject ?predicate brick:Grains . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Grains . }"
+    },
+    {
+      "description": "Hail => Hail",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hail . } INSERT{ ?subject ?predicate brick:Hail . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hail . }"
+    },
+    {
+      "description": "Hail_Sensor => Hail_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hail_Sensor . } INSERT{ ?subject ?predicate brick:Hail_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hail_Sensor . }"
+    },
+    {
+      "description": "Hand_Auto_Status => Hand_Auto_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hand_Auto_Status . } INSERT{ ?subject ?predicate brick:Hand_Auto_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hand_Auto_Status . }"
+    },
+    {
+      "description": "Heat_Exchanger => Heat_Exchanger",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger . } INSERT{ ?subject ?predicate brick:Heat_Exchanger . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger . }"
+    },
+    {
+      "description": "Heat_Exchanger_Discharge_Water_Temperature_Sensor => Discharge_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Discharge_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Discharge_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Heat_Exchanger_Discharge_Water_Temperature_Setpoint => Discharge_Water_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Discharge_Water_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Water_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Discharge_Water_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Heat_Exchanger_Supply_Water_Temperature => Temperature + Heat_Exchanger_Supply_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Heat_Exchanger_Supply_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature . }"
+    },
+    {
+      "description": "Heat_Exchanger_Supply_Water_Temperature_Dead_Band_Setpoint => Supply_Water_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Heat_Exchanger_Supply_Water_Temperature_Proportional_Band_Setpoint => Supply_Water_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Heat_Exchanger_Supply_Water_Temperature_Sensor => Heat_Exchanger_Supply_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_Supply_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Heat_Exchanger_Supply_Water_Temperature_Setpoint => Supply_Water_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Supply_Water_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Heat_Exchanger_System_Enable => Heat_Exchanger_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_System_Enable . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_System_Enable . }"
+    },
+    {
+      "description": "Heat_Exchanger_System_Enable_Status => Heat_Exchanger_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_System_Enable_Status . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_System_Enable_Status . }"
+    },
+    {
+      "description": "Heat_Exchanger_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Valve_Command . }"
+    },
+    {
+      "description": "Heat_Exchanger_Valve_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Exchanger_Valve_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Exchanger_Valve_Status . }"
+    },
+    {
+      "description": "Heat_Wheel_Differential_Pressure => Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Differential_Pressure . } INSERT{ ?subject ?predicate brick:Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Differential_Pressure . }"
+    },
+    {
+      "description": "Heat_Wheel_Differential_Pressure_Sensor => Air_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Air_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Heat_Wheel_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Heat_Wheel_Speed => Speed",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Speed . } INSERT{ ?subject ?predicate brick:Speed . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Speed . }"
+    },
+    {
+      "description": "Heat_Wheel_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Speed_Sensor . }"
+    },
+    {
+      "description": "Heat_Wheel_Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Heat_Wheel_VFD => Heat_Wheel_VFD",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_VFD . } INSERT{ ?subject ?predicate brick:Heat_Wheel_VFD . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_VFD . }"
+    },
+    {
+      "description": "Heat_Wheel_Voltage => Voltage",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Voltage . } INSERT{ ?subject ?predicate brick:Voltage . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Voltage . }"
+    },
+    {
+      "description": "Heat_Wheel_Voltage_Sensor => Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heat_Wheel_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heat_Wheel_Voltage_Sensor . }"
+    },
+    {
+      "description": "Heating_Coil => Heating_Coil",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Coil . } INSERT{ ?subject ?predicate brick:Heating_Coil . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Coil . }"
+    },
+    {
+      "description": "Heating_Command => Heating_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Command . } INSERT{ ?subject ?predicate brick:Heating_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Command . }"
+    },
+    {
+      "description": "Heating_Demand_Setpoint => Heating_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Demand_Setpoint . }"
+    },
+    {
+      "description": "Heating_Discharge_Air_Flow_Setpoint => Heating_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_Discharge_Air_Temperature_Dead_Band_Setpoint => Discharge_Air_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Discharge_Air_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Discharge_Air_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Heating_Discharge_Air_Temperature_Integral_Time_Setpoint => Air_Temperature_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Discharge_Air_Temperature_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Air_Temperature_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Discharge_Air_Temperature_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Heating_Discharge_Air_Temperature_Proportional_Band => Heating_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Discharge_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Discharge_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint => Heating_Discharge_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Discharge_Air_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Heating_Max_Discharge_Air_Flow_Setpoint => Max_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_Max_Supply_Air_Flow_Setpoint => Max_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_Min_Discharge_Air_Flow_Setpoint => Min_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_Min_Supply_Air_Flow_Setpoint => Min_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_On_Off => Heating_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_On_Off . } INSERT{ ?subject ?predicate brick:Heating_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_On_Off . }"
+    },
+    {
+      "description": "Heating_On_Off_Status => Heating_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_On_Off_Status . } INSERT{ ?subject ?predicate brick:Heating_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_On_Off_Status . }"
+    },
+    {
+      "description": "Heating_Request_Percent_Setpoint => Heating_Request_Percent_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Request_Percent_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Request_Percent_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Request_Percent_Setpoint . }"
+    },
+    {
+      "description": "Heating_Request_Setpoint => Heating_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Request_Setpoint . }"
+    },
+    {
+      "description": "Heating_Supply_Air_Flow_Setpoint => Heating_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Heating_Supply_Air_Temperature_Proportional_Band => Heating_Supply_Air_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Supply_Air_Temperature_Proportional_Band . } INSERT{ ?subject ?predicate brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Supply_Air_Temperature_Proportional_Band . }"
+    },
+    {
+      "description": "Heating_Temperature_Setpoint => Heating_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Heating_Thermal_Power_Sensor => Heating_Thermal_Power_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Thermal_Power_Sensor . } INSERT{ ?subject ?predicate brick:Heating_Thermal_Power_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Thermal_Power_Sensor . }"
+    },
+    {
+      "description": "Heating_Valve => Heating_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Valve . } INSERT{ ?subject ?predicate brick:Heating_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Valve . }"
+    },
+    {
+      "description": "Heating_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Valve_Command . }"
+    },
+    {
+      "description": "Heating_Ventilation_Air_Conditioning_System => Heating_Ventilation_Air_Conditioning_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Heating_Ventilation_Air_Conditioning_System . } INSERT{ ?subject ?predicate brick:Heating_Ventilation_Air_Conditioning_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Heating_Ventilation_Air_Conditioning_System . }"
+    },
+    {
+      "description": "High_Head_Pressure_Alarm => High_Head_Pressure_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Head_Pressure_Alarm . } INSERT{ ?subject ?predicate brick:High_Head_Pressure_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Head_Pressure_Alarm . }"
+    },
+    {
+      "description": "High_Humidity_Alarm => High_Humidity_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Humidity_Alarm . } INSERT{ ?subject ?predicate brick:High_Humidity_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Humidity_Alarm . }"
+    },
+    {
+      "description": "High_Humidity_Alarm_Setpoint => High_Humidity_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Humidity_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:High_Humidity_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Humidity_Alarm_Setpoint . }"
+    },
+    {
+      "description": "High_Static_Pressure_Cutout_Limit => High_Static_Pressure_Cutout_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Static_Pressure_Cutout_Limit . } INSERT{ ?subject ?predicate brick:High_Static_Pressure_Cutout_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Static_Pressure_Cutout_Limit . }"
+    },
+    {
+      "description": "High_Static_Pressure_Cutout_Limit_Setpoint => High_Static_Pressure_Cutout_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Static_Pressure_Cutout_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:High_Static_Pressure_Cutout_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Static_Pressure_Cutout_Limit_Setpoint . }"
+    },
+    {
+      "description": "High_Temperature_Alarm => High_Temperature_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Temperature_Alarm . } INSERT{ ?subject ?predicate brick:High_Temperature_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Temperature_Alarm . }"
+    },
+    {
+      "description": "High_Temperature_Alarm_Setpoint => High_Temperature_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Temperature_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:High_Temperature_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Temperature_Alarm_Setpoint . }"
+    },
+    {
+      "description": "High_Temperature_Hot_Water_Return_Temperature_Sensor => High_Temperature_Hot_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Temperature_Hot_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:High_Temperature_Hot_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Temperature_Hot_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "High_Temperature_Hot_Water_Supply_Temperature_Sensor => High_Temperature_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:High_Temperature_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:High_Temperature_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Highest_Zone_Cooling_Command => Highest_Zone_Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Highest_Zone_Cooling_Command . } INSERT{ ?subject ?predicate brick:Highest_Zone_Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Highest_Zone_Cooling_Command . }"
+    },
+    {
+      "description": "Highest_Zone_Temperature_Sensor => Highest_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Highest_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Highest_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Highest_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Hold_Status => Hold_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hold_Status . } INSERT{ ?subject ?predicate brick:Hold_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hold_Status . }"
+    },
+    {
+      "description": "Hot_Box => Hot_Box",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Box . } INSERT{ ?subject ?predicate brick:Hot_Box . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Box . }"
+    },
+    {
+      "description": "Hot_Water => Hot_Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water . } INSERT{ ?subject ?predicate brick:Hot_Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water . }"
+    },
+    {
+      "description": "Hot_Water_Coil_Entering_Temperature => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Coil_Entering_Temperature . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Coil_Entering_Temperature . }"
+    },
+    {
+      "description": "Hot_Water_Coil_Entering_Temperature_Sensor => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Coil_Entering_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Coil_Entering_Temperature_Sensor . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure => Hot_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Dead_Band_Setpoint => Hot_Water_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Integral_Time_Setpoint => Hot_Water_Differential_Pressure_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Proportional_Band => Hot_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Proportional_Band_Setpoint => Hot_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Sensor => Hot_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Hot_Water_Differential_Pressure_Setpoint => Hot_Water_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Flow_Sensor => Hot_Water_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Flow_Sensor . }"
+    },
+    {
+      "description": "Hot_Water_Pump => Hot_Water_Pump",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Pump . } INSERT{ ?subject ?predicate brick:Hot_Water_Pump . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Pump . }"
+    },
+    {
+      "description": "Hot_Water_Pump_Alarm => Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Pump_Alarm . } INSERT{ ?subject ?predicate brick:Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Pump_Alarm . }"
+    },
+    {
+      "description": "Hot_Water_Pump_Lead_Lag_Command => Lead_Lag_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Pump_Lead_Lag_Command . } INSERT{ ?subject ?predicate brick:Lead_Lag_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Pump_Lead_Lag_Command . }"
+    },
+    {
+      "description": "Hot_Water_Pump_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Pump_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Pump_Start_Stop_Command . }"
+    },
+    {
+      "description": "Hot_Water_Pump_VFD_Speed_Command => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Pump_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Pump_VFD_Speed_Command . }"
+    },
+    {
+      "description": "Hot_Water_Return_Temperature => Hot_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Return_Temperature . } INSERT{ ?subject ?predicate brick:Hot_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Return_Temperature . }"
+    },
+    {
+      "description": "Hot_Water_Return_Temperature_Sensor => Hot_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "Hot_Water_Static_Pressure_Setpoint => Hot_Water_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Supply_Temperature => Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Supply_Temperature . } INSERT{ ?subject ?predicate brick:Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Supply_Temperature . }"
+    },
+    {
+      "description": "Hot_Water_Supply_Temperature_High_Reset_Setpoint => Hot_Water_Supply_Temperature_High_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Supply_Temperature_High_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Supply_Temperature_High_Reset_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Supply_Temperature_Low_Reset_Setpoint => Hot_Water_Supply_Temperature_Low_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Supply_Temperature_Low_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Supply_Temperature_Low_Reset_Setpoint . }"
+    },
+    {
+      "description": "Hot_Water_Supply_Temperature_Sensor => Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Hot_Water_System => Hot_Water_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_System . } INSERT{ ?subject ?predicate brick:Hot_Water_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_System . }"
+    },
+    {
+      "description": "Hot_Water_System_Enable => Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_System_Enable . } INSERT{ ?subject ?predicate brick:Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_System_Enable . }"
+    },
+    {
+      "description": "Hot_Water_System_Enable_Command => Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "Hot_Water_Usage_Sensor => Hot_Water_Usage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Hot_Water_Usage_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Usage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Hot_Water_Usage_Sensor . }"
+    },
+    {
+      "description": "Humidification_On_Off => Humidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidification_On_Off . } INSERT{ ?subject ?predicate brick:Humidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidification_On_Off . }"
+    },
+    {
+      "description": "Humidification_On_Off_Status => Humidification_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidification_On_Off_Status . } INSERT{ ?subject ?predicate brick:Humidification_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidification_On_Off_Status . }"
+    },
+    {
+      "description": "Humidifier => Humidifier",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidifier . } INSERT{ ?subject ?predicate brick:Humidifier . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidifier . }"
+    },
+    {
+      "description": "Humidifier_Alarm => Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidifier_Alarm . } INSERT{ ?subject ?predicate brick:Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidifier_Alarm . }"
+    },
+    {
+      "description": "Humidifier_Fault_Status => Humidifier_Fault_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidifier_Fault_Status . } INSERT{ ?subject ?predicate brick:Humidifier_Fault_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidifier_Fault_Status . }"
+    },
+    {
+      "description": "Humidifier_Panel_No_Water_Alarm => No_Water_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidifier_Panel_No_Water_Alarm . } INSERT{ ?subject ?predicate brick:No_Water_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidifier_Panel_No_Water_Alarm . }"
+    },
+    {
+      "description": "Humidify_Command => Humidify_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidify_Command . } INSERT{ ?subject ?predicate brick:Humidify_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidify_Command . }"
+    },
+    {
+      "description": "Humidity => Humidity",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidity . } INSERT{ ?subject ?predicate brick:Humidity . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidity . }"
+    },
+    {
+      "description": "Humidity_Sensor => Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidity_Sensor . }"
+    },
+    {
+      "description": "Humidity_Setpoint => Humidity_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidity_Setpoint . } INSERT{ ?subject ?predicate brick:Humidity_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidity_Setpoint . }"
+    },
+    {
+      "description": "Humidity_Tolerance_Setpoint => Humidity_Tolerance_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Humidity_Tolerance_Setpoint . } INSERT{ ?subject ?predicate brick:Humidity_Tolerance_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Humidity_Tolerance_Setpoint . }"
+    },
+    {
+      "description": "HVAC => HVAC",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC . } INSERT{ ?subject ?predicate brick:HVAC . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC . }"
+    },
+    {
+      "description": "HVAC_Average_Cooling_Demand_Sensor => Average_Cooling_Demand_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC_Average_Cooling_Demand_Sensor . } INSERT{ ?subject ?predicate brick:Average_Cooling_Demand_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC_Average_Cooling_Demand_Sensor . }"
+    },
+    {
+      "description": "HVAC_Average_Discharge_Air_Flow_Sensor => Average_Discharge_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC_Average_Discharge_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Average_Discharge_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC_Average_Discharge_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "HVAC_Average_Supply_Air_Flow_Sensor => Average_Supply_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC_Average_Supply_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Average_Supply_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC_Average_Supply_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "HVAC_Highest_Zone_Cooling_Command => Highest_Zone_Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC_Highest_Zone_Cooling_Command . } INSERT{ ?subject ?predicate brick:Highest_Zone_Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC_Highest_Zone_Cooling_Command . }"
+    },
+    {
+      "description": "HVAC_Zone => HVAC_Zone",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HVAC_Zone . } INSERT{ ?subject ?predicate brick:HVAC_Zone . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HVAC_Zone . }"
+    },
+    {
+      "description": "HWS => HWS",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS . } INSERT{ ?subject ?predicate brick:HWS . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS . }"
+    },
+    {
+      "description": "HWS_Heat_Exchanger_Supply_Water_Temperature_Sensor => Heat_Exchanger_Supply_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Heat_Exchanger_Supply_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_Supply_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Heat_Exchanger_Supply_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Heat_Exchanger_Supply_Water_Temperature_Setpoint => Supply_Water_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Heat_Exchanger_Supply_Water_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Heat_Exchanger_Supply_Water_Temperature_Setpoint . }"
+    },
+    {
+      "description": "HWS_Heat_Exchanger_System_Enable_Status => Heat_Exchanger_System_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Heat_Exchanger_System_Enable_Status . } INSERT{ ?subject ?predicate brick:Heat_Exchanger_System_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Heat_Exchanger_System_Enable_Status . }"
+    },
+    {
+      "description": "HWS_High_Temperature_Hot_Water_Supply_Temperature_Sensor => High_Temperature_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_High_Temperature_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_High_Temperature_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Coil_Entering_Temperature_Sensor => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Coil_Entering_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Coil_Entering_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Differential_Pressure_Sensor => Hot_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Differential_Pressure_Setpoint => Hot_Water_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Return_Temperature_Sensor => Hot_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Static_Pressure_Setpoint => Hot_Water_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Hot_Water_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "HWS_Hot_Water_Supply_Temperature_Sensor => Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Hot_Water_System_Enable_Command => Hot_Water_System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Hot_Water_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Hot_Water_System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Hot_Water_System_Enable_Command . }"
+    },
+    {
+      "description": "HWS_Medium_Temperature_Hot_Water_Supply_Temperature_Sensor => Medium_Temperature_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "HWS_Open_Heating_Valve_Outside_Air_Temperature_Setpoint => Open_Heating_Valve_Outside_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HWS_Open_Heating_Valve_Outside_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HWS_Open_Heating_Valve_Outside_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "HX => HX",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:HX . } INSERT{ ?subject ?predicate brick:HX . } WHERE { ?subject  ?predicate  brick_v_1_0_3:HX . }"
+    },
+    {
+      "description": "Ice_Tank_Entering_Water_Temperature_Sensor => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Ice_Tank_Entering_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Ice_Tank_Entering_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Ice_Tank_Leaving_Water_Temperature_Sensor => Ice_Tank_Leaving_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Ice_Tank_Leaving_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Ice_Tank_Leaving_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Ice_Tank_Leaving_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Integral_Time_Setpoint => Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Inverter => Inverter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Inverter . } INSERT{ ?subject ?predicate brick:Inverter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Inverter . }"
+    },
+    {
+      "description": "Isolation_Valve => Isolation_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Isolation_Valve . } INSERT{ ?subject ?predicate brick:Isolation_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Isolation_Valve . }"
+    },
+    {
+      "description": "Laboratory => Laboratory",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Laboratory . } INSERT{ ?subject ?predicate brick:Laboratory . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Laboratory . }"
+    },
+    {
+      "description": "Last_Fault_Code => Last_Fault_Code_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Last_Fault_Code . } INSERT{ ?subject ?predicate brick:Last_Fault_Code_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Last_Fault_Code . }"
+    },
+    {
+      "description": "Last_Fault_Code_Status => Last_Fault_Code_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Last_Fault_Code_Status . } INSERT{ ?subject ?predicate brick:Last_Fault_Code_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Last_Fault_Code_Status . }"
+    },
+    {
+      "description": "Leaving_Water_Temperature_Sensor => Leaving_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Leaving_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Leaving_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Leaving_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Lighting_System => Lighting_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Lighting_System . } INSERT{ ?subject ?predicate brick:Lighting_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Lighting_System . }"
+    },
+    {
+      "description": "Lighting_Zone => Lighting_Zone",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Lighting_Zone . } INSERT{ ?subject ?predicate brick:Lighting_Zone . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Lighting_Zone . }"
+    },
+    {
+      "description": "Liquid_Detected_Alarm => Liquid_Detected_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Liquid_Detected_Alarm . } INSERT{ ?subject ?predicate brick:Liquid_Detected_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Liquid_Detected_Alarm . }"
+    },
+    {
+      "description": "Load_Current_Sensor => Load_Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Load_Current_Sensor . } INSERT{ ?subject ?predicate brick:Load_Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Load_Current_Sensor . }"
+    },
+    {
+      "description": "Load_Setpoint => Load_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Load_Setpoint . } INSERT{ ?subject ?predicate brick:Load_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Load_Setpoint . }"
+    },
+    {
+      "description": "Load_Shed_Command => Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Load_Shed_Command . }"
+    },
+    {
+      "description": "Load_Shed_Differential_Pressure_Setpoint => Load_Shed_Differential_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Load_Shed_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Load_Shed_Differential_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Load_Shed_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Load_Shed_Status => Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Load_Shed_Status . }"
+    },
+    {
+      "description": "Locally_On_Off => Locally_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Locally_On_Off . } INSERT{ ?subject ?predicate brick:Locally_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Locally_On_Off . }"
+    },
+    {
+      "description": "Locally_On_Off_Status => Locally_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Locally_On_Off_Status . } INSERT{ ?subject ?predicate brick:Locally_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Locally_On_Off_Status . }"
+    },
+    {
+      "description": "Location => Location",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Location . } INSERT{ ?subject ?predicate brick:Location . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Location . }"
+    },
+    {
+      "description": "Low_Humidity_Alarm => Low_Humidity_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Humidity_Alarm . } INSERT{ ?subject ?predicate brick:Low_Humidity_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Humidity_Alarm . }"
+    },
+    {
+      "description": "Low_Humidity_Alarm_Setpoint => Low_Humidity_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Humidity_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Humidity_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Humidity_Alarm_Setpoint . }"
+    },
+    {
+      "description": "Low_Outside_Air_Temperature_Enable_Differential_Sensor => Low_Outside_Air_Temperature_Enable_Differential_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Outside_Air_Temperature_Enable_Differential_Sensor . } INSERT{ ?subject ?predicate brick:Low_Outside_Air_Temperature_Enable_Differential_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Outside_Air_Temperature_Enable_Differential_Sensor . }"
+    },
+    {
+      "description": "Low_Outside_Air_Temperature_Enable_Setpoint => Low_Outside_Air_Temperature_Enable_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Outside_Air_Temperature_Enable_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Outside_Air_Temperature_Enable_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Outside_Air_Temperature_Enable_Setpoint . }"
+    },
+    {
+      "description": "Low_Suction_Pressure_Alarm => Low_Suction_Pressure_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Suction_Pressure_Alarm . } INSERT{ ?subject ?predicate brick:Low_Suction_Pressure_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Suction_Pressure_Alarm . }"
+    },
+    {
+      "description": "Low_Temperature_Alarm => Low_Temperature_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Temperature_Alarm . } INSERT{ ?subject ?predicate brick:Low_Temperature_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Temperature_Alarm . }"
+    },
+    {
+      "description": "Low_Temperature_Alarm_Setpoint => Low_Temperature_Alarm_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Low_Temperature_Alarm_Setpoint . } INSERT{ ?subject ?predicate brick:Low_Temperature_Alarm_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Low_Temperature_Alarm_Setpoint . }"
+    },
+    {
+      "description": "Lowest_Exhaust_Air_Static_Pressure_Sensor => Lowest_Exhaust_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Lowest_Exhaust_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Lowest_Exhaust_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Lowest_Exhaust_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Lowest_Zone_Temperature_Sensor => Lowest_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Lowest_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Lowest_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Lowest_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Luminance => Luminance",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Luminance . } INSERT{ ?subject ?predicate brick:Luminance . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Luminance . }"
+    },
+    {
+      "description": "Luminance_Alarm => Luminance_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Luminance_Alarm . } INSERT{ ?subject ?predicate brick:Luminance_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Luminance_Alarm . }"
+    },
+    {
+      "description": "Luminance_Command => Luminance_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Luminance_Command . } INSERT{ ?subject ?predicate brick:Luminance_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Luminance_Command . }"
+    },
+    {
+      "description": "Luminance_Sensor => Luminance_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Luminance_Sensor . } INSERT{ ?subject ?predicate brick:Luminance_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Luminance_Sensor . }"
+    },
+    {
+      "description": "Luminance_Setpoint => Luminance_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Luminance_Setpoint . } INSERT{ ?subject ?predicate brick:Luminance_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Luminance_Setpoint . }"
+    },
+    {
+      "description": "Maintenance_Mode_Command => Maintenance_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Maintenance_Mode_Command . } INSERT{ ?subject ?predicate brick:Maintenance_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Maintenance_Mode_Command . }"
+    },
+    {
+      "description": "Maintenance_Required_Alarm => Maintenance_Required_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Maintenance_Required_Alarm . } INSERT{ ?subject ?predicate brick:Maintenance_Required_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Maintenance_Required_Alarm . }"
+    },
+    {
+      "description": "Manual_Auto_Status => Manual_Auto_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Manual_Auto_Status . } INSERT{ ?subject ?predicate brick:Manual_Auto_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Manual_Auto_Status . }"
+    },
+    {
+      "description": "Max_Chilled_Water_Differential_Pressure_Setpoint => Max_Chilled_Water_Differential_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Max_Discharge_Air_Static_Pressure_Setpoint => Max_Discharge_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Max_Discharge_Air_Temperature_Setpoint => Max_Discharge_Air_Temperature_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Discharge_Air_Temperature_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Max_Frequency_Command => Max_Frequency_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Frequency_Command . } INSERT{ ?subject ?predicate brick:Max_Frequency_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Frequency_Command . }"
+    },
+    {
+      "description": "Max_Load_Setpoint => Max_Load_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Load_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Load_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Load_Setpoint . }"
+    },
+    {
+      "description": "Max_Return_Air_CO2_Setpoint => Max_Return_Air_CO2_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Return_Air_CO2_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Return_Air_CO2_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Return_Air_CO2_Setpoint . }"
+    },
+    {
+      "description": "Max_Supply_Air_Static_Pressure_Setpoint => Max_Supply_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Max_VFD_Speed_Setpoint => Max_Speed_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Max_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Speed_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Max_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "MeasurementProperty => Quantity",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:MeasurementProperty . } INSERT{ ?subject ?predicate brick:Quantity . } WHERE { ?subject  ?predicate  brick_v_1_0_3:MeasurementProperty . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status => Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint => Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status => Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Differential_Pressure_Sensor => Medium_Temperature_Hot_Water_Differential_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint => Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint => Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Return_Temperature_Sensor => Medium_Temperature_Hot_Water_Return_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Return_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Return_Temperature_Sensor . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint => Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint => Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status => Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint => Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint . }"
+    },
+    {
+      "description": "Medium_Temperature_Hot_Water_Supply_Temperature_Sensor => Medium_Temperature_Hot_Water_Supply_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Meter => Meter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Meter . } INSERT{ ?subject ?predicate brick:Meter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Meter . }"
+    },
+    {
+      "description": "Min_Air_Flow => Min_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Air_Flow . } INSERT{ ?subject ?predicate brick:Min_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Air_Flow . }"
+    },
+    {
+      "description": "Min_Chilled_Water_Differential_Pressure => Min_Chilled_Water_Differential_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Chilled_Water_Differential_Pressure . } INSERT{ ?subject ?predicate brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Chilled_Water_Differential_Pressure . }"
+    },
+    {
+      "description": "Min_Chilled_Water_Differential_Pressure_Setpoint => Min_Chilled_Water_Differential_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Chilled_Water_Differential_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Chilled_Water_Differential_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Min_Discharge_Air_Static_Pressure => Min_Discharge_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Discharge_Air_Static_Pressure . } INSERT{ ?subject ?predicate brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Discharge_Air_Static_Pressure . }"
+    },
+    {
+      "description": "Min_Discharge_Air_Static_Pressure_Setpoint => Min_Discharge_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Discharge_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Discharge_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Min_Discharge_Air_Temperature_Setpoint => Min_Discharge_Air_Temperature_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Discharge_Air_Temperature_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Min_Supply_Air_Static_Pressure => Min_Supply_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Supply_Air_Static_Pressure . } INSERT{ ?subject ?predicate brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Supply_Air_Static_Pressure . }"
+    },
+    {
+      "description": "Min_Supply_Air_Static_Pressure_Setpoint => Min_Supply_Air_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Min_VFD_Speed_Setpoint => Min_Speed_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Min_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Speed_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Min_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "Mixed_Air => Mixed_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air . } INSERT{ ?subject ?predicate brick:Mixed_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air . }"
+    },
+    {
+      "description": "Mixed_Air_Damper_Position_Command => Position_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air_Damper_Position_Command . } INSERT{ ?subject ?predicate brick:Position_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air_Damper_Position_Command . }"
+    },
+    {
+      "description": "Mixed_Air_Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "Mixed_Air_Filter => Mixed_Air_Filter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air_Filter . } INSERT{ ?subject ?predicate brick:Mixed_Air_Filter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air_Filter . }"
+    },
+    {
+      "description": "Mixed_Air_Temperature_Sensor => Mixed_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Mixed_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Mixed_Air_Temperature_Setpoint => Mixed_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mixed_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Mixed_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mixed_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Mode_Command => Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mode_Command . } INSERT{ ?subject ?predicate brick:Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mode_Command . }"
+    },
+    {
+      "description": "Mode_Setpoint => Mode_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mode_Setpoint . } INSERT{ ?subject ?predicate brick:Mode_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mode_Setpoint . }"
+    },
+    {
+      "description": "Mode_Status => Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Mode_Status . } INSERT{ ?subject ?predicate brick:Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Mode_Status . }"
+    },
+    {
+      "description": "Monthly_Steam_Usage_Sensor => Monthly_Steam_Usage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Monthly_Steam_Usage_Sensor . } INSERT{ ?subject ?predicate brick:Monthly_Steam_Usage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Monthly_Steam_Usage_Sensor . }"
+    },
+    {
+      "description": "Motion_Sensor => Motion_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motion_Sensor . } INSERT{ ?subject ?predicate brick:Motion_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motion_Sensor . }"
+    },
+    {
+      "description": "Motor_Current_Sensor => Motor_Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Current_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Current_Sensor . }"
+    },
+    {
+      "description": "Motor_Direction_Command => Direction_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Direction_Command . } INSERT{ ?subject ?predicate brick:Direction_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Direction_Command . }"
+    },
+    {
+      "description": "Motor_Direction_Status => Motor_Direction_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Direction_Status . } INSERT{ ?subject ?predicate brick:Motor_Direction_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Direction_Status . }"
+    },
+    {
+      "description": "Motor_Speed_Sensor => Motor_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Speed_Sensor . }"
+    },
+    {
+      "description": "Motor_Start_Stop => Motor_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Start_Stop . } INSERT{ ?subject ?predicate brick:Motor_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Start_Stop . }"
+    },
+    {
+      "description": "Motor_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Start_Stop_Command . }"
+    },
+    {
+      "description": "Motor_Start_Stop_Status => Motor_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Motor_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Start_Stop_Status . }"
+    },
+    {
+      "description": "Motor_Torque_Sensor => Motor_Torque_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Motor_Torque_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Torque_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Motor_Torque_Sensor . }"
+    },
+    {
+      "description": "Occupancy => Occupancy",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupancy . } INSERT{ ?subject ?predicate brick:Occupancy . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupancy . }"
+    },
+    {
+      "description": "Occupancy_Command => Occupancy_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupancy_Command . } INSERT{ ?subject ?predicate brick:Occupancy_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupancy_Command . }"
+    },
+    {
+      "description": "Occupancy_Sensor => Occupancy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupancy_Sensor . } INSERT{ ?subject ?predicate brick:Occupancy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupancy_Sensor . }"
+    },
+    {
+      "description": "Occupied_Cooling_Discharge_Air_Flow_Setpoint => Occupied_Cooling_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint => Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Max_Supply_Air_Flow_Setpoint => Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint => Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Min_Supply_Air_Flow_Setpoint => Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Supply_Air_Flow_Setpoint => Occupied_Cooling_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Cooling_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Cooling_Temperature_Dead_Band_Setpoint => Occupied_Cooling_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Cooling_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Cooling_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Cooling_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Discharge_Air_Flow_Setpoint => Occupied_Heating_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Heating_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Max_Discharge_Air_Flow_Setpoint => Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Max_Supply_Air_Flow_Setpoint => Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Min_Discharge_Air_Flow_Setpoint => Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Min_Supply_Air_Flow_Setpoint => Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Supply_Air_Flow_Setpoint => Occupied_Heating_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Heating_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Heating_Temperature_Dead_Band_Setpoint => Occupied_Heating_Temperature_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Heating_Temperature_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Heating_Temperature_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Heating_Temperature_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Occupied_Mode_Status => Occupied_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Occupied_Mode_Status . } INSERT{ ?subject ?predicate brick:Occupied_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Occupied_Mode_Status . }"
+    },
+    {
+      "description": "Off => Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Off . } INSERT{ ?subject ?predicate brick:Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Off . }"
+    },
+    {
+      "description": "On => On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:On . } INSERT{ ?subject ?predicate brick:On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:On . }"
+    },
+    {
+      "description": "On_Off => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:On_Off . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:On_Off . }"
+    },
+    {
+      "description": "On_Off_Command => On_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:On_Off_Command . } INSERT{ ?subject ?predicate brick:On_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:On_Off_Command . }"
+    },
+    {
+      "description": "On_Off_Status => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:On_Off_Status . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:On_Off_Status . }"
+    },
+    {
+      "description": "On_Timer_Sensor => On_Timer_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:On_Timer_Sensor . } INSERT{ ?subject ?predicate brick:On_Timer_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:On_Timer_Sensor . }"
+    },
+    {
+      "description": "Open_Heating_Valve_Outside_Air_Temperature_Setpoint => Open_Heating_Valve_Outside_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Open_Heating_Valve_Outside_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Open_Heating_Valve_Outside_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Output_Frequency_Sensor => Output_Frequency_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Output_Frequency_Sensor . } INSERT{ ?subject ?predicate brick:Output_Frequency_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Output_Frequency_Sensor . }"
+    },
+    {
+      "description": "Output_Voltage_Sensor => Output_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Output_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Output_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Output_Voltage_Sensor . }"
+    },
+    {
+      "description": "Outside => Outside",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside . } INSERT{ ?subject ?predicate brick:Outside . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside . }"
+    },
+    {
+      "description": "Outside_Air => Outside_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air . } INSERT{ ?subject ?predicate brick:Outside_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air . }"
+    },
+    {
+      "description": "Outside_Air_CO2_Sensor => Outside_Air_CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_CO2_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_CO2_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Damper_Close_Limit_Setpoint => Close_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Damper_Close_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:Close_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Damper_Close_Limit_Setpoint . }"
+    },
+    {
+      "description": "Outside_Air_Damper_Min_Position_Setpoint => Min_Position_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Damper_Min_Position_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Position_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Damper_Min_Position_Setpoint . }"
+    },
+    {
+      "description": "Outside_Air_Damper_Position_Command => Position_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Damper_Position_Command . } INSERT{ ?subject ?predicate brick:Position_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Damper_Position_Command . }"
+    },
+    {
+      "description": "Outside_Air_Damper_Position_Sensor => Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Dewpoint_Sensor => Outside_Air_Dewpoint_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Dewpoint_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Dewpoint_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Dewpoint_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Enthalpy_Sensor => Outside_Air_Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Flow_Sensor => Outside_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Grains_Sensor => Outside_Air_Grains_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Grains_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Grains_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Grains_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Humidity_Sensor => Outside_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Lockout_Temperature_Differential_Sensor => Outside_Air_Lockout_Temperature_Differential_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Lockout_Temperature_Differential_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Lockout_Temperature_Differential_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Lockout_Temperature_Differential_Sensor . }"
+    },
+    {
+      "description": "Outside_Air_Lockout_Temperature_Setpoint => Outside_Air_Lockout_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Lockout_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Lockout_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Lockout_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Outside_Air_Temperature_High_Reset_Setpoint => Outside_Air_Temperature_High_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Temperature_High_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Temperature_High_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Temperature_High_Reset_Setpoint . }"
+    },
+    {
+      "description": "Outside_Air_Temperature_Low_Reset_Setpoint => Outside_Air_Temperature_Low_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Temperature_Low_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Outside_Air_Temperature_Low_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Temperature_Low_Reset_Setpoint . }"
+    },
+    {
+      "description": "Outside_Air_Temperature_Sensor => Outside_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Outside_Enthalpy_Sensor => Outside_Air_Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Outside_Air_Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "Outside_Luminance_Sensor => Luminance_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Luminance_Sensor . } INSERT{ ?subject ?predicate brick:Luminance_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Luminance_Sensor . }"
+    },
+    {
+      "description": "Outside_Min_Air_Flow_Setpoint => Min_Outside_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Outside_Min_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Outside_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Outside_Min_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Overridden_Off_Status => Overridden_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Overridden_Off_Status . } INSERT{ ?subject ?predicate brick:Overridden_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Overridden_Off_Status . }"
+    },
+    {
+      "description": "Overridden_On_Status => Overridden_On_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Overridden_On_Status . } INSERT{ ?subject ?predicate brick:Overridden_On_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Overridden_On_Status . }"
+    },
+    {
+      "description": "Overridden_Status => Overridden_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Overridden_Status . } INSERT{ ?subject ?predicate brick:Overridden_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Overridden_Status . }"
+    },
+    {
+      "description": "Override_Command => Override_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Override_Command . } INSERT{ ?subject ?predicate brick:Override_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Override_Command . }"
+    },
+    {
+      "description": "Panel_Lockout_Command => Lockout_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Panel_Lockout_Command . } INSERT{ ?subject ?predicate brick:Lockout_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Panel_Lockout_Command . }"
+    },
+    {
+      "description": "Peak_Power_Demand_Sensor => Peak_Power_Demand_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Peak_Power_Demand_Sensor . } INSERT{ ?subject ?predicate brick:Peak_Power_Demand_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Peak_Power_Demand_Sensor . }"
+    },
+    {
+      "description": "Perimeter_Heating_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Perimeter_Heating_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Perimeter_Heating_Valve_Command . }"
+    },
+    {
+      "description": "Photovoltaic_Current_Output_Sensor => Photovoltaic_Current_Output_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Photovoltaic_Current_Output_Sensor . } INSERT{ ?subject ?predicate brick:Photovoltaic_Current_Output_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Photovoltaic_Current_Output_Sensor . }"
+    },
+    {
+      "description": "Piezoelectric_Sensor => Piezoelectric_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Piezoelectric_Sensor . } INSERT{ ?subject ?predicate brick:Piezoelectric_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Piezoelectric_Sensor . }"
+    },
+    {
+      "description": "PIR_Sensor => PIR_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:PIR_Sensor . } INSERT{ ?subject ?predicate brick:PIR_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:PIR_Sensor . }"
+    },
+    {
+      "description": "Point => Point",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Point . } INSERT{ ?subject ?predicate brick:Point . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Point . }"
+    },
+    {
+      "description": "Position => Position",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Position . } INSERT{ ?subject ?predicate brick:Position . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Position . }"
+    },
+    {
+      "description": "Power => Power",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Power . } INSERT{ ?subject ?predicate brick:Power . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Power . }"
+    },
+    {
+      "description": "Power_Loss_Alarm => Power_Loss_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Power_Loss_Alarm . } INSERT{ ?subject ?predicate brick:Power_Loss_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Power_Loss_Alarm . }"
+    },
+    {
+      "description": "Power_Sensor => Power_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Power_Sensor . } INSERT{ ?subject ?predicate brick:Power_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Power_Sensor . }"
+    },
+    {
+      "description": "Power_System => Power_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Power_System . } INSERT{ ?subject ?predicate brick:Power_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Power_System . }"
+    },
+    {
+      "description": "Power_System_Peak_Power_Demand_Sensor => Peak_Power_Demand_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Power_System_Peak_Power_Demand_Sensor . } INSERT{ ?subject ?predicate brick:Peak_Power_Demand_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Power_System_Peak_Power_Demand_Sensor . }"
+    },
+    {
+      "description": "Pre_Filter_Status => Pre_Filter_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pre_Filter_Status . } INSERT{ ?subject ?predicate brick:Pre_Filter_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pre_Filter_Status . }"
+    },
+    {
+      "description": "Preheat_Coil_Entering_Air_Temperature_Sensor => Entering_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Coil_Entering_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Entering_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Coil_Entering_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Preheat_Coil_Leaving_Water_Temperature_Sensor => Leaving_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Coil_Leaving_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Leaving_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Coil_Leaving_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Preheat_Demand_Setpoint => Preheat_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Preheat_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Demand_Setpoint . }"
+    },
+    {
+      "description": "Preheat_Discharge_Air_Temperature_Sensor => Preheat_Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Preheat_Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Preheat_Hot_Water_Valve => Preheat_Hot_Water_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Hot_Water_Valve . } INSERT{ ?subject ?predicate brick:Preheat_Hot_Water_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Hot_Water_Valve . }"
+    },
+    {
+      "description": "Preheat_Supply_Air_Temperature => Preheat_Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Supply_Air_Temperature . } INSERT{ ?subject ?predicate brick:Preheat_Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Supply_Air_Temperature . }"
+    },
+    {
+      "description": "Preheat_Supply_Air_Temperature_Sensor => Preheat_Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Preheat_Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Preheat_Valve_Command => Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Valve_Command . } INSERT{ ?subject ?predicate brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Valve_Command . }"
+    },
+    {
+      "description": "Preheat_Valve_VFD => Preheat_Valve_VFD",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Preheat_Valve_VFD . } INSERT{ ?subject ?predicate brick:Preheat_Valve_VFD . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Preheat_Valve_VFD . }"
+    },
+    {
+      "description": "Pressure => Pressure",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pressure . } INSERT{ ?subject ?predicate brick:Pressure . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pressure . }"
+    },
+    {
+      "description": "Pressure_Sensor => Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pressure_Sensor . }"
+    },
+    {
+      "description": "Pressure_Setpoint => Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pressure_Setpoint . }"
+    },
+    {
+      "description": "Pressure_Status => Pressure_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pressure_Status . } INSERT{ ?subject ?predicate brick:Pressure_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pressure_Status . }"
+    },
+    {
+      "description": "Proportional_Band_Setpoint => Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Pump => Pump",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump . } INSERT{ ?subject ?predicate brick:Pump . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump . }"
+    },
+    {
+      "description": "Pump_Alarm => Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Alarm . } INSERT{ ?subject ?predicate brick:Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Alarm . }"
+    },
+    {
+      "description": "Pump_Alarm_Delay_Setpoint => Alarm_Delay_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Alarm_Delay_Setpoint . } INSERT{ ?subject ?predicate brick:Alarm_Delay_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Alarm_Delay_Setpoint . }"
+    },
+    {
+      "description": "Pump_Command => Pump_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Command . } INSERT{ ?subject ?predicate brick:Pump_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Command . }"
+    },
+    {
+      "description": "Pump_Enable_Status => Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Enable_Status . } INSERT{ ?subject ?predicate brick:Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Enable_Status . }"
+    },
+    {
+      "description": "Pump_Lead_Lag_Command => Lead_Lag_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Lead_Lag_Command . } INSERT{ ?subject ?predicate brick:Lead_Lag_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Lead_Lag_Command . }"
+    },
+    {
+      "description": "Pump_Lead_Lag_Status => Lead_Lag_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Lead_Lag_Status . } INSERT{ ?subject ?predicate brick:Lead_Lag_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Lead_Lag_Status . }"
+    },
+    {
+      "description": "Pump_Lead_On_Off_Command => Lead_On_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Lead_On_Off_Command . } INSERT{ ?subject ?predicate brick:Lead_On_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Lead_On_Off_Command . }"
+    },
+    {
+      "description": "Pump_Start_Stop => Pump_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Start_Stop . } INSERT{ ?subject ?predicate brick:Pump_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Start_Stop . }"
+    },
+    {
+      "description": "Pump_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Start_Stop_Command . }"
+    },
+    {
+      "description": "Pump_Start_Stop_Status => Pump_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Pump_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Start_Stop_Status . }"
+    },
+    {
+      "description": "Pump_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Pump_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Pump_Status . }"
+    },
+    {
+      "description": "PV_Current_Output => Current_Output_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:PV_Current_Output . } INSERT{ ?subject ?predicate brick:Current_Output_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:PV_Current_Output . }"
+    },
+    {
+      "description": "PV_Current_Output_Sensor => PV_Current_Output_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:PV_Current_Output_Sensor . } INSERT{ ?subject ?predicate brick:PV_Current_Output_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:PV_Current_Output_Sensor . }"
+    },
+    {
+      "description": "Rain_Duration_Sensor => Rain_Duration_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Rain_Duration_Sensor . } INSERT{ ?subject ?predicate brick:Rain_Duration_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Rain_Duration_Sensor . }"
+    },
+    {
+      "description": "Rain_Sensor => Rain_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Rain_Sensor . } INSERT{ ?subject ?predicate brick:Rain_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Rain_Sensor . }"
+    },
+    {
+      "description": "Rated_Speed_Setpoint => Rated_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Rated_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Rated_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Rated_Speed_Setpoint . }"
+    },
+    {
+      "description": "Reheat_Valve => Reheat_Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Reheat_Valve . } INSERT{ ?subject ?predicate brick:Reheat_Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Reheat_Valve . }"
+    },
+    {
+      "description": "Reheat_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Reheat_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Reheat_Valve_Command . }"
+    },
+    {
+      "description": "Relative_Humidity => Relative_Humidity",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Relative_Humidity . } INSERT{ ?subject ?predicate brick:Relative_Humidity . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Relative_Humidity . }"
+    },
+    {
+      "description": "Relative_Humidity_Sensor => Relative_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Relative_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Relative_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Relative_Humidity_Sensor . }"
+    },
+    {
+      "description": "Remotely_On_Off => Remotely_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Remotely_On_Off . } INSERT{ ?subject ?predicate brick:Remotely_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Remotely_On_Off . }"
+    },
+    {
+      "description": "Remotely_On_Off_Status => Remotely_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Remotely_On_Off_Status . } INSERT{ ?subject ?predicate brick:Remotely_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Remotely_On_Off_Status . }"
+    },
+    {
+      "description": "Reset_Command => Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Reset_Command . } INSERT{ ?subject ?predicate brick:Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Reset_Command . }"
+    },
+    {
+      "description": "Reset_Setpoint => Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Reset_Setpoint . }"
+    },
+    {
+      "description": "Return_Air => Return_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air . } INSERT{ ?subject ?predicate brick:Return_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air . }"
+    },
+    {
+      "description": "Return_Air_CO2_Sensor => Return_Air_CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_CO2_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_CO2_Sensor . }"
+    },
+    {
+      "description": "Return_Air_CO2_Setpoint => Return_Air_CO2_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_CO2_Setpoint . } INSERT{ ?subject ?predicate brick:Return_Air_CO2_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_CO2_Setpoint . }"
+    },
+    {
+      "description": "Return_Air_Dewpoint_Sensor => Return_Air_Dewpoint_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Dewpoint_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Dewpoint_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Dewpoint_Sensor . }"
+    },
+    {
+      "description": "Return_Air_Enthalpy_Sensor => Return_Air_Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "Return_Air_Flow => Return_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Flow . } INSERT{ ?subject ?predicate brick:Return_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Flow . }"
+    },
+    {
+      "description": "Return_Air_Flow_Sensor => Return_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Return_Air_Grains_Sensor => Return_Air_Grains_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Grains_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Grains_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Grains_Sensor . }"
+    },
+    {
+      "description": "Return_Air_Humidity_Sensor => Return_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "Return_Air_Preheat_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Preheat_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Preheat_Valve_Command . }"
+    },
+    {
+      "description": "Return_Air_Temperature_High_Limit_Alarm => High_Return_Air_Temperature_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Temperature_High_Limit_Alarm . } INSERT{ ?subject ?predicate brick:High_Return_Air_Temperature_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Temperature_High_Limit_Alarm . }"
+    },
+    {
+      "description": "Return_Air_Temperature_Low_Limit_Alarm => Low_Return_Air_Temperature_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Temperature_Low_Limit_Alarm . } INSERT{ ?subject ?predicate brick:Low_Return_Air_Temperature_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Temperature_Low_Limit_Alarm . }"
+    },
+    {
+      "description": "Return_Air_Temperature_Sensor => Return_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Return_Discharge_Fan_Differential_Speed_Setpoint => Return_Fan_Differential_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Discharge_Fan_Differential_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Return_Fan_Differential_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Discharge_Fan_Differential_Speed_Setpoint . }"
+    },
+    {
+      "description": "Return_Fan => Return_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan . } INSERT{ ?subject ?predicate brick:Return_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan . }"
+    },
+    {
+      "description": "Return_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Return_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Command . }"
+    },
+    {
+      "description": "Return_Fan_Differential_Speed_Sensor => Differential_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Differential_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Differential_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Differential_Speed_Sensor . }"
+    },
+    {
+      "description": "Return_Fan_Differential_Speed_Setpoint => Return_Fan_Differential_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Differential_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Return_Fan_Differential_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Differential_Speed_Setpoint . }"
+    },
+    {
+      "description": "Return_Fan_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Return_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "Return_Fan_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Start_Stop_Status . }"
+    },
+    {
+      "description": "Return_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_Status . }"
+    },
+    {
+      "description": "Return_Fan_VFD_Speed_Command => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_VFD_Speed_Command . }"
+    },
+    {
+      "description": "Return_Fan_VFD_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_VFD_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_VFD_Speed_Sensor . }"
+    },
+    {
+      "description": "Return_Fan_VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "Return_Fan_VFD_Speed_Status => Speed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Fan_VFD_Speed_Status . } INSERT{ ?subject ?predicate brick:Speed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Fan_VFD_Speed_Status . }"
+    },
+    {
+      "description": "Return_Heat_Valve_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Heat_Valve_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Heat_Valve_Command . }"
+    },
+    {
+      "description": "Return_Supply_Fan_Differential_Speed_Setpoint => Return_Fan_Differential_Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Supply_Fan_Differential_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Return_Fan_Differential_Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Supply_Fan_Differential_Speed_Setpoint . }"
+    },
+    {
+      "description": "Return_Water_Temperature_Sensor => Return_Water_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Return_Water_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Return_Water_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Return_Water_Temperature_Sensor . }"
+    },
+    {
+      "description": "Roof => Roof",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Roof . } INSERT{ ?subject ?predicate brick:Roof . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Roof . }"
+    },
+    {
+      "description": "Room => Room",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Room . } INSERT{ ?subject ?predicate brick:Room . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Room . }"
+    },
+    {
+      "description": "Room_Temperature_Sensor => Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Room_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Room_Temperature_Sensor . }"
+    },
+    {
+      "description": "Room_Temperature_Setpoint => Room_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Room_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Room_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Room_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Run_Direction_Command => Direction_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Direction_Command . } INSERT{ ?subject ?predicate brick:Direction_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Direction_Command . }"
+    },
+    {
+      "description": "Run_Direction_Status => Direction_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Direction_Status . } INSERT{ ?subject ?predicate brick:Direction_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Direction_Status . }"
+    },
+    {
+      "description": "Run_Enable_Command => Run_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Enable_Command . } INSERT{ ?subject ?predicate brick:Run_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Enable_Command . }"
+    },
+    {
+      "description": "Run_Enable_Status => Run_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Enable_Status . } INSERT{ ?subject ?predicate brick:Run_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Enable_Status . }"
+    },
+    {
+      "description": "Run_Request_Command => Run_Request_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Request_Command . } INSERT{ ?subject ?predicate brick:Run_Request_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Request_Command . }"
+    },
+    {
+      "description": "Run_Status => Run_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Status . } INSERT{ ?subject ?predicate brick:Run_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Status . }"
+    },
+    {
+      "description": "Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Run_Time_Sensor . }"
+    },
+    {
+      "description": "Running_Hour_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Running_Hour_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Running_Hour_Sensor . }"
+    },
+    {
+      "description": "Schedule_Temperature_Setpoint => Schedule_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Schedule_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Schedule_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Schedule_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Sensor => Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Sensor . } INSERT{ ?subject ?predicate brick:Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Sensor . }"
+    },
+    {
+      "description": "Server_Room => Server_Room",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Server_Room . } INSERT{ ?subject ?predicate brick:Server_Room . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Server_Room . }"
+    },
+    {
+      "description": "Setpoint => Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Setpoint . } INSERT{ ?subject ?predicate brick:Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Setpoint . }"
+    },
+    {
+      "description": "Shading_System => Shading_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Shading_System . } INSERT{ ?subject ?predicate brick:Shading_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Shading_System . }"
+    },
+    {
+      "description": "Short_Cycle_Alarm => Short_Cycle_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Short_Cycle_Alarm . } INSERT{ ?subject ?predicate brick:Short_Cycle_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Short_Cycle_Alarm . }"
+    },
+    {
+      "description": "Shutdown_Command => Shutdown_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Shutdown_Command . } INSERT{ ?subject ?predicate brick:Shutdown_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Shutdown_Command . }"
+    },
+    {
+      "description": "Shutdown_Hot_Water_When_Unoccupied_Command => Unoccupied_Hot_Water_Shutdown_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Shutdown_Hot_Water_When_Unoccupied_Command . } INSERT{ ?subject ?predicate brick:Unoccupied_Hot_Water_Shutdown_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Shutdown_Hot_Water_When_Unoccupied_Command . }"
+    },
+    {
+      "description": "Smoke_Detected_Alarm => Smoke_Detected_Alarm",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Smoke_Detected_Alarm . } INSERT{ ?subject ?predicate brick:Smoke_Detected_Alarm . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Smoke_Detected_Alarm . }"
+    },
+    {
+      "description": "Solar_Azimuth_Angle => Solar_Azimuth_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Azimuth_Angle . } INSERT{ ?subject ?predicate brick:Solar_Azimuth_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Azimuth_Angle . }"
+    },
+    {
+      "description": "Solar_Azimuth_Angle_Sensor => Solar_Azimuth_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Azimuth_Angle_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Azimuth_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Azimuth_Angle_Sensor . }"
+    },
+    {
+      "description": "Solar_Panel => Solar_Panel",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel . } INSERT{ ?subject ?predicate brick:Solar_Panel . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel . }"
+    },
+    {
+      "description": "Solar_Panel_Battery_Voltage_Sensor => Battery_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel_Battery_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Battery_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel_Battery_Voltage_Sensor . }"
+    },
+    {
+      "description": "Solar_Panel_Photovoltaic_Current_Output_Sensor => Photovoltaic_Current_Output_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel_Photovoltaic_Current_Output_Sensor . } INSERT{ ?subject ?predicate brick:Photovoltaic_Current_Output_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel_Photovoltaic_Current_Output_Sensor . }"
+    },
+    {
+      "description": "Solar_Panel_PV_Current_Output_Sensor => PV_Current_Output_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel_PV_Current_Output_Sensor . } INSERT{ ?subject ?predicate brick:PV_Current_Output_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel_PV_Current_Output_Sensor . }"
+    },
+    {
+      "description": "Solar_Panel_Solar_Azimuth_Angle_Sensor => Solar_Azimuth_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel_Solar_Azimuth_Angle_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Azimuth_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel_Solar_Azimuth_Angle_Sensor . }"
+    },
+    {
+      "description": "Solar_Panel_Solar_Zenith_Angle_Sensor => Solar_Zenith_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Panel_Solar_Zenith_Angle_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Zenith_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Panel_Solar_Zenith_Angle_Sensor . }"
+    },
+    {
+      "description": "Solar_Radiance => Solar_Radiance",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Radiance . } INSERT{ ?subject ?predicate brick:Solar_Radiance . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Radiance . }"
+    },
+    {
+      "description": "Solar_Radiance_Sensor => Solar_Radiance_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Radiance_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Radiance_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Radiance_Sensor . }"
+    },
+    {
+      "description": "Solar_Zenith_Angle => Solar_Zenith_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Zenith_Angle . } INSERT{ ?subject ?predicate brick:Solar_Zenith_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Zenith_Angle . }"
+    },
+    {
+      "description": "Solar_Zenith_Angle_Sensor => Solar_Zenith_Angle_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Solar_Zenith_Angle_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Zenith_Angle_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Solar_Zenith_Angle_Sensor . }"
+    },
+    {
+      "description": "Space => Space",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Space . } INSERT{ ?subject ?predicate brick:Space . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Space . }"
+    },
+    {
+      "description": "Space_Heater => Space_Heater",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Space_Heater . } INSERT{ ?subject ?predicate brick:Space_Heater . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Space_Heater . }"
+    },
+    {
+      "description": "Speed => Speed",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Speed . } INSERT{ ?subject ?predicate brick:Speed . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Speed . }"
+    },
+    {
+      "description": "Speed_Reset_Command => Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Speed_Reset_Command . } INSERT{ ?subject ?predicate brick:Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Speed_Reset_Command . }"
+    },
+    {
+      "description": "Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Speed_Sensor . }"
+    },
+    {
+      "description": "Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Speed_Setpoint . }"
+    },
+    {
+      "description": "Stages_Status => Stages_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Stages_Status . } INSERT{ ?subject ?predicate brick:Stages_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Stages_Status . }"
+    },
+    {
+      "description": "Standby_Fan => Standby_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Fan . } INSERT{ ?subject ?predicate brick:Standby_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Fan . }"
+    },
+    {
+      "description": "Standby_Fan_Status => Fan_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Fan_Status . } INSERT{ ?subject ?predicate brick:Fan_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Fan_Status . }"
+    },
+    {
+      "description": "Standby_Glycool_Unit_On_Off => Standby_Glycool_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Glycool_Unit_On_Off . } INSERT{ ?subject ?predicate brick:Standby_Glycool_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Glycool_Unit_On_Off . }"
+    },
+    {
+      "description": "Standby_Glycool_Unit_On_Off_Status => Standby_Glycool_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Glycool_Unit_On_Off_Status . } INSERT{ ?subject ?predicate brick:Standby_Glycool_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Glycool_Unit_On_Off_Status . }"
+    },
+    {
+      "description": "Standby_Load_Shed => Standby_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Load_Shed . } INSERT{ ?subject ?predicate brick:Standby_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Load_Shed . }"
+    },
+    {
+      "description": "Standby_Load_Shed_Command => Standby_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Standby_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Load_Shed_Command . }"
+    },
+    {
+      "description": "Standby_Unit_On_Off => Standby_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Unit_On_Off . } INSERT{ ?subject ?predicate brick:Standby_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Unit_On_Off . }"
+    },
+    {
+      "description": "Standby_Unit_On_Off_Status => Standby_Unit_On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Standby_Unit_On_Off_Status . } INSERT{ ?subject ?predicate brick:Standby_Unit_On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Standby_Unit_On_Off_Status . }"
+    },
+    {
+      "description": "Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Start_Stop_Command . }"
+    },
+    {
+      "description": "Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Start_Stop_Status . }"
+    },
+    {
+      "description": "Static_Pressure => Static_Pressure",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Static_Pressure . } INSERT{ ?subject ?predicate brick:Static_Pressure . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Static_Pressure . }"
+    },
+    {
+      "description": "Static_Pressure_Max_Setpoint => Max_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Static_Pressure_Max_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Static_Pressure_Max_Setpoint . }"
+    },
+    {
+      "description": "Static_Pressure_Min_Setpoint => Min_Static_Pressure_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Static_Pressure_Min_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Static_Pressure_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Static_Pressure_Min_Setpoint . }"
+    },
+    {
+      "description": "Static_Pressure_Sensor => Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Static_Pressure_Setpoint => Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Status . }"
+    },
+    {
+      "description": "Steam => Steam",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Steam . } INSERT{ ?subject ?predicate brick:Steam . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Steam . }"
+    },
+    {
+      "description": "Steam_On_Off => Steam_On_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Steam_On_Off . } INSERT{ ?subject ?predicate brick:Steam_On_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Steam_On_Off . }"
+    },
+    {
+      "description": "Steam_On_Off_Command => Steam_On_Off_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Steam_On_Off_Command . } INSERT{ ?subject ?predicate brick:Steam_On_Off_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Steam_On_Off_Command . }"
+    },
+    {
+      "description": "Steam_System => Steam_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Steam_System . } INSERT{ ?subject ?predicate brick:Steam_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Steam_System . }"
+    },
+    {
+      "description": "Steam_Usage_Sensor => Steam_Usage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Steam_Usage_Sensor . } INSERT{ ?subject ?predicate brick:Steam_Usage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Steam_Usage_Sensor . }"
+    },
+    {
+      "description": "Supply_Air => Supply_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air . } INSERT{ ?subject ?predicate brick:Supply_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air . }"
+    },
+    {
+      "description": "Supply_Air_Duct_Pressure_Status => Supply_Air_Duct_Pressure_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Duct_Pressure_Status . } INSERT{ ?subject ?predicate brick:Supply_Air_Duct_Pressure_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Duct_Pressure_Status . }"
+    },
+    {
+      "description": "Supply_Air_Flow => Flow + Supply_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Flow . } INSERT{ ?subject ?predicate brick:Flow, brick:Supply_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Flow . }"
+    },
+    {
+      "description": "Supply_Air_Flow_Demand_Setpoint => Supply_Air_Flow_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Flow_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Flow_Demand_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Flow_Sensor => Supply_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Supply_Air_Flow_Setpoint => Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Humidity_Sensor => Supply_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Humidity_Sensor . }"
+    },
+    {
+      "description": "Supply_Air_Integrative_Gain_Factor => Integral_Gain_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Integrative_Gain_Factor . } INSERT{ ?subject ?predicate brick:Integral_Gain_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Integrative_Gain_Factor . }"
+    },
+    {
+      "description": "Supply_Air_Proportional_Gain_Factor => Proportional_Gain_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Proportional_Gain_Factor . } INSERT{ ?subject ?predicate brick:Proportional_Gain_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Proportional_Gain_Factor . }"
+    },
+    {
+      "description": "Supply_Air_Static_Pressure_Dead_Band_Setpoint => Supply_Air_Static_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Static_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Static_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Static_Pressure_Proportional_Band => Supply_Air_Static_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Static_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Static_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Supply_Air_Static_Pressure_Sensor => Supply_Air_Static_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Static_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Static_Pressure_Sensor . }"
+    },
+    {
+      "description": "Supply_Air_Static_Pressure_Setpoint => Supply_Air_Static_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Static_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Static_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Static_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Temperature => Temperature + Supply_Air",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature . } INSERT{ ?subject ?predicate brick:Temperature, brick:Supply_Air . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature . }"
+    },
+    {
+      "description": "Supply_Air_Temperature_Reset_Differential_Setpoint => Supply_Air_Temperature_Reset_Differential_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature_Reset_Differential_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Reset_Differential_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature_Reset_Differential_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Temperature_Reset_High_Setpoint => Supply_Air_Temperature_Reset_High_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature_Reset_High_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Reset_High_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature_Reset_High_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Temperature_Reset_Low_Setpoint => Supply_Air_Temperature_Reset_Low_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature_Reset_Low_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Reset_Low_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature_Reset_Low_Setpoint . }"
+    },
+    {
+      "description": "Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Supply_Air_Temperature_Setpoint_Increase_Decrease_Step => Supply_Air_Temperature_Step_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Temperature_Setpoint_Increase_Decrease_Step . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Step_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Temperature_Setpoint_Increase_Decrease_Step . }"
+    },
+    {
+      "description": "Supply_Air_Velocity_Pressure_Sensor => Supply_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "Supply_Fan => Supply_Fan",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan . } INSERT{ ?subject ?predicate brick:Supply_Fan . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan . }"
+    },
+    {
+      "description": "Supply_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "Supply_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_Command . }"
+    },
+    {
+      "description": "Supply_Fan_Fan_Speed_Reset_Command => Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_Fan_Speed_Reset_Command . } INSERT{ ?subject ?predicate brick:Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_Fan_Speed_Reset_Command . }"
+    },
+    {
+      "description": "Supply_Fan_Piezoelectric_Sensor => Piezoelectric_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_Piezoelectric_Sensor . } INSERT{ ?subject ?predicate brick:Piezoelectric_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_Piezoelectric_Sensor . }"
+    },
+    {
+      "description": "Supply_Fan_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_Status . }"
+    },
+    {
+      "description": "Supply_Fan_VFD_Speed_Command => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_VFD_Speed_Command . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_VFD_Speed_Command . }"
+    },
+    {
+      "description": "Supply_Fan_VFD_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_VFD_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_VFD_Speed_Sensor . }"
+    },
+    {
+      "description": "Supply_Fan_VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "Supply_Fan_VFD_Speed_Status => Speed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Fan_VFD_Speed_Status . } INSERT{ ?subject ?predicate brick:Speed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Fan_VFD_Speed_Status . }"
+    },
+    {
+      "description": "Supply_Water_Differential_Pressure_Proportional_Band => Supply_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Water_Differential_Pressure_Proportional_Band . } INSERT{ ?subject ?predicate brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Water_Differential_Pressure_Proportional_Band . }"
+    },
+    {
+      "description": "Supply_Water_Differential_Pressure_Proportional_Band_Setpoint => Supply_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Water_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Water_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Supply_Water_Flow_Sensor => Supply_Water_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Water_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Water_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Water_Flow_Sensor . }"
+    },
+    {
+      "description": "Supply_Water_Temperature_Proportional_Band_Setpoint => Supply_Water_Temperature_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Water_Temperature_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Water_Temperature_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Supply_Water_Temperature_Setpoint => Supply_Water_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Supply_Water_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Supply_Water_Temperature_Setpoint . }"
+    },
+    {
+      "description": "System_Enable_Command => System_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Enable_Command . } INSERT{ ?subject ?predicate brick:System_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Enable_Command . }"
+    },
+    {
+      "description": "System_Mode => Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Mode . } INSERT{ ?subject ?predicate brick:Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Mode . }"
+    },
+    {
+      "description": "System_Mode_Status => System_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Mode_Status . } INSERT{ ?subject ?predicate brick:System_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Mode_Status . }"
+    },
+    {
+      "description": "System_Shutdown_Command => Shutdown_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Shutdown_Command . } INSERT{ ?subject ?predicate brick:Shutdown_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Shutdown_Command . }"
+    },
+    {
+      "description": "System_Shutdown_Status => System_Shutdown_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Shutdown_Status . } INSERT{ ?subject ?predicate brick:System_Shutdown_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Shutdown_Status . }"
+    },
+    {
+      "description": "System_Status => System_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:System_Status . } INSERT{ ?subject ?predicate brick:System_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:System_Status . }"
+    },
+    {
+      "description": "Temperature => Temperature",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature . } INSERT{ ?subject ?predicate brick:Temperature . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature . }"
+    },
+    {
+      "description": "Temperature_High_Reset_Setpoint => Temperature_High_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature_High_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_High_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature_High_Reset_Setpoint . }"
+    },
+    {
+      "description": "Temperature_Low_Reset_Setpoint => Temperature_Low_Reset_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature_Low_Reset_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_Low_Reset_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature_Low_Reset_Setpoint . }"
+    },
+    {
+      "description": "Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature_Sensor . }"
+    },
+    {
+      "description": "Temperature_Setpoint => Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature_Setpoint . }"
+    },
+    {
+      "description": "Temperature_Tolerance_Setpoint => Temperature_Tolerance_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Temperature_Tolerance_Setpoint . } INSERT{ ?subject ?predicate brick:Temperature_Tolerance_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Temperature_Tolerance_Setpoint . }"
+    },
+    {
+      "description": "Terminal_Unit => Terminal_Unit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Terminal_Unit . } INSERT{ ?subject ?predicate brick:Terminal_Unit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Terminal_Unit . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Dead_Band_Setpoint => Discharge_Water_Differential_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Integral_Time_Setpoint => Discharge_Water_Differential_Pressure_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Water_Differential_Pressure_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Proportional_Band_Setpoint => Discharge_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Dead_Band_Setpoint => Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Dead_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Dead_Band_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Integral_Time_Setpoint => Supply_Water_Differential_Pressure_Integral_Time_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Integral_Time_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Integral_Time_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Proportional_Band_Setpoint => Supply_Water_Differential_Pressure_Proportional_Band_Parameter",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Proportional_Band_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Proportional_Band_Setpoint . }"
+    },
+    {
+      "description": "Thermal_Power_Sensor => Thermal_Power_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermal_Power_Sensor . } INSERT{ ?subject ?predicate brick:Thermal_Power_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermal_Power_Sensor . }"
+    },
+    {
+      "description": "Thermostat => Thermostat",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermostat . } INSERT{ ?subject ?predicate brick:Thermostat . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermostat . }"
+    },
+    {
+      "description": "Thermostat_Adjust_Sensor => Temperature_Adjust_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thermostat_Adjust_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Adjust_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thermostat_Adjust_Sensor . }"
+    },
+    {
+      "description": "Thumbwheel_Temperature_High_Limit_Setpoint => Max_Temperature_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thumbwheel_Temperature_High_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Temperature_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thumbwheel_Temperature_High_Limit_Setpoint . }"
+    },
+    {
+      "description": "Thumbwheel_Temperature_Low_Limit_Setpoint => Min_Temperature_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Thumbwheel_Temperature_Low_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Temperature_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Thumbwheel_Temperature_Low_Limit_Setpoint . }"
+    },
+    {
+      "description": "Time => Time",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Time . } INSERT{ ?subject ?predicate brick:Time . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Time . }"
+    },
+    {
+      "description": "Torque => Torque",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Torque . } INSERT{ ?subject ?predicate brick:Torque . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Torque . }"
+    },
+    {
+      "description": "Torque_Sensor => Torque_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Torque_Sensor . } INSERT{ ?subject ?predicate brick:Torque_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Torque_Sensor . }"
+    },
+    {
+      "description": "Trace_Heat_Sensor => Trace_Heat_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Trace_Heat_Sensor . } INSERT{ ?subject ?predicate brick:Trace_Heat_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Trace_Heat_Sensor . }"
+    },
+    {
+      "description": "Turn_Off_Status => Turn_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Turn_Off_Status . } INSERT{ ?subject ?predicate brick:Turn_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Turn_Off_Status . }"
+    },
+    {
+      "description": "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint => Unoccupied_Cooling_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "Unoccupied_Cooling_Temperature_Setpoint => Unoccupied_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Cooling_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Unoccupied_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Cooling_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Unoccupied_Heating_Temperature_Setpoint => Unoccupied_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Heating_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Unoccupied_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Heating_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Unoccupied_Load_Shed => Unoccupied_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Load_Shed . } INSERT{ ?subject ?predicate brick:Unoccupied_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Load_Shed . }"
+    },
+    {
+      "description": "Unoccupied_Load_Shed_Command => Unoccupied_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Unoccupied_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Load_Shed_Command . }"
+    },
+    {
+      "description": "Unoccupied_Mode_Setpoint => Unoccupied_Mode_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Unoccupied_Mode_Setpoint . } INSERT{ ?subject ?predicate brick:Unoccupied_Mode_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Unoccupied_Mode_Setpoint . }"
+    },
+    {
+      "description": "Valve => Valve",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Valve . } INSERT{ ?subject ?predicate brick:Valve . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Valve . }"
+    },
+    {
+      "description": "Valve_Command => Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Valve_Command . } INSERT{ ?subject ?predicate brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Valve_Command . }"
+    },
+    {
+      "description": "Valve_Pressure_Sensor => Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Valve_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Valve_Pressure_Sensor . }"
+    },
+    {
+      "description": "Valve_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Valve_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Valve_Status . }"
+    },
+    {
+      "description": "Variable_Air_Volume => Variable_Air_Volume_Box",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Variable_Air_Volume . } INSERT{ ?subject ?predicate brick:Variable_Air_Volume_Box . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Variable_Air_Volume . }"
+    },
+    {
+      "description": "Variable_Frequency_Drive => Variable_Frequency_Drive",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Variable_Frequency_Drive . } INSERT{ ?subject ?predicate brick:Variable_Frequency_Drive . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Variable_Frequency_Drive . }"
+    },
+    {
+      "description": "VAV => VAV",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV . } INSERT{ ?subject ?predicate brick:VAV . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV . }"
+    },
+    {
+      "description": "VAV_Booster_Fan_Air_Flow_Sensor => Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Booster_Fan_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Booster_Fan_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "VAV_Booster_Fan_Air_Flow_Setpoint => Fan_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Booster_Fan_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Fan_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Booster_Fan_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Booster_Fan_Command => Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Booster_Fan_Command . } INSERT{ ?subject ?predicate brick:Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Booster_Fan_Command . }"
+    },
+    {
+      "description": "VAV_Booster_Fan_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Booster_Fan_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Booster_Fan_Start_Stop_Command . }"
+    },
+    {
+      "description": "VAV_Box_Mode_Command => Box_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Box_Mode_Command . } INSERT{ ?subject ?predicate brick:Box_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Box_Mode_Command . }"
+    },
+    {
+      "description": "VAV_Box_Operating_Mode_Status => Operating_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Box_Operating_Mode_Status . } INSERT{ ?subject ?predicate brick:Operating_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Box_Operating_Mode_Status . }"
+    },
+    {
+      "description": "VAV_CO2_Level_Sensor => CO2_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_CO2_Level_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_CO2_Level_Sensor . }"
+    },
+    {
+      "description": "VAV_CO2_Sensor => CO2_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_CO2_Sensor . } INSERT{ ?subject ?predicate brick:CO2_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_CO2_Sensor . }"
+    },
+    {
+      "description": "VAV_Cooling_Command => Cooling_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Command . } INSERT{ ?subject ?predicate brick:Cooling_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Command . }"
+    },
+    {
+      "description": "VAV_Cooling_Demand_Setpoint => Cooling_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Demand_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Max_Discharge_Air_Flow_Setpoint => Max_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Max_Supply_Air_Flow_Setpoint => Max_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Min_Discharge_Air_Flow_Setpoint => Min_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Min_Supply_Air_Flow_Setpoint => Min_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Request_Setpoint => Cooling_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Cooling_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Request_Setpoint . }"
+    },
+    {
+      "description": "VAV_Cooling_Valve_Command => Cooling_Command + Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Cooling_Valve_Command . } INSERT{ ?subject ?predicate brick:Cooling_Command, brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Cooling_Valve_Command . }"
+    },
+    {
+      "description": "VAV_Damper_Command => Damper_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Damper_Command . } INSERT{ ?subject ?predicate brick:Damper_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Damper_Command . }"
+    },
+    {
+      "description": "VAV_Damper_Position_Sensor => Damper_Position_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Damper_Position_Sensor . } INSERT{ ?subject ?predicate brick:Damper_Position_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Damper_Position_Sensor . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Duct_Pressure_Status => Discharge_Air_Duct_Pressure_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Duct_Pressure_Status . } INSERT{ ?subject ?predicate brick:Discharge_Air_Duct_Pressure_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Duct_Pressure_Status . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Flow_Sensor => Discharge_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Flow_Setpoint => Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Temperature_Cooling_Setpoint => Discharge_Air_Temperature_Cooling_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Temperature_Cooling_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Cooling_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Temperature_Cooling_Setpoint . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Temperature_Heating_Setpoint => Discharge_Air_Temperature_Heating_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Temperature_Heating_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Heating_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Temperature_Heating_Setpoint . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Temperature_Sensor => Discharge_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Temperature_Setpoint => Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "VAV_Discharge_Air_Velocity_Pressure_Sensor => Discharge_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Discharge_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Discharge_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Discharge_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "VAV_Heating_Command => Heating_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Command . } INSERT{ ?subject ?predicate brick:Heating_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Command . }"
+    },
+    {
+      "description": "VAV_Heating_Demand_Setpoint => Heating_Demand_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Demand_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Demand_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Demand_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Discharge_Air_Flow_Setpoint => Heating_Discharge_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Discharge_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Max_Discharge_Air_Flow_Setpoint => Max_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Max_Supply_Air_Flow_Setpoint => Max_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Min_Discharge_Air_Flow_Setpoint => Min_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Min_Supply_Air_Flow_Setpoint => Min_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Request_Setpoint => Heating_Request_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Request_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Request_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Request_Setpoint . }"
+    },
+    {
+      "description": "VAV_Heating_Supply_Air_Flow_Setpoint => Heating_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Heating_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Heating_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Heating_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_High_Static_Pressure_Cutout_Limit_Setpoint => High_Static_Pressure_Cutout_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_High_Static_Pressure_Cutout_Limit_Setpoint . } INSERT{ ?subject ?predicate brick:High_Static_Pressure_Cutout_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_High_Static_Pressure_Cutout_Limit_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupancy_Sensor => Occupancy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupancy_Sensor . } INSERT{ ?subject ?predicate brick:Occupancy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupancy_Sensor . }"
+    },
+    {
+      "description": "VAV_Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint => Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Cooling_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Cooling_Max_Supply_Air_Flow_Setpoint => Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Cooling_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Cooling_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint => Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Cooling_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Cooling_Min_Supply_Air_Flow_Setpoint => Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Cooling_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Cooling_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Cooling_Supply_Air_Flow_Setpoint => Occupied_Cooling_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Cooling_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Cooling_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Cooling_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Heating_Max_Discharge_Air_Flow_Setpoint => Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Heating_Max_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Heating_Max_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Heating_Max_Supply_Air_Flow_Setpoint => Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Heating_Max_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Heating_Max_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Heating_Min_Discharge_Air_Flow_Setpoint => Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Heating_Min_Discharge_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Heating_Min_Discharge_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Heating_Min_Supply_Air_Flow_Setpoint => Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Heating_Min_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Heating_Min_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Occupied_Heating_Supply_Air_Flow_Setpoint => Occupied_Heating_Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Occupied_Heating_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Occupied_Heating_Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Occupied_Heating_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Reheat_Valve_Command => Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Reheat_Valve_Command . } INSERT{ ?subject ?predicate brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Reheat_Valve_Command . }"
+    },
+    {
+      "description": "VAV_Return_Air_Temperature_Sensor => Return_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Return_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Return_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Return_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "VAV_Room_Temperature_Setpoint => Room_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Room_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Room_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Room_Temperature_Setpoint . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Duct_Pressure_Status => Supply_Air_Duct_Pressure_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Duct_Pressure_Status . } INSERT{ ?subject ?predicate brick:Supply_Air_Duct_Pressure_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Duct_Pressure_Status . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Flow_Sensor => Supply_Air_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Flow_Sensor . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Flow_Setpoint => Supply_Air_Flow_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Flow_Setpoint . } INSERT{ ?subject ?predicate brick:Supply_Air_Flow_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Flow_Setpoint . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Temperature_Sensor => Supply_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Temperature_Setpoint => Discharge_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Discharge_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Temperature_Setpoint . }"
+    },
+    {
+      "description": "VAV_Supply_Air_Velocity_Pressure_Sensor => Supply_Air_Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Supply_Air_Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Supply_Air_Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Supply_Air_Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "VAV_Vent_Operating_Mode_Status => Vent_Operating_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Vent_Operating_Mode_Status . } INSERT{ ?subject ?predicate brick:Vent_Operating_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Vent_Operating_Mode_Status . }"
+    },
+    {
+      "description": "VAV_Zone_Air_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Zone_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Zone_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "VAV_Zone_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "VAV_Zone_Temperature_Setpoint => Zone_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VAV_Zone_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VAV_Zone_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Velocity_Pressure => Velocity_Pressure",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Velocity_Pressure . } INSERT{ ?subject ?predicate brick:Velocity_Pressure . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Velocity_Pressure . }"
+    },
+    {
+      "description": "Velocity_Pressure_Sensor => Velocity_Pressure_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Velocity_Pressure_Sensor . } INSERT{ ?subject ?predicate brick:Velocity_Pressure_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Velocity_Pressure_Sensor . }"
+    },
+    {
+      "description": "Velocity_Pressure_Setpoint => Velocity_Pressure_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Velocity_Pressure_Setpoint . } INSERT{ ?subject ?predicate brick:Velocity_Pressure_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Velocity_Pressure_Setpoint . }"
+    },
+    {
+      "description": "Vent_Operating_Mode => Vent_Operating_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Vent_Operating_Mode . } INSERT{ ?subject ?predicate brick:Vent_Operating_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Vent_Operating_Mode . }"
+    },
+    {
+      "description": "Vent_Operating_Mode_Status => Vent_Operating_Mode_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Vent_Operating_Mode_Status . } INSERT{ ?subject ?predicate brick:Vent_Operating_Mode_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Vent_Operating_Mode_Status . }"
+    },
+    {
+      "description": "VFD => VFD",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD . } INSERT{ ?subject ?predicate brick:VFD . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD . }"
+    },
+    {
+      "description": "VFD_Cooling_Valve_Command => Cooling_Command + Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Cooling_Valve_Command . } INSERT{ ?subject ?predicate brick:Cooling_Command, brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Cooling_Valve_Command . }"
+    },
+    {
+      "description": "VFD_Current_Sensor => Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Current_Sensor . } INSERT{ ?subject ?predicate brick:Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Current_Sensor . }"
+    },
+    {
+      "description": "VFD_DC_Bus_Voltage_Sensor => DC_Bus_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_DC_Bus_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:DC_Bus_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_DC_Bus_Voltage_Sensor . }"
+    },
+    {
+      "description": "VFD_Drive_Ready_Status => Drive_Ready_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Drive_Ready_Status . } INSERT{ ?subject ?predicate brick:Drive_Ready_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Drive_Ready_Status . }"
+    },
+    {
+      "description": "VFD_Enable_Command => VFD_Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Enable_Command . } INSERT{ ?subject ?predicate brick:VFD_Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Enable_Command . }"
+    },
+    {
+      "description": "VFD_Energy_Sensor => Energy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Energy_Sensor . } INSERT{ ?subject ?predicate brick:Energy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Energy_Sensor . }"
+    },
+    {
+      "description": "VFD_Fault_Indicator_Status => Fault_Indicator_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Fault_Indicator_Status . } INSERT{ ?subject ?predicate brick:Fault_Indicator_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Fault_Indicator_Status . }"
+    },
+    {
+      "description": "VFD_Fault_Reset_Command => Fault_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Fault_Reset_Command . } INSERT{ ?subject ?predicate brick:Fault_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Fault_Reset_Command . }"
+    },
+    {
+      "description": "VFD_Fault_Status => Fault_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Fault_Status . } INSERT{ ?subject ?predicate brick:Fault_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Fault_Status . }"
+    },
+    {
+      "description": "VFD_Filter_Reset_Command => Filter_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Filter_Reset_Command . } INSERT{ ?subject ?predicate brick:Filter_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Filter_Reset_Command . }"
+    },
+    {
+      "description": "VFD_Frequency_Command => Frequency_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Frequency_Command . } INSERT{ ?subject ?predicate brick:Frequency_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Frequency_Command . }"
+    },
+    {
+      "description": "VFD_Hand_Auto_Status => Hand_Auto_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Hand_Auto_Status . } INSERT{ ?subject ?predicate brick:Hand_Auto_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Hand_Auto_Status . }"
+    },
+    {
+      "description": "VFD_Last_Fault_Code_Status => Last_Fault_Code_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Last_Fault_Code_Status . } INSERT{ ?subject ?predicate brick:Last_Fault_Code_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Last_Fault_Code_Status . }"
+    },
+    {
+      "description": "VFD_Load_Current_Sensor => Load_Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Load_Current_Sensor . } INSERT{ ?subject ?predicate brick:Load_Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Load_Current_Sensor . }"
+    },
+    {
+      "description": "VFD_Maintenance_Mode_Command => Maintenance_Mode_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Maintenance_Mode_Command . } INSERT{ ?subject ?predicate brick:Maintenance_Mode_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Maintenance_Mode_Command . }"
+    },
+    {
+      "description": "VFD_Manual_Auto_Status => Manual_Auto_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Manual_Auto_Status . } INSERT{ ?subject ?predicate brick:Manual_Auto_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Manual_Auto_Status . }"
+    },
+    {
+      "description": "VFD_Motor_Current_Sensor => Motor_Current_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Motor_Current_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Current_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Motor_Current_Sensor . }"
+    },
+    {
+      "description": "VFD_Motor_Direction_Status => Motor_Direction_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Motor_Direction_Status . } INSERT{ ?subject ?predicate brick:Motor_Direction_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Motor_Direction_Status . }"
+    },
+    {
+      "description": "VFD_Motor_Speed_Sensor => Motor_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Motor_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Motor_Speed_Sensor . }"
+    },
+    {
+      "description": "VFD_Motor_Start_Stop_Status => Motor_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Motor_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Motor_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Motor_Start_Stop_Status . }"
+    },
+    {
+      "description": "VFD_Motor_Torque_Sensor => Motor_Torque_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Motor_Torque_Sensor . } INSERT{ ?subject ?predicate brick:Motor_Torque_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Motor_Torque_Sensor . }"
+    },
+    {
+      "description": "VFD_On_Off_Status => On_Off_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_On_Off_Status . } INSERT{ ?subject ?predicate brick:On_Off_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_On_Off_Status . }"
+    },
+    {
+      "description": "VFD_On_Timer_Sensor => On_Timer_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_On_Timer_Sensor . } INSERT{ ?subject ?predicate brick:On_Timer_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_On_Timer_Sensor . }"
+    },
+    {
+      "description": "VFD_Output_Frequency_Sensor => Output_Frequency_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Output_Frequency_Sensor . } INSERT{ ?subject ?predicate brick:Output_Frequency_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Output_Frequency_Sensor . }"
+    },
+    {
+      "description": "VFD_Output_Voltage_Sensor => Output_Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Output_Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Output_Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Output_Voltage_Sensor . }"
+    },
+    {
+      "description": "VFD_Run_Direction_Status => Direction_Status + Run_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Run_Direction_Status . } INSERT{ ?subject ?predicate brick:Direction_Status, brick:Run_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Run_Direction_Status . }"
+    },
+    {
+      "description": "VFD_Run_Enable_Command => Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Run_Enable_Command . } INSERT{ ?subject ?predicate brick:Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Run_Enable_Command . }"
+    },
+    {
+      "description": "VFD_Run_Enable_Status => Run_Enable_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Run_Enable_Status . } INSERT{ ?subject ?predicate brick:Run_Enable_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Run_Enable_Status . }"
+    },
+    {
+      "description": "VFD_Run_Status => Run_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Run_Status . } INSERT{ ?subject ?predicate brick:Run_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Run_Status . }"
+    },
+    {
+      "description": "VFD_Run_Time_Sensor => Run_Time_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Run_Time_Sensor . } INSERT{ ?subject ?predicate brick:Run_Time_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Run_Time_Sensor . }"
+    },
+    {
+      "description": "VFD_Speed_Reset_Command => Speed_Reset_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Speed_Reset_Command . } INSERT{ ?subject ?predicate brick:Speed_Reset_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Speed_Reset_Command . }"
+    },
+    {
+      "description": "VFD_Speed_Sensor => Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Speed_Sensor . }"
+    },
+    {
+      "description": "VFD_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Speed_Setpoint . }"
+    },
+    {
+      "description": "VFD_Speed_Status => Speed_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Speed_Status . } INSERT{ ?subject ?predicate brick:Speed_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Speed_Status . }"
+    },
+    {
+      "description": "VFD_Start_Stop_Command => Start_Stop_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Start_Stop_Command . } INSERT{ ?subject ?predicate brick:Start_Stop_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Start_Stop_Command . }"
+    },
+    {
+      "description": "VFD_Start_Stop_Status => Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Start_Stop_Status . }"
+    },
+    {
+      "description": "VFD_Status => Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_Status . } INSERT{ ?subject ?predicate brick:Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_Status . }"
+    },
+    {
+      "description": "VFD_System_Enable_Command => Enable_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:VFD_System_Enable_Command . } INSERT{ ?subject ?predicate brick:Enable_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:VFD_System_Enable_Command . }"
+    },
+    {
+      "description": "Voltage => Voltage",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Voltage . } INSERT{ ?subject ?predicate brick:Voltage . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Voltage . }"
+    },
+    {
+      "description": "Voltage_Sensor => Voltage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Voltage_Sensor . } INSERT{ ?subject ?predicate brick:Voltage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Voltage_Sensor . }"
+    },
+    {
+      "description": "Warm_Cool_Adjust_Sensor => Warm_Cool_Adjust_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Warm_Cool_Adjust_Sensor . } INSERT{ ?subject ?predicate brick:Warm_Cool_Adjust_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Warm_Cool_Adjust_Sensor . }"
+    },
+    {
+      "description": "Warmest_Zone_Temperature_Sensor => Warmest_Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Warmest_Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Warmest_Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Warmest_Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Water => Water",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water . } INSERT{ ?subject ?predicate brick:Water . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water . }"
+    },
+    {
+      "description": "Water_Flow => Flow",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Flow . } INSERT{ ?subject ?predicate brick:Flow . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Flow . }"
+    },
+    {
+      "description": "Water_Flow_Sensor => Water_Flow_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Flow_Sensor . } INSERT{ ?subject ?predicate brick:Water_Flow_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Flow_Sensor . }"
+    },
+    {
+      "description": "Water_Level_Sensor => Water_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Level_Sensor . } INSERT{ ?subject ?predicate brick:Water_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Level_Sensor . }"
+    },
+    {
+      "description": "Water_Meter => Water_Usage_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Meter . } INSERT{ ?subject ?predicate brick:Water_Usage_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Meter . }"
+    },
+    {
+      "description": "Water_Supply_Temperature => Temperature",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Supply_Temperature . } INSERT{ ?subject ?predicate brick:Temperature . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Supply_Temperature . }"
+    },
+    {
+      "description": "Water_Supply_Temperature_Sensor => Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_Supply_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_Supply_Temperature_Sensor . }"
+    },
+    {
+      "description": "Water_System => Water_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System . } INSERT{ ?subject ?predicate brick:Water_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System . }"
+    },
+    {
+      "description": "Water_System_Cooling_Tower_Fan_Speed_Setpoint => Speed_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Cooling_Tower_Fan_Speed_Setpoint . } INSERT{ ?subject ?predicate brick:Speed_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Cooling_Tower_Fan_Speed_Setpoint . }"
+    },
+    {
+      "description": "Water_System_Deionised_Water_Conductivity_Sensor => Deionised_Water_Conductivity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Deionised_Water_Conductivity_Sensor . } INSERT{ ?subject ?predicate brick:Deionised_Water_Conductivity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Deionised_Water_Conductivity_Sensor . }"
+    },
+    {
+      "description": "Water_System_Deionised_Water_Level_Sensor => Deionised_Water_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Deionised_Water_Level_Sensor . } INSERT{ ?subject ?predicate brick:Deionised_Water_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Deionised_Water_Level_Sensor . }"
+    },
+    {
+      "description": "Water_System_DI_Water_Level_Sensor => Deionised_Water_Level_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_DI_Water_Level_Sensor . } INSERT{ ?subject ?predicate brick:Deionised_Water_Level_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_DI_Water_Level_Sensor . }"
+    },
+    {
+      "description": "Water_System_Freeze_Status => Freeze_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Freeze_Status . } INSERT{ ?subject ?predicate brick:Freeze_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Freeze_Status . }"
+    },
+    {
+      "description": "Water_System_Pump_Start_Stop_Status => Pump_Start_Stop_Status",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Pump_Start_Stop_Status . } INSERT{ ?subject ?predicate brick:Pump_Start_Stop_Status . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Pump_Start_Stop_Status . }"
+    },
+    {
+      "description": "Water_System_Valve_Command => Valve_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Water_System_Valve_Command . } INSERT{ ?subject ?predicate brick:Valve_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Water_System_Valve_Command . }"
+    },
+    {
+      "description": "Weather => Weather",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather . } INSERT{ ?subject ?predicate brick:Weather . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather . }"
+    },
+    {
+      "description": "Weather_Hail_Sensor => Hail_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Hail_Sensor . } INSERT{ ?subject ?predicate brick:Hail_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Hail_Sensor . }"
+    },
+    {
+      "description": "Weather_Outside_Enthalpy_Sensor => Enthalpy_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Outside_Enthalpy_Sensor . } INSERT{ ?subject ?predicate brick:Enthalpy_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Outside_Enthalpy_Sensor . }"
+    },
+    {
+      "description": "Weather_Rain_Duration_Sensor => Rain_Duration_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Rain_Duration_Sensor . } INSERT{ ?subject ?predicate brick:Rain_Duration_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Rain_Duration_Sensor . }"
+    },
+    {
+      "description": "Weather_Rain_Sensor => Rain_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Rain_Sensor . } INSERT{ ?subject ?predicate brick:Rain_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Rain_Sensor . }"
+    },
+    {
+      "description": "Weather_Relative_Humidity_Sensor => Relative_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Relative_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Relative_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Relative_Humidity_Sensor . }"
+    },
+    {
+      "description": "Weather_Solar_Radiance_Sensor => Solar_Radiance_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Solar_Radiance_Sensor . } INSERT{ ?subject ?predicate brick:Solar_Radiance_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Solar_Radiance_Sensor . }"
+    },
+    {
+      "description": "Weather_Wind_Direction_Sensor => Wind_Direction_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Wind_Direction_Sensor . } INSERT{ ?subject ?predicate brick:Wind_Direction_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Wind_Direction_Sensor . }"
+    },
+    {
+      "description": "Weather_Wind_Speed_Sensor => Wind_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Weather_Wind_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Wind_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Weather_Wind_Speed_Sensor . }"
+    },
+    {
+      "description": "Wind_Direction => Wind_Direction",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Wind_Direction . } INSERT{ ?subject ?predicate brick:Wind_Direction . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Wind_Direction . }"
+    },
+    {
+      "description": "Wind_Direction_Sensor => Wind_Direction_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Wind_Direction_Sensor . } INSERT{ ?subject ?predicate brick:Wind_Direction_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Wind_Direction_Sensor . }"
+    },
+    {
+      "description": "Wind_Speed => Wind_Speed",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Wind_Speed . } INSERT{ ?subject ?predicate brick:Wind_Speed . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Wind_Speed . }"
+    },
+    {
+      "description": "Wind_Speed_Sensor => Wind_Speed_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Wind_Speed_Sensor . } INSERT{ ?subject ?predicate brick:Wind_Speed_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Wind_Speed_Sensor . }"
+    },
+    {
+      "description": "Wing => Wing",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Wing . } INSERT{ ?subject ?predicate brick:Wing . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Wing . }"
+    },
+    {
+      "description": "WS => Water_System",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:WS . } INSERT{ ?subject ?predicate brick:Water_System . } WHERE { ?subject  ?predicate  brick_v_1_0_3:WS . }"
+    },
+    {
+      "description": "Zone => Zone",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone . } INSERT{ ?subject ?predicate brick:Zone . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone . }"
+    },
+    {
+      "description": "Zone_Air_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Air_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Air_Temperature_Sensor . }"
+    },
+    {
+      "description": "Zone_Humidity_Sensor => Zone_Air_Humidity_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Humidity_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Humidity_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Humidity_Sensor . }"
+    },
+    {
+      "description": "Zone_Standby_Load_Shed_Command => Zone_Standby_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Standby_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Zone_Standby_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Standby_Load_Shed_Command . }"
+    },
+    {
+      "description": "Zone_Temperature_Sensor => Zone_Air_Temperature_Sensor",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Temperature_Sensor . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Sensor . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Temperature_Sensor . }"
+    },
+    {
+      "description": "Zone_Temperature_Setpoint => Zone_Air_Temperature_Setpoint",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Temperature_Setpoint . } INSERT{ ?subject ?predicate brick:Zone_Air_Temperature_Setpoint . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Temperature_Setpoint . }"
+    },
+    {
+      "description": "Zone_Unoccupied_Load_Shed_Command => Zone_Unoccupied_Load_Shed_Command",
+      "query": "DELETE{ ?subject ?predicate brick_v_1_0_3:Zone_Unoccupied_Load_Shed_Command . } INSERT{ ?subject ?predicate brick:Zone_Unoccupied_Load_Shed_Command . } WHERE { ?subject  ?predicate  brick_v_1_0_3:Zone_Unoccupied_Load_Shed_Command . }"
+    },
+    {
+      "description": "AHU => AHU",
+      "query": "DELETE{ ?subject ?predicate btag:AHU . } INSERT{ ?subject ?predicate tag:AHU . } WHERE { ?subject  ?predicate  btag:AHU . }"
+    },
+    {
+      "description": "Acceleration => Acceleration",
+      "query": "DELETE{ ?subject ?predicate btag:Acceleration . } INSERT{ ?subject ?predicate tag:Acceleration . } WHERE { ?subject  ?predicate  btag:Acceleration . }"
+    },
+    {
+      "description": "Adjust => Adjust",
+      "query": "DELETE{ ?subject ?predicate btag:Adjust . } INSERT{ ?subject ?predicate tag:Adjust . } WHERE { ?subject  ?predicate  btag:Adjust . }"
+    },
+    {
+      "description": "Air => Air",
+      "query": "DELETE{ ?subject ?predicate btag:Air . } INSERT{ ?subject ?predicate tag:Air . } WHERE { ?subject  ?predicate  btag:Air . }"
+    },
+    {
+      "description": "Alarm => Alarm",
+      "query": "DELETE{ ?subject ?predicate btag:Alarm . } INSERT{ ?subject ?predicate tag:Alarm . } WHERE { ?subject  ?predicate  btag:Alarm . }"
+    },
+    {
+      "description": "Angle => Angle",
+      "query": "DELETE{ ?subject ?predicate btag:Angle . } INSERT{ ?subject ?predicate tag:Angle . } WHERE { ?subject  ?predicate  btag:Angle . }"
+    },
+    {
+      "description": "Auto => Auto",
+      "query": "DELETE{ ?subject ?predicate btag:Auto . } INSERT{ ?subject ?predicate tag:Auto . } WHERE { ?subject  ?predicate  btag:Auto . }"
+    },
+    {
+      "description": "Automatic => Automatic",
+      "query": "DELETE{ ?subject ?predicate btag:Automatic . } INSERT{ ?subject ?predicate tag:Automatic . } WHERE { ?subject  ?predicate  btag:Automatic . }"
+    },
+    {
+      "description": "Average => Average",
+      "query": "DELETE{ ?subject ?predicate btag:Average . } INSERT{ ?subject ?predicate tag:Average . } WHERE { ?subject  ?predicate  btag:Average . }"
+    },
+    {
+      "description": "Azimuth => Azimuth",
+      "query": "DELETE{ ?subject ?predicate btag:Azimuth . } INSERT{ ?subject ?predicate tag:Azimuth . } WHERE { ?subject  ?predicate  btag:Azimuth . }"
+    },
+    {
+      "description": "Band => Band",
+      "query": "DELETE{ ?subject ?predicate btag:Band . } INSERT{ ?subject ?predicate tag:Band . } WHERE { ?subject  ?predicate  btag:Band . }"
+    },
+    {
+      "description": "Basement => Basement",
+      "query": "DELETE{ ?subject ?predicate btag:Basement . } INSERT{ ?subject ?predicate tag:Basement . } WHERE { ?subject  ?predicate  btag:Basement . }"
+    },
+    {
+      "description": "Battery => Battery",
+      "query": "DELETE{ ?subject ?predicate btag:Battery . } INSERT{ ?subject ?predicate tag:Battery . } WHERE { ?subject  ?predicate  btag:Battery . }"
+    },
+    {
+      "description": "Boiler => Boiler",
+      "query": "DELETE{ ?subject ?predicate btag:Boiler . } INSERT{ ?subject ?predicate tag:Boiler . } WHERE { ?subject  ?predicate  btag:Boiler . }"
+    },
+    {
+      "description": "Booster => Booster",
+      "query": "DELETE{ ?subject ?predicate btag:Booster . } INSERT{ ?subject ?predicate tag:Booster . } WHERE { ?subject  ?predicate  btag:Booster . }"
+    },
+    {
+      "description": "Box => Box",
+      "query": "DELETE{ ?subject ?predicate btag:Box . } INSERT{ ?subject ?predicate tag:Box . } WHERE { ?subject  ?predicate  btag:Box . }"
+    },
+    {
+      "description": "Building => Building",
+      "query": "DELETE{ ?subject ?predicate btag:Building . } INSERT{ ?subject ?predicate tag:Building . } WHERE { ?subject  ?predicate  btag:Building . }"
+    },
+    {
+      "description": "Bus => Bus",
+      "query": "DELETE{ ?subject ?predicate btag:Bus . } INSERT{ ?subject ?predicate tag:Bus . } WHERE { ?subject  ?predicate  btag:Bus . }"
+    },
+    {
+      "description": "Button => Button",
+      "query": "DELETE{ ?subject ?predicate btag:Button . } INSERT{ ?subject ?predicate tag:Button . } WHERE { ?subject  ?predicate  btag:Button . }"
+    },
+    {
+      "description": "Bypass => Bypass",
+      "query": "DELETE{ ?subject ?predicate btag:Bypass . } INSERT{ ?subject ?predicate tag:Bypass . } WHERE { ?subject  ?predicate  btag:Bypass . }"
+    },
+    {
+      "description": "CO2 => CO2",
+      "query": "DELETE{ ?subject ?predicate btag:CO2 . } INSERT{ ?subject ?predicate tag:CO2 . } WHERE { ?subject  ?predicate  btag:CO2 . }"
+    },
+    {
+      "description": "CRAC => CRAC",
+      "query": "DELETE{ ?subject ?predicate btag:CRAC . } INSERT{ ?subject ?predicate tag:CRAC . } WHERE { ?subject  ?predicate  btag:CRAC . }"
+    },
+    {
+      "description": "CWS => CWS",
+      "query": "DELETE{ ?subject ?predicate btag:CWS . } INSERT{ ?subject ?predicate tag:CWS . } WHERE { ?subject  ?predicate  btag:CWS . }"
+    },
+    {
+      "description": "Capacity => Capacity",
+      "query": "DELETE{ ?subject ?predicate btag:Capacity . } INSERT{ ?subject ?predicate tag:Capacity . } WHERE { ?subject  ?predicate  btag:Capacity . }"
+    },
+    {
+      "description": "Change => Change",
+      "query": "DELETE{ ?subject ?predicate btag:Change . } INSERT{ ?subject ?predicate tag:Change . } WHERE { ?subject  ?predicate  btag:Change . }"
+    },
+    {
+      "description": "Chilled => Chilled",
+      "query": "DELETE{ ?subject ?predicate btag:Chilled . } INSERT{ ?subject ?predicate tag:Chilled . } WHERE { ?subject  ?predicate  btag:Chilled . }"
+    },
+    {
+      "description": "Chiller => Chiller",
+      "query": "DELETE{ ?subject ?predicate btag:Chiller . } INSERT{ ?subject ?predicate tag:Chiller . } WHERE { ?subject  ?predicate  btag:Chiller . }"
+    },
+    {
+      "description": "City => City",
+      "query": "DELETE{ ?subject ?predicate btag:City . } INSERT{ ?subject ?predicate tag:City . } WHERE { ?subject  ?predicate  btag:City . }"
+    },
+    {
+      "description": "Close => Close",
+      "query": "DELETE{ ?subject ?predicate btag:Close . } INSERT{ ?subject ?predicate tag:Close . } WHERE { ?subject  ?predicate  btag:Close . }"
+    },
+    {
+      "description": "Code => Code",
+      "query": "DELETE{ ?subject ?predicate btag:Code . } INSERT{ ?subject ?predicate tag:Code . } WHERE { ?subject  ?predicate  btag:Code . }"
+    },
+    {
+      "description": "Coil => Coil",
+      "query": "DELETE{ ?subject ?predicate btag:Coil . } INSERT{ ?subject ?predicate tag:Coil . } WHERE { ?subject  ?predicate  btag:Coil . }"
+    },
+    {
+      "description": "Cold => Cold",
+      "query": "DELETE{ ?subject ?predicate btag:Cold . } INSERT{ ?subject ?predicate tag:Cold . } WHERE { ?subject  ?predicate  btag:Cold . }"
+    },
+    {
+      "description": "Coldest => Coldest",
+      "query": "DELETE{ ?subject ?predicate btag:Coldest . } INSERT{ ?subject ?predicate tag:Coldest . } WHERE { ?subject  ?predicate  btag:Coldest . }"
+    },
+    {
+      "description": "Command => Command",
+      "query": "DELETE{ ?subject ?predicate btag:Command . } INSERT{ ?subject ?predicate tag:Command . } WHERE { ?subject  ?predicate  btag:Command . }"
+    },
+    {
+      "description": "Communication => Communication",
+      "query": "DELETE{ ?subject ?predicate btag:Communication . } INSERT{ ?subject ?predicate tag:Communication . } WHERE { ?subject  ?predicate  btag:Communication . }"
+    },
+    {
+      "description": "Compressor => Compressor",
+      "query": "DELETE{ ?subject ?predicate btag:Compressor . } INSERT{ ?subject ?predicate tag:Compressor . } WHERE { ?subject  ?predicate  btag:Compressor . }"
+    },
+    {
+      "description": "Computer => Computer",
+      "query": "DELETE{ ?subject ?predicate btag:Computer . } INSERT{ ?subject ?predicate tag:Computer . } WHERE { ?subject  ?predicate  btag:Computer . }"
+    },
+    {
+      "description": "Condensate => Condensate",
+      "query": "DELETE{ ?subject ?predicate btag:Condensate . } INSERT{ ?subject ?predicate tag:Condensate . } WHERE { ?subject  ?predicate  btag:Condensate . }"
+    },
+    {
+      "description": "Condenser => Condenser",
+      "query": "DELETE{ ?subject ?predicate btag:Condenser . } INSERT{ ?subject ?predicate tag:Condenser . } WHERE { ?subject  ?predicate  btag:Condenser . }"
+    },
+    {
+      "description": "Condensor => Condenser",
+      "query": "DELETE{ ?subject ?predicate btag:Condenser . } INSERT{ ?subject ?predicate tag:Condenser . } WHERE { ?subject  ?predicate  btag:Condenser . }"
+    },
+    {
+      "description": "Conditioning => Conditioning",
+      "query": "DELETE{ ?subject ?predicate btag:Conditioning . } INSERT{ ?subject ?predicate tag:Conditioning . } WHERE { ?subject  ?predicate  btag:Conditioning . }"
+    },
+    {
+      "description": "Conductivity => Conductivity",
+      "query": "DELETE{ ?subject ?predicate btag:Conductivity . } INSERT{ ?subject ?predicate tag:Conductivity . } WHERE { ?subject  ?predicate  btag:Conductivity . }"
+    },
+    {
+      "description": "Control => Control",
+      "query": "DELETE{ ?subject ?predicate btag:Control . } INSERT{ ?subject ?predicate tag:Control . } WHERE { ?subject  ?predicate  btag:Control . }"
+    },
+    {
+      "description": "Cool => Cool",
+      "query": "DELETE{ ?subject ?predicate btag:Cool . } INSERT{ ?subject ?predicate tag:Cool . } WHERE { ?subject  ?predicate  btag:Cool . }"
+    },
+    {
+      "description": "Cooling => Cool",
+      "query": "DELETE{ ?subject ?predicate btag:Cool . } INSERT{ ?subject ?predicate tag:Cool . } WHERE { ?subject  ?predicate  btag:Cool . }"
+    },
+    {
+      "description": "Current => Current",
+      "query": "DELETE{ ?subject ?predicate btag:Current . } INSERT{ ?subject ?predicate tag:Current . } WHERE { ?subject  ?predicate  btag:Current . }"
+    },
+    {
+      "description": "Curtailment => Curtailment",
+      "query": "DELETE{ ?subject ?predicate btag:Curtailment . } INSERT{ ?subject ?predicate tag:Curtailment . } WHERE { ?subject  ?predicate  btag:Curtailment . }"
+    },
+    {
+      "description": "Cutout => Cutout",
+      "query": "DELETE{ ?subject ?predicate btag:Cutout . } INSERT{ ?subject ?predicate tag:Cutout . } WHERE { ?subject  ?predicate  btag:Cutout . }"
+    },
+    {
+      "description": "Cycle => Cycle",
+      "query": "DELETE{ ?subject ?predicate btag:Cycle . } INSERT{ ?subject ?predicate tag:Cycle . } WHERE { ?subject  ?predicate  btag:Cycle . }"
+    },
+    {
+      "description": "DC => DC",
+      "query": "DELETE{ ?subject ?predicate btag:DC . } INSERT{ ?subject ?predicate tag:DC . } WHERE { ?subject  ?predicate  btag:DC . }"
+    },
+    {
+      "description": "Damper => Damper",
+      "query": "DELETE{ ?subject ?predicate btag:Damper . } INSERT{ ?subject ?predicate tag:Damper . } WHERE { ?subject  ?predicate  btag:Damper . }"
+    },
+    {
+      "description": "Deceleration => Deceleration",
+      "query": "DELETE{ ?subject ?predicate btag:Deceleration . } INSERT{ ?subject ?predicate tag:Deceleration . } WHERE { ?subject  ?predicate  btag:Deceleration . }"
+    },
+    {
+      "description": "Dehumidification => Dehumidification",
+      "query": "DELETE{ ?subject ?predicate btag:Dehumidification . } INSERT{ ?subject ?predicate tag:Dehumidification . } WHERE { ?subject  ?predicate  btag:Dehumidification . }"
+    },
+    {
+      "description": "Deionised => Deionised",
+      "query": "DELETE{ ?subject ?predicate btag:Deionised . } INSERT{ ?subject ?predicate tag:Deionised . } WHERE { ?subject  ?predicate  btag:Deionised . }"
+    },
+    {
+      "description": "Delay => Delay",
+      "query": "DELETE{ ?subject ?predicate btag:Delay . } INSERT{ ?subject ?predicate tag:Delay . } WHERE { ?subject  ?predicate  btag:Delay . }"
+    },
+    {
+      "description": "Demand => Demand",
+      "query": "DELETE{ ?subject ?predicate btag:Demand . } INSERT{ ?subject ?predicate tag:Demand . } WHERE { ?subject  ?predicate  btag:Demand . }"
+    },
+    {
+      "description": "Detected => Detected",
+      "query": "DELETE{ ?subject ?predicate btag:Detected . } INSERT{ ?subject ?predicate tag:Detected . } WHERE { ?subject  ?predicate  btag:Detected . }"
+    },
+    {
+      "description": "Detection => Detection",
+      "query": "DELETE{ ?subject ?predicate btag:Detection . } INSERT{ ?subject ?predicate tag:Detection . } WHERE { ?subject  ?predicate  btag:Detection . }"
+    },
+    {
+      "description": "Dewpoint => Dewpoint",
+      "query": "DELETE{ ?subject ?predicate btag:Dewpoint . } INSERT{ ?subject ?predicate tag:Dewpoint . } WHERE { ?subject  ?predicate  btag:Dewpoint . }"
+    },
+    {
+      "description": "Differential => Differential",
+      "query": "DELETE{ ?subject ?predicate btag:Differential . } INSERT{ ?subject ?predicate tag:Differential . } WHERE { ?subject  ?predicate  btag:Differential . }"
+    },
+    {
+      "description": "Direction => Direction",
+      "query": "DELETE{ ?subject ?predicate btag:Direction . } INSERT{ ?subject ?predicate tag:Direction . } WHERE { ?subject  ?predicate  btag:Direction . }"
+    },
+    {
+      "description": "Disable => Disable",
+      "query": "DELETE{ ?subject ?predicate btag:Disable . } INSERT{ ?subject ?predicate tag:Disable . } WHERE { ?subject  ?predicate  btag:Disable . }"
+    },
+    {
+      "description": "Discharge => Discharge",
+      "query": "DELETE{ ?subject ?predicate btag:Discharge . } INSERT{ ?subject ?predicate tag:Discharge . } WHERE { ?subject  ?predicate  btag:Discharge . }"
+    },
+    {
+      "description": "Domestic => Domestic",
+      "query": "DELETE{ ?subject ?predicate btag:Domestic . } INSERT{ ?subject ?predicate tag:Domestic . } WHERE { ?subject  ?predicate  btag:Domestic . }"
+    },
+    {
+      "description": "Drive => Drive",
+      "query": "DELETE{ ?subject ?predicate btag:Drive . } INSERT{ ?subject ?predicate tag:Drive . } WHERE { ?subject  ?predicate  btag:Drive . }"
+    },
+    {
+      "description": "Dual => Dual",
+      "query": "DELETE{ ?subject ?predicate btag:Dual . } INSERT{ ?subject ?predicate tag:Dual . } WHERE { ?subject  ?predicate  btag:Dual . }"
+    },
+    {
+      "description": "Duct => Duct",
+      "query": "DELETE{ ?subject ?predicate btag:Duct . } INSERT{ ?subject ?predicate tag:Duct . } WHERE { ?subject  ?predicate  btag:Duct . }"
+    },
+    {
+      "description": "Duration => Duration",
+      "query": "DELETE{ ?subject ?predicate btag:Duration . } INSERT{ ?subject ?predicate tag:Duration . } WHERE { ?subject  ?predicate  btag:Duration . }"
+    },
+    {
+      "description": "EconCycle => EconCycle",
+      "query": "DELETE{ ?subject ?predicate btag:EconCycle . } INSERT{ ?subject ?predicate tag:EconCycle . } WHERE { ?subject  ?predicate  btag:EconCycle . }"
+    },
+    {
+      "description": "Economizer => Economizer",
+      "query": "DELETE{ ?subject ?predicate btag:Economizer . } INSERT{ ?subject ?predicate tag:Economizer . } WHERE { ?subject  ?predicate  btag:Economizer . }"
+    },
+    {
+      "description": "Effective => Effective",
+      "query": "DELETE{ ?subject ?predicate btag:Effective . } INSERT{ ?subject ?predicate tag:Effective . } WHERE { ?subject  ?predicate  btag:Effective . }"
+    },
+    {
+      "description": "Electrical => Electrical",
+      "query": "DELETE{ ?subject ?predicate btag:Electrical . } INSERT{ ?subject ?predicate tag:Electrical . } WHERE { ?subject  ?predicate  btag:Electrical . }"
+    },
+    {
+      "description": "Elevator => Elevator",
+      "query": "DELETE{ ?subject ?predicate btag:Elevator . } INSERT{ ?subject ?predicate tag:Elevator . } WHERE { ?subject  ?predicate  btag:Elevator . }"
+    },
+    {
+      "description": "Emergency => Emergency",
+      "query": "DELETE{ ?subject ?predicate btag:Emergency . } INSERT{ ?subject ?predicate tag:Emergency . } WHERE { ?subject  ?predicate  btag:Emergency . }"
+    },
+    {
+      "description": "Enable => Enable",
+      "query": "DELETE{ ?subject ?predicate btag:Enable . } INSERT{ ?subject ?predicate tag:Enable . } WHERE { ?subject  ?predicate  btag:Enable . }"
+    },
+    {
+      "description": "Energy => Energy",
+      "query": "DELETE{ ?subject ?predicate btag:Energy . } INSERT{ ?subject ?predicate tag:Energy . } WHERE { ?subject  ?predicate  btag:Energy . }"
+    },
+    {
+      "description": "Entering => Entering",
+      "query": "DELETE{ ?subject ?predicate btag:Entering . } INSERT{ ?subject ?predicate tag:Entering . } WHERE { ?subject  ?predicate  btag:Entering . }"
+    },
+    {
+      "description": "Enthalpy => Enthalpy",
+      "query": "DELETE{ ?subject ?predicate btag:Enthalpy . } INSERT{ ?subject ?predicate tag:Enthalpy . } WHERE { ?subject  ?predicate  btag:Enthalpy . }"
+    },
+    {
+      "description": "Environment => Environment",
+      "query": "DELETE{ ?subject ?predicate btag:Environment . } INSERT{ ?subject ?predicate tag:Environment . } WHERE { ?subject  ?predicate  btag:Environment . }"
+    },
+    {
+      "description": "Equipment => Equipment",
+      "query": "DELETE{ ?subject ?predicate btag:Equipment . } INSERT{ ?subject ?predicate tag:Equipment . } WHERE { ?subject  ?predicate  btag:Equipment . }"
+    },
+    {
+      "description": "Even => Even",
+      "query": "DELETE{ ?subject ?predicate btag:Even . } INSERT{ ?subject ?predicate tag:Even . } WHERE { ?subject  ?predicate  btag:Even . }"
+    },
+    {
+      "description": "Exchanger => Exchanger",
+      "query": "DELETE{ ?subject ?predicate btag:Exchanger . } INSERT{ ?subject ?predicate tag:Exchanger . } WHERE { ?subject  ?predicate  btag:Exchanger . }"
+    },
+    {
+      "description": "Exhaust => Exhaust",
+      "query": "DELETE{ ?subject ?predicate btag:Exhaust . } INSERT{ ?subject ?predicate tag:Exhaust . } WHERE { ?subject  ?predicate  btag:Exhaust . }"
+    },
+    {
+      "description": "FCP => FCP",
+      "query": "DELETE{ ?subject ?predicate btag:FCP . } INSERT{ ?subject ?predicate tag:FCP . } WHERE { ?subject  ?predicate  btag:FCP . }"
+    },
+    {
+      "description": "FCU => FCU",
+      "query": "DELETE{ ?subject ?predicate btag:FCU . } INSERT{ ?subject ?predicate tag:FCU . } WHERE { ?subject  ?predicate  btag:FCU . }"
+    },
+    {
+      "description": "Failed => Failure",
+      "query": "DELETE{ ?subject ?predicate btag:Failure . } INSERT{ ?subject ?predicate tag:Failure . } WHERE { ?subject  ?predicate  btag:Failure . }"
+    },
+    {
+      "description": "Failure => Failure",
+      "query": "DELETE{ ?subject ?predicate btag:Failure . } INSERT{ ?subject ?predicate tag:Failure . } WHERE { ?subject  ?predicate  btag:Failure . }"
+    },
+    {
+      "description": "Fan => Fan",
+      "query": "DELETE{ ?subject ?predicate btag:Fan . } INSERT{ ?subject ?predicate tag:Fan . } WHERE { ?subject  ?predicate  btag:Fan . }"
+    },
+    {
+      "description": "Fault => Fault",
+      "query": "DELETE{ ?subject ?predicate btag:Fault . } INSERT{ ?subject ?predicate tag:Fault . } WHERE { ?subject  ?predicate  btag:Fault . }"
+    },
+    {
+      "description": "Filter => Filter",
+      "query": "DELETE{ ?subject ?predicate btag:Filter . } INSERT{ ?subject ?predicate tag:Filter . } WHERE { ?subject  ?predicate  btag:Filter . }"
+    },
+    {
+      "description": "Fire => Fire",
+      "query": "DELETE{ ?subject ?predicate btag:Fire . } INSERT{ ?subject ?predicate tag:Fire . } WHERE { ?subject  ?predicate  btag:Fire . }"
+    },
+    {
+      "description": "Fixed => Fixed",
+      "query": "DELETE{ ?subject ?predicate btag:Fixed . } INSERT{ ?subject ?predicate tag:Fixed . } WHERE { ?subject  ?predicate  btag:Fixed . }"
+    },
+    {
+      "description": "Floor => Floor",
+      "query": "DELETE{ ?subject ?predicate btag:Floor . } INSERT{ ?subject ?predicate tag:Floor . } WHERE { ?subject  ?predicate  btag:Floor . }"
+    },
+    {
+      "description": "Flow => Flow",
+      "query": "DELETE{ ?subject ?predicate btag:Flow . } INSERT{ ?subject ?predicate tag:Flow . } WHERE { ?subject  ?predicate  btag:Flow . }"
+    },
+    {
+      "description": "Freeze => Freeze",
+      "query": "DELETE{ ?subject ?predicate btag:Freeze . } INSERT{ ?subject ?predicate tag:Freeze . } WHERE { ?subject  ?predicate  btag:Freeze . }"
+    },
+    {
+      "description": "Freezer => Freezer",
+      "query": "DELETE{ ?subject ?predicate btag:Freezer . } INSERT{ ?subject ?predicate tag:Freezer . } WHERE { ?subject  ?predicate  btag:Freezer . }"
+    },
+    {
+      "description": "Frequency => Frequency",
+      "query": "DELETE{ ?subject ?predicate btag:Frequency . } INSERT{ ?subject ?predicate tag:Frequency . } WHERE { ?subject  ?predicate  btag:Frequency . }"
+    },
+    {
+      "description": "Fresh => Fresh",
+      "query": "DELETE{ ?subject ?predicate btag:Fresh . } INSERT{ ?subject ?predicate tag:Fresh . } WHERE { ?subject  ?predicate  btag:Fresh . }"
+    },
+    {
+      "description": "Frost => Frost",
+      "query": "DELETE{ ?subject ?predicate btag:Frost . } INSERT{ ?subject ?predicate tag:Frost . } WHERE { ?subject  ?predicate  btag:Frost . }"
+    },
+    {
+      "description": "Fume => Fume",
+      "query": "DELETE{ ?subject ?predicate btag:Fume . } INSERT{ ?subject ?predicate tag:Fume . } WHERE { ?subject  ?predicate  btag:Fume . }"
+    },
+    {
+      "description": "Furniture => Furniture",
+      "query": "DELETE{ ?subject ?predicate btag:Furniture . } INSERT{ ?subject ?predicate tag:Furniture . } WHERE { ?subject  ?predicate  btag:Furniture . }"
+    },
+    {
+      "description": "Gain => Gain",
+      "query": "DELETE{ ?subject ?predicate btag:Gain . } INSERT{ ?subject ?predicate tag:Gain . } WHERE { ?subject  ?predicate  btag:Gain . }"
+    },
+    {
+      "description": "Gas => Gas",
+      "query": "DELETE{ ?subject ?predicate btag:Gas . } INSERT{ ?subject ?predicate tag:Gas . } WHERE { ?subject  ?predicate  btag:Gas . }"
+    },
+    {
+      "description": "Generator => Generator",
+      "query": "DELETE{ ?subject ?predicate btag:Generator . } INSERT{ ?subject ?predicate tag:Generator . } WHERE { ?subject  ?predicate  btag:Generator . }"
+    },
+    {
+      "description": "Glycool => Glycool",
+      "query": "DELETE{ ?subject ?predicate btag:Glycool . } INSERT{ ?subject ?predicate tag:Glycool . } WHERE { ?subject  ?predicate  btag:Glycool . }"
+    },
+    {
+      "description": "Grains => Grains",
+      "query": "DELETE{ ?subject ?predicate btag:Grains . } INSERT{ ?subject ?predicate tag:Grains . } WHERE { ?subject  ?predicate  btag:Grains . }"
+    },
+    {
+      "description": "HVAC => HVAC",
+      "query": "DELETE{ ?subject ?predicate btag:HVAC . } INSERT{ ?subject ?predicate tag:HVAC . } WHERE { ?subject  ?predicate  btag:HVAC . }"
+    },
+    {
+      "description": "HWS => HWS",
+      "query": "DELETE{ ?subject ?predicate btag:HWS . } INSERT{ ?subject ?predicate tag:HWS . } WHERE { ?subject  ?predicate  btag:HWS . }"
+    },
+    {
+      "description": "HX => HX",
+      "query": "DELETE{ ?subject ?predicate btag:HX . } INSERT{ ?subject ?predicate tag:HX . } WHERE { ?subject  ?predicate  btag:HX . }"
+    },
+    {
+      "description": "Hail => Hail",
+      "query": "DELETE{ ?subject ?predicate btag:Hail . } INSERT{ ?subject ?predicate tag:Hail . } WHERE { ?subject  ?predicate  btag:Hail . }"
+    },
+    {
+      "description": "Hand => Hand",
+      "query": "DELETE{ ?subject ?predicate btag:Hand . } INSERT{ ?subject ?predicate tag:Hand . } WHERE { ?subject  ?predicate  btag:Hand . }"
+    },
+    {
+      "description": "Handler => Handler",
+      "query": "DELETE{ ?subject ?predicate btag:Handler . } INSERT{ ?subject ?predicate tag:Handler . } WHERE { ?subject  ?predicate  btag:Handler . }"
+    },
+    {
+      "description": "Head => Head",
+      "query": "DELETE{ ?subject ?predicate btag:Head . } INSERT{ ?subject ?predicate tag:Head . } WHERE { ?subject  ?predicate  btag:Head . }"
+    },
+    {
+      "description": "Heat => Heat",
+      "query": "DELETE{ ?subject ?predicate btag:Heat . } INSERT{ ?subject ?predicate tag:Heat . } WHERE { ?subject  ?predicate  btag:Heat . }"
+    },
+    {
+      "description": "Heater => Heater",
+      "query": "DELETE{ ?subject ?predicate btag:Heater . } INSERT{ ?subject ?predicate tag:Heater . } WHERE { ?subject  ?predicate  btag:Heater . }"
+    },
+    {
+      "description": "Heating => Heat",
+      "query": "DELETE{ ?subject ?predicate btag:Heat . } INSERT{ ?subject ?predicate tag:Heat . } WHERE { ?subject  ?predicate  btag:Heat . }"
+    },
+    {
+      "description": "High => High",
+      "query": "DELETE{ ?subject ?predicate btag:High . } INSERT{ ?subject ?predicate tag:High . } WHERE { ?subject  ?predicate  btag:High . }"
+    },
+    {
+      "description": "Highest => Highest",
+      "query": "DELETE{ ?subject ?predicate btag:Highest . } INSERT{ ?subject ?predicate tag:Highest . } WHERE { ?subject  ?predicate  btag:Highest . }"
+    },
+    {
+      "description": "Hold => Hold",
+      "query": "DELETE{ ?subject ?predicate btag:Hold . } INSERT{ ?subject ?predicate tag:Hold . } WHERE { ?subject  ?predicate  btag:Hold . }"
+    },
+    {
+      "description": "Hood => Hood",
+      "query": "DELETE{ ?subject ?predicate btag:Hood . } INSERT{ ?subject ?predicate tag:Hood . } WHERE { ?subject  ?predicate  btag:Hood . }"
+    },
+    {
+      "description": "Hot => Hot",
+      "query": "DELETE{ ?subject ?predicate btag:Hot . } INSERT{ ?subject ?predicate tag:Hot . } WHERE { ?subject  ?predicate  btag:Hot . }"
+    },
+    {
+      "description": "Humidification => Humidification",
+      "query": "DELETE{ ?subject ?predicate btag:Humidification . } INSERT{ ?subject ?predicate tag:Humidification . } WHERE { ?subject  ?predicate  btag:Humidification . }"
+    },
+    {
+      "description": "Humidifier => Humidifier",
+      "query": "DELETE{ ?subject ?predicate btag:Humidifier . } INSERT{ ?subject ?predicate tag:Humidifier . } WHERE { ?subject  ?predicate  btag:Humidifier . }"
+    },
+    {
+      "description": "Humidify => Humidify",
+      "query": "DELETE{ ?subject ?predicate btag:Humidify . } INSERT{ ?subject ?predicate tag:Humidify . } WHERE { ?subject  ?predicate  btag:Humidify . }"
+    },
+    {
+      "description": "Humidity => Humidity",
+      "query": "DELETE{ ?subject ?predicate btag:Humidity . } INSERT{ ?subject ?predicate tag:Humidity . } WHERE { ?subject  ?predicate  btag:Humidity . }"
+    },
+    {
+      "description": "Ice => Ice",
+      "query": "DELETE{ ?subject ?predicate btag:Ice . } INSERT{ ?subject ?predicate tag:Ice . } WHERE { ?subject  ?predicate  btag:Ice . }"
+    },
+    {
+      "description": "Indicator => Indicator",
+      "query": "DELETE{ ?subject ?predicate btag:Indicator . } INSERT{ ?subject ?predicate tag:Indicator . } WHERE { ?subject  ?predicate  btag:Indicator . }"
+    },
+    {
+      "description": "Integral => Integral",
+      "query": "DELETE{ ?subject ?predicate btag:Integral . } INSERT{ ?subject ?predicate tag:Integral . } WHERE { ?subject  ?predicate  btag:Integral . }"
+    },
+    {
+      "description": "Inverter => Inverter",
+      "query": "DELETE{ ?subject ?predicate btag:Inverter . } INSERT{ ?subject ?predicate tag:Inverter . } WHERE { ?subject  ?predicate  btag:Inverter . }"
+    },
+    {
+      "description": "Isolation => Isolation",
+      "query": "DELETE{ ?subject ?predicate btag:Isolation . } INSERT{ ?subject ?predicate tag:Isolation . } WHERE { ?subject  ?predicate  btag:Isolation . }"
+    },
+    {
+      "description": "Laboratory => Laboratory",
+      "query": "DELETE{ ?subject ?predicate btag:Laboratory . } INSERT{ ?subject ?predicate tag:Laboratory . } WHERE { ?subject  ?predicate  btag:Laboratory . }"
+    },
+    {
+      "description": "Lag => Lag",
+      "query": "DELETE{ ?subject ?predicate btag:Lag . } INSERT{ ?subject ?predicate tag:Lag . } WHERE { ?subject  ?predicate  btag:Lag . }"
+    },
+    {
+      "description": "Last => Last",
+      "query": "DELETE{ ?subject ?predicate btag:Last . } INSERT{ ?subject ?predicate tag:Last . } WHERE { ?subject  ?predicate  btag:Last . }"
+    },
+    {
+      "description": "Lead => Lead",
+      "query": "DELETE{ ?subject ?predicate btag:Lead . } INSERT{ ?subject ?predicate tag:Lead . } WHERE { ?subject  ?predicate  btag:Lead . }"
+    },
+    {
+      "description": "Leak => Leak",
+      "query": "DELETE{ ?subject ?predicate btag:Leak . } INSERT{ ?subject ?predicate tag:Leak . } WHERE { ?subject  ?predicate  btag:Leak . }"
+    },
+    {
+      "description": "Leaving => Leaving",
+      "query": "DELETE{ ?subject ?predicate btag:Leaving . } INSERT{ ?subject ?predicate tag:Leaving . } WHERE { ?subject  ?predicate  btag:Leaving . }"
+    },
+    {
+      "description": "Level => Level",
+      "query": "DELETE{ ?subject ?predicate btag:Level . } INSERT{ ?subject ?predicate tag:Level . } WHERE { ?subject  ?predicate  btag:Level . }"
+    },
+    {
+      "description": "Lighting => Lighting",
+      "query": "DELETE{ ?subject ?predicate btag:Lighting . } INSERT{ ?subject ?predicate tag:Lighting . } WHERE { ?subject  ?predicate  btag:Lighting . }"
+    },
+    {
+      "description": "Limit => Limit",
+      "query": "DELETE{ ?subject ?predicate btag:Limit . } INSERT{ ?subject ?predicate tag:Limit . } WHERE { ?subject  ?predicate  btag:Limit . }"
+    },
+    {
+      "description": "Liquid => Liquid",
+      "query": "DELETE{ ?subject ?predicate btag:Liquid . } INSERT{ ?subject ?predicate tag:Liquid . } WHERE { ?subject  ?predicate  btag:Liquid . }"
+    },
+    {
+      "description": "Load => Load",
+      "query": "DELETE{ ?subject ?predicate btag:Load . } INSERT{ ?subject ?predicate tag:Load . } WHERE { ?subject  ?predicate  btag:Load . }"
+    },
+    {
+      "description": "Locally => Locally",
+      "query": "DELETE{ ?subject ?predicate btag:Locally . } INSERT{ ?subject ?predicate tag:Locally . } WHERE { ?subject  ?predicate  btag:Locally . }"
+    },
+    {
+      "description": "Location => Location",
+      "query": "DELETE{ ?subject ?predicate btag:Location . } INSERT{ ?subject ?predicate tag:Location . } WHERE { ?subject  ?predicate  btag:Location . }"
+    },
+    {
+      "description": "Lockout => Lockout",
+      "query": "DELETE{ ?subject ?predicate btag:Lockout . } INSERT{ ?subject ?predicate tag:Lockout . } WHERE { ?subject  ?predicate  btag:Lockout . }"
+    },
+    {
+      "description": "Loss => Loss",
+      "query": "DELETE{ ?subject ?predicate btag:Loss . } INSERT{ ?subject ?predicate tag:Loss . } WHERE { ?subject  ?predicate  btag:Loss . }"
+    },
+    {
+      "description": "Louver => Louver",
+      "query": "DELETE{ ?subject ?predicate btag:Louver . } INSERT{ ?subject ?predicate tag:Louver . } WHERE { ?subject  ?predicate  btag:Louver . }"
+    },
+    {
+      "description": "Low => Low",
+      "query": "DELETE{ ?subject ?predicate btag:Low . } INSERT{ ?subject ?predicate tag:Low . } WHERE { ?subject  ?predicate  btag:Low . }"
+    },
+    {
+      "description": "Lowest => Lowest",
+      "query": "DELETE{ ?subject ?predicate btag:Lowest . } INSERT{ ?subject ?predicate tag:Lowest . } WHERE { ?subject  ?predicate  btag:Lowest . }"
+    },
+    {
+      "description": "Luminance => Luminance",
+      "query": "DELETE{ ?subject ?predicate btag:Luminance . } INSERT{ ?subject ?predicate tag:Luminance . } WHERE { ?subject  ?predicate  btag:Luminance . }"
+    },
+    {
+      "description": "Maintenance => Maintenance",
+      "query": "DELETE{ ?subject ?predicate btag:Maintenance . } INSERT{ ?subject ?predicate tag:Maintenance . } WHERE { ?subject  ?predicate  btag:Maintenance . }"
+    },
+    {
+      "description": "Manual => Manual",
+      "query": "DELETE{ ?subject ?predicate btag:Manual . } INSERT{ ?subject ?predicate tag:Manual . } WHERE { ?subject  ?predicate  btag:Manual . }"
+    },
+    {
+      "description": "Max => Max",
+      "query": "DELETE{ ?subject ?predicate btag:Max . } INSERT{ ?subject ?predicate tag:Max . } WHERE { ?subject  ?predicate  btag:Max . }"
+    },
+    {
+      "description": "Medium => Medium",
+      "query": "DELETE{ ?subject ?predicate btag:Medium . } INSERT{ ?subject ?predicate tag:Medium . } WHERE { ?subject  ?predicate  btag:Medium . }"
+    },
+    {
+      "description": "Meter => Meter",
+      "query": "DELETE{ ?subject ?predicate btag:Meter . } INSERT{ ?subject ?predicate tag:Meter . } WHERE { ?subject  ?predicate  btag:Meter . }"
+    },
+    {
+      "description": "Min => Min",
+      "query": "DELETE{ ?subject ?predicate btag:Min . } INSERT{ ?subject ?predicate tag:Min . } WHERE { ?subject  ?predicate  btag:Min . }"
+    },
+    {
+      "description": "Minimum => Min",
+      "query": "DELETE{ ?subject ?predicate btag:Min . } INSERT{ ?subject ?predicate tag:Min . } WHERE { ?subject  ?predicate  btag:Min . }"
+    },
+    {
+      "description": "Mixed => Mixed",
+      "query": "DELETE{ ?subject ?predicate btag:Mixed . } INSERT{ ?subject ?predicate tag:Mixed . } WHERE { ?subject  ?predicate  btag:Mixed . }"
+    },
+    {
+      "description": "Mode => Mode",
+      "query": "DELETE{ ?subject ?predicate btag:Mode . } INSERT{ ?subject ?predicate tag:Mode . } WHERE { ?subject  ?predicate  btag:Mode . }"
+    },
+    {
+      "description": "Month => Month",
+      "query": "DELETE{ ?subject ?predicate btag:Month . } INSERT{ ?subject ?predicate tag:Month . } WHERE { ?subject  ?predicate  btag:Month . }"
+    },
+    {
+      "description": "Monthly => Monthly",
+      "query": "DELETE{ ?subject ?predicate btag:Monthly . } INSERT{ ?subject ?predicate tag:Monthly . } WHERE { ?subject  ?predicate  btag:Monthly . }"
+    },
+    {
+      "description": "Motor => Motor",
+      "query": "DELETE{ ?subject ?predicate btag:Motor . } INSERT{ ?subject ?predicate tag:Motor . } WHERE { ?subject  ?predicate  btag:Motor . }"
+    },
+    {
+      "description": "No => No",
+      "query": "DELETE{ ?subject ?predicate btag:No . } INSERT{ ?subject ?predicate tag:No . } WHERE { ?subject  ?predicate  btag:No . }"
+    },
+    {
+      "description": "Occupancy => Occupancy",
+      "query": "DELETE{ ?subject ?predicate btag:Occupancy . } INSERT{ ?subject ?predicate tag:Occupancy . } WHERE { ?subject  ?predicate  btag:Occupancy . }"
+    },
+    {
+      "description": "Occupied => Occupied",
+      "query": "DELETE{ ?subject ?predicate btag:Occupied . } INSERT{ ?subject ?predicate tag:Occupied . } WHERE { ?subject  ?predicate  btag:Occupied . }"
+    },
+    {
+      "description": "Off => Off",
+      "query": "DELETE{ ?subject ?predicate btag:Off . } INSERT{ ?subject ?predicate tag:Off . } WHERE { ?subject  ?predicate  btag:Off . }"
+    },
+    {
+      "description": "On => On",
+      "query": "DELETE{ ?subject ?predicate btag:On . } INSERT{ ?subject ?predicate tag:On . } WHERE { ?subject  ?predicate  btag:On . }"
+    },
+    {
+      "description": "Open => Open",
+      "query": "DELETE{ ?subject ?predicate btag:Open . } INSERT{ ?subject ?predicate tag:Open . } WHERE { ?subject  ?predicate  btag:Open . }"
+    },
+    {
+      "description": "Operating => Operating",
+      "query": "DELETE{ ?subject ?predicate btag:Operating . } INSERT{ ?subject ?predicate tag:Operating . } WHERE { ?subject  ?predicate  btag:Operating . }"
+    },
+    {
+      "description": "Output => Output",
+      "query": "DELETE{ ?subject ?predicate btag:Output . } INSERT{ ?subject ?predicate tag:Output . } WHERE { ?subject  ?predicate  btag:Output . }"
+    },
+    {
+      "description": "Outside => Outside",
+      "query": "DELETE{ ?subject ?predicate btag:Outside . } INSERT{ ?subject ?predicate tag:Outside . } WHERE { ?subject  ?predicate  btag:Outside . }"
+    },
+    {
+      "description": "Overload => Overload",
+      "query": "DELETE{ ?subject ?predicate btag:Overload . } INSERT{ ?subject ?predicate tag:Overload . } WHERE { ?subject  ?predicate  btag:Overload . }"
+    },
+    {
+      "description": "Overridden => Overridden",
+      "query": "DELETE{ ?subject ?predicate btag:Overridden . } INSERT{ ?subject ?predicate tag:Overridden . } WHERE { ?subject  ?predicate  btag:Overridden . }"
+    },
+    {
+      "description": "Override => Override",
+      "query": "DELETE{ ?subject ?predicate btag:Override . } INSERT{ ?subject ?predicate tag:Override . } WHERE { ?subject  ?predicate  btag:Override . }"
+    },
+    {
+      "description": "PID => PID",
+      "query": "DELETE{ ?subject ?predicate btag:PID . } INSERT{ ?subject ?predicate tag:PID . } WHERE { ?subject  ?predicate  btag:PID . }"
+    },
+    {
+      "description": "PIR => PIR",
+      "query": "DELETE{ ?subject ?predicate btag:PIR . } INSERT{ ?subject ?predicate tag:PIR . } WHERE { ?subject  ?predicate  btag:PIR . }"
+    },
+    {
+      "description": "PV => PV",
+      "query": "DELETE{ ?subject ?predicate btag:PV . } INSERT{ ?subject ?predicate tag:PV . } WHERE { ?subject  ?predicate  btag:PV . }"
+    },
+    {
+      "description": "Panel => Panel",
+      "query": "DELETE{ ?subject ?predicate btag:Panel . } INSERT{ ?subject ?predicate tag:Panel . } WHERE { ?subject  ?predicate  btag:Panel . }"
+    },
+    {
+      "description": "Peak => Peak",
+      "query": "DELETE{ ?subject ?predicate btag:Peak . } INSERT{ ?subject ?predicate tag:Peak . } WHERE { ?subject  ?predicate  btag:Peak . }"
+    },
+    {
+      "description": "Percent => Percent",
+      "query": "DELETE{ ?subject ?predicate btag:Percent . } INSERT{ ?subject ?predicate tag:Percent . } WHERE { ?subject  ?predicate  btag:Percent . }"
+    },
+    {
+      "description": "Photovoltaic => Photovoltaic",
+      "query": "DELETE{ ?subject ?predicate btag:Photovoltaic . } INSERT{ ?subject ?predicate tag:Photovoltaic . } WHERE { ?subject  ?predicate  btag:Photovoltaic . }"
+    },
+    {
+      "description": "Piezoelectric => Piezoelectric",
+      "query": "DELETE{ ?subject ?predicate btag:Piezoelectric . } INSERT{ ?subject ?predicate tag:Piezoelectric . } WHERE { ?subject  ?predicate  btag:Piezoelectric . }"
+    },
+    {
+      "description": "Point => Point",
+      "query": "DELETE{ ?subject ?predicate btag:Point . } INSERT{ ?subject ?predicate tag:Point . } WHERE { ?subject  ?predicate  btag:Point . }"
+    },
+    {
+      "description": "Position => Position",
+      "query": "DELETE{ ?subject ?predicate btag:Position . } INSERT{ ?subject ?predicate tag:Position . } WHERE { ?subject  ?predicate  btag:Position . }"
+    },
+    {
+      "description": "Power => Power",
+      "query": "DELETE{ ?subject ?predicate btag:Power . } INSERT{ ?subject ?predicate tag:Power . } WHERE { ?subject  ?predicate  btag:Power . }"
+    },
+    {
+      "description": "Pre => Pre",
+      "query": "DELETE{ ?subject ?predicate btag:Pre . } INSERT{ ?subject ?predicate tag:Pre . } WHERE { ?subject  ?predicate  btag:Pre . }"
+    },
+    {
+      "description": "Preheat => Preheat",
+      "query": "DELETE{ ?subject ?predicate btag:Preheat . } INSERT{ ?subject ?predicate tag:Preheat . } WHERE { ?subject  ?predicate  btag:Preheat . }"
+    },
+    {
+      "description": "Pressure => Pressure",
+      "query": "DELETE{ ?subject ?predicate btag:Pressure . } INSERT{ ?subject ?predicate tag:Pressure . } WHERE { ?subject  ?predicate  btag:Pressure . }"
+    },
+    {
+      "description": "Proportional => Proportional",
+      "query": "DELETE{ ?subject ?predicate btag:Proportional . } INSERT{ ?subject ?predicate tag:Proportional . } WHERE { ?subject  ?predicate  btag:Proportional . }"
+    },
+    {
+      "description": "Protect => Protect",
+      "query": "DELETE{ ?subject ?predicate btag:Protect . } INSERT{ ?subject ?predicate tag:Protect . } WHERE { ?subject  ?predicate  btag:Protect . }"
+    },
+    {
+      "description": "Pump => Pump",
+      "query": "DELETE{ ?subject ?predicate btag:Pump . } INSERT{ ?subject ?predicate tag:Pump . } WHERE { ?subject  ?predicate  btag:Pump . }"
+    },
+    {
+      "description": "Push => Push",
+      "query": "DELETE{ ?subject ?predicate btag:Push . } INSERT{ ?subject ?predicate tag:Push . } WHERE { ?subject  ?predicate  btag:Push . }"
+    },
+    {
+      "description": "Radiance => Radiance",
+      "query": "DELETE{ ?subject ?predicate btag:Radiance . } INSERT{ ?subject ?predicate tag:Radiance . } WHERE { ?subject  ?predicate  btag:Radiance . }"
+    },
+    {
+      "description": "Rain => Rain",
+      "query": "DELETE{ ?subject ?predicate btag:Rain . } INSERT{ ?subject ?predicate tag:Rain . } WHERE { ?subject  ?predicate  btag:Rain . }"
+    },
+    {
+      "description": "Rated => Rated",
+      "query": "DELETE{ ?subject ?predicate btag:Rated . } INSERT{ ?subject ?predicate tag:Rated . } WHERE { ?subject  ?predicate  btag:Rated . }"
+    },
+    {
+      "description": "Ratio => Ratio",
+      "query": "DELETE{ ?subject ?predicate btag:Ratio . } INSERT{ ?subject ?predicate tag:Ratio . } WHERE { ?subject  ?predicate  btag:Ratio . }"
+    },
+    {
+      "description": "Ready => Ready",
+      "query": "DELETE{ ?subject ?predicate btag:Ready . } INSERT{ ?subject ?predicate tag:Ready . } WHERE { ?subject  ?predicate  btag:Ready . }"
+    },
+    {
+      "description": "Reheat => Reheat",
+      "query": "DELETE{ ?subject ?predicate btag:Reheat . } INSERT{ ?subject ?predicate tag:Reheat . } WHERE { ?subject  ?predicate  btag:Reheat . }"
+    },
+    {
+      "description": "Relative => Relative",
+      "query": "DELETE{ ?subject ?predicate btag:Relative . } INSERT{ ?subject ?predicate tag:Relative . } WHERE { ?subject  ?predicate  btag:Relative . }"
+    },
+    {
+      "description": "Remotely => Remotely",
+      "query": "DELETE{ ?subject ?predicate btag:Remotely . } INSERT{ ?subject ?predicate tag:Remotely . } WHERE { ?subject  ?predicate  btag:Remotely . }"
+    },
+    {
+      "description": "Request => Request",
+      "query": "DELETE{ ?subject ?predicate btag:Request . } INSERT{ ?subject ?predicate tag:Request . } WHERE { ?subject  ?predicate  btag:Request . }"
+    },
+    {
+      "description": "Required => Required",
+      "query": "DELETE{ ?subject ?predicate btag:Required . } INSERT{ ?subject ?predicate tag:Required . } WHERE { ?subject  ?predicate  btag:Required . }"
+    },
+    {
+      "description": "Reset => Reset",
+      "query": "DELETE{ ?subject ?predicate btag:Reset . } INSERT{ ?subject ?predicate tag:Reset . } WHERE { ?subject  ?predicate  btag:Reset . }"
+    },
+    {
+      "description": "Return => Return",
+      "query": "DELETE{ ?subject ?predicate btag:Return . } INSERT{ ?subject ?predicate tag:Return . } WHERE { ?subject  ?predicate  btag:Return . }"
+    },
+    {
+      "description": "Roof => Roof",
+      "query": "DELETE{ ?subject ?predicate btag:Roof . } INSERT{ ?subject ?predicate tag:Roof . } WHERE { ?subject  ?predicate  btag:Roof . }"
+    },
+    {
+      "description": "Room => Room",
+      "query": "DELETE{ ?subject ?predicate btag:Room . } INSERT{ ?subject ?predicate tag:Room . } WHERE { ?subject  ?predicate  btag:Room . }"
+    },
+    {
+      "description": "Run => Run",
+      "query": "DELETE{ ?subject ?predicate btag:Run . } INSERT{ ?subject ?predicate tag:Run . } WHERE { ?subject  ?predicate  btag:Run . }"
+    },
+    {
+      "description": "Running => Run",
+      "query": "DELETE{ ?subject ?predicate btag:Run . } INSERT{ ?subject ?predicate tag:Run . } WHERE { ?subject  ?predicate  btag:Run . }"
+    },
+    {
+      "description": "Safety => Safety",
+      "query": "DELETE{ ?subject ?predicate btag:Safety . } INSERT{ ?subject ?predicate tag:Safety . } WHERE { ?subject  ?predicate  btag:Safety . }"
+    },
+    {
+      "description": "Sash => Sash",
+      "query": "DELETE{ ?subject ?predicate btag:Sash . } INSERT{ ?subject ?predicate tag:Sash . } WHERE { ?subject  ?predicate  btag:Sash . }"
+    },
+    {
+      "description": "Schedule => Schedule",
+      "query": "DELETE{ ?subject ?predicate btag:Schedule . } INSERT{ ?subject ?predicate tag:Schedule . } WHERE { ?subject  ?predicate  btag:Schedule . }"
+    },
+    {
+      "description": "Scheduled => Schedule",
+      "query": "DELETE{ ?subject ?predicate btag:Schedule . } INSERT{ ?subject ?predicate tag:Schedule . } WHERE { ?subject  ?predicate  btag:Schedule . }"
+    },
+    {
+      "description": "Sensor => Sensor",
+      "query": "DELETE{ ?subject ?predicate btag:Sensor . } INSERT{ ?subject ?predicate tag:Sensor . } WHERE { ?subject  ?predicate  btag:Sensor . }"
+    },
+    {
+      "description": "Server => Server",
+      "query": "DELETE{ ?subject ?predicate btag:Server . } INSERT{ ?subject ?predicate tag:Server . } WHERE { ?subject  ?predicate  btag:Server . }"
+    },
+    {
+      "description": "Setpoint => Setpoint",
+      "query": "DELETE{ ?subject ?predicate btag:Setpoint . } INSERT{ ?subject ?predicate tag:Setpoint . } WHERE { ?subject  ?predicate  btag:Setpoint . }"
+    },
+    {
+      "description": "Shading => Shade",
+      "query": "DELETE{ ?subject ?predicate btag:Shade . } INSERT{ ?subject ?predicate tag:Shade . } WHERE { ?subject  ?predicate  btag:Shade . }"
+    },
+    {
+      "description": "Shed => Shed",
+      "query": "DELETE{ ?subject ?predicate btag:Shed . } INSERT{ ?subject ?predicate tag:Shed . } WHERE { ?subject  ?predicate  btag:Shed . }"
+    },
+    {
+      "description": "Short => Short",
+      "query": "DELETE{ ?subject ?predicate btag:Short . } INSERT{ ?subject ?predicate tag:Short . } WHERE { ?subject  ?predicate  btag:Short . }"
+    },
+    {
+      "description": "Shutdown => Shutdown",
+      "query": "DELETE{ ?subject ?predicate btag:Shutdown . } INSERT{ ?subject ?predicate tag:Shutdown . } WHERE { ?subject  ?predicate  btag:Shutdown . }"
+    },
+    {
+      "description": "Smoke => Smoke",
+      "query": "DELETE{ ?subject ?predicate btag:Smoke . } INSERT{ ?subject ?predicate tag:Smoke . } WHERE { ?subject  ?predicate  btag:Smoke . }"
+    },
+    {
+      "description": "Solar => Solar",
+      "query": "DELETE{ ?subject ?predicate btag:Solar . } INSERT{ ?subject ?predicate tag:Solar . } WHERE { ?subject  ?predicate  btag:Solar . }"
+    },
+    {
+      "description": "Space => Space",
+      "query": "DELETE{ ?subject ?predicate btag:Space . } INSERT{ ?subject ?predicate tag:Space . } WHERE { ?subject  ?predicate  btag:Space . }"
+    },
+    {
+      "description": "Speed => Speed",
+      "query": "DELETE{ ?subject ?predicate btag:Speed . } INSERT{ ?subject ?predicate tag:Speed . } WHERE { ?subject  ?predicate  btag:Speed . }"
+    },
+    {
+      "description": "Stack => Stack",
+      "query": "DELETE{ ?subject ?predicate btag:Stack . } INSERT{ ?subject ?predicate tag:Stack . } WHERE { ?subject  ?predicate  btag:Stack . }"
+    },
+    {
+      "description": "Stage => Stages",
+      "query": "DELETE{ ?subject ?predicate btag:Stages . } INSERT{ ?subject ?predicate tag:Stages . } WHERE { ?subject  ?predicate  btag:Stages . }"
+    },
+    {
+      "description": "Stages => Stages",
+      "query": "DELETE{ ?subject ?predicate btag:Stages . } INSERT{ ?subject ?predicate tag:Stages . } WHERE { ?subject  ?predicate  btag:Stages . }"
+    },
+    {
+      "description": "Standby => Standby",
+      "query": "DELETE{ ?subject ?predicate btag:Standby . } INSERT{ ?subject ?predicate tag:Standby . } WHERE { ?subject  ?predicate  btag:Standby . }"
+    },
+    {
+      "description": "Start => Start",
+      "query": "DELETE{ ?subject ?predicate btag:Start . } INSERT{ ?subject ?predicate tag:Start . } WHERE { ?subject  ?predicate  btag:Start . }"
+    },
+    {
+      "description": "Static => Static",
+      "query": "DELETE{ ?subject ?predicate btag:Static . } INSERT{ ?subject ?predicate tag:Static . } WHERE { ?subject  ?predicate  btag:Static . }"
+    },
+    {
+      "description": "Status => Status",
+      "query": "DELETE{ ?subject ?predicate btag:Status . } INSERT{ ?subject ?predicate tag:Status . } WHERE { ?subject  ?predicate  btag:Status . }"
+    },
+    {
+      "description": "Steam => Steam",
+      "query": "DELETE{ ?subject ?predicate btag:Steam . } INSERT{ ?subject ?predicate tag:Steam . } WHERE { ?subject  ?predicate  btag:Steam . }"
+    },
+    {
+      "description": "Step => Step",
+      "query": "DELETE{ ?subject ?predicate btag:Step . } INSERT{ ?subject ?predicate tag:Step . } WHERE { ?subject  ?predicate  btag:Step . }"
+    },
+    {
+      "description": "Stop => Stop",
+      "query": "DELETE{ ?subject ?predicate btag:Stop . } INSERT{ ?subject ?predicate tag:Stop . } WHERE { ?subject  ?predicate  btag:Stop . }"
+    },
+    {
+      "description": "Storage => Storage",
+      "query": "DELETE{ ?subject ?predicate btag:Storage . } INSERT{ ?subject ?predicate tag:Storage . } WHERE { ?subject  ?predicate  btag:Storage . }"
+    },
+    {
+      "description": "Suction => Suction",
+      "query": "DELETE{ ?subject ?predicate btag:Suction . } INSERT{ ?subject ?predicate tag:Suction . } WHERE { ?subject  ?predicate  btag:Suction . }"
+    },
+    {
+      "description": "Supply => Supply",
+      "query": "DELETE{ ?subject ?predicate btag:Supply . } INSERT{ ?subject ?predicate tag:Supply . } WHERE { ?subject  ?predicate  btag:Supply . }"
+    },
+    {
+      "description": "Switch => Switch",
+      "query": "DELETE{ ?subject ?predicate btag:Switch . } INSERT{ ?subject ?predicate tag:Switch . } WHERE { ?subject  ?predicate  btag:Switch . }"
+    },
+    {
+      "description": "System => System",
+      "query": "DELETE{ ?subject ?predicate btag:System . } INSERT{ ?subject ?predicate tag:System . } WHERE { ?subject  ?predicate  btag:System . }"
+    },
+    {
+      "description": "Tank => Tank",
+      "query": "DELETE{ ?subject ?predicate btag:Tank . } INSERT{ ?subject ?predicate tag:Tank . } WHERE { ?subject  ?predicate  btag:Tank . }"
+    },
+    {
+      "description": "Temperature => Temperature",
+      "query": "DELETE{ ?subject ?predicate btag:Temperature . } INSERT{ ?subject ?predicate tag:Temperature . } WHERE { ?subject  ?predicate  btag:Temperature . }"
+    },
+    {
+      "description": "Temporary => Temporary",
+      "query": "DELETE{ ?subject ?predicate btag:Temporary . } INSERT{ ?subject ?predicate tag:Temporary . } WHERE { ?subject  ?predicate  btag:Temporary . }"
+    },
+    {
+      "description": "Terminal => Terminal",
+      "query": "DELETE{ ?subject ?predicate btag:Terminal . } INSERT{ ?subject ?predicate tag:Terminal . } WHERE { ?subject  ?predicate  btag:Terminal . }"
+    },
+    {
+      "description": "Thermal => Thermal",
+      "query": "DELETE{ ?subject ?predicate btag:Thermal . } INSERT{ ?subject ?predicate tag:Thermal . } WHERE { ?subject  ?predicate  btag:Thermal . }"
+    },
+    {
+      "description": "Thermostat => Thermostat",
+      "query": "DELETE{ ?subject ?predicate btag:Thermostat . } INSERT{ ?subject ?predicate tag:Thermostat . } WHERE { ?subject  ?predicate  btag:Thermostat . }"
+    },
+    {
+      "description": "Time => Time",
+      "query": "DELETE{ ?subject ?predicate btag:Time . } INSERT{ ?subject ?predicate tag:Time . } WHERE { ?subject  ?predicate  btag:Time . }"
+    },
+    {
+      "description": "Timer => Timer",
+      "query": "DELETE{ ?subject ?predicate btag:Timer . } INSERT{ ?subject ?predicate tag:Timer . } WHERE { ?subject  ?predicate  btag:Timer . }"
+    },
+    {
+      "description": "Today => Today",
+      "query": "DELETE{ ?subject ?predicate btag:Today . } INSERT{ ?subject ?predicate tag:Today . } WHERE { ?subject  ?predicate  btag:Today . }"
+    },
+    {
+      "description": "Tolerance => Tolerance",
+      "query": "DELETE{ ?subject ?predicate btag:Tolerance . } INSERT{ ?subject ?predicate tag:Tolerance . } WHERE { ?subject  ?predicate  btag:Tolerance . }"
+    },
+    {
+      "description": "Torque => Torque",
+      "query": "DELETE{ ?subject ?predicate btag:Torque . } INSERT{ ?subject ?predicate tag:Torque . } WHERE { ?subject  ?predicate  btag:Torque . }"
+    },
+    {
+      "description": "Tower => Tower",
+      "query": "DELETE{ ?subject ?predicate btag:Tower . } INSERT{ ?subject ?predicate tag:Tower . } WHERE { ?subject  ?predicate  btag:Tower . }"
+    },
+    {
+      "description": "Trace => Trace",
+      "query": "DELETE{ ?subject ?predicate btag:Trace . } INSERT{ ?subject ?predicate tag:Trace . } WHERE { ?subject  ?predicate  btag:Trace . }"
+    },
+    {
+      "description": "Turn => Turn",
+      "query": "DELETE{ ?subject ?predicate btag:Turn . } INSERT{ ?subject ?predicate tag:Turn . } WHERE { ?subject  ?predicate  btag:Turn . }"
+    },
+    {
+      "description": "Underfloor => Underfloor",
+      "query": "DELETE{ ?subject ?predicate btag:Underfloor . } INSERT{ ?subject ?predicate tag:Underfloor . } WHERE { ?subject  ?predicate  btag:Underfloor . }"
+    },
+    {
+      "description": "Unit => Unit",
+      "query": "DELETE{ ?subject ?predicate btag:Unit . } INSERT{ ?subject ?predicate tag:Unit . } WHERE { ?subject  ?predicate  btag:Unit . }"
+    },
+    {
+      "description": "Unoccupied => Unoccupied",
+      "query": "DELETE{ ?subject ?predicate btag:Unoccupied . } INSERT{ ?subject ?predicate tag:Unoccupied . } WHERE { ?subject  ?predicate  btag:Unoccupied . }"
+    },
+    {
+      "description": "Usage => Usage",
+      "query": "DELETE{ ?subject ?predicate btag:Usage . } INSERT{ ?subject ?predicate tag:Usage . } WHERE { ?subject  ?predicate  btag:Usage . }"
+    },
+    {
+      "description": "VAV => VAV",
+      "query": "DELETE{ ?subject ?predicate btag:VAV . } INSERT{ ?subject ?predicate tag:VAV . } WHERE { ?subject  ?predicate  btag:VAV . }"
+    },
+    {
+      "description": "VFD => VFD",
+      "query": "DELETE{ ?subject ?predicate btag:VFD . } INSERT{ ?subject ?predicate tag:VFD . } WHERE { ?subject  ?predicate  btag:VFD . }"
+    },
+    {
+      "description": "Valve => Valve",
+      "query": "DELETE{ ?subject ?predicate btag:Valve . } INSERT{ ?subject ?predicate tag:Valve . } WHERE { ?subject  ?predicate  btag:Valve . }"
+    },
+    {
+      "description": "Variable => Variable",
+      "query": "DELETE{ ?subject ?predicate btag:Variable . } INSERT{ ?subject ?predicate tag:Variable . } WHERE { ?subject  ?predicate  btag:Variable . }"
+    },
+    {
+      "description": "Velocity => Velocity",
+      "query": "DELETE{ ?subject ?predicate btag:Velocity . } INSERT{ ?subject ?predicate tag:Velocity . } WHERE { ?subject  ?predicate  btag:Velocity . }"
+    },
+    {
+      "description": "Vent => Vent",
+      "query": "DELETE{ ?subject ?predicate btag:Vent . } INSERT{ ?subject ?predicate tag:Vent . } WHERE { ?subject  ?predicate  btag:Vent . }"
+    },
+    {
+      "description": "Ventilation => Ventilation",
+      "query": "DELETE{ ?subject ?predicate btag:Ventilation . } INSERT{ ?subject ?predicate tag:Ventilation . } WHERE { ?subject  ?predicate  btag:Ventilation . }"
+    },
+    {
+      "description": "Voltage => Voltage",
+      "query": "DELETE{ ?subject ?predicate btag:Voltage . } INSERT{ ?subject ?predicate tag:Voltage . } WHERE { ?subject  ?predicate  btag:Voltage . }"
+    },
+    {
+      "description": "Volume => Volume",
+      "query": "DELETE{ ?subject ?predicate btag:Volume . } INSERT{ ?subject ?predicate tag:Volume . } WHERE { ?subject  ?predicate  btag:Volume . }"
+    },
+    {
+      "description": "WS => Water + System",
+      "query": "DELETE{ ?subject ?predicate btag:Water . } INSERT{ ?subject ?predicate tag:Water, brick:System . } WHERE { ?subject  ?predicate  btag:Water . }"
+    },
+    {
+      "description": "Warm => Warm",
+      "query": "DELETE{ ?subject ?predicate btag:Warm . } INSERT{ ?subject ?predicate tag:Warm . } WHERE { ?subject  ?predicate  btag:Warm . }"
+    },
+    {
+      "description": "Warmest => Warmest",
+      "query": "DELETE{ ?subject ?predicate btag:Warmest . } INSERT{ ?subject ?predicate tag:Warmest . } WHERE { ?subject  ?predicate  btag:Warmest . }"
+    },
+    {
+      "description": "Water => Water",
+      "query": "DELETE{ ?subject ?predicate btag:Water . } INSERT{ ?subject ?predicate tag:Water . } WHERE { ?subject  ?predicate  btag:Water . }"
+    },
+    {
+      "description": "Weather => Weather",
+      "query": "DELETE{ ?subject ?predicate btag:Weather . } INSERT{ ?subject ?predicate tag:Weather . } WHERE { ?subject  ?predicate  btag:Weather . }"
+    },
+    {
+      "description": "Wheel => Wheel",
+      "query": "DELETE{ ?subject ?predicate btag:Wheel . } INSERT{ ?subject ?predicate tag:Wheel . } WHERE { ?subject  ?predicate  btag:Wheel . }"
+    },
+    {
+      "description": "Wind => Wind",
+      "query": "DELETE{ ?subject ?predicate btag:Wind . } INSERT{ ?subject ?predicate tag:Wind . } WHERE { ?subject  ?predicate  btag:Wind . }"
+    },
+    {
+      "description": "Wing => Wing",
+      "query": "DELETE{ ?subject ?predicate btag:Wing . } INSERT{ ?subject ?predicate tag:Wing . } WHERE { ?subject  ?predicate  btag:Wing . }"
+    },
+    {
+      "description": "Yearly => Yearly",
+      "query": "DELETE{ ?subject ?predicate btag:Yearly . } INSERT{ ?subject ?predicate tag:Yearly . } WHERE { ?subject  ?predicate  btag:Yearly . }"
+    },
+    {
+      "description": "Zenith => Zenith",
+      "query": "DELETE{ ?subject ?predicate btag:Zenith . } INSERT{ ?subject ?predicate tag:Zenith . } WHERE { ?subject  ?predicate  btag:Zenith . }"
+    },
+    {
+      "description": "Zone => Zone",
+      "query": "DELETE{ ?subject ?predicate btag:Zone . } INSERT{ ?subject ?predicate tag:Zone . } WHERE { ?subject  ?predicate  btag:Zone . }"
+    }
+  ]
+}

--- a/tools/convert/conversions/versions.ttl
+++ b/tools/convert/conversions/versions.ttl
@@ -6,3 +6,5 @@
 version:convertsTo a owl:TransitiveProperty .
 
 "1.0.2" version:convertsTo "1.1" .
+
+"1.0.3" version:convertsTo "1.1" .


### PR DESCRIPTION
This includes mappings of classes, relationships, and tags from Brick `v1.0.3` to `v1.1`. 