### PR TITLE
Autogen SHACL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,17 @@
 Brick.ttl: bricksrc/*.py generate_brick.py
 	python generate_brick.py
 
+shacl/BrickShape.ttl: bricksrc/*.py generate_brick.py shacl/generate_shacl.py
+	cd shacl && python generate_shacl.py
+
 format:
 	black generate_brick.py
+	black shacl/
 	black bricksrc/
 	black tests/
 	black tools/
 
-test: Brick.ttl
+test: Brick.ttl shacl/BrickShape.ttl
 	pytest -s -vvvv tests
 
 quantity-test: Brick.ttl

--- a/shacl/generate_shacl.py
+++ b/shacl/generate_shacl.py
@@ -1,13 +1,10 @@
-from rdflib import Graph, Literal, BNode, URIRef, Namespace
-from rdflib.collection import Collection
-from rdflib.plugins.sparql import prepareQuery
-
+from rdflib import Graph, Literal, BNode
 import sys
-sys.path.append('..')
-from bricksrc.namespaces import RDF, RDFS, BRICK, BSH, SH, SKOS
-from bricksrc.namespaces import bind_prefixes
-# add SHACL shapes from properties
-from bricksrc.properties import properties as property_definitions
+
+sys.path.append("..")
+from bricksrc.namespaces import RDF, RDFS, BRICK, BSH, SH, SKOS  # noqa: E402
+from bricksrc.namespaces import bind_prefixes  # noqa: E402
+from bricksrc.properties import properties as property_definitions  # noqa: E402
 
 G = Graph()
 bind_prefixes(G)
@@ -17,29 +14,41 @@ domainShapeDict = {}
 rangeShapeDict = {}
 subpropertyDict = {}
 
+
 # Make shape for expectedDomain property
 def addDomainShape(propertyName, expectedType):
     domainShapeDict[propertyName] = expectedType
-    sh_prop = BNode()
     shapename = f"{propertyName}DomainShape"
     G.add((BSH[shapename], A, SH.NodeShape))
     G.add((BSH[shapename], SH.targetSubjectsOf, BRICK[propertyName]))
-    G.add((BSH[shapename], SH['class'], expectedType))
-    G.add((BSH[shapename], SH['message'],
-           Literal(f"Property {propertyName} has subject with incorrect type")))
+    G.add((BSH[shapename], SH["class"], expectedType))
+    G.add(
+        (
+            BSH[shapename],
+            SH["message"],
+            Literal(f"Property {propertyName} has subject with incorrect type"),
+        )
+    )
+
 
 # Make shape for expectedRange property
 def addRangeShape(propertyName, expectedType):
     rangeShapeDict[propertyName] = expectedType
     sh_prop = BNode()
     shapename = f"{propertyName}RangeShape"
-    G.add((BSH[shapename], SH['property'], sh_prop))
+    G.add((BSH[shapename], SH["property"], sh_prop))
     G.add((BSH[shapename], A, SH.NodeShape))
-    G.add((sh_prop, SH['path'], BRICK[propertyName]))
-    G.add((sh_prop, SH['class'], expectedType))
+    G.add((sh_prop, SH["path"], BRICK[propertyName]))
+    G.add((sh_prop, SH["class"], expectedType))
     G.add((BSH[shapename], SH.targetSubjectsOf, BRICK[propertyName]))
-    G.add((sh_prop, SH['message'],
-           Literal(f"Property {propertyName} has object with incorrect type")))
+    G.add(
+        (
+            sh_prop,
+            SH["message"],
+            Literal(f"Property {propertyName} has object with incorrect type"),
+        )
+    )
+
 
 for name, properties in property_definitions.items():
     for pred, obj in properties.items():
@@ -55,7 +64,7 @@ for name, properties in property_definitions.items():
             addRangeShape(name, obj)
 
         # subproperties are considered after "domain" and "range" are counted for
-        if pred == 'subproperties':
+        if pred == "subproperties":
             for subprop, desc in obj.items():
                 subpropertyDict[subprop] = desc
 
@@ -63,10 +72,7 @@ for name, properties in property_definitions.items():
 # using OWL restrictions while generateing Brick.ttl.  But
 # that kind of schema change is beyond the scope for now.
 substance_subproperties = {
-    'feedsAir':  {
-        'substanceType': BRICK.Air,
-        'substanceSuperType': BRICK.Substance,
-    },
+    "feedsAir": {"substanceType": BRICK.Air, "substanceSuperType": BRICK.Substance},
 }
 
 # For each substance_subproperties element, such as Brick:feedsAir,
@@ -81,17 +87,24 @@ for subprop, desc in subpropertyDict.items():
         continue
 
     for propertyName, expectedType in rangeShapeDict.items():
-        if expectedType == subpropInfo['substanceSuperType']:
+        if expectedType == subpropInfo["substanceSuperType"]:
             sh_prop = BNode()
             capitalized = f"{propertyName[0].upper()}{propertyName[1:]}"
             shapename = f"feedsAir{capitalized}Shape"
-            G.add((BSH[shapename], SH['property'], sh_prop))
+            G.add((BSH[shapename], SH["property"], sh_prop))
             G.add((BSH[shapename], A, SH.NodeShape))
-            G.add((sh_prop, SH['path'], BRICK[propertyName]))
-            G.add((sh_prop, SH['class'], subpropInfo['substanceType']))
-            G.add((sh_prop, SH['message'],
-            Literal(f"Subject of property {subprop} has object with incorrect type")))
+            G.add((sh_prop, SH["path"], BRICK[propertyName]))
+            G.add((sh_prop, SH["class"], subpropInfo["substanceType"]))
+            G.add(
+                (
+                    sh_prop,
+                    SH["message"],
+                    Literal(
+                        f"Subject of property {subprop} has object with incorrect type"
+                    ),
+                )
+            )
             G.add((BSH[shapename], SH.targetSubjectsOf, BRICK[subprop]))
 
-with open('BrickShape.ttl', 'wb') as f:
-    f.write(G.serialize(format='ttl'))
+with open("BrickShape.ttl", "wb") as f:
+    f.write(G.serialize(format="ttl"))

--- a/tests/test_generate_shacl.py
+++ b/tests/test_generate_shacl.py
@@ -1,14 +1,15 @@
 import sys
-from rdflib import RDFS, Graph
+from rdflib import Graph
 from bricksrc.namespaces import A, OWL, RDFS, SKOS, BRICK, SH, BSH, bind_prefixes
 from .util import make_readable
 
 sys.path.append("..")
-from bricksrc.properties import properties
+from bricksrc.properties import properties  # noqa: E402
 
 g = Graph()
-g.parse('shacl/BrickShape.ttl', format='turtle')
+g.parse("shacl/BrickShape.ttl", format="turtle")
 bind_prefixes(g)
+
 
 def test_domainProperties():
     for (name, props) in properties.items():
@@ -18,11 +19,10 @@ def test_domainProperties():
             ?shape sh:targetSubjectsOf brick:{name} .
             ?shape sh:class <{props[RDFS.domain]}> . }}
             """
-            res = make_readable(
-                g.query(q)
-            )
-            assert len(res) == 1, 'unexpected # of query results'
+            res = make_readable(g.query(q))
+            assert len(res) == 1, "unexpected # of query results"
     return
+
 
 def test_rangeProperties():
     for (name, props) in properties.items():
@@ -34,8 +34,6 @@ def test_rangeProperties():
             sh:path brick:{name} ;
             ] }}
             """
-            res = make_readable(
-                g.query(q)
-            )
-            assert len(res) == 1, 'unexpected # of query results'
+            res = make_readable(g.query(q))
+            assert len(res) == 1, "unexpected # of query results"
     return


### PR DESCRIPTION
Fixing up some loose ends in the SHACL implementation that cause future PRs to fail if they introduce new classes with properties that are validated by SHACL

- SHACL generation, tests should be properly formatted now
- BrickShape.ttl file is automatically generated when its dependencies change