### PR TITLE
Units prototype with QUDT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ script:
   # generate new Brick ontology (in case this hasn't been run)
   - python generate_brick.py
   # regenerate SHACL shapes
-  - cd shacl && python generate_shacl.py
+  - cd shacl && python generate_shacl.py && cd ..
   # -s flag: do not capture output (avoids killing test after 10 min)
   - pytest -s -vvvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ install:
 script:
   # generate new Brick ontology (in case this hasn't been run)
   - python generate_brick.py
+  # regenerate SHACL shapes
+  - cd shacl && python generate_shacl.py
   # -s flag: do not capture output (avoids killing test after 10 min)
   - pytest -s -vvvv

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -5631,13 +5631,6 @@ brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
         tag:Unoccupied,
         tag:Zone .
 
-brick:associatedQuantityKind a owl:AsymmetricProperty,
-        owl:IrreflexiveProperty,
-        owl:ObjectProperty ;
-    rdfs:domain brick:Quantity ;
-    rdfs:range qudt:QuantityKind ;
-    skos:definition "The QUDT QuantityKind associated with this Quantity" .
-
 brick:feedsAir a owl:ObjectProperty ;
     rdfs:subPropertyOf brick:feeds ;
     skos:definition "Passes air" .

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -131,9 +131,9 @@ brick:Alternating_Current_Frequency a qudt:QuantityKind,
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
     skos:broader qudtqk:Frequency,
-        brick:Electric_Current,
         brick:Frequency ;
-    skos:definition "The frequency of the oscillations of alternating current" .
+    skos:definition "The frequency of the oscillations of alternating current" ;
+    skos:related brick:Electric_Current .
 
 brick:Apparent_Power a qudt:QuantityKind,
         brick:Quantity ;
@@ -382,6 +382,17 @@ brick:Bypass_Command a owl:Class ;
         tag:Command,
         tag:Point .
 
+brick:CO2_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "CO2 Concentration",
+        "CO2Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of CO2 in air" .
+
 brick:CO2_Differential_Sensor a owl:Class ;
     rdfs:label "CO2 Differential Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Differential _:has_Sensor ) ],
@@ -390,17 +401,6 @@ brick:CO2_Differential_Sensor a owl:Class ;
         tag:Differential,
         tag:Point,
         tag:Sensor .
-
-brick:CO2_Level a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "CO2 Level",
-        "Concentration" ;
-    qudt:applicableUnit unit:PPM ;
-    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
-    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader qudtqk:Dimensionless,
-        brick:Air_Quality ;
-    skos:definition "The concentration ratio of some substance" .
 
 brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
@@ -929,9 +929,9 @@ brick:Current_Angle a qudt:QuantityKind,
         unit:REV ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Electric_Current,
-        brick:PhasorAngle ;
-    skos:definition "Angle of current phasor" .
+    skos:broader brick:PhasorAngle ;
+    skos:definition "Angle of current phasor" ;
+    skos:related brick:Electric_Current .
 
 brick:Current_Imbalance a qudt:QuantityKind,
         brick:Quantity ;
@@ -940,9 +940,9 @@ brick:Current_Imbalance a qudt:QuantityKind,
     qudt:applicableUnit unit:PERCENT ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Dimensionless,
-        brick:Electric_Current ;
-    skos:definition "The percent deviation from average current" .
+    skos:broader brick:Dimensionless ;
+    skos:definition "The percent deviation from average current" ;
+    skos:related brick:Electric_Current .
 
 brick:Current_Limit a owl:Class ;
     rdfs:label "Current Limit" ;
@@ -953,19 +953,6 @@ brick:Current_Limit a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Current_Magnitude a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Current Magnitude",
-        "CurrentMagnitude" ;
-    qudt:applicableUnit unit:A,
-        unit:KiloA,
-        unit:MicroA,
-        unit:MilliA ;
-    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Electric_Current,
-        brick:PhasorMagnitude ;
-    skos:definition "Magnitude of current phasor" .
-
 brick:Current_Total_Harmonic_Distortion a qudt:QuantityKind,
         brick:Quantity ;
     rdfs:label "Current Total Harmonic Distortion",
@@ -974,9 +961,9 @@ brick:Current_Total_Harmonic_Distortion a qudt:QuantityKind,
         unit:PERCENT ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Dimensionless,
-        brick:Electric_Current ;
-    skos:definition "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)" .
+    skos:broader brick:Dimensionless ;
+    skos:definition "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)" ;
+    skos:related brick:Electric_Current .
 
 brick:Curtailment_Override_Command a owl:Class ;
     rdfs:label "Curtailment Override Command" ;
@@ -1682,10 +1669,14 @@ brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
 
 brick:Electric_Energy a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Electric Energy" ;
+    rdfs:label "Electric Energy",
+        "ElectricEnergy" ;
     qudt:applicableUnit unit:J ;
-    owl:sameAs qudtqk:Energy ;
-    skos:broader brick:Energy .
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Energy,
+        brick:Energy ;
+    skos:definition "A form of energy resulting from the flow of electrical charge" .
 
 brick:Elevator a owl:Class ;
     rdfs:label "Elevator" ;
@@ -2136,16 +2127,6 @@ brick:Fan_Coil_Unit a owl:Class ;
         tag:Fan,
         tag:Unit .
 
-brick:Fan_Speed_Reset_Command a owl:Class ;
-    rdfs:label "Fan Speed Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Speed _:has_Reset _:has_Command ) ],
-        brick:Speed_Reset_Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Fan,
-        tag:Point,
-        tag:Reset,
-        tag:Speed .
-
 brick:Fan_Start_Stop_Status a owl:Class ;
     rdfs:label "Fan Start Stop Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Start _:has_Stop _:has_Status ) ],
@@ -2225,8 +2206,13 @@ brick:Fire_Zone a owl:Class ;
 
 brick:Flow_Loss a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Flow Loss" ;
-    skos:broader brick:Flow .
+    rdfs:label "Flow Loss",
+        "FlowLoss" ;
+    qudt:applicableUnit unit:M3-PER-SEC ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Flow ;
+    skos:definition "The amount of flow rate that is lost during distribution" .
 
 brick:Freeze_Status a owl:Class ;
     rdfs:label "Freeze Status" ;
@@ -2295,6 +2281,16 @@ brick:Gas_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Gas,
         tag:Point,
         tag:Sensor .
+
+brick:GrainsOfMoisture a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "GrainsOfMoisture" ;
+    qudt:applicableUnit unit:GRAIN ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Mass,
+        brick:Mass ;
+    skos:definition "Mass of moisture per pround of air, measured in grains of water" .
 
 brick:HVAC_Zone a owl:Class ;
     rdfs:label "HVAC Zone" ;
@@ -2952,14 +2948,6 @@ brick:Locally_On_Off_Status a owl:Class ;
         tag:On,
         tag:Point,
         tag:Status .
-
-brick:Lockout_Command a owl:Class ;
-    rdfs:label "Lockout Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lockout _:has_Command ) ],
-        brick:Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Lockout,
-        tag:Point .
 
 brick:Louver a owl:Class ;
     rdfs:label "Louver" ;
@@ -4318,27 +4306,27 @@ brick:PIR_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:PM10_Level a qudt:QuantityKind,
+brick:PM10_Concentration a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Concentration",
-        "PM10 Level" ;
+    rdfs:label "PM10 Concentration",
+        "PM10Concentration" ;
     qudt:applicableUnit unit:PPM ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
     skos:broader qudtqk:Dimensionless,
         brick:Air_Quality ;
-    skos:definition "The concentration ratio of some substance" .
+    skos:definition "The concentration of particulates with diameter of 10 microns or less in air" .
 
-brick:PM25_Level a qudt:QuantityKind,
+brick:PM25_Concentration a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Concentration",
-        "PM25 Level" ;
+    rdfs:label "PM25 Concentration",
+        "PM25Concentration" ;
     qudt:applicableUnit unit:PPM ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
     skos:broader qudtqk:Dimensionless,
         brick:Air_Quality ;
-    skos:definition "The concentration ratio of some substance" .
+    skos:definition "The concentration of particulates with diameter of 25 microns or less in air" .
 
 brick:Peak_Power_Demand_Sensor a owl:Class ;
     rdfs:label "Peak Power Demand Sensor" ;
@@ -4354,6 +4342,25 @@ brick:Peak_Power_Demand_Sensor a owl:Class ;
         tag:Point,
         tag:Power,
         tag:Sensor .
+
+brick:PhasorMagnitude a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PhasorMagnitude" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:definition "Magnitude component of a phasor" ;
+    skos:related brick:Phasor .
 
 brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     rdfs:label "Photovoltaic Current Output Sensor" ;
@@ -4759,15 +4766,6 @@ brick:Run_Enable_Status a owl:Class ;
         tag:Run,
         tag:Status .
 
-brick:Run_Request_Command a owl:Class ;
-    rdfs:label "Run Request Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Request _:has_Command ) ],
-        brick:Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Point,
-        tag:Request,
-        tag:Run .
-
 brick:Run_Request_Status a owl:Class ;
     rdfs:label "Run Request Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Request _:has_Run _:has_Status ) ],
@@ -4905,6 +4903,15 @@ brick:Space_Heater a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Heater,
         tag:Space .
+
+brick:Speed_Reset_Command a owl:Class ;
+    rdfs:label "Speed Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Reset,
+        tag:Speed .
 
 brick:Speed_Status a owl:Class ;
     rdfs:label "Speed Status" ;
@@ -5287,7 +5294,9 @@ brick:System_Mode_Status a owl:Class ;
 
 brick:System_Shutdown_Status a owl:Class ;
     rdfs:label "System Shutdown Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Shutdown _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System [ a owl:Restriction ;
+                        owl:hasValue tag:Shutdown ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status,
         brick:System_Status ;
     brick:hasAssociatedTag tag:Point,
@@ -5295,16 +5304,16 @@ brick:System_Shutdown_Status a owl:Class ;
         tag:Status,
         tag:System .
 
-brick:TVOC_Level a qudt:QuantityKind,
+brick:TVOC_Concentration a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Concentration",
-        "TVOC Level" ;
+    rdfs:label "TVOC Concentration",
+        "TVOCConcentration" ;
     qudt:applicableUnit unit:PPM ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
     skos:broader qudtqk:Dimensionless,
         brick:Air_Quality ;
-    skos:definition "The concentration ratio of some substance" .
+    skos:definition "The concentration of total volatile organic compounds in air" .
 
 brick:Temperature_Adjust_Sensor a owl:Class ;
     rdfs:label "Temperature Adjust Sensor" ;
@@ -5381,7 +5390,8 @@ brick:Thermal_Power a qudt:QuantityKind,
         brick:Quantity ;
     rdfs:label "Thermal Power",
         "ThermalPower" ;
-    qudt:applicableUnit unit:KiloW,
+    qudt:applicableUnit unit:BTU_IT,
+        unit:KiloW,
         unit:MegaW,
         unit:MilliW,
         unit:W ;
@@ -5516,17 +5526,6 @@ brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Unoccupied .
 
-brick:Unoccupied_Hot_Water_Shutdown_Command a owl:Class ;
-    rdfs:label "Unoccupied Hot Water Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
-        brick:Hot_Water_Shutdown_Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Hot,
-        tag:Point,
-        tag:Shutdown,
-        tag:Unoccupied,
-        tag:Water .
-
 brick:Unoccupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Mode Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Mode _:has_Setpoint ) ],
@@ -5635,9 +5634,9 @@ brick:Voltage_Angle a qudt:QuantityKind,
         unit:REV ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:PhasorAngle,
-        brick:Voltage ;
-    skos:definition "Angle of voltage phasor" .
+    skos:broader brick:PhasorAngle ;
+    skos:definition "Angle of voltage phasor" ;
+    skos:related brick:Voltage .
 
 brick:Voltage_Imbalance a qudt:QuantityKind,
         brick:Quantity ;
@@ -5646,15 +5645,9 @@ brick:Voltage_Imbalance a qudt:QuantityKind,
     qudt:applicableUnit unit:PERCENT ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Dimensionless,
-        brick:Voltage ;
-    skos:definition "The percent deviation from average voltage" .
-
-brick:Voltage_Magnitude a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Voltage Magnitude" ;
-    owl:sameAs qudtqk:Voltage ;
-    skos:broader brick:Voltage .
+    skos:broader brick:Dimensionless ;
+    skos:definition "The percent deviation from average voltage" ;
+    skos:related brick:Voltage .
 
 brick:Warm_Cool_Adjust_Sensor a owl:Class ;
     rdfs:label "Warm Cool Adjust Sensor" ;
@@ -5853,6 +5846,8 @@ brick:regulates a owl:AsymmetricProperty,
     owl:inverseOf brick:isRegulatedBy ;
     skos:definition "The subject contributes to or performs the regulation of the substance given by the object" .
 
+unit:A qudt:symbol "A" .
+
 unit:AMU qudt:symbol "\\(\\mu\\)" .
 
 unit:A_Ab qudt:symbol "abA" .
@@ -5862,8 +5857,6 @@ unit:A_Stat qudt:symbol "statA" .
 unit:BARYE qudt:symbol "\\rho" .
 
 unit:BIOT qudt:symbol "Bi" .
-
-unit:BTU_IT qudt:symbol "Btu_{it}" .
 
 unit:BTU_TH qudt:symbol "Btu_{th}" .
 
@@ -5896,7 +5889,7 @@ unit:HR_Sidereal qudt:symbol "hr" .
 
 unit:HZ qudt:symbol "Hz" .
 
-unit:J qudt:symbol "J" .
+unit:KiloA qudt:symbol "kA" .
 
 unit:KiloCAL qudt:symbol "kcal" .
 
@@ -5924,7 +5917,11 @@ unit:MO qudt:symbol "mo" .
 
 unit:MegaHZ qudt:symbol "MHz" .
 
+unit:MicroA qudt:symbol "µA" .
+
 unit:MicroSEC qudt:symbol "microsec" .
+
+unit:MilliA qudt:symbol "mA" .
 
 unit:MilliSEC qudt:symbol "ms" .
 
@@ -6724,16 +6721,6 @@ brick:Hot_Water_Meter a owl:Class ;
         tag:Meter,
         tag:Water .
 
-brick:Hot_Water_Shutdown_Command a owl:Class ;
-    rdfs:label "Hot Water Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
-        brick:Shutdown_Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Hot,
-        tag:Point,
-        tag:Shutdown,
-        tag:Water .
-
 brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Load Shed Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
@@ -7086,30 +7073,17 @@ brick:PV_Current_Output_Sensor a owl:Class ;
 
 brick:Peak_Power a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "Peak Power" ;
-    qudt:applicableUnit unit:KiloW ;
-    owl:sameAs qudtqk:ElectricPower ;
-    skos:broader brick:Power ;
-    skos:definition "Tracks the highest (peak) observed power in some interval" .
-
-brick:PhasorMagnitude a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "PhasorMagnitude" ;
-    qudt:applicableUnit unit:ARCMIN,
-        unit:ARCSEC,
-        unit:DEG,
-        unit:GON,
-        unit:GRAD,
-        unit:MIL,
-        unit:MicroRAD,
-        unit:MilliARCSEC,
-        unit:MilliRAD,
-        unit:RAD,
-        unit:REV ;
-    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:label "Peak Power",
+        "PeakPower" ;
+    qudt:applicableUnit unit:KiloW,
+        unit:MegaW,
+        unit:MilliW,
+        unit:W ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:Phasor ;
-    skos:definition "Magnitude component of a phasor" .
+    skos:broader qudtqk:Power,
+        brick:Power ;
+    skos:definition "Tracks the highest (peak) observed power in some interval" .
 
 brick:Position a qudt:QuantityKind,
         brick:Quantity ;
@@ -7241,14 +7215,6 @@ brick:Shading_System a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Shade .
 
-brick:Shutdown_Command a owl:Class ;
-    rdfs:label "Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shutdown _:has_Command ) ],
-        brick:Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Point,
-        tag:Shutdown .
-
 brick:Smoke_Alarm a owl:Class ;
     rdfs:label "Smoke Alarm" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Alarm ) ],
@@ -7274,7 +7240,7 @@ brick:Solar_Radiance a qudt:QuantityKind,
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
     skos:broader qudtqk:Radiance,
         brick:Radiance ;
-    skos:definition "The amount of light that passes through or is emitted from the sun and falls withi na given solid angle in a specified direction" .
+    skos:definition "The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction" .
 
 brick:Space a owl:Class ;
     rdfs:label "Space" ;
@@ -7282,15 +7248,6 @@ brick:Space a owl:Class ;
         brick:Location ;
     brick:hasAssociatedTag tag:Location,
         tag:Space .
-
-brick:Speed_Reset_Command a owl:Class ;
-    rdfs:label "Speed Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Reset _:has_Command ) ],
-        brick:Reset_Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Point,
-        tag:Reset,
-        tag:Speed .
 
 brick:Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Standby Load Shed Command" ;
@@ -7629,17 +7586,9 @@ brick:isTagOf a owl:AsymmetricProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Tag .
 
-unit:A qudt:symbol "A" .
+unit:BTU_IT qudt:symbol "Btu_{it}" .
 
 unit:GRAIN qudt:symbol "gr" .
-
-unit:KiloA qudt:symbol "kA" .
-
-unit:MicroA qudt:symbol "µA" .
-
-unit:MilliA qudt:symbol "mA" .
-
-unit:W qudt:symbol "W" .
 
 brick:Active_Power a qudt:QuantityKind,
         brick:Quantity ;
@@ -7798,10 +7747,6 @@ brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Flow,
         tag:Point,
         tag:Setpoint .
-
-brick:Current a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Current" .
 
 brick:Current_Output_Sensor a owl:Class ;
     rdfs:label "Current Output Sensor" ;
@@ -8351,9 +8296,9 @@ brick:PhasorAngle a qudt:QuantityKind,
         unit:REV ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader qudtqk:PlaneAngle,
-        brick:Phasor ;
-    skos:definition "Angle component of a phasor" .
+    skos:broader qudtqk:PlaneAngle ;
+    skos:definition "Angle component of a phasor" ;
+    skos:related brick:Phasor .
 
 brick:Position_Limit a owl:Class ;
     rdfs:label "Position Limit" ;
@@ -8937,6 +8882,9 @@ tag:Server a brick:Tag ;
 tag:Short a brick:Tag ;
     rdfs:label "Short" .
 
+tag:Shutdown a brick:Tag ;
+    rdfs:label "Shutdown" .
+
 tag:Stages a brick:Tag ;
     rdfs:label "Stages" .
 
@@ -8998,6 +8946,8 @@ tag:Zenith a brick:Tag ;
     rdfs:label "Zenith" .
 
 unit:UNITLESS qudt:symbol "U" .
+
+unit:W qudt:symbol "W" .
 
 brick:AHU a owl:Class ;
     rdfs:label "AHU" ;
@@ -9180,15 +9130,6 @@ brick:Gain_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Grains a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Grains" ;
-    qudt:applicableUnit unit:GRAIN ;
-    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
-    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader qudtqk:Mass,
-        brick:Mass .
-
 brick:Hot_Water a owl:Class,
         brick:Hot_Water ;
     rdfs:label "Hot Water" ;
@@ -9247,7 +9188,8 @@ brick:Level a qudt:QuantityKind,
         unit:YD ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader qudtqk:Length .
+    skos:broader qudtqk:Length ;
+    skos:definition "Amount of substance in a container; typically measured in height" .
 
 brick:Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Load Shed Setpoint" ;
@@ -9486,6 +9428,11 @@ brick:Video_Surveillance_Equipment a owl:Class ;
         tag:Security,
         tag:Surveillance,
         tag:Video .
+
+brick:Voltage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage" ;
+    owl:sameAs qudtqk:Voltage .
 
 brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
@@ -9892,6 +9839,20 @@ brick:Discharge_Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
+brick:Electric_Current a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Electric Current" ;
+    qudt:applicableUnit unit:A,
+        unit:A_Ab,
+        unit:A_Stat,
+        unit:BIOT,
+        unit:KiloA,
+        unit:MicroA,
+        unit:MilliA,
+        unit:NanoA,
+        unit:PicoA ;
+    owl:sameAs qudtqk:ElectricCurrent .
+
 brick:Electrical_System a owl:Class ;
     rdfs:label "Electrical System" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
@@ -10070,10 +10031,6 @@ brick:Velocity_Pressure a qudt:QuantityKind,
         brick:Dynamic_Pressure ;
     skos:broader brick:Pressure .
 
-brick:Voltage a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Voltage" .
-
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Alarm ) ],
@@ -10189,21 +10146,6 @@ brick:Disable_Command a owl:Class ;
         tag:Disable,
         tag:Point .
 
-brick:Electric_Current a qudt:QuantityKind,
-        brick:Quantity ;
-    rdfs:label "Electric Current" ;
-    qudt:applicableUnit unit:A,
-        unit:A_Ab,
-        unit:A_Stat,
-        unit:BIOT,
-        unit:KiloA,
-        unit:MicroA,
-        unit:MilliA,
-        unit:NanoA,
-        unit:PicoA ;
-    owl:sameAs qudtqk:ElectricCurrent ;
-    skos:broader brick:Current .
-
 brick:Electric_Power a qudt:QuantityKind,
         brick:Quantity ;
     rdfs:label "Electric Power" ;
@@ -10304,6 +10246,9 @@ tag:Interface a brick:Tag ;
 tag:Leaving a brick:Tag ;
     rdfs:label "Leaving" .
 
+tag:Lockout a brick:Tag ;
+    rdfs:label "Lockout" .
+
 tag:Luminance a brick:Tag ;
     rdfs:label "Luminance" .
 
@@ -10312,9 +10257,6 @@ tag:Mixed a brick:Tag ;
 
 tag:Occupancy a brick:Tag ;
     rdfs:label "Occupancy" .
-
-tag:Shutdown a brick:Tag ;
-    rdfs:label "Shutdown" .
 
 tag:Solar a brick:Tag ;
     rdfs:label "Solar" .
@@ -10420,9 +10362,6 @@ tag:Fault a brick:Tag ;
 tag:Laboratory a brick:Tag ;
     rdfs:label "Laboratory" .
 
-tag:Lockout a brick:Tag ;
-    rdfs:label "Lockout" .
-
 tag:Loss a brick:Tag ;
     rdfs:label "Loss" .
 
@@ -10434,6 +10373,9 @@ tag:Output a brick:Tag ;
 
 tag:Preheat a brick:Tag ;
     rdfs:label "Preheat" .
+
+tag:Run a brick:Tag ;
+    rdfs:label "Run" .
 
 tag:Stack a brick:Tag ;
     rdfs:label "Stack" .
@@ -10532,8 +10474,8 @@ tag:Fire a brick:Tag ;
 tag:Gain a brick:Tag ;
     rdfs:label "Gain" .
 
-tag:Run a brick:Tag ;
-    rdfs:label "Run" .
+tag:Request a brick:Tag ;
+    rdfs:label "Request" .
 
 tag:Standby a brick:Tag ;
     rdfs:label "Standby" .
@@ -10604,9 +10546,6 @@ tag:Electrical a brick:Tag ;
 
 tag:Filter a brick:Tag ;
     rdfs:label "Filter" .
-
-tag:Request a brick:Tag ;
-    rdfs:label "Request" .
 
 brick:Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Air Temperature Setpoint" ;
@@ -10769,6 +10708,12 @@ brick:Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
+tag:Speed a brick:Tag ;
+    rdfs:label "Speed" .
+
+tag:Unoccupied a brick:Tag ;
+    rdfs:label "Unoccupied" .
+
 brick:Equipment a owl:Class ;
     rdfs:label "Equipment" ;
     rdfs:subClassOf _:has_Equipment,
@@ -10777,12 +10722,6 @@ brick:Equipment a owl:Class ;
 
 tag:Power a brick:Tag ;
     rdfs:label "Power" .
-
-tag:Speed a brick:Tag ;
-    rdfs:label "Speed" .
-
-tag:Unoccupied a brick:Tag ;
-    rdfs:label "Unoccupied" .
 
 brick:Air a owl:Class,
         brick:Air ;
@@ -10805,6 +10744,9 @@ tag:Low a brick:Tag ;
 tag:Occupied a brick:Tag ;
     rdfs:label "Occupied" .
 
+tag:Fan a brick:Tag ;
+    rdfs:label "Fan" .
+
 tag:Integral a brick:Tag ;
     rdfs:label "Integral" .
 
@@ -10817,9 +10759,6 @@ brick:Temperature a qudt:QuantityKind,
     qudt:applicableUnit unit:DEG_R,
         unit:K ;
     owl:sameAs qudtqk:ThermodynamicTemperature .
-
-tag:Fan a brick:Tag ;
-    rdfs:label "Fan" .
 
 brick:Setpoint a owl:Class ;
     rdfs:label "Setpoint" ;
@@ -10873,6 +10812,19 @@ tag:Proportional a brick:Tag ;
 tag:Time a brick:Tag ;
     rdfs:label "Time" .
 
+brick:Command a owl:Class ;
+    rdfs:label "Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Command ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Parameter,
+        brick:Sensor,
+        brick:Setpoint,
+        brick:Status ;
+    skos:definition "A Command is an output point that directly determines the behavior of equipment and/or affects relevant operational points." ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point .
+
 brick:HVAC a owl:Class ;
     rdfs:label "HVAC" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Ventilation _:has_Air _:has_Conditioning _:has_System ) ],
@@ -10908,18 +10860,11 @@ tag:Max a brick:Tag ;
 tag:Outside a brick:Tag ;
     rdfs:label "Outside" .
 
-brick:Command a owl:Class ;
-    rdfs:label "Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Command ) ],
-        brick:Point ;
-    owl:disjointWith brick:Alarm,
-        brick:Parameter,
-        brick:Sensor,
-        brick:Setpoint,
-        brick:Status ;
-    skos:definition "A Command is an output point that directly determines the behavior of equipment and/or affects relevant operational points." ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Point .
+tag:Reset a brick:Tag ;
+    rdfs:label "Reset" .
+
+tag:Chilled a brick:Tag ;
+    rdfs:label "Chilled" .
 
 <https://brickschema.org/schema/1.1/Brick> a owl:Ontology ;
     rdfs:label "Brick" ;
@@ -10931,12 +10876,6 @@ brick:Command a owl:Class ;
     dcterms:license <https://github.com/BrickSchema/brick/blob/master/LICENSE> ;
     dcterms:version "1.1.0" ;
     rdfs:seeAlso <https://brickschema.org> .
-
-tag:Chilled a brick:Tag ;
-    rdfs:label "Chilled" .
-
-tag:Reset a brick:Tag ;
-    rdfs:label "Reset" .
 
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
@@ -10987,25 +10926,25 @@ tag:Heat a brick:Tag ;
 tag:Alarm a brick:Tag ;
     rdfs:label "Alarm" .
 
-tag:Limit a brick:Tag ;
-    rdfs:label "Limit" .
-
 tag:Command a brick:Tag ;
     rdfs:label "Command" .
 
+tag:Limit a brick:Tag ;
+    rdfs:label "Limit" .
+
 tag:Differential a brick:Tag ;
     rdfs:label "Differential" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf skos:Concept,
+        sosa:ObservableProperty,
+        brick:Measurable .
 
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
 
 tag:Status a brick:Tag ;
     rdfs:label "Status" .
-
-brick:Quantity a owl:Class ;
-    rdfs:subClassOf skos:Concept,
-        sosa:ObservableProperty,
-        brick:Measurable .
 
 tag:Flow a brick:Tag ;
     rdfs:label "Flow" .
@@ -11399,6 +11338,10 @@ _:has_Leaving a owl:Restriction ;
     owl:hasValue tag:Leaving ;
     owl:onProperty brick:hasTag .
 
+_:has_Lockout a owl:Restriction ;
+    owl:hasValue tag:Lockout ;
+    owl:onProperty brick:hasTag .
+
 _:has_Luminance a owl:Restriction ;
     owl:hasValue tag:Luminance ;
     owl:onProperty brick:hasTag .
@@ -11409,10 +11352,6 @@ _:has_Mixed a owl:Restriction ;
 
 _:has_Occupancy a owl:Restriction ;
     owl:hasValue tag:Occupancy ;
-    owl:onProperty brick:hasTag .
-
-_:has_Shutdown a owl:Restriction ;
-    owl:hasValue tag:Shutdown ;
     owl:onProperty brick:hasTag .
 
 _:has_Solar a owl:Restriction ;
@@ -11455,10 +11394,6 @@ _:has_Laboratory a owl:Restriction ;
     owl:hasValue tag:Laboratory ;
     owl:onProperty brick:hasTag .
 
-_:has_Lockout a owl:Restriction ;
-    owl:hasValue tag:Lockout ;
-    owl:onProperty brick:hasTag .
-
 _:has_Loss a owl:Restriction ;
     owl:hasValue tag:Loss ;
     owl:onProperty brick:hasTag .
@@ -11473,6 +11408,10 @@ _:has_Output a owl:Restriction ;
 
 _:has_Preheat a owl:Restriction ;
     owl:hasValue tag:Preheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Run a owl:Restriction ;
+    owl:hasValue tag:Run ;
     owl:onProperty brick:hasTag .
 
 _:has_Stack a owl:Restriction ;
@@ -11511,8 +11450,8 @@ _:has_Gain a owl:Restriction ;
     owl:hasValue tag:Gain ;
     owl:onProperty brick:hasTag .
 
-_:has_Run a owl:Restriction ;
-    owl:hasValue tag:Run ;
+_:has_Request a owl:Restriction ;
+    owl:hasValue tag:Request ;
     owl:onProperty brick:hasTag .
 
 _:has_Standby a owl:Restriction ;
@@ -11537,10 +11476,6 @@ _:has_Electrical a owl:Restriction ;
 
 _:has_Filter a owl:Restriction ;
     owl:hasValue tag:Filter ;
-    owl:onProperty brick:hasTag .
-
-_:has_Request a owl:Restriction ;
-    owl:hasValue tag:Request ;
     owl:onProperty brick:hasTag .
 
 _:has_Steam a owl:Restriction ;
@@ -11627,16 +11562,16 @@ _:has_Zone a owl:Restriction ;
     owl:hasValue tag:Zone ;
     owl:onProperty brick:hasTag .
 
-_:has_Power a owl:Restriction ;
-    owl:hasValue tag:Power ;
-    owl:onProperty brick:hasTag .
-
 _:has_Speed a owl:Restriction ;
     owl:hasValue tag:Speed ;
     owl:onProperty brick:hasTag .
 
 _:has_Unoccupied a owl:Restriction ;
     owl:hasValue tag:Unoccupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Power a owl:Restriction ;
+    owl:hasValue tag:Power ;
     owl:onProperty brick:hasTag .
 
 _:has_Gas a owl:Restriction ;
@@ -11655,16 +11590,16 @@ _:has_Occupied a owl:Restriction ;
     owl:hasValue tag:Occupied ;
     owl:onProperty brick:hasTag .
 
+_:has_Fan a owl:Restriction ;
+    owl:hasValue tag:Fan ;
+    owl:onProperty brick:hasTag .
+
 _:has_Integral a owl:Restriction ;
     owl:hasValue tag:Integral ;
     owl:onProperty brick:hasTag .
 
 _:has_On a owl:Restriction ;
     owl:hasValue tag:On ;
-    owl:onProperty brick:hasTag .
-
-_:has_Fan a owl:Restriction ;
-    owl:hasValue tag:Fan ;
     owl:onProperty brick:hasTag .
 
 _:has_Location a owl:Restriction ;
@@ -11767,12 +11702,12 @@ _:has_Alarm a owl:Restriction ;
     owl:hasValue tag:Alarm ;
     owl:onProperty brick:hasTag .
 
-_:has_Limit a owl:Restriction ;
-    owl:hasValue tag:Limit ;
-    owl:onProperty brick:hasTag .
-
 _:has_Command a owl:Restriction ;
     owl:hasValue tag:Command ;
+    owl:onProperty brick:hasTag .
+
+_:has_Limit a owl:Restriction ;
+    owl:hasValue tag:Limit ;
     owl:onProperty brick:hasTag .
 
 _:has_Differential a owl:Restriction ;

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -5777,8 +5777,8 @@ brick:Access_Control_Equipment a owl:Class ;
 
 brick:Active_Power a brick:Quantity ;
     rdfs:label "Active Power" ;
-    owl:equivalentClass brick:Real_Power ;
-    owl:sameAs qudtqk:ActivePower ;
+    owl:sameAs qudtqk:ActivePower,
+        brick:Real_Power ;
     skos:broader brick:Electric_Power .
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
@@ -9690,8 +9690,8 @@ brick:Valve a owl:Class ;
 
 brick:Velocity_Pressure a brick:Quantity ;
     rdfs:label "Velocity Pressure" ;
-    owl:equivalentClass brick:Dynamic_Pressure ;
-    owl:sameAs qudtqk:DynamicPressure ;
+    owl:sameAs qudtqk:DynamicPressure,
+        brick:Dynamic_Pressure ;
     skos:broader brick:Pressure .
 
 brick:Voltage a brick:Quantity ;

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -1,17 +1,16 @@
 @prefix brick: <https://brickschema.org/schema/1.1/Brick#> .
-@prefix bsh: <https://brickschema.org/schema/1.1/BrickShape#> .
 @prefix dcterms: <http://purl.org/dc/terms#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qudtqk: <http://qudt.org/vocab/quantitykind/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sdo: <http://schema.org#> .
-@prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sosa: <http://www.w3.org/ns/sosa#> .
 @prefix tag: <https://brickschema.org/schema/1.1/BrickTag#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://brickschema.org/schema/1.1/Brick> a owl:Ontology ;
     rdfs:label "Brick" ;
@@ -24,6 +23,12 @@
     dcterms:version "1.1.0" ;
     rdfs:seeAlso <https://brickschema.org> .
 
+brick:Absolute_Humidity a brick:Quantity ;
+    rdfs:label "Absolute Humidity" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:AbsoluteHumidity ;
+    skos:broader brick:Humidity .
+
 brick:Absorption_Chiller a owl:Class ;
     rdfs:label "Absorption Chiller" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
@@ -33,6 +38,10 @@ brick:Absorption_Chiller a owl:Class ;
     brick:hasAssociatedTag tag:Absorption,
         tag:Chiller,
         tag:Equipment .
+
+brick:Acceleration_Time a brick:Quantity ;
+    rdfs:label "Acceleration Time" ;
+    skos:broader brick:Time .
 
 brick:Acceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Acceleration Time Setpoint" ;
@@ -106,6 +115,21 @@ brick:Alarm_Delay_Parameter a owl:Class ;
         tag:Delay,
         tag:Parameter,
         tag:Point .
+
+brick:Alternating_Current_Frequency a brick:Quantity ;
+    rdfs:label "Alternating Current Frequency" ;
+    skos:broader brick:Electric_Current,
+        brick:Frequency .
+
+brick:Apparent_Power a brick:Quantity ;
+    rdfs:label "Apparent Power" ;
+    owl:sameAs qudtqk:ApparentPower ;
+    skos:broader brick:Electric_Power .
+
+brick:Atmospheric_Pressure a brick:Quantity ;
+    rdfs:label "Atmospheric Pressure" ;
+    owl:sameAs qudtqk:AtmosphericPressure ;
+    skos:broader brick:Pressure .
 
 brick:Automatic_Mode_Command a owl:Class ;
     rdfs:label "Automatic Mode Command" ;
@@ -350,6 +374,11 @@ brick:CO2_Differential_Sensor a owl:Class ;
         tag:Differential,
         tag:Point,
         tag:Sensor .
+
+brick:CO2_Level a brick:Quantity ;
+    rdfs:label "CO2 Level" ;
+    skos:broader brick:Air_Quality,
+        brick:Level .
 
 brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
@@ -614,6 +643,10 @@ brick:Close_Limit a owl:Class ;
         tag:Parameter,
         tag:Point .
 
+brick:Cloudage a brick:Quantity ;
+    rdfs:label "Cloudage" ;
+    skos:broader brick:Quantity .
+
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
     rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
@@ -636,6 +669,11 @@ brick:Communication_Loss_Alarm a owl:Class ;
         tag:Communication,
         tag:Loss,
         tag:Point .
+
+brick:Complex_Power a brick:Quantity ;
+    rdfs:label "Complex Power" ;
+    owl:sameAs qudtqk:ComplexPower ;
+    skos:broader brick:Electric_Power .
 
 brick:Compressor a owl:Class ;
     rdfs:label "Compressor" ;
@@ -833,6 +871,14 @@ brick:Cooling_Valve a owl:Class ;
         tag:Equipment,
         tag:Valve .
 
+brick:Current_Angle a brick:Quantity ;
+    rdfs:label "Current Angle" ;
+    skos:broader brick:Electric_Current .
+
+brick:Current_Imbalance a brick:Quantity ;
+    rdfs:label "Current Imbalance" ;
+    skos:broader brick:Electric_Current .
+
 brick:Current_Limit a owl:Class ;
     rdfs:label "Current Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Limit _:has_Parameter ) ],
@@ -841,6 +887,14 @@ brick:Current_Limit a owl:Class ;
         tag:Limit,
         tag:Parameter,
         tag:Point .
+
+brick:Current_Magnitude a brick:Quantity ;
+    rdfs:label "Current Magnitude" ;
+    skos:broader brick:Electric_Current .
+
+brick:Current_Total_Harmonic_Distortion a brick:Quantity ;
+    rdfs:label "Current Total Harmonic Distortion" ;
+    skos:broader brick:Electric_Current .
 
 brick:Curtailment_Override_Command a owl:Class ;
     rdfs:label "Curtailment Override Command" ;
@@ -906,6 +960,14 @@ brick:Damper_Position_Setpoint a owl:Class ;
         tag:Point,
         tag:Position,
         tag:Setpoint .
+
+brick:Daytime a brick:Quantity ;
+    rdfs:label "Daytime" ;
+    skos:broader brick:Quantity .
+
+brick:Deceleration_Time a brick:Quantity ;
+    rdfs:label "Deceleration Time" ;
+    skos:broader brick:Time .
 
 brick:Deceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Deceleration Time Setpoint" ;
@@ -1462,6 +1524,10 @@ brick:Drive_Ready_Status a owl:Class ;
         tag:Ready,
         tag:Status .
 
+brick:Dry_Bulb_Temperature a brick:Quantity ;
+    rdfs:label "Dry Bulb Temperature" ;
+    skos:broader brick:Temperature .
+
 brick:Dual_Band_Mode_Setpoint a owl:Class ;
     rdfs:label "Dual Band Mode Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
@@ -1525,6 +1591,12 @@ brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint,
         tag:Temperature .
+
+brick:Electric_Energy a brick:Quantity ;
+    rdfs:label "Electric Energy" ;
+    qudt:applicableUnit unit:J ;
+    owl:sameAs qudtqk:Energy ;
+    skos:broader brick:Energy .
 
 brick:Elevator a owl:Class ;
     rdfs:label "Elevator" ;
@@ -2050,6 +2122,10 @@ brick:Fire_Zone a owl:Class ;
     brick:hasAssociatedTag tag:Fire,
         tag:Location,
         tag:Zone .
+
+brick:Flow_Loss a brick:Quantity ;
+    rdfs:label "Flow Loss" ;
+    skos:broader brick:Flow .
 
 brick:Freeze_Status a owl:Class ;
     rdfs:label "Freeze Status" ;
@@ -2973,6 +3049,19 @@ brick:Luminance_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint .
 
+brick:Luminous_Flux a brick:Quantity ;
+    rdfs:label "Luminous Flux" ;
+    qudt:applicableUnit unit:LM ;
+    owl:sameAs qudtqk:LuminousFlux ;
+    skos:broader brick:Luminance .
+
+brick:Luminous_Intensity a brick:Quantity ;
+    rdfs:label "Luminous Intensity" ;
+    qudt:applicableUnit unit:CD,
+        unit:CP ;
+    owl:sameAs qudtqk:LuminousIntensity ;
+    skos:broader brick:Luminance .
+
 brick:Maintenance_Mode_Command a owl:Class ;
     rdfs:label "Maintenance Mode Command" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance _:has_Mode _:has_Command ) ],
@@ -3761,6 +3850,14 @@ brick:Occupancy_Command a owl:Class ;
         tag:Occupancy,
         tag:Point .
 
+brick:Occupancy_Count a brick:Quantity ;
+    rdfs:label "Occupancy Count" ;
+    skos:broader brick:Occupancy .
+
+brick:Occupancy_Percentage a brick:Quantity ;
+    rdfs:label "Occupancy Percentage" ;
+    skos:broader brick:Occupancy .
+
 brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Discharge Air Flow Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
@@ -3881,6 +3978,10 @@ brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature,
         tag:Valve .
+
+brick:Operative_Temperature a brick:Quantity ;
+    rdfs:label "Operative Temperature" ;
+    skos:broader brick:Temperature .
 
 brick:Output_Frequency_Sensor a owl:Class ;
     rdfs:label "Output Frequency Sensor" ;
@@ -4101,6 +4202,16 @@ brick:PIR_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
+brick:PM10_Level a brick:Quantity ;
+    rdfs:label "PM10 Level" ;
+    skos:broader brick:Air_Quality,
+        brick:Level .
+
+brick:PM25_Level a brick:Quantity ;
+    rdfs:label "PM25 Level" ;
+    skos:broader brick:Air_Quality,
+        brick:Level .
+
 brick:Peak_Power_Demand_Sensor a owl:Class ;
     rdfs:label "Peak Power Demand Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Peak _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
@@ -4148,6 +4259,12 @@ brick:PlugStrip a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:PlugStrip .
 
+brick:Power_Factor a brick:Quantity ;
+    rdfs:label "Power Factor" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:PowerFactor ;
+    skos:broader brick:Quantity .
+
 brick:Pre_Filter_Status a owl:Class ;
     rdfs:label "Pre Filter Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
@@ -4158,6 +4275,10 @@ brick:Pre_Filter_Status a owl:Class ;
         tag:Point,
         tag:Pre,
         tag:Status .
+
+brick:Precipitation a brick:Quantity ;
+    rdfs:label "Precipitation" ;
+    skos:broader brick:Quantity .
 
 brick:Preheat_Demand_Setpoint a owl:Class ;
     rdfs:label "Preheat Demand Setpoint" ;
@@ -4228,6 +4349,10 @@ brick:Pump_Start_Stop_Status a owl:Class ;
         tag:Start,
         tag:Status,
         tag:Stop .
+
+brick:Radiant_Temperature a brick:Quantity ;
+    rdfs:label "Radiant Temperature" ;
+    skos:broader brick:Temperature .
 
 brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:label "Rain Duration Sensor" ;
@@ -4573,6 +4698,10 @@ brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor,
         tag:Solar .
+
+brick:Solar_Irradiance a brick:Quantity ;
+    rdfs:label "Solar Irradiance" ;
+    skos:broader brick:Irradiance .
 
 brick:Solar_Panel a owl:Class ;
     rdfs:label "Solar Panel" ;
@@ -4994,6 +5123,11 @@ brick:System_Shutdown_Status a owl:Class ;
         tag:Status,
         tag:System .
 
+brick:TVOC_Level a brick:Quantity ;
+    rdfs:label "TVOC Level" ;
+    skos:broader brick:Air_Quality,
+        brick:Level .
+
 brick:Temperature_Adjust_Sensor a owl:Class ;
     rdfs:label "Temperature Adjust Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust _:has_Temperature ) ],
@@ -5024,6 +5158,16 @@ brick:Temporary_Occupancy_Status a owl:Class ;
         tag:Status,
         tag:Temporary .
 
+brick:Thermal_Energy a brick:Quantity ;
+    rdfs:label "Thermal Energy" ;
+    qudt:applicableUnit unit:BTU_IT,
+        unit:BTU_TH,
+        unit:CAL_TH,
+        unit:KiloCAL,
+        unit:THM_US ;
+    owl:sameAs qudtqk:ThermalEnergy ;
+    skos:broader brick:Energy .
+
 brick:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Thermal Energy Storage Discharge Water Differential Pressure Deadband Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Thermal _:has_Energy _:has_Storage _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
@@ -5053,6 +5197,10 @@ brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoin
         tag:Supply,
         tag:Thermal,
         tag:Water .
+
+brick:Thermal_Power a brick:Quantity ;
+    rdfs:label "Thermal Power" ;
+    skos:broader brick:Power .
 
 brick:Thermostat a owl:Class ;
     rdfs:label "Thermostat" ;
@@ -5272,6 +5420,19 @@ brick:Ventilation_Air_Flow_Ratio_Limit a owl:Class ;
         tag:Ratio,
         tag:Ventilation .
 
+brick:Voltage_Angle a brick:Quantity ;
+    rdfs:label "Voltage Angle" ;
+    skos:broader brick:Voltage .
+
+brick:Voltage_Imbalance a brick:Quantity ;
+    rdfs:label "Voltage Imbalance" ;
+    skos:broader brick:Voltage .
+
+brick:Voltage_Magnitude a brick:Quantity ;
+    rdfs:label "Voltage Magnitude" ;
+    owl:sameAs qudtqk:Voltage ;
+    skos:broader brick:Voltage .
+
 brick:Warm_Cool_Adjust_Sensor a owl:Class ;
     rdfs:label "Warm Cool Adjust Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust [ a owl:Restriction ;
@@ -5300,6 +5461,14 @@ brick:Weather a owl:Class ;
             owl:onProperty brick:hasTag ],
         brick:Equipment ;
     brick:hasAssociatedTag tag:Weather .
+
+brick:Weather_Condition a brick:Quantity ;
+    rdfs:label "Weather Condition" ;
+    skos:broader brick:Quantity .
+
+brick:Wet_Bulb_Temperature a brick:Quantity ;
+    rdfs:label "Wet Bulb Temperature" ;
+    skos:broader brick:Temperature .
 
 brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
@@ -5401,6 +5570,13 @@ brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
         tag:Unoccupied,
         tag:Zone .
 
+brick:associatedQuantityKind a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Quantity ;
+    rdfs:range qudt:QuantityKind ;
+    skos:definition "The QUDT QuantityKind associated with this Quantity" .
+
 brick:feedsAir a owl:ObjectProperty ;
     rdfs:subPropertyOf brick:feeds ;
     skos:definition "Passes air" .
@@ -5423,6 +5599,13 @@ brick:hasOutputSubstance a owl:AsymmetricProperty,
     rdfs:range brick:Substance ;
     skos:definition "The subject produces or exports the given substance from its internal process" .
 
+brick:hasUnit a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Point ;
+    rdfs:range unit:Unit ;
+    skos:definition "The QUDT unit associated with this Point" .
+
 brick:regulates a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
         owl:ObjectProperty ;
@@ -5431,10 +5614,97 @@ brick:regulates a owl:AsymmetricProperty,
     owl:inverseOf brick:isRegulatedBy ;
     skos:definition "The subject contributes to or performs the regulation of the substance given by the object" .
 
-brick:Acceleration_Time a owl:Class,
-        brick:Acceleration_Time ;
-    rdfs:label "Acceleration Time" ;
-    rdfs:subClassOf brick:Time .
+unit:A qudt:symbol "A" .
+
+unit:A_Ab qudt:symbol "abA" .
+
+unit:A_Stat qudt:symbol "statA" .
+
+unit:BIOT qudt:symbol "Bi" .
+
+unit:BTU_IT qudt:symbol "Btu_{it}" .
+
+unit:BTU_TH qudt:symbol "Btu_{th}" .
+
+unit:CAL_TH qudt:symbol "cal_{th}" .
+
+unit:CD qudt:symbol "cd" .
+
+unit:CP qudt:symbol "cd" .
+
+unit:DAY qudt:symbol "d" .
+
+unit:DAY_Sidereal qudt:symbol "d" .
+
+unit:GigaHZ qudt:symbol "GHz" .
+
+unit:HR qudt:symbol "hr" .
+
+unit:HR_Sidereal qudt:symbol "hr" .
+
+unit:HZ qudt:symbol "Hz" .
+
+unit:J qudt:symbol "J" .
+
+unit:KiloA qudt:symbol "kA" .
+
+unit:KiloCAL qudt:symbol "kcal" .
+
+unit:KiloHZ qudt:symbol "KHz" .
+
+unit:KiloSEC qudt:symbol "ks" .
+
+unit:KiloW qudt:symbol "kW" .
+
+unit:LM qudt:symbol "lm" .
+
+unit:MIN qudt:symbol "min" .
+
+unit:MIN_Angle qudt:symbol "'" .
+
+unit:MIN_Sidereal qudt:symbol "min" .
+
+unit:MO qudt:symbol "mo" .
+
+unit:MegaHZ qudt:symbol "MHz" .
+
+unit:MicroA qudt:symbol "µA" .
+
+unit:MicroSEC qudt:symbol "microsec" .
+
+unit:MilliA qudt:symbol "mA" .
+
+unit:MilliSEC qudt:symbol "ms" .
+
+unit:N-M qudt:symbol "N-m" .
+
+unit:NanoA qudt:symbol "nA" .
+
+unit:NanoSEC qudt:symbol "ms" .
+
+unit:PicoA qudt:symbol "pA" .
+
+unit:PlanckTime qudt:symbol "tP" .
+
+unit:SEC qudt:symbol "s" .
+
+unit:SH qudt:symbol "Sh" .
+
+unit:THM_US qudt:symbol "thm" .
+
+unit:WK qudt:symbol "wk" .
+
+unit:YR qudt:symbol "yr" .
+
+unit:YR_Sidereal qudt:symbol "yr" .
+
+unit:YR_TROPICAL qudt:symbol "a_{t}" .
+
+brick:Active_Power a brick:Quantity ;
+    rdfs:label "Active Power" ;
+    owl:equivalentClass brick:Real_Power ;
+    owl:sameAs qudtqk:ActivePower ;
+    skos:broader brick:Electric_Power .
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Air Flow Deadband Setpoint" ;
@@ -5469,21 +5739,12 @@ brick:Air_Temperature_Setpoint_Limit a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Alternating_Current_Frequency a owl:Class,
-        brick:Alternating_Current_Frequency ;
-    rdfs:label "Alternating Current Frequency" ;
-    rdfs:subClassOf brick:Electric_Current,
-        brick:Frequency .
-
-brick:Apparent_Power a owl:Class,
-        brick:Apparent_Power ;
-    rdfs:label "Apparent Power" ;
-    rdfs:subClassOf brick:Electric_Power .
-
-brick:Atmospheric_Pressure a owl:Class,
-        brick:Atmospheric_Pressure ;
-    rdfs:label "Atmospheric Pressure" ;
-    rdfs:subClassOf brick:Pressure .
+brick:Angle a brick:Quantity ;
+    rdfs:label "Angle" ;
+    qudt:applicableUnit unit:MIN_Angle ;
+    rdfs:seeAlso qudtqk:Angle ;
+    owl:sameAs qudtqk:Angle ;
+    skos:broader brick:Quantity .
 
 brick:Blowdown_Water a owl:Class,
         brick:Blowdown_Water ;
@@ -5512,12 +5773,6 @@ brick:CO2_Alarm a owl:Class ;
         tag:CO2,
         tag:Point .
 
-brick:CO2_Level a owl:Class,
-        brick:CO2_Level ;
-    rdfs:label "CO2 Level" ;
-    rdfs:subClassOf brick:Air_Quality,
-        brick:Level .
-
 brick:CO2_Setpoint a owl:Class ;
     rdfs:label "CO2 Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Setpoint ) ],
@@ -5534,6 +5789,11 @@ brick:CWS a owl:Class ;
         brick:Water_System ;
     owl:equivalentClass brick:Chilled_Water_System ;
     brick:hasAssociatedTag tag:CWS .
+
+brick:Capacity a brick:Quantity ;
+    rdfs:label "Capacity" ;
+    owl:sameAs qudtqk:Capacity ;
+    skos:broader brick:Quantity .
 
 brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
@@ -5571,11 +5831,6 @@ brick:Chilled_Water_Meter a owl:Class ;
         tag:Meter,
         tag:Water .
 
-brick:Cloudage a owl:Class,
-        brick:Cloudage ;
-    rdfs:label "Cloudage" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Coldest Zone Air Temperature Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
@@ -5588,11 +5843,6 @@ brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
-
-brick:Complex_Power a owl:Class,
-        brick:Complex_Power ;
-    rdfs:label "Complex Power" ;
-    rdfs:subClassOf brick:Electric_Power .
 
 brick:Computer_Room_Air_Conditioning a owl:Class ;
     rdfs:label "Computer Room Air Conditioning" ;
@@ -5668,26 +5918,6 @@ brick:Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Supply .
 
-brick:Current_Angle a owl:Class,
-        brick:Current_Angle ;
-    rdfs:label "Current Angle" ;
-    rdfs:subClassOf brick:Electric_Current .
-
-brick:Current_Imbalance a owl:Class,
-        brick:Current_Imbalance ;
-    rdfs:label "Current Imbalance" ;
-    rdfs:subClassOf brick:Electric_Current .
-
-brick:Current_Magnitude a owl:Class,
-        brick:Current_Magnitude ;
-    rdfs:label "Current Magnitude" ;
-    rdfs:subClassOf brick:Electric_Current .
-
-brick:Current_Total_Harmonic_Distortion a owl:Class,
-        brick:Current_Total_Harmonic_Distortion ;
-    rdfs:label "Current Total Harmonic Distortion" ;
-    rdfs:subClassOf brick:Electric_Current .
-
 brick:Cycle_Alarm a owl:Class ;
     rdfs:label "Cycle Alarm" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cycle _:has_Alarm ) ],
@@ -5703,16 +5933,6 @@ brick:Damper_Command a owl:Class ;
     brick:hasAssociatedTag tag:Command,
         tag:Damper,
         tag:Point .
-
-brick:Daytime a owl:Class,
-        brick:Daytime ;
-    rdfs:label "Daytime" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Deceleration_Time a owl:Class,
-        brick:Deceleration_Time ;
-    rdfs:label "Deceleration Time" ;
-    rdfs:subClassOf brick:Time .
 
 brick:Delay_Parameter a owl:Class ;
     rdfs:label "Delay Parameter" ;
@@ -5884,15 +6104,9 @@ brick:Domestic_Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
-brick:Dry_Bulb_Temperature a owl:Class,
-        brick:Dry_Bulb_Temperature ;
-    rdfs:label "Dry Bulb Temperature" ;
-    rdfs:subClassOf brick:Temperature .
-
-brick:Electric_Energy a owl:Class,
-        brick:Electric_Energy ;
-    rdfs:label "Electric Energy" ;
-    rdfs:subClassOf brick:Energy .
+brick:Dynamic_Pressure a brick:Quantity ;
+    rdfs:label "Dynamic Pressure" ;
+    skos:broader brick:Pressure .
 
 brick:Electrical_Meter a owl:Class ;
     rdfs:label "Electrical Meter" ;
@@ -6042,11 +6256,6 @@ brick:Filter_Status a owl:Class ;
     brick:hasAssociatedTag tag:Filter,
         tag:Point,
         tag:Status .
-
-brick:Flow_Loss a owl:Class,
-        brick:Flow_Loss ;
-    rdfs:label "Flow Loss" ;
-    rdfs:subClassOf brick:Flow .
 
 brick:Flow_Setpoint a owl:Class ;
     rdfs:label "Flow Setpoint" ;
@@ -6294,6 +6503,11 @@ brick:Ice a owl:Class,
     brick:hasAssociatedTag tag:Ice,
         tag:Solid .
 
+brick:Illuminance a brick:Quantity ;
+    rdfs:label "Illuminance" ;
+    owl:sameAs qudtqk:Illuminance ;
+    skos:broader brick:Quantity .
+
 brick:Illuminance_Sensor a owl:Class ;
     rdfs:label "Illuminance Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance ) ],
@@ -6314,6 +6528,11 @@ brick:Integral_Gain_Parameter a owl:Class ;
         tag:PID,
         tag:Parameter,
         tag:Point .
+
+brick:Irradiance a brick:Quantity ;
+    rdfs:label "Irradiance" ;
+    owl:sameAs qudtqk:Irradiance ;
+    skos:broader brick:Quantity .
 
 brick:Leak_Alarm a owl:Class ;
     rdfs:label "Leak Alarm" ;
@@ -6385,16 +6604,6 @@ brick:Low_Temperature_Alarm a owl:Class ;
         tag:Point,
         tag:Temperature .
 
-brick:Luminous_Flux a owl:Class,
-        brick:Luminous_Flux ;
-    rdfs:label "Luminous Flux" ;
-    rdfs:subClassOf brick:Luminance .
-
-brick:Luminous_Intensity a owl:Class,
-        brick:Luminous_Intensity ;
-    rdfs:label "Luminous Intensity" ;
-    rdfs:subClassOf brick:Luminance .
-
 brick:Makeup_Water a owl:Class,
         brick:Makeup_Water ;
     rdfs:label "Makeup Water" ;
@@ -6465,16 +6674,6 @@ brick:Natural_Gas a owl:Class,
         tag:Gas,
         tag:Natural .
 
-brick:Occupancy_Count a owl:Class,
-        brick:Occupancy_Count ;
-    rdfs:label "Occupancy Count" ;
-    rdfs:subClassOf brick:Occupancy .
-
-brick:Occupancy_Percentage a owl:Class,
-        brick:Occupancy_Percentage ;
-    rdfs:label "Occupancy Percentage" ;
-    rdfs:subClassOf brick:Occupancy .
-
 brick:Occupancy_Sensor a owl:Class ;
     rdfs:label "Occupancy Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Occupancy ) ],
@@ -6519,11 +6718,6 @@ brick:Operating_Mode_Status a owl:Class ;
         tag:Point,
         tag:Status .
 
-brick:Operative_Temperature a owl:Class,
-        brick:Operative_Temperature ;
-    rdfs:label "Operative Temperature" ;
-    rdfs:subClassOf brick:Temperature .
-
 brick:Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Temperature Enable Differential Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
@@ -6544,18 +6738,6 @@ brick:Override_Command a owl:Class ;
         tag:Override,
         tag:Point .
 
-brick:PM10_Level a owl:Class,
-        brick:PM10_Level ;
-    rdfs:label "PM10 Level" ;
-    rdfs:subClassOf brick:Air_Quality,
-        brick:Level .
-
-brick:PM25_Level a owl:Class,
-        brick:PM25_Level ;
-    rdfs:label "PM25 Level" ;
-    rdfs:subClassOf brick:Air_Quality,
-        brick:Level .
-
 brick:PV_Current_Output_Sensor a owl:Class ;
     rdfs:label "PV Current Output Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
@@ -6567,6 +6749,17 @@ brick:PV_Current_Output_Sensor a owl:Class ;
         tag:PV,
         tag:Point,
         tag:Sensor .
+
+brick:Peak_Power a brick:Quantity ;
+    rdfs:label "Peak Power" ;
+    qudt:applicableUnit unit:KiloW ;
+    owl:sameAs qudtqk:ElectricPower ;
+    skos:broader brick:Power ;
+    skos:definition "Tracks the highest (peak) observed power in some interval" .
+
+brick:Position a brick:Quantity ;
+    rdfs:label "Position" ;
+    skos:broader brick:Quantity .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
@@ -6584,11 +6777,6 @@ brick:Power_Alarm a owl:Class ;
         tag:Point,
         tag:Power .
 
-brick:Power_Factor a owl:Class,
-        brick:Power_Factor ;
-    rdfs:label "Power Factor" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Power_Loss_Alarm a owl:Class ;
     rdfs:label "Power Loss Alarm" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Alarm ) ],
@@ -6597,11 +6785,6 @@ brick:Power_Loss_Alarm a owl:Class ;
         tag:Loss,
         tag:Point,
         tag:Power .
-
-brick:Precipitation a owl:Class,
-        brick:Precipitation ;
-    rdfs:label "Precipitation" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Proportional_Gain_Parameter a owl:Class ;
     rdfs:label "Proportional Gain Parameter" ;
@@ -6640,10 +6823,10 @@ brick:RVAV a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:RVAV .
 
-brick:Radiant_Temperature a owl:Class,
-        brick:Radiant_Temperature ;
-    rdfs:label "Radiant Temperature" ;
-    rdfs:subClassOf brick:Temperature .
+brick:Radiance a brick:Quantity ;
+    rdfs:label "Radiance" ;
+    owl:sameAs qudtqk:Radiance ;
+    skos:broader brick:Quantity .
 
 brick:Rain_Sensor a owl:Class ;
     rdfs:label "Rain Sensor" ;
@@ -6652,6 +6835,21 @@ brick:Rain_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Point,
         tag:Rain,
         tag:Sensor .
+
+brick:Reactive_Power a brick:Quantity ;
+    rdfs:label "Reactive Power" ;
+    owl:sameAs qudtqk:ReactivePower ;
+    skos:broader brick:Electric_Power .
+
+brick:Real_Power a brick:Quantity ;
+    rdfs:label "Real Power" ;
+    skos:broader brick:Electric_Power .
+
+brick:Relative_Humidity a brick:Quantity ;
+    rdfs:label "Relative Humidity" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:RelativeHumidity ;
+    skos:broader brick:Humidity .
 
 brick:Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Return Air CO2 Setpoint" ;
@@ -6704,10 +6902,9 @@ brick:Smoke_Detected_Alarm a owl:Class ;
         tag:Point,
         tag:Smoke .
 
-brick:Solar_Irradiance a owl:Class,
-        brick:Solar_Irradiance ;
-    rdfs:label "Solar Irradiance" ;
-    rdfs:subClassOf brick:Irradiance .
+brick:Solar_Radiance a brick:Quantity ;
+    rdfs:label "Solar Radiance" ;
+    skos:broader brick:Radiance .
 
 brick:Space a owl:Class ;
     rdfs:label "Space" ;
@@ -6860,12 +7057,6 @@ brick:Switch a owl:Class ;
         tag:Interface,
         tag:Switch .
 
-brick:TVOC_Level a owl:Class,
-        brick:TVOC_Level ;
-    rdfs:label "TVOC Level" ;
-    rdfs:subClassOf brick:Air_Quality,
-        brick:Level .
-
 brick:Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Temperature Step Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Step _:has_Parameter ) ],
@@ -6876,16 +7067,6 @@ brick:Temperature_Step_Parameter a owl:Class ;
         tag:Step,
         tag:Temperature .
 
-brick:Thermal_Energy a owl:Class,
-        brick:Thermal_Energy ;
-    rdfs:label "Thermal Energy" ;
-    rdfs:subClassOf brick:Energy .
-
-brick:Thermal_Power a owl:Class,
-        brick:Thermal_Power ;
-    rdfs:label "Thermal Power" ;
-    rdfs:subClassOf brick:Power .
-
 brick:Thermal_Power_Sensor a owl:Class ;
     rdfs:label "Thermal Power Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Thermal ) ],
@@ -6894,6 +7075,12 @@ brick:Thermal_Power_Sensor a owl:Class ;
         tag:Power,
         tag:Sensor,
         tag:Thermal .
+
+brick:Torque a brick:Quantity ;
+    rdfs:label "Torque" ;
+    qudt:applicableUnit unit:N-M ;
+    owl:sameAs qudtqk:Torque ;
+    skos:broader brick:Quantity .
 
 brick:Torque_Sensor a owl:Class ;
     rdfs:label "Torque Sensor" ;
@@ -6924,21 +7111,6 @@ brick:VAV a owl:Class ;
         brick:Terminal_Unit ;
     brick:hasAssociatedTag tag:Equipment,
         tag:VAV .
-
-brick:Voltage_Angle a owl:Class,
-        brick:Voltage_Angle ;
-    rdfs:label "Voltage Angle" ;
-    rdfs:subClassOf brick:Electric_Voltage .
-
-brick:Voltage_Imbalance a owl:Class,
-        brick:Voltage_Imbalance ;
-    rdfs:label "Voltage Imbalance" ;
-    rdfs:subClassOf brick:Electric_Voltage .
-
-brick:Voltage_Magnitude a owl:Class,
-        brick:Voltage_Magnitude ;
-    rdfs:label "Voltage Magnitude" ;
-    rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Warmest Zone Air Temperature Sensor" ;
@@ -6976,15 +7148,13 @@ brick:Water_Usage_Sensor a owl:Class ;
         tag:Usage,
         tag:Water .
 
-brick:Weather_Condition a owl:Class,
-        brick:Weather_Condition ;
-    rdfs:label "Weather Condition" ;
-    rdfs:subClassOf brick:Quantity .
+brick:Wind_Direction a brick:Quantity ;
+    rdfs:label "Wind Direction" ;
+    skos:broader brick:Direction .
 
-brick:Wet_Bulb_Temperature a owl:Class,
-        brick:Wet_Bulb_Temperature ;
-    rdfs:label "Wet Bulb Temperature" ;
-    rdfs:subClassOf brick:Temperature .
+brick:Wind_Speed a brick:Quantity ;
+    rdfs:label "Wind Speed" ;
+    skos:broader brick:Speed .
 
 brick:controls a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -7072,12 +7242,6 @@ brick:isTagOf a owl:AsymmetricProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Tag .
 
-brick:Active_Power a owl:Class,
-        brick:Active_Power ;
-    rdfs:label "Active Power" ;
-    rdfs:subClassOf brick:Electric_Power ;
-    owl:equivalentClass brick:Real_Power .
-
 brick:Adjust_Sensor a owl:Class ;
     rdfs:label "Adjust Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust ) ],
@@ -7146,11 +7310,6 @@ brick:Air_Temperature_Step_Parameter a owl:Class ;
         tag:Step,
         tag:Temperature .
 
-brick:Angle a owl:Class,
-        brick:Angle ;
-    rdfs:label "Angle" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Angle _:has_Sensor ) ],
@@ -7192,11 +7351,6 @@ brick:CRAC a owl:Class ;
     brick:hasAssociatedTag tag:CRAC,
         tag:Equipment .
 
-brick:Capacity a owl:Class,
-        brick:Capacity ;
-    rdfs:label "Capacity" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
@@ -7223,6 +7377,11 @@ brick:Coil a owl:Class ;
     brick:hasAssociatedTag tag:Coil,
         tag:Equipment .
 
+brick:Conductivity a brick:Quantity ;
+    rdfs:label "Conductivity" ;
+    owl:sameAs qudtqk:Conductivity ;
+    skos:broader brick:Quantity .
+
 brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Flow Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
@@ -7233,6 +7392,10 @@ brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Flow,
         tag:Point,
         tag:Setpoint .
+
+brick:Current a brick:Quantity ;
+    rdfs:label "Current" ;
+    skos:broader brick:Quantity .
 
 brick:Current_Output_Sensor a owl:Class ;
     rdfs:label "Current Output Sensor" ;
@@ -7253,6 +7416,10 @@ brick:Dewpoint_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Dewpoint,
         tag:Point,
         tag:Sensor .
+
+brick:Direction a brick:Quantity ;
+    rdfs:label "Direction" ;
+    skos:broader brick:Quantity .
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Setpoint" ;
@@ -7410,6 +7577,15 @@ brick:Flow_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
+brick:Frequency a brick:Quantity ;
+    rdfs:label "Frequency" ;
+    qudt:applicableUnit unit:GigaHZ,
+        unit:HZ,
+        unit:KiloHZ,
+        unit:MegaHZ ;
+    owl:sameAs qudtqk:Frequency ;
+    skos:broader brick:Quantity .
+
 brick:Frost a owl:Class,
         brick:Frost ;
     rdfs:label "Frost" ;
@@ -7489,22 +7665,12 @@ brick:Humidity_Alarm a owl:Class ;
         tag:Humidity,
         tag:Point .
 
-brick:Illuminance a owl:Class,
-        brick:Illuminance ;
-    rdfs:label "Illuminance" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Interface a owl:Class ;
     rdfs:label "Interface" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface ) ],
         brick:Lighting_System ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Interface .
-
-brick:Irradiance a owl:Class,
-        brick:Irradiance ;
-    rdfs:label "Irradiance" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Leaving_Water a owl:Class,
         brick:Leaving_Water ;
@@ -7751,17 +7917,6 @@ brick:Overridden_Status a owl:Class ;
         tag:Point,
         tag:Status .
 
-brick:Peak_Power a owl:Class,
-        brick:Peak_Power ;
-    rdfs:label "Peak Power" ;
-    rdfs:subClassOf brick:Power ;
-    skos:definition "Tracks the highest (peak) observed power in some interval" .
-
-brick:Position a owl:Class,
-        brick:Position ;
-    rdfs:label "Position" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Position_Limit a owl:Class ;
     rdfs:label "Position Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Limit ) ],
@@ -7799,26 +7954,6 @@ brick:Pressure_Alarm a owl:Class ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Point,
         tag:Pressure .
-
-brick:Radiance a owl:Class,
-        brick:Radiance ;
-    rdfs:label "Radiance" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Reactive_Power a owl:Class,
-        brick:Reactive_Power ;
-    rdfs:label "Reactive Power" ;
-    rdfs:subClassOf brick:Electric_Power .
-
-brick:Real_Power a owl:Class,
-        brick:Real_Power ;
-    rdfs:label "Real Power" ;
-    rdfs:subClassOf brick:Electric_Power .
-
-brick:Relative_Humidity a owl:Class,
-        brick:Relative_Humidity ;
-    rdfs:label "Relative Humidity" ;
-    rdfs:subClassOf brick:Humidity .
 
 brick:Request_Setpoint a owl:Class ;
     rdfs:label "Request Setpoint" ;
@@ -7863,10 +7998,10 @@ brick:Run_Status a owl:Class ;
         tag:Run,
         tag:Status .
 
-brick:Solar_Radiance a owl:Class,
-        brick:Solar_Radiance ;
-    rdfs:label "Solar Radiance" ;
-    rdfs:subClassOf brick:Radiance .
+brick:Speed a brick:Quantity ;
+    rdfs:label "Speed" ;
+    owl:sameAs qudtqk:Speed ;
+    skos:broader brick:Quantity .
 
 brick:Speed_Setpoint a owl:Class ;
     rdfs:label "Speed Setpoint" ;
@@ -7987,6 +8122,29 @@ brick:Temperature_Sensor a owl:Class ;
         tag:Sensor,
         tag:Temperature .
 
+brick:Time a brick:Quantity ;
+    rdfs:label "Time" ;
+    qudt:applicableUnit unit:DAY,
+        unit:DAY_Sidereal,
+        unit:HR,
+        unit:HR_Sidereal,
+        unit:KiloSEC,
+        unit:MIN,
+        unit:MIN_Sidereal,
+        unit:MO,
+        unit:MicroSEC,
+        unit:MilliSEC,
+        unit:NanoSEC,
+        unit:PlanckTime,
+        unit:SEC,
+        unit:SH,
+        unit:WK,
+        unit:YR,
+        unit:YR_Sidereal,
+        unit:YR_TROPICAL ;
+    owl:sameAs qudtqk:Time ;
+    skos:broader brick:Quantity .
+
 brick:Time_Parameter a owl:Class ;
     rdfs:label "Time Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Time ) ],
@@ -8010,11 +8168,6 @@ brick:Tolerance_Parameter a owl:Class ;
     brick:hasAssociatedTag tag:Parameter,
         tag:Point,
         tag:Tolerance .
-
-brick:Torque a owl:Class,
-        brick:Torque ;
-    rdfs:label "Torque" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Unoccupied_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Setpoint" ;
@@ -8045,16 +8198,6 @@ brick:Water_Temperature_Alarm a owl:Class ;
         tag:Point,
         tag:Temperature,
         tag:Water .
-
-brick:Wind_Direction a owl:Class,
-        brick:Wind_Direction ;
-    rdfs:label "Wind Direction" ;
-    rdfs:subClassOf brick:Direction .
-
-brick:Wind_Speed a owl:Class,
-        brick:Wind_Speed ;
-    rdfs:label "Wind Speed" ;
-    rdfs:subClassOf brick:Speed .
 
 brick:feeds a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -8398,6 +8541,8 @@ tag:Wing a brick:Tag ;
 tag:Zenith a brick:Tag ;
     rdfs:label "Zenith" .
 
+unit:UNITLESS qudt:symbol "U" .
+
 brick:AHU a owl:Class ;
     rdfs:label "AHU" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_AHU ) ],
@@ -8438,16 +8583,6 @@ brick:Chilled_Water_Temperature_Sensor a owl:Class ;
         tag:Temperature,
         tag:Water .
 
-brick:Conductivity a owl:Class,
-        brick:Conductivity ;
-    rdfs:label "Conductivity" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Current a owl:Class,
-        brick:Current ;
-    rdfs:label "Current" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Current_Sensor a owl:Class ;
     rdfs:label "Current Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Current ) ],
@@ -8478,6 +8613,11 @@ brick:Demand_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
+brick:Dewpoint a brick:Quantity ;
+    rdfs:label "Dewpoint" ;
+    owl:sameAs qudtqk:DewPointTemperature ;
+    skos:broader brick:Quantity .
+
 brick:Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Differential Pressure Load Shed Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
@@ -8498,11 +8638,6 @@ brick:Differential_Speed_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint,
         tag:Speed .
-
-brick:Direction a owl:Class,
-        brick:Direction ;
-    rdfs:label "Direction" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint" ;
@@ -8542,6 +8677,10 @@ brick:Emergency_Power_Off_Status a owl:Class ;
         tag:Power,
         tag:Status .
 
+brick:Energy a brick:Quantity ;
+    rdfs:label "Energy" ;
+    skos:broader brick:Quantity .
+
 brick:Energy_Usage_Sensor a owl:Class ;
     rdfs:label "Energy Usage Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy _:has_Usage ) ],
@@ -8576,11 +8715,6 @@ brick:Fluid a owl:Class,
         brick:Substance ;
     brick:hasAssociatedTag tag:Fluid .
 
-brick:Frequency a owl:Class,
-        brick:Frequency ;
-    rdfs:label "Frequency" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Gain_Parameter a owl:Class ;
     rdfs:label "Gain Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain ) ],
@@ -8589,6 +8723,10 @@ brick:Gain_Parameter a owl:Class ;
         tag:PID,
         tag:Parameter,
         tag:Point .
+
+brick:Grains a brick:Quantity ;
+    rdfs:label "Grains" ;
+    skos:broader brick:Quantity .
 
 brick:Hot_Water a owl:Class,
         brick:Hot_Water ;
@@ -8652,6 +8790,10 @@ brick:Load_Shed_Status a owl:Class ;
         tag:Shed,
         tag:Status .
 
+brick:Luminance a brick:Quantity ;
+    rdfs:label "Luminance" ;
+    skos:broader brick:Quantity .
+
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Command ) ],
@@ -8675,6 +8817,10 @@ brick:Mode_Status a owl:Class ;
     brick:hasAssociatedTag tag:Mode,
         tag:Point,
         tag:Status .
+
+brick:Occupancy a brick:Quantity ;
+    rdfs:label "Occupancy" ;
+    skos:broader brick:Quantity .
 
 brick:On_Status a owl:Class ;
     rdfs:label "On Status" ;
@@ -8733,11 +8879,6 @@ brick:Return_Water_Temperature_Sensor a owl:Class ;
         tag:Sensor,
         tag:Temperature,
         tag:Water .
-
-brick:Speed a owl:Class,
-        brick:Speed ;
-    rdfs:label "Speed" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Speed_Sensor a owl:Class ;
     rdfs:label "Speed Sensor" ;
@@ -8830,11 +8971,6 @@ brick:Temperature_Low_Reset_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Time a owl:Class,
-        brick:Time ;
-    rdfs:label "Time" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Usage_Sensor a owl:Class ;
     rdfs:label "Usage Sensor" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage ) ],
@@ -8861,11 +8997,6 @@ brick:Velocity_Pressure_Sensor a owl:Class ;
         tag:Pressure,
         tag:Sensor,
         tag:Velocity .
-
-brick:Voltage a owl:Class,
-        brick:Voltage ;
-    rdfs:label "Voltage" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
@@ -9094,6 +9225,10 @@ tag:Wind a brick:Tag ;
 tag:Yearly a brick:Tag ;
     rdfs:label "Yearly" .
 
+brick:Air_Quality a brick:Quantity ;
+    rdfs:label "Air Quality" ;
+    skos:broader brick:Quantity .
+
 brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Air Temperature Integral Time Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
@@ -9164,11 +9299,6 @@ brick:Demand_Setpoint a owl:Class ;
     brick:hasAssociatedTag tag:Demand,
         tag:Point,
         tag:Setpoint .
-
-brick:Dewpoint a owl:Class,
-        brick:Dewpoint ;
-    rdfs:label "Dewpoint" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Deadband Setpoint" ;
@@ -9253,11 +9383,6 @@ brick:Discharge_Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
-brick:Electric_Voltage a owl:Class,
-        brick:Electric_Voltage ;
-    rdfs:label "Electric Voltage" ;
-    rdfs:subClassOf brick:Voltage .
-
 brick:Electrical_System a owl:Class ;
     rdfs:label "Electrical System" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
@@ -9265,15 +9390,11 @@ brick:Electrical_System a owl:Class ;
     brick:hasAssociatedTag tag:Electrical,
         tag:System .
 
-brick:Energy a owl:Class,
-        brick:Energy ;
-    rdfs:label "Energy" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Grains a owl:Class,
-        brick:Grains ;
-    rdfs:label "Grains" ;
-    rdfs:subClassOf brick:Quantity .
+brick:Enthalpy a brick:Quantity ;
+    rdfs:label "Enthalpy" ;
+    owl:sameAs qudtqk:Enthalpy ;
+    skos:broader brick:Quantity ;
+    skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
 
 brick:Heating_Valve a owl:Class ;
     rdfs:label "Heating Valve" ;
@@ -9290,11 +9411,6 @@ brick:Laboratory a owl:Class ;
     brick:hasAssociatedTag tag:Laboratory,
         tag:Location,
         tag:Room .
-
-brick:Luminance a owl:Class,
-        brick:Luminance ;
-    rdfs:label "Luminance" ;
-    rdfs:subClassOf brick:Quantity .
 
 brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Air Flow Setpoint Limit" ;
@@ -9320,11 +9436,6 @@ brick:Meter a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Meter .
 
-brick:Occupancy a owl:Class,
-        brick:Occupancy ;
-    rdfs:label "Occupancy" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Off_Status a owl:Class ;
     rdfs:label "Off Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Status ) ],
@@ -9340,6 +9451,10 @@ brick:PID_Parameter a owl:Class ;
     brick:hasAssociatedTag tag:PID,
         tag:Parameter,
         tag:Point .
+
+brick:Power a brick:Quantity ;
+    rdfs:label "Power" ;
+    skos:broader brick:Quantity .
 
 brick:Reset_Setpoint a owl:Class ;
     rdfs:label "Reset Setpoint" ;
@@ -9365,6 +9480,11 @@ brick:Start_Stop_Status a owl:Class ;
         tag:Start,
         tag:Status,
         tag:Stop .
+
+brick:Static_Pressure a brick:Quantity ;
+    rdfs:label "Static Pressure" ;
+    owl:sameAs qudtqk:StaticPressure ;
+    skos:broader brick:Pressure .
 
 brick:Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Static Pressure Sensor" ;
@@ -9420,6 +9540,16 @@ brick:Valve a owl:Class ;
         brick:HVAC ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Valve .
+
+brick:Velocity_Pressure a brick:Quantity ;
+    rdfs:label "Velocity Pressure" ;
+    owl:equivalentClass brick:Dynamic_Pressure ;
+    owl:sameAs qudtqk:DynamicPressure ;
+    skos:broader brick:Pressure .
+
+brick:Voltage a brick:Quantity ;
+    rdfs:label "Voltage" ;
+    skos:broader brick:Quantity .
 
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
@@ -9492,11 +9622,6 @@ tag:Tolerance a brick:Tag ;
 tag:Variable a brick:Tag ;
     rdfs:label "Variable" .
 
-brick:Air_Quality a owl:Class,
-        brick:Air_Quality ;
-    rdfs:label "Air Quality" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Building_Meter a owl:Class ;
     rdfs:label "Building Meter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Building ) ],
@@ -9533,11 +9658,23 @@ brick:Disable_Command a owl:Class ;
         tag:Disable,
         tag:Point .
 
-brick:Enthalpy a owl:Class,
-        brick:Enthalpy ;
-    rdfs:label "Enthalpy" ;
-    rdfs:subClassOf brick:Quantity ;
-    skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
+brick:Electric_Current a brick:Quantity ;
+    rdfs:label "Electric Current" ;
+    qudt:applicableUnit unit:A,
+        unit:A_Ab,
+        unit:A_Stat,
+        unit:BIOT,
+        unit:KiloA,
+        unit:MicroA,
+        unit:MilliA,
+        unit:NanoA,
+        unit:PicoA ;
+    owl:sameAs qudtqk:ElectricCurrent ;
+    skos:broader brick:Current .
+
+brick:Electric_Power a brick:Quantity ;
+    rdfs:label "Electric Power" ;
+    skos:broader brick:Power .
 
 brick:Gas a owl:Class,
         brick:Gas ;
@@ -9587,16 +9724,6 @@ brick:Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Power a owl:Class,
-        brick:Power ;
-    rdfs:label "Power" ;
-    rdfs:subClassOf brick:Quantity .
-
-brick:Static_Pressure a owl:Class,
-        brick:Static_Pressure ;
-    rdfs:label "Static Pressure" ;
-    rdfs:subClassOf brick:Pressure .
-
 brick:Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Temperature Deadband Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
@@ -9606,11 +9733,6 @@ brick:Temperature_Deadband_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint,
         tag:Temperature .
-
-brick:Velocity_Pressure a owl:Class,
-        brick:Velocity_Pressure ;
-    rdfs:label "Velocity Pressure" ;
-    rdfs:subClassOf brick:Pressure .
 
 brick:Water_System a owl:Class ;
     rdfs:label "Water System" ;
@@ -9698,16 +9820,6 @@ brick:Discharge_Air a owl:Class,
         tag:Fluid,
         tag:Gas .
 
-brick:Electric_Current a owl:Class,
-        brick:Electric_Current ;
-    rdfs:label "Electric Current" ;
-    rdfs:subClassOf brick:Current .
-
-brick:Electric_Power a owl:Class,
-        brick:Electric_Power ;
-    rdfs:label "Electric Power" ;
-    rdfs:subClassOf brick:Power .
-
 brick:Exhaust_Air a owl:Class,
         brick:Exhaust_Air ;
     rdfs:label "Exhaust Air" ;
@@ -9746,8 +9858,13 @@ brick:Integral_Time_Parameter a owl:Class ;
         tag:Point,
         tag:Time .
 
+brick:Level a brick:Quantity ;
+    rdfs:label "Level" ;
+    skos:broader brick:Quantity .
+
 brick:Substance a owl:Class ;
-    rdfs:subClassOf sosa:FeatureOfInterest,
+    rdfs:subClassOf skos:Concept,
+        sosa:FeatureOfInterest,
         brick:Measurable .
 
 brick:Supply_Air a owl:Class,
@@ -9848,11 +9965,6 @@ brick:Air_Humidity_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Level a owl:Class,
-        brick:Level ;
-    rdfs:label "Level" ;
-    rdfs:subClassOf brick:Quantity .
-
 brick:Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Proportional Band Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
@@ -9951,10 +10063,9 @@ brick:Outside_Air a owl:Class,
         tag:Gas,
         tag:Outside .
 
-brick:Pressure a owl:Class,
-        brick:Pressure ;
+brick:Pressure a brick:Quantity ;
     rdfs:label "Pressure" ;
-    rdfs:subClassOf brick:Quantity .
+    skos:broader brick:Quantity .
 
 brick:Return_Air a owl:Class,
         brick:Return_Air ;
@@ -10009,10 +10120,9 @@ tag:Pump a brick:Tag ;
 tag:Steam a brick:Tag ;
     rdfs:label "Steam" .
 
-brick:Humidity a owl:Class,
-        brick:Humidity ;
+brick:Humidity a brick:Quantity ;
     rdfs:label "Humidity" ;
-    rdfs:subClassOf brick:Quantity .
+    skos:broader brick:Quantity .
 
 brick:Location a owl:Class ;
     rdfs:label "Location" ;
@@ -10029,12 +10139,6 @@ brick:Min_Limit a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Point a owl:Class ;
-    rdfs:label "Point" ;
-    rdfs:subClassOf _:has_Point,
-        brick:Class ;
-    brick:hasAssociatedTag tag:Point .
-
 tag:Building a brick:Tag ;
     rdfs:label "Building" .
 
@@ -10049,6 +10153,12 @@ tag:Position a brick:Tag ;
 
 tag:Room a brick:Tag ;
     rdfs:label "Room" .
+
+brick:Point a owl:Class ;
+    rdfs:label "Point" ;
+    rdfs:subClassOf _:has_Point,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Point .
 
 tag:Energy a brick:Tag ;
     rdfs:label "Energy" .
@@ -10091,6 +10201,11 @@ tag:Medium a brick:Tag ;
 tag:Meter a brick:Tag ;
     rdfs:label "Meter" .
 
+brick:Flow a brick:Quantity ;
+    rdfs:label "Flow" ;
+    owl:sameAs qudtqk:VolumeFlowRate ;
+    skos:broader brick:Quantity .
+
 brick:Temperature_Parameter a owl:Class ;
     rdfs:label "Temperature Parameter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Parameter ) ],
@@ -10113,11 +10228,6 @@ brick:Equipment a owl:Class ;
     rdfs:subClassOf _:has_Equipment,
         brick:Class ;
     brick:hasAssociatedTag tag:Equipment .
-
-brick:Flow a owl:Class,
-        brick:Flow ;
-    rdfs:label "Flow" ;
-    rdfs:subClassOf brick:Quantity .
 
 tag:System a brick:Tag ;
     rdfs:label "System" .
@@ -10171,6 +10281,11 @@ tag:Integral a brick:Tag ;
 tag:On a brick:Tag ;
     rdfs:label "On" .
 
+brick:Temperature a brick:Quantity ;
+    rdfs:label "Temperature" ;
+    owl:sameAs qudtqk:Temperature ;
+    skos:broader brick:Quantity .
+
 tag:Fan a brick:Tag ;
     rdfs:label "Fan" .
 
@@ -10185,11 +10300,6 @@ brick:Setpoint a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Point,
         tag:Setpoint .
-
-brick:Temperature a owl:Class,
-        brick:Temperature ;
-    rdfs:label "Temperature" ;
-    rdfs:subClassOf brick:Quantity .
 
 tag:Band a brick:Tag ;
     rdfs:label "Band" .
@@ -10280,10 +10390,6 @@ tag:Chilled a brick:Tag ;
 tag:Reset a brick:Tag ;
     rdfs:label "Reset" .
 
-brick:Quantity a owl:Class ;
-    rdfs:subClassOf sosa:ObservableProperty,
-        brick:Measurable .
-
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Status ) ],
@@ -10355,6 +10461,11 @@ tag:Pressure a brick:Tag ;
 
 tag:Equipment a brick:Tag ;
     rdfs:label "Equipment" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf skos:Concept,
+        sosa:ObservableProperty,
+        brick:Measurable .
 
 tag:Parameter a brick:Tag ;
     rdfs:label "Parameter" .

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -12,18 +12,8 @@
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 
-<https://brickschema.org/schema/1.1/Brick> a owl:Ontology ;
-    rdfs:label "Brick" ;
-    dcterms:creator ( [ a sdo:Person ;
-                sdo:email "gtfierro@cs.berkeley.edu" ;
-                sdo:name "Gabe Fierro" ] [ a sdo:Person ;
-                sdo:email "jbkoh@eng.ucsd.edu" ;
-                sdo:name "Jason Koh" ] ) ;
-    dcterms:license <https://github.com/BrickSchema/brick/blob/master/LICENSE> ;
-    dcterms:version "1.1.0" ;
-    rdfs:seeAlso <https://brickschema.org> .
-
-brick:Absolute_Humidity a brick:Quantity ;
+brick:Absolute_Humidity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Absolute Humidity" ;
     qudt:applicableUnit unit:UNITLESS ;
     owl:sameAs qudtqk:AbsoluteHumidity ;
@@ -39,7 +29,8 @@ brick:Absorption_Chiller a owl:Class ;
         tag:Chiller,
         tag:Equipment .
 
-brick:Acceleration_Time a brick:Quantity ;
+brick:Acceleration_Time a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Acceleration Time" ;
     skos:broader brick:Time .
 
@@ -129,17 +120,29 @@ brick:Alarm_Delay_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Alternating_Current_Frequency a brick:Quantity ;
-    rdfs:label "Alternating Current Frequency" ;
-    skos:broader brick:Electric_Current,
-        brick:Frequency .
+brick:Alternating_Current_Frequency a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Alternating Current Frequency",
+        "Alternating_Current_Frequency" ;
+    qudt:applicableUnit qudt:GigaHZ,
+        qudt:HZ,
+        qudt:KiloHZ,
+        qudt:MegaHZ ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Frequency,
+        brick:Electric_Current,
+        brick:Frequency ;
+    skos:definition "The frequency of the oscillations of alternating current" .
 
-brick:Apparent_Power a brick:Quantity ;
+brick:Apparent_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Apparent Power" ;
     owl:sameAs qudtqk:ApparentPower ;
     skos:broader brick:Electric_Power .
 
-brick:Atmospheric_Pressure a brick:Quantity ;
+brick:Atmospheric_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Atmospheric Pressure" ;
     owl:sameAs qudtqk:AtmosphericPressure ;
     skos:broader brick:Pressure .
@@ -388,11 +391,16 @@ brick:CO2_Differential_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:CO2_Level a brick:Quantity ;
-    rdfs:label "CO2 Level" ;
-    owl:sameAs qudtqk:Concentration ;
-    skos:broader brick:Air_Quality,
-        brick:Level .
+brick:CO2_Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "CO2 Level",
+        "Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration ratio of some substance" .
 
 brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
@@ -657,8 +665,13 @@ brick:Close_Limit a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Cloudage a brick:Quantity ;
-    rdfs:label "Cloudage" .
+brick:Cloudage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Cloudage" ;
+    qudt:applicableUnit unit:Okta ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless ;
+    skos:definition "The fraction of the sky obscured by clouds when observed from a particular location" .
 
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
@@ -697,7 +710,8 @@ brick:Communication_Loss_Alarm a owl:Class ;
         tag:Loss,
         tag:Point .
 
-brick:Complex_Power a brick:Quantity ;
+brick:Complex_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Complex Power" ;
     owl:sameAs qudtqk:ComplexPower ;
     skos:broader brick:Electric_Power .
@@ -898,13 +912,37 @@ brick:Cooling_Valve a owl:Class ;
         tag:Equipment,
         tag:Valve .
 
-brick:Current_Angle a brick:Quantity ;
-    rdfs:label "Current Angle" ;
-    skos:broader brick:Electric_Current .
+brick:Current_Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Angle",
+        "CurrentAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Electric_Current,
+        brick:PhasorAngle ;
+    skos:definition "Angle of current phasor" .
 
-brick:Current_Imbalance a brick:Quantity ;
-    rdfs:label "Current Imbalance" ;
-    skos:broader brick:Electric_Current .
+brick:Current_Imbalance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Imbalance",
+        "CurrentImbalance" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Dimensionless,
+        brick:Electric_Current ;
+    skos:definition "The percent deviation from average current" .
 
 brick:Current_Limit a owl:Class ;
     rdfs:label "Current Limit" ;
@@ -915,13 +953,30 @@ brick:Current_Limit a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Current_Magnitude a brick:Quantity ;
-    rdfs:label "Current Magnitude" ;
-    skos:broader brick:Electric_Current .
+brick:Current_Magnitude a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Magnitude",
+        "CurrentMagnitude" ;
+    qudt:applicableUnit unit:A,
+        unit:KiloA,
+        unit:MicroA,
+        unit:MilliA ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Electric_Current,
+        brick:PhasorMagnitude ;
+    skos:definition "Magnitude of current phasor" .
 
-brick:Current_Total_Harmonic_Distortion a brick:Quantity ;
-    rdfs:label "Current Total Harmonic Distortion" ;
-    skos:broader brick:Electric_Current .
+brick:Current_Total_Harmonic_Distortion a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Total Harmonic Distortion",
+        "CurrentTotalHarmonicDistortion" ;
+    qudt:applicableUnit unit:DeciB_M,
+        unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Dimensionless,
+        brick:Electric_Current ;
+    skos:definition "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)" .
 
 brick:Curtailment_Override_Command a owl:Class ;
     rdfs:label "Curtailment Override Command" ;
@@ -988,10 +1043,8 @@ brick:Damper_Position_Setpoint a owl:Class ;
         tag:Position,
         tag:Setpoint .
 
-brick:Daytime a brick:Quantity ;
-    rdfs:label "Daytime" .
-
-brick:Deceleration_Time a brick:Quantity ;
+brick:Deceleration_Time a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Deceleration Time" ;
     skos:broader brick:Time .
 
@@ -1550,9 +1603,18 @@ brick:Drive_Ready_Status a owl:Class ;
         tag:Ready,
         tag:Status .
 
-brick:Dry_Bulb_Temperature a brick:Quantity ;
-    rdfs:label "Dry Bulb Temperature" ;
-    skos:broader brick:Temperature .
+brick:Dry_Bulb_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Dry Bulb Temperature",
+        "Dry_Bulb_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The temperature of air measured by a thermometer freely exposed to the air, but shielded from radiation and moisture. (https://en.wikipedia.org/wiki/Dry-bulb_temperature)" .
 
 brick:Dual_Band_Mode_Setpoint a owl:Class ;
     rdfs:label "Dual Band Mode Setpoint" ;
@@ -1618,7 +1680,8 @@ brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Electric_Energy a brick:Quantity ;
+brick:Electric_Energy a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Electric Energy" ;
     qudt:applicableUnit unit:J ;
     owl:sameAs qudtqk:Energy ;
@@ -2160,7 +2223,8 @@ brick:Fire_Zone a owl:Class ;
         tag:Location,
         tag:Zone .
 
-brick:Flow_Loss a brick:Quantity ;
+brick:Flow_Loss a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Flow Loss" ;
     skos:broader brick:Flow .
 
@@ -3077,13 +3141,15 @@ brick:Luminance_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint .
 
-brick:Luminous_Flux a brick:Quantity ;
+brick:Luminous_Flux a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Luminous Flux" ;
     qudt:applicableUnit unit:LM ;
     owl:sameAs qudtqk:LuminousFlux ;
     skos:broader brick:Luminance .
 
-brick:Luminous_Intensity a brick:Quantity ;
+brick:Luminous_Intensity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Luminous Intensity" ;
     qudt:applicableUnit unit:CD,
         unit:CP ;
@@ -3878,13 +3944,26 @@ brick:Occupancy_Command a owl:Class ;
         tag:Occupancy,
         tag:Point .
 
-brick:Occupancy_Count a brick:Quantity ;
-    rdfs:label "Occupancy Count" ;
-    skos:broader brick:Occupancy .
+brick:Occupancy_Count a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Occupancy Count",
+        "Occupancy_Count" ;
+    qudt:applicableUnit unit:People ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Occupancy ;
+    skos:definition "Number of people in an area" .
 
-brick:Occupancy_Percentage a brick:Quantity ;
-    rdfs:label "Occupancy Percentage" ;
-    skos:broader brick:Occupancy .
+brick:Occupancy_Percentage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Occupancy Percentage",
+        "Occupancy_Percentage" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Occupancy ;
+    skos:definition "Percent of total occupancy of space that is occupied" .
 
 brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Discharge Air Flow Setpoint" ;
@@ -4007,9 +4086,18 @@ brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Temperature,
         tag:Valve .
 
-brick:Operative_Temperature a brick:Quantity ;
-    rdfs:label "Operative Temperature" ;
-    skos:broader brick:Temperature .
+brick:Operative_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Operative Temperature",
+        "Operative_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The uniform temperature of an imaginary black enclosure in which an occupant would exchange the same amount of heat by radiation plus convection as in the actual nonuniform environment (https://en.wikipedia.org/wiki/Operative_temperature)" .
 
 brick:Output_Frequency_Sensor a owl:Class ;
     rdfs:label "Output Frequency Sensor" ;
@@ -4230,17 +4318,27 @@ brick:PIR_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:PM10_Level a brick:Quantity ;
-    rdfs:label "PM10 Level" ;
-    owl:sameAs qudtqk:Concentration ;
-    skos:broader brick:Air_Quality,
-        brick:Level .
+brick:PM10_Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Concentration",
+        "PM10 Level" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration ratio of some substance" .
 
-brick:PM25_Level a brick:Quantity ;
-    rdfs:label "PM25 Level" ;
-    owl:sameAs qudtqk:Concentration ;
-    skos:broader brick:Air_Quality,
-        brick:Level .
+brick:PM25_Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Concentration",
+        "PM25 Level" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration ratio of some substance" .
 
 brick:Peak_Power_Demand_Sensor a owl:Class ;
     rdfs:label "Peak Power Demand Sensor" ;
@@ -4289,7 +4387,8 @@ brick:PlugStrip a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:PlugStrip .
 
-brick:Power_Factor a brick:Quantity ;
+brick:Power_Factor a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Power Factor" ;
     qudt:applicableUnit unit:UNITLESS ;
     owl:sameAs qudtqk:PowerFactor .
@@ -4305,8 +4404,23 @@ brick:Pre_Filter_Status a owl:Class ;
         tag:Pre,
         tag:Status .
 
-brick:Precipitation a brick:Quantity ;
-    rdfs:label "Precipitation" .
+brick:Precipitation a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Precipitation" ;
+    qudt:applicableUnit unit:CentiM,
+        unit:DeciM,
+        unit:FT,
+        unit:IN,
+        unit:KiloM,
+        unit:M,
+        unit:MicroM,
+        unit:MilliM,
+        unit:YD ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Length,
+        brick:Level ;
+    skos:definition "Amount of atmospheric water vapor fallen including rain, sleet, snow, and hail (https://project-haystack.dev/doc/lib-phScience/precipitation)" .
 
 brick:Preheat_Demand_Setpoint a owl:Class ;
     rdfs:label "Preheat Demand Setpoint" ;
@@ -4378,9 +4492,18 @@ brick:Pump_Start_Stop_Status a owl:Class ;
         tag:Status,
         tag:Stop .
 
-brick:Radiant_Temperature a brick:Quantity ;
-    rdfs:label "Radiant Temperature" ;
-    skos:broader brick:Temperature .
+brick:Radiant_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Radiant Temperature",
+        "Radiant_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "the uniform temperature of an imaginary enclosure in which the radiant heat transfer from the human body is equal to the radiant heat transfer in the actual non-uniform enclosure. (https://en.wikipedia.org/wiki/Mean_radiant_temperature)" .
 
 brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:label "Rain Duration Sensor" ;
@@ -4727,9 +4850,17 @@ brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
         tag:Sensor,
         tag:Solar .
 
-brick:Solar_Irradiance a brick:Quantity ;
-    rdfs:label "Solar Irradiance" ;
-    skos:broader brick:Irradiance .
+brick:Solar_Irradiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Solar Irradiance",
+        "SolarIrradiance" ;
+    qudt:applicableUnit unit:W-PER-CeniM2,
+        unit:W-PER-FT2,
+        unit:W-PER-IN2,
+        unit:W-PER-M2 ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Irradiance ;
+    skos:definition "The power per unit area of solar electromagnetic radiation incident on a surface" .
 
 brick:Solar_Panel a owl:Class ;
     rdfs:label "Solar Panel" ;
@@ -5164,11 +5295,16 @@ brick:System_Shutdown_Status a owl:Class ;
         tag:Status,
         tag:System .
 
-brick:TVOC_Level a brick:Quantity ;
-    rdfs:label "TVOC Level" ;
-    owl:sameAs qudtqk:Concentration ;
-    skos:broader brick:Air_Quality,
-        brick:Level .
+brick:TVOC_Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Concentration",
+        "TVOC Level" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration ratio of some substance" .
 
 brick:Temperature_Adjust_Sensor a owl:Class ;
     rdfs:label "Temperature Adjust Sensor" ;
@@ -5200,7 +5336,8 @@ brick:Temporary_Occupancy_Status a owl:Class ;
         tag:Status,
         tag:Temporary .
 
-brick:Thermal_Energy a brick:Quantity ;
+brick:Thermal_Energy a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Thermal Energy" ;
     qudt:applicableUnit unit:BTU_IT,
         unit:BTU_TH,
@@ -5240,9 +5377,18 @@ brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoin
         tag:Thermal,
         tag:Water .
 
-brick:Thermal_Power a brick:Quantity ;
-    rdfs:label "Thermal Power" ;
-    skos:broader brick:Power .
+brick:Thermal_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Thermal Power",
+        "ThermalPower" ;
+    qudt:applicableUnit unit:KiloW,
+        unit:MegaW,
+        unit:MilliW,
+        unit:W ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Power,
+        brick:Power .
 
 brick:Thermostat a owl:Class ;
     rdfs:label "Thermostat" ;
@@ -5472,15 +5618,40 @@ brick:Video_Intercom a owl:Class ;
         tag:Security,
         tag:Video .
 
-brick:Voltage_Angle a brick:Quantity ;
-    rdfs:label "Voltage Angle" ;
-    skos:broader brick:Voltage .
+brick:Voltage_Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage Angle",
+        "VoltageAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:PhasorAngle,
+        brick:Voltage ;
+    skos:definition "Angle of voltage phasor" .
 
-brick:Voltage_Imbalance a brick:Quantity ;
-    rdfs:label "Voltage Imbalance" ;
-    skos:broader brick:Voltage .
+brick:Voltage_Imbalance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage Imbalance",
+        "VoltageImbalance" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Dimensionless,
+        brick:Voltage ;
+    skos:definition "The percent deviation from average voltage" .
 
-brick:Voltage_Magnitude a brick:Quantity ;
+brick:Voltage_Magnitude a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Voltage Magnitude" ;
     owl:sameAs qudtqk:Voltage ;
     skos:broader brick:Voltage .
@@ -5528,12 +5699,22 @@ brick:Weather a owl:Class ;
         brick:Equipment ;
     brick:hasAssociatedTag tag:Weather .
 
-brick:Weather_Condition a brick:Quantity ;
+brick:Weather_Condition a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Weather Condition" .
 
-brick:Wet_Bulb_Temperature a brick:Quantity ;
-    rdfs:label "Wet Bulb Temperature" ;
-    skos:broader brick:Temperature .
+brick:Wet_Bulb_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wet Bulb Temperature",
+        "Wet_Bulb_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)" .
 
 brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
@@ -5672,7 +5853,7 @@ brick:regulates a owl:AsymmetricProperty,
     owl:inverseOf brick:isRegulatedBy ;
     skos:definition "The subject contributes to or performs the regulation of the substance given by the object" .
 
-unit:A qudt:symbol "A" .
+unit:AMU qudt:symbol "\\(\\mu\\)" .
 
 unit:A_Ab qudt:symbol "abA" .
 
@@ -5699,6 +5880,10 @@ unit:DAY_Sidereal qudt:symbol "d" .
 unit:DEG_R qudt:symbol "°R",
         "°Ra" .
 
+unit:DWT qudt:symbol "dwt" .
+
+unit:GM qudt:symbol "g" .
+
 unit:GigaHZ qudt:symbol "GHz" .
 
 unit:HP qudt:symbol "HP" .
@@ -5713,17 +5898,19 @@ unit:HZ qudt:symbol "Hz" .
 
 unit:J qudt:symbol "J" .
 
-unit:K qudt:symbol "K" .
-
-unit:KiloA qudt:symbol "kA" .
-
 unit:KiloCAL qudt:symbol "kcal" .
+
+unit:KiloGM qudt:symbol "kg" .
 
 unit:KiloHZ qudt:symbol "KHz" .
 
 unit:KiloSEC qudt:symbol "ks" .
 
 unit:LA qudt:symbol "L" .
+
+unit:LB_M qudt:symbol "lbm" .
+
+unit:LB_T qudt:symbol "lbt" .
 
 unit:LM qudt:symbol "lm" .
 
@@ -5737,11 +5924,7 @@ unit:MO qudt:symbol "mo" .
 
 unit:MegaHZ qudt:symbol "MHz" .
 
-unit:MicroA qudt:symbol "µA" .
-
 unit:MicroSEC qudt:symbol "microsec" .
-
-unit:MilliA qudt:symbol "mA" .
 
 unit:MilliSEC qudt:symbol "ms" .
 
@@ -5753,9 +5936,15 @@ unit:NanoA qudt:symbol "nA" .
 
 unit:NanoSEC qudt:symbol "ms" .
 
+unit:OZ_M qudt:symbol "ozm" .
+
+unit:OZ_TROY qudt:symbol "oz" .
+
 unit:PA qudt:symbol "Pa" .
 
 unit:PicoA qudt:symbol "pA" .
+
+unit:PlanckMass qudt:symbol "m_P" .
 
 unit:PlanckTime qudt:symbol "tP" .
 
@@ -5763,11 +5952,23 @@ unit:SEC qudt:symbol "s" .
 
 unit:SH qudt:symbol "Sh" .
 
+unit:SLUG qudt:symbol "slug" .
+
 unit:STILB qudt:symbol "sb" .
+
+unit:SolarMass qudt:symbol "S" .
 
 unit:THM_US qudt:symbol "thm" .
 
-unit:W qudt:symbol "W" .
+unit:TON_Assay qudt:symbol "AT" .
+
+unit:TON_LONG qudt:symbol "ton" .
+
+unit:TON_M qudt:symbol "mT" .
+
+unit:TON_SHORT qudt:symbol "ton" .
+
+unit:U qudt:symbol "u" .
 
 unit:WK qudt:symbol "wk" .
 
@@ -5785,12 +5986,6 @@ brick:Access_Control_Equipment a owl:Class ;
         tag:Control,
         tag:Equipment,
         tag:Security .
-
-brick:Active_Power a brick:Quantity ;
-    rdfs:label "Active Power" ;
-    owl:sameAs qudtqk:ActivePower,
-        brick:Real_Power ;
-    skos:broader brick:Electric_Power .
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Air Flow Deadband Setpoint" ;
@@ -5825,7 +6020,8 @@ brick:Air_Temperature_Setpoint_Limit a owl:Class ;
         tag:Setpoint,
         tag:Temperature .
 
-brick:Angle a brick:Quantity ;
+brick:Angle a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Angle" ;
     qudt:applicableUnit unit:MIN_Angle ;
     owl:sameAs qudtqk:Angle .
@@ -5881,7 +6077,8 @@ brick:Camera a owl:Class ;
     brick:hasAssociatedTag tag:Camera,
         tag:Equipment .
 
-brick:Capacity a brick:Quantity ;
+brick:Capacity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Capacity" ;
     owl:sameAs qudtqk:Capacity .
 
@@ -6181,7 +6378,8 @@ brick:Domestic_Water a owl:Class,
         tag:Liquid,
         tag:Water .
 
-brick:Dynamic_Pressure a brick:Quantity ;
+brick:Dynamic_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Dynamic Pressure" ;
     skos:broader brick:Pressure .
 
@@ -6580,7 +6778,8 @@ brick:Ice a owl:Class,
     brick:hasAssociatedTag tag:Ice,
         tag:Solid .
 
-brick:Illuminance a brick:Quantity ;
+brick:Illuminance a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Illuminance" ;
     owl:sameAs qudtqk:Illuminance .
 
@@ -6605,9 +6804,16 @@ brick:Integral_Gain_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Irradiance a brick:Quantity ;
+brick:Irradiance a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Irradiance" ;
-    owl:sameAs qudtqk:Irradiance .
+    qudt:applicableUnit unit:W-PER-CeniM2,
+        unit:W-PER-FT2,
+        unit:W-PER-IN2,
+        unit:W-PER-M2 ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:PowerPerArea ;
+    skos:definition "The power per unit area of electromagnetic radiation incident on a surface" .
 
 brick:Leak_Alarm a owl:Class ;
     rdfs:label "Leak Alarm" ;
@@ -6691,6 +6897,28 @@ brick:Makeup_Water a owl:Class,
         tag:Liquid,
         tag:Makeup,
         tag:Water .
+
+brick:Mass a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Mass" ;
+    qudt:applicableUnit unit:AMU,
+        unit:DWT,
+        unit:GM,
+        unit:GRAIN,
+        unit:KiloGM,
+        unit:LB_M,
+        unit:LB_T,
+        unit:OZ_M,
+        unit:OZ_TROY,
+        unit:PlanckMass,
+        unit:SLUG,
+        unit:SolarMass,
+        unit:TON_Assay,
+        unit:TON_LONG,
+        unit:TON_M,
+        unit:TON_SHORT,
+        unit:U ;
+    owl:sameAs qudtqk:Mass .
 
 brick:Max_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Temperature Setpoint Limit" ;
@@ -6856,15 +7084,41 @@ brick:PV_Current_Output_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Peak_Power a brick:Quantity ;
+brick:Peak_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Peak Power" ;
     qudt:applicableUnit unit:KiloW ;
     owl:sameAs qudtqk:ElectricPower ;
     skos:broader brick:Power ;
     skos:definition "Tracks the highest (peak) observed power in some interval" .
 
-brick:Position a brick:Quantity ;
-    rdfs:label "Position" .
+brick:PhasorMagnitude a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PhasorMagnitude" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Phasor ;
+    skos:definition "Magnitude component of a phasor" .
+
+brick:Position a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Position" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Dimensionless ;
+    skos:definition "The fraction of the full range of motion" .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
@@ -6928,7 +7182,8 @@ brick:RVAV a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:RVAV .
 
-brick:Radiance a brick:Quantity ;
+brick:Radiance a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Radiance" ;
     owl:sameAs qudtqk:Radiance .
 
@@ -6940,16 +7195,21 @@ brick:Rain_Sensor a owl:Class ;
         tag:Rain,
         tag:Sensor .
 
-brick:Reactive_Power a brick:Quantity ;
+brick:Reactive_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Reactive Power" ;
     owl:sameAs qudtqk:ReactivePower ;
     skos:broader brick:Electric_Power .
 
-brick:Real_Power a brick:Quantity ;
+brick:Real_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Real Power" ;
+    owl:sameAs qudtqk:ActivePower,
+        brick:Active_Power ;
     skos:broader brick:Electric_Power .
 
-brick:Relative_Humidity a brick:Quantity ;
+brick:Relative_Humidity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Relative Humidity" ;
     qudt:applicableUnit unit:UNITLESS ;
     owl:sameAs qudtqk:RelativeHumidity ;
@@ -7006,9 +7266,15 @@ brick:Smoke_Detected_Alarm a owl:Class ;
         tag:Point,
         tag:Smoke .
 
-brick:Solar_Radiance a brick:Quantity ;
-    rdfs:label "Solar Radiance" ;
-    skos:broader brick:Radiance .
+brick:Solar_Radiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Solar Radiance",
+        "Solar_Radiance" ;
+    qudt:applicableUnit unit:W-PER-M2-SR ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Radiance,
+        brick:Radiance ;
+    skos:definition "The amount of light that passes through or is emitted from the sun and falls withi na given solid angle in a specified direction" .
 
 brick:Space a owl:Class ;
     rdfs:label "Space" ;
@@ -7180,7 +7446,8 @@ brick:Thermal_Power_Sensor a owl:Class ;
         tag:Sensor,
         tag:Thermal .
 
-brick:Torque a brick:Quantity ;
+brick:Torque a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Torque" ;
     qudt:applicableUnit unit:N-M ;
     owl:sameAs qudtqk:Torque .
@@ -7238,13 +7505,43 @@ brick:Water_Usage_Sensor a owl:Class ;
         tag:Usage,
         tag:Water .
 
-brick:Wind_Direction a brick:Quantity ;
-    rdfs:label "Wind Direction" ;
-    skos:broader brick:Direction .
+brick:Wind_Direction a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wind Direction",
+        "Wind_Direction" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader brick:Direction ;
+    skos:definition "Direction of wind relative to North" .
 
-brick:Wind_Speed a brick:Quantity ;
-    rdfs:label "Wind Speed" ;
-    skos:broader brick:Speed .
+brick:Wind_Speed a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wind Speed",
+        "Wind_Speed" ;
+    qudt:applicableUnit unit:FT-PER-HR,
+        unit:FT-PER-SEC,
+        unit:KiloM-PER-HR,
+        unit:KiloM-PER-SEC,
+        unit:M-PER-HR,
+        unit:M-PER-SEC,
+        unit:MI-PER-HR,
+        unit:MI-PER-SEC ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Speed,
+        brick:Speed ;
+    skos:definition "Measured speed of wind, caused by air moving from high to low pressure" .
 
 brick:controls a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -7331,6 +7628,25 @@ brick:isTagOf a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Tag .
+
+unit:A qudt:symbol "A" .
+
+unit:GRAIN qudt:symbol "gr" .
+
+unit:KiloA qudt:symbol "kA" .
+
+unit:MicroA qudt:symbol "µA" .
+
+unit:MilliA qudt:symbol "mA" .
+
+unit:W qudt:symbol "W" .
+
+brick:Active_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Active Power" ;
+    owl:sameAs qudtqk:ActivePower,
+        brick:Real_Power ;
+    skos:broader brick:Electric_Power .
 
 brick:Adjust_Sensor a owl:Class ;
     rdfs:label "Adjust Sensor" ;
@@ -7467,7 +7783,8 @@ brick:Coil a owl:Class ;
     brick:hasAssociatedTag tag:Coil,
         tag:Equipment .
 
-brick:Conductivity a brick:Quantity ;
+brick:Conductivity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Conductivity" ;
     owl:sameAs qudtqk:Conductivity .
 
@@ -7482,7 +7799,8 @@ brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Point,
         tag:Setpoint .
 
-brick:Current a brick:Quantity ;
+brick:Current a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Current" .
 
 brick:Current_Output_Sensor a owl:Class ;
@@ -7505,7 +7823,8 @@ brick:Dewpoint_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Direction a brick:Quantity ;
+brick:Direction a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Direction" .
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
@@ -7664,7 +7983,8 @@ brick:Flow_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Frequency a brick:Quantity ;
+brick:Frequency a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Frequency" ;
     qudt:applicableUnit unit:GigaHZ,
         unit:HZ,
@@ -8011,6 +8331,30 @@ brick:Overridden_Status a owl:Class ;
         tag:Point,
         tag:Status .
 
+brick:Phasor a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Phasor" .
+
+brick:PhasorAngle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PhasorAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:PlaneAngle,
+        brick:Phasor ;
+    skos:definition "Angle component of a phasor" .
+
 brick:Position_Limit a owl:Class ;
     rdfs:label "Position Limit" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Limit ) ],
@@ -8092,7 +8436,8 @@ brick:Run_Status a owl:Class ;
         tag:Run,
         tag:Status .
 
-brick:Speed a brick:Quantity ;
+brick:Speed a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Speed" ;
     owl:sameAs qudtqk:Speed .
 
@@ -8215,7 +8560,8 @@ brick:Temperature_Sensor a owl:Class ;
         tag:Sensor,
         tag:Temperature .
 
-brick:Time a brick:Quantity ;
+brick:Time a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Time" ;
     qudt:applicableUnit unit:DAY,
         unit:DAY_Sidereal,
@@ -8651,8 +8997,6 @@ tag:Wing a brick:Tag ;
 tag:Zenith a brick:Tag ;
     rdfs:label "Zenith" .
 
-unit:KiloW qudt:symbol "kW" .
-
 unit:UNITLESS qudt:symbol "U" .
 
 brick:AHU a owl:Class ;
@@ -8725,7 +9069,8 @@ brick:Demand_Sensor a owl:Class ;
         tag:Point,
         tag:Sensor .
 
-brick:Dewpoint a brick:Quantity ;
+brick:Dewpoint a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Dewpoint" ;
     owl:sameAs qudtqk:DewPointTemperature .
 
@@ -8788,7 +9133,8 @@ brick:Emergency_Power_Off_Status a owl:Class ;
         tag:Power,
         tag:Status .
 
-brick:Energy a brick:Quantity ;
+brick:Energy a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Energy" .
 
 brick:Energy_Usage_Sensor a owl:Class ;
@@ -8834,8 +9180,14 @@ brick:Gain_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Grains a brick:Quantity ;
-    rdfs:label "Grains" .
+brick:Grains a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Grains" ;
+    qudt:applicableUnit unit:GRAIN ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Mass,
+        brick:Mass .
 
 brick:Hot_Water a owl:Class,
         brick:Hot_Water ;
@@ -8881,6 +9233,22 @@ brick:Humidity_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
+brick:Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Level" ;
+    qudt:applicableUnit unit:CentiM,
+        unit:DeciM,
+        unit:FT,
+        unit:IN,
+        unit:KiloM,
+        unit:M,
+        unit:MicroM,
+        unit:MilliM,
+        unit:YD ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
+    skos:broader qudtqk:Length .
+
 brick:Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Load Shed Setpoint" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shed _:has_Load _:has_Setpoint ) ],
@@ -8899,7 +9267,8 @@ brick:Load_Shed_Status a owl:Class ;
         tag:Shed,
         tag:Status .
 
-brick:Luminance a brick:Quantity ;
+brick:Luminance a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Luminance" ;
     qudt:applicableUnit unit:LA,
         unit:STILB ;
@@ -8929,7 +9298,8 @@ brick:Mode_Status a owl:Class ;
         tag:Point,
         tag:Status .
 
-brick:Occupancy a brick:Quantity ;
+brick:Occupancy a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Occupancy" .
 
 brick:On_Status a owl:Class ;
@@ -9362,15 +9732,10 @@ tag:Wind a brick:Tag ;
 tag:Yearly a brick:Tag ;
     rdfs:label "Yearly" .
 
-qudtqk:Concentration a qudt:QuantityKind ;
-    rdfs:label "Concentration" ;
-    qudt:applicableUnit unit:PPM ;
-    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
-    qudt:plainTextDescription "The concentration ratio of some substance" ;
-    rdfs:isDefinedBy <http://qudt.org/vocab/quantitykind> ;
-    skos:broader qudtqk:Dimensionless .
+unit:KiloW qudt:symbol "kW" .
 
-brick:Air_Quality a brick:Quantity ;
+brick:Air_Quality a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Air Quality" .
 
 brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
@@ -9534,7 +9899,8 @@ brick:Electrical_System a owl:Class ;
     brick:hasAssociatedTag tag:Electrical,
         tag:System .
 
-brick:Enthalpy a brick:Quantity ;
+brick:Enthalpy a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Enthalpy" ;
     owl:sameAs qudtqk:Enthalpy ;
     skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
@@ -9595,7 +9961,8 @@ brick:PID_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point .
 
-brick:Power a brick:Quantity ;
+brick:Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Power" ;
     qudt:applicableUnit unit:HP,
         unit:HP_Water,
@@ -9635,7 +10002,8 @@ brick:Start_Stop_Status a owl:Class ;
         tag:Status,
         tag:Stop .
 
-brick:Static_Pressure a brick:Quantity ;
+brick:Static_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Static Pressure" ;
     owl:sameAs qudtqk:StaticPressure ;
     skos:broader brick:Pressure .
@@ -9695,13 +10063,15 @@ brick:Valve a owl:Class ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Valve .
 
-brick:Velocity_Pressure a brick:Quantity ;
+brick:Velocity_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Velocity Pressure" ;
     owl:sameAs qudtqk:DynamicPressure,
         brick:Dynamic_Pressure ;
     skos:broader brick:Pressure .
 
-brick:Voltage a brick:Quantity ;
+brick:Voltage a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Voltage" .
 
 brick:Water_Alarm a owl:Class ;
@@ -9781,6 +10151,8 @@ tag:Tolerance a brick:Tag ;
 tag:Variable a brick:Tag ;
     rdfs:label "Variable" .
 
+unit:K qudt:symbol "K" .
+
 brick:Building_Meter a owl:Class ;
     rdfs:label "Building Meter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Building ) ],
@@ -9817,7 +10189,8 @@ brick:Disable_Command a owl:Class ;
         tag:Disable,
         tag:Point .
 
-brick:Electric_Current a brick:Quantity ;
+brick:Electric_Current a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Electric Current" ;
     qudt:applicableUnit unit:A,
         unit:A_Ab,
@@ -9831,7 +10204,8 @@ brick:Electric_Current a brick:Quantity ;
     owl:sameAs qudtqk:ElectricCurrent ;
     skos:broader brick:Current .
 
-brick:Electric_Power a brick:Quantity ;
+brick:Electric_Power a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Electric Power" ;
     qudt:applicableUnit unit:KiloW ;
     owl:sameAs qudtqk:ElectricPower ;
@@ -10007,9 +10381,6 @@ brick:Integral_Time_Parameter a owl:Class ;
         tag:Parameter,
         tag:Point,
         tag:Time .
-
-brick:Level a brick:Quantity ;
-    rdfs:label "Level" .
 
 brick:Substance a owl:Class ;
     rdfs:subClassOf sosa:FeatureOfInterest,
@@ -10203,7 +10574,8 @@ brick:Outside_Air a owl:Class,
         tag:Gas,
         tag:Outside .
 
-brick:Pressure a brick:Quantity ;
+brick:Pressure a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Pressure" ;
     qudt:applicableUnit unit:BARYE,
         unit:N-PER-M2,
@@ -10274,7 +10646,8 @@ tag:Pump a brick:Tag ;
 tag:Steam a brick:Tag ;
     rdfs:label "Steam" .
 
-brick:Humidity a brick:Quantity ;
+brick:Humidity a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Humidity" .
 
 brick:Location a owl:Class ;
@@ -10355,7 +10728,8 @@ tag:Medium a brick:Tag ;
 tag:Meter a brick:Tag ;
     rdfs:label "Meter" .
 
-brick:Flow a brick:Quantity ;
+brick:Flow a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Flow" ;
     owl:sameAs qudtqk:VolumeFlowRate .
 
@@ -10437,7 +10811,8 @@ tag:Integral a brick:Tag ;
 tag:On a brick:Tag ;
     rdfs:label "On" .
 
-brick:Temperature a brick:Quantity ;
+brick:Temperature a qudt:QuantityKind,
+        brick:Quantity ;
     rdfs:label "Temperature" ;
     qudt:applicableUnit unit:DEG_R,
         unit:K ;
@@ -10546,6 +10921,17 @@ brick:Command a owl:Class ;
     brick:hasAssociatedTag tag:Command,
         tag:Point .
 
+<https://brickschema.org/schema/1.1/Brick> a owl:Ontology ;
+    rdfs:label "Brick" ;
+    dcterms:creator ( [ a sdo:Person ;
+                sdo:email "gtfierro@cs.berkeley.edu" ;
+                sdo:name "Gabe Fierro" ] [ a sdo:Person ;
+                sdo:email "jbkoh@eng.ucsd.edu" ;
+                sdo:name "Jason Koh" ] ) ;
+    dcterms:license <https://github.com/BrickSchema/brick/blob/master/LICENSE> ;
+    dcterms:version "1.1.0" ;
+    rdfs:seeAlso <https://brickschema.org> .
+
 tag:Chilled a brick:Tag ;
     rdfs:label "Chilled" .
 
@@ -10610,16 +10996,16 @@ tag:Command a brick:Tag ;
 tag:Differential a brick:Tag ;
     rdfs:label "Differential" .
 
-brick:Quantity a owl:Class ;
-    rdfs:subClassOf skos:Concept,
-        sosa:ObservableProperty,
-        brick:Measurable .
-
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
 
 tag:Status a brick:Tag ;
     rdfs:label "Status" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf skos:Concept,
+        sosa:ObservableProperty,
+        brick:Measurable .
 
 tag:Flow a brick:Tag ;
     rdfs:label "Flow" .

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -657,8 +657,7 @@ brick:Close_Limit a owl:Class ;
         tag:Point .
 
 brick:Cloudage a brick:Quantity ;
-    rdfs:label "Cloudage" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Cloudage" .
 
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
@@ -989,8 +988,7 @@ brick:Damper_Position_Setpoint a owl:Class ;
         tag:Setpoint .
 
 brick:Daytime a brick:Quantity ;
-    rdfs:label "Daytime" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Daytime" .
 
 brick:Deceleration_Time a brick:Quantity ;
     rdfs:label "Deceleration Time" ;
@@ -4291,8 +4289,7 @@ brick:PlugStrip a owl:Class ;
 brick:Power_Factor a brick:Quantity ;
     rdfs:label "Power Factor" ;
     qudt:applicableUnit unit:UNITLESS ;
-    owl:sameAs qudtqk:PowerFactor ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:PowerFactor .
 
 brick:Pre_Filter_Status a owl:Class ;
     rdfs:label "Pre Filter Status" ;
@@ -4306,8 +4303,7 @@ brick:Pre_Filter_Status a owl:Class ;
         tag:Status .
 
 brick:Precipitation a brick:Quantity ;
-    rdfs:label "Precipitation" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Precipitation" .
 
 brick:Preheat_Demand_Setpoint a owl:Class ;
     rdfs:label "Preheat Demand Setpoint" ;
@@ -5529,8 +5525,7 @@ brick:Weather a owl:Class ;
     brick:hasAssociatedTag tag:Weather .
 
 brick:Weather_Condition a brick:Quantity ;
-    rdfs:label "Weather Condition" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Weather Condition" .
 
 brick:Wet_Bulb_Temperature a brick:Quantity ;
     rdfs:label "Wet Bulb Temperature" ;
@@ -5686,6 +5681,8 @@ unit:A_Ab qudt:symbol "abA" .
 
 unit:A_Stat qudt:symbol "statA" .
 
+unit:BARYE qudt:symbol "\\rho" .
+
 unit:BIOT qudt:symbol "Bi" .
 
 unit:BTU_IT qudt:symbol "Btu_{it}" .
@@ -5702,7 +5699,14 @@ unit:DAY qudt:symbol "d" .
 
 unit:DAY_Sidereal qudt:symbol "d" .
 
+unit:DEG_R qudt:symbol "°R",
+        "°Ra" .
+
 unit:GigaHZ qudt:symbol "GHz" .
+
+unit:HP qudt:symbol "HP" .
+
+unit:HP_Water qudt:symbol "hp_water" .
 
 unit:HR qudt:symbol "hr" .
 
@@ -5712,6 +5716,8 @@ unit:HZ qudt:symbol "Hz" .
 
 unit:J qudt:symbol "J" .
 
+unit:K qudt:symbol "K" .
+
 unit:KiloA qudt:symbol "kA" .
 
 unit:KiloCAL qudt:symbol "kcal" .
@@ -5720,7 +5726,7 @@ unit:KiloHZ qudt:symbol "KHz" .
 
 unit:KiloSEC qudt:symbol "ks" .
 
-unit:KiloW qudt:symbol "kW" .
+unit:LA qudt:symbol "L" .
 
 unit:LM qudt:symbol "lm" .
 
@@ -5744,9 +5750,13 @@ unit:MilliSEC qudt:symbol "ms" .
 
 unit:N-M qudt:symbol "N-m" .
 
+unit:N-PER-M2 qudt:symbol "Pa" .
+
 unit:NanoA qudt:symbol "nA" .
 
 unit:NanoSEC qudt:symbol "ms" .
+
+unit:PA qudt:symbol "Pa" .
 
 unit:PicoA qudt:symbol "pA" .
 
@@ -5756,7 +5766,11 @@ unit:SEC qudt:symbol "s" .
 
 unit:SH qudt:symbol "Sh" .
 
+unit:STILB qudt:symbol "sb" .
+
 unit:THM_US qudt:symbol "thm" .
+
+unit:W qudt:symbol "W" .
 
 unit:WK qudt:symbol "wk" .
 
@@ -5817,9 +5831,7 @@ brick:Air_Temperature_Setpoint_Limit a owl:Class ;
 brick:Angle a brick:Quantity ;
     rdfs:label "Angle" ;
     qudt:applicableUnit unit:MIN_Angle ;
-    rdfs:seeAlso qudtqk:Angle ;
-    owl:sameAs qudtqk:Angle ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Angle .
 
 brick:Blowdown_Water a owl:Class,
         brick:Blowdown_Water ;
@@ -5874,8 +5886,7 @@ brick:Camera a owl:Class ;
 
 brick:Capacity a brick:Quantity ;
     rdfs:label "Capacity" ;
-    owl:sameAs qudtqk:Capacity ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Capacity .
 
 brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
@@ -6574,8 +6585,7 @@ brick:Ice a owl:Class,
 
 brick:Illuminance a brick:Quantity ;
     rdfs:label "Illuminance" ;
-    owl:sameAs qudtqk:Illuminance ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Illuminance .
 
 brick:Illuminance_Sensor a owl:Class ;
     rdfs:label "Illuminance Sensor" ;
@@ -6600,8 +6610,7 @@ brick:Integral_Gain_Parameter a owl:Class ;
 
 brick:Irradiance a brick:Quantity ;
     rdfs:label "Irradiance" ;
-    owl:sameAs qudtqk:Irradiance ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Irradiance .
 
 brick:Leak_Alarm a owl:Class ;
     rdfs:label "Leak Alarm" ;
@@ -6858,8 +6867,7 @@ brick:Peak_Power a brick:Quantity ;
     skos:definition "Tracks the highest (peak) observed power in some interval" .
 
 brick:Position a brick:Quantity ;
-    rdfs:label "Position" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Position" .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
@@ -6925,8 +6933,7 @@ brick:RVAV a owl:Class ;
 
 brick:Radiance a brick:Quantity ;
     rdfs:label "Radiance" ;
-    owl:sameAs qudtqk:Radiance ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Radiance .
 
 brick:Rain_Sensor a owl:Class ;
     rdfs:label "Rain Sensor" ;
@@ -7179,8 +7186,7 @@ brick:Thermal_Power_Sensor a owl:Class ;
 brick:Torque a brick:Quantity ;
     rdfs:label "Torque" ;
     qudt:applicableUnit unit:N-M ;
-    owl:sameAs qudtqk:Torque ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Torque .
 
 brick:Torque_Sensor a owl:Class ;
     rdfs:label "Torque Sensor" ;
@@ -7466,8 +7472,7 @@ brick:Coil a owl:Class ;
 
 brick:Conductivity a brick:Quantity ;
     rdfs:label "Conductivity" ;
-    owl:sameAs qudtqk:Conductivity ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Conductivity .
 
 brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Flow Setpoint" ;
@@ -7481,8 +7486,7 @@ brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Setpoint .
 
 brick:Current a brick:Quantity ;
-    rdfs:label "Current" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Current" .
 
 brick:Current_Output_Sensor a owl:Class ;
     rdfs:label "Current Output Sensor" ;
@@ -7505,8 +7509,7 @@ brick:Dewpoint_Sensor a owl:Class ;
         tag:Sensor .
 
 brick:Direction a brick:Quantity ;
-    rdfs:label "Direction" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Direction" .
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Setpoint" ;
@@ -7670,8 +7673,7 @@ brick:Frequency a brick:Quantity ;
         unit:HZ,
         unit:KiloHZ,
         unit:MegaHZ ;
-    owl:sameAs qudtqk:Frequency ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Frequency .
 
 brick:Frost a owl:Class,
         brick:Frost ;
@@ -8095,8 +8097,7 @@ brick:Run_Status a owl:Class ;
 
 brick:Speed a brick:Quantity ;
     rdfs:label "Speed" ;
-    owl:sameAs qudtqk:Speed ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Speed .
 
 brick:Speed_Setpoint a owl:Class ;
     rdfs:label "Speed Setpoint" ;
@@ -8237,8 +8238,7 @@ brick:Time a brick:Quantity ;
         unit:YR,
         unit:YR_Sidereal,
         unit:YR_TROPICAL ;
-    owl:sameAs qudtqk:Time ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:Time .
 
 brick:Time_Parameter a owl:Class ;
     rdfs:label "Time Parameter" ;
@@ -8654,6 +8654,8 @@ tag:Wing a brick:Tag ;
 tag:Zenith a brick:Tag ;
     rdfs:label "Zenith" .
 
+unit:KiloW qudt:symbol "kW" .
+
 unit:UNITLESS qudt:symbol "U" .
 
 brick:AHU a owl:Class ;
@@ -8728,8 +8730,7 @@ brick:Demand_Sensor a owl:Class ;
 
 brick:Dewpoint a brick:Quantity ;
     rdfs:label "Dewpoint" ;
-    owl:sameAs qudtqk:DewPointTemperature ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:DewPointTemperature .
 
 brick:Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Differential Pressure Load Shed Status" ;
@@ -8791,8 +8792,7 @@ brick:Emergency_Power_Off_Status a owl:Class ;
         tag:Status .
 
 brick:Energy a brick:Quantity ;
-    rdfs:label "Energy" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Energy" .
 
 brick:Energy_Usage_Sensor a owl:Class ;
     rdfs:label "Energy Usage Sensor" ;
@@ -8838,8 +8838,7 @@ brick:Gain_Parameter a owl:Class ;
         tag:Point .
 
 brick:Grains a brick:Quantity ;
-    rdfs:label "Grains" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Grains" .
 
 brick:Hot_Water a owl:Class,
         brick:Hot_Water ;
@@ -8905,7 +8904,9 @@ brick:Load_Shed_Status a owl:Class ;
 
 brick:Luminance a brick:Quantity ;
     rdfs:label "Luminance" ;
-    skos:broader brick:Quantity .
+    qudt:applicableUnit unit:LA,
+        unit:STILB ;
+    owl:sameAs qudtqk:Luminance .
 
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
@@ -8932,8 +8933,7 @@ brick:Mode_Status a owl:Class ;
         tag:Status .
 
 brick:Occupancy a brick:Quantity ;
-    rdfs:label "Occupancy" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Occupancy" .
 
 brick:On_Status a owl:Class ;
     rdfs:label "On Status" ;
@@ -9366,8 +9366,7 @@ tag:Yearly a brick:Tag ;
     rdfs:label "Yearly" .
 
 brick:Air_Quality a brick:Quantity ;
-    rdfs:label "Air Quality" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Air Quality" .
 
 brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Air Temperature Integral Time Parameter" ;
@@ -9533,7 +9532,6 @@ brick:Electrical_System a owl:Class ;
 brick:Enthalpy a brick:Quantity ;
     rdfs:label "Enthalpy" ;
     owl:sameAs qudtqk:Enthalpy ;
-    skos:broader brick:Quantity ;
     skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
 
 brick:Heating_Valve a owl:Class ;
@@ -9594,7 +9592,11 @@ brick:PID_Parameter a owl:Class ;
 
 brick:Power a brick:Quantity ;
     rdfs:label "Power" ;
-    skos:broader brick:Quantity .
+    qudt:applicableUnit unit:HP,
+        unit:HP_Water,
+        unit:KiloW,
+        unit:W ;
+    owl:sameAs qudtqk:Power .
 
 brick:Reset_Setpoint a owl:Class ;
     rdfs:label "Reset Setpoint" ;
@@ -9695,8 +9697,7 @@ brick:Velocity_Pressure a brick:Quantity ;
     skos:broader brick:Pressure .
 
 brick:Voltage a brick:Quantity ;
-    rdfs:label "Voltage" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Voltage" .
 
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
@@ -9827,6 +9828,8 @@ brick:Electric_Current a brick:Quantity ;
 
 brick:Electric_Power a brick:Quantity ;
     rdfs:label "Electric Power" ;
+    qudt:applicableUnit unit:KiloW ;
+    owl:sameAs qudtqk:ElectricPower ;
     skos:broader brick:Power .
 
 brick:Gas a owl:Class,
@@ -10001,8 +10004,7 @@ brick:Integral_Time_Parameter a owl:Class ;
         tag:Time .
 
 brick:Level a brick:Quantity ;
-    rdfs:label "Level" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Level" .
 
 brick:Substance a owl:Class ;
     rdfs:subClassOf skos:Concept,
@@ -10199,7 +10201,10 @@ brick:Outside_Air a owl:Class,
 
 brick:Pressure a brick:Quantity ;
     rdfs:label "Pressure" ;
-    skos:broader brick:Quantity .
+    qudt:applicableUnit unit:BARYE,
+        unit:N-PER-M2,
+        unit:PA ;
+    owl:sameAs qudtqk:Pressure .
 
 brick:Return_Air a owl:Class,
         brick:Return_Air ;
@@ -10266,8 +10271,7 @@ tag:Steam a brick:Tag ;
     rdfs:label "Steam" .
 
 brick:Humidity a brick:Quantity ;
-    rdfs:label "Humidity" ;
-    skos:broader brick:Quantity .
+    rdfs:label "Humidity" .
 
 brick:Location a owl:Class ;
     rdfs:label "Location" ;
@@ -10349,8 +10353,7 @@ tag:Meter a brick:Tag ;
 
 brick:Flow a brick:Quantity ;
     rdfs:label "Flow" ;
-    owl:sameAs qudtqk:VolumeFlowRate ;
-    skos:broader brick:Quantity .
+    owl:sameAs qudtqk:VolumeFlowRate .
 
 brick:Temperature_Parameter a owl:Class ;
     rdfs:label "Temperature Parameter" ;
@@ -10432,8 +10435,9 @@ tag:On a brick:Tag ;
 
 brick:Temperature a brick:Quantity ;
     rdfs:label "Temperature" ;
-    owl:sameAs qudtqk:Temperature ;
-    skos:broader brick:Quantity .
+    qudt:applicableUnit unit:DEG_R,
+        unit:K ;
+    owl:sameAs qudtqk:ThermodynamicTemperature .
 
 tag:Fan a brick:Tag ;
     rdfs:label "Fan" .
@@ -10602,6 +10606,11 @@ tag:Command a brick:Tag ;
 tag:Differential a brick:Tag ;
     rdfs:label "Differential" .
 
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf skos:Concept,
+        sosa:ObservableProperty,
+        brick:Measurable .
+
 tag:Discharge a brick:Tag ;
     rdfs:label "Discharge" .
 
@@ -10616,11 +10625,6 @@ tag:Supply a brick:Tag ;
 
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .
-
-brick:Quantity a owl:Class ;
-    rdfs:subClassOf skos:Concept,
-        sosa:ObservableProperty,
-        brick:Measurable .
 
 tag:Equipment a brick:Tag ;
     rdfs:label "Equipment" .

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -390,6 +390,7 @@ brick:CO2_Differential_Sensor a owl:Class ;
 
 brick:CO2_Level a brick:Quantity ;
     rdfs:label "CO2 Level" ;
+    owl:sameAs qudtqk:Concentration ;
     skos:broader brick:Air_Quality,
         brick:Level .
 
@@ -4231,11 +4232,13 @@ brick:PIR_Sensor a owl:Class ;
 
 brick:PM10_Level a brick:Quantity ;
     rdfs:label "PM10 Level" ;
+    owl:sameAs qudtqk:Concentration ;
     skos:broader brick:Air_Quality,
         brick:Level .
 
 brick:PM25_Level a brick:Quantity ;
     rdfs:label "PM25 Level" ;
+    owl:sameAs qudtqk:Concentration ;
     skos:broader brick:Air_Quality,
         brick:Level .
 
@@ -5163,6 +5166,7 @@ brick:System_Shutdown_Status a owl:Class ;
 
 brick:TVOC_Level a brick:Quantity ;
     rdfs:label "TVOC Level" ;
+    owl:sameAs qudtqk:Concentration ;
     skos:broader brick:Air_Quality,
         brick:Level .
 
@@ -9358,6 +9362,14 @@ tag:Wind a brick:Tag ;
 tag:Yearly a brick:Tag ;
     rdfs:label "Yearly" .
 
+qudtqk:Concentration a qudt:QuantityKind ;
+    rdfs:label "Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    qudt:plainTextDescription "The concentration ratio of some substance" ;
+    rdfs:isDefinedBy <http://qudt.org/vocab/quantitykind> ;
+    skos:broader qudtqk:Dimensionless .
+
 brick:Air_Quality a brick:Quantity ;
     rdfs:label "Air Quality" .
 
@@ -10000,8 +10012,7 @@ brick:Level a brick:Quantity ;
     rdfs:label "Level" .
 
 brick:Substance a owl:Class ;
-    rdfs:subClassOf skos:Concept,
-        sosa:FeatureOfInterest,
+    rdfs:subClassOf sosa:FeatureOfInterest,
         brick:Measurable .
 
 brick:Supply_Air a owl:Class,

--- a/Brick.ttl
+++ b/Brick.ttl
@@ -929,7 +929,7 @@ brick:Current_Angle a qudt:QuantityKind,
         unit:REV ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:PhasorAngle ;
+    skos:broader brick:Phasor_Angle ;
     skos:definition "Angle of current phasor" ;
     skos:related brick:Electric_Current .
 
@@ -4343,9 +4343,10 @@ brick:Peak_Power_Demand_Sensor a owl:Class ;
         tag:Power,
         tag:Sensor .
 
-brick:PhasorMagnitude a qudt:QuantityKind,
+brick:Phasor_Magnitude a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "PhasorMagnitude" ;
+    rdfs:label "Phasor Magnitude",
+        "PhasorMagnitude" ;
     qudt:applicableUnit unit:ARCMIN,
         unit:ARCSEC,
         unit:DEG,
@@ -5634,7 +5635,7 @@ brick:Voltage_Angle a qudt:QuantityKind,
         unit:REV ;
     qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
     rdfs:isDefinedBy <https://brickschema.org/schema/1.1/Brick> ;
-    skos:broader brick:PhasorAngle ;
+    skos:broader brick:Phasor_Angle ;
     skos:definition "Angle of voltage phasor" ;
     skos:related brick:Voltage .
 
@@ -8280,9 +8281,10 @@ brick:Phasor a qudt:QuantityKind,
         brick:Quantity ;
     rdfs:label "Phasor" .
 
-brick:PhasorAngle a qudt:QuantityKind,
+brick:Phasor_Angle a qudt:QuantityKind,
         brick:Quantity ;
-    rdfs:label "PhasorAngle" ;
+    rdfs:label "Phasor Angle",
+        "PhasorAngle" ;
     qudt:applicableUnit unit:ARCMIN,
         unit:ARCSEC,
         unit:DEG,

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 Brick.ttl: bricksrc/*.py generate_brick.py
 	python generate_brick.py
+	cd shacl && python generate_shacl.py
 
 shacl/BrickShape.ttl: bricksrc/*.py generate_brick.py shacl/generate_shacl.py
 	cd shacl && python generate_shacl.py

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -56,43 +56,6 @@ command_definitions = {
                     },
                     "Speed_Reset_Command": {
                         "tags": [TAG.Point, TAG.Speed, TAG.Reset, TAG.Command],
-                        "subclasses": {
-                            "Fan_Speed_Reset_Command": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Fan,
-                                    TAG.Speed,
-                                    TAG.Reset,
-                                    TAG.Command,
-                                ],
-                            },
-                        },
-                    },
-                },
-            },
-            "Shutdown_Command": {
-                "tags": [TAG.Point, TAG.Shutdown, TAG.Command],
-                "subclasses": {
-                    "Hot_Water_Shutdown_Command": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Hot,
-                            TAG.Water,
-                            TAG.Shutdown,
-                            TAG.Command,
-                        ],
-                        "subclasses": {
-                            "Unoccupied_Hot_Water_Shutdown_Command": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Unoccupied,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Shutdown,
-                                    TAG.Command,
-                                ],
-                            },
-                        },
                     },
                 },
             },
@@ -378,10 +341,6 @@ command_definitions = {
                         "tags": [TAG.Point, TAG.Curtailment, TAG.Override, TAG.Command],
                     },
                 },
-            },
-            "Lockout_Command": {"tags": [TAG.Point, TAG.Lockout, TAG.Command]},
-            "Run_Request_Command": {
-                "tags": [TAG.Point, TAG.Run, TAG.Request, TAG.Command],
             },
         },
     }

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -14,10 +14,11 @@ SDO = Namespace("http://schema.org#")
 SOSA = Namespace("http://www.w3.org/ns/sosa#")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
 
-# QUDT prefixes
+# QUDT namespaces
 QUDT = Namespace("http://qudt.org/schema/qudt/")
 QUDTQK = Namespace("http://qudt.org/vocab/quantitykind/")
-QUDTUNIT = Namespace("http://qudt.org/vocab/unit/")
+UNIT = Namespace("http://qudt.org/vocab/unit/")
+
 A = RDF.type
 
 
@@ -34,6 +35,6 @@ def bind_prefixes(g):
     g.bind("tag", TAG)
     g.bind("vcard", VCARD)
     g.bind("bsh", BSH)
-    g.bind("qudt", QUDT)
     g.bind("qudtqk", QUDTQK)
-    g.bind("qudtunit", QUDTUNIT)
+    g.bind("qudt", QUDT)
+    g.bind("unit", UNIT)

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -12,6 +12,7 @@ SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 DCTERMS = Namespace("http://purl.org/dc/terms#")
 SDO = Namespace("http://schema.org#")
 SOSA = Namespace("http://www.w3.org/ns/sosa#")
+QUDTQK = Namespace("http://qudt.org/vocab/quantitykind/")
 A = RDF.type
 
 

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -13,6 +13,7 @@ DCTERMS = Namespace("http://purl.org/dc/terms#")
 SDO = Namespace("http://schema.org#")
 SOSA = Namespace("http://www.w3.org/ns/sosa#")
 QUDTQK = Namespace("http://qudt.org/vocab/quantitykind/")
+QUDTUNIT = Namespace("http://qudt.org/vocab/unit/")
 A = RDF.type
 
 

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -12,6 +12,9 @@ SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 DCTERMS = Namespace("http://purl.org/dc/terms#")
 SDO = Namespace("http://schema.org#")
 SOSA = Namespace("http://www.w3.org/ns/sosa#")
+
+# QUDT prefixes
+QUDT = Namespace("http://qudt.org/schema/qudt/")
 QUDTQK = Namespace("http://qudt.org/vocab/quantitykind/")
 QUDTUNIT = Namespace("http://qudt.org/vocab/unit/")
 A = RDF.type
@@ -29,3 +32,6 @@ def bind_prefixes(g):
     g.bind("brick", BRICK)
     g.bind("tag", TAG)
     g.bind("bsh", BSH)
+    g.bind("qudt", QUDT)
+    g.bind("qudtqk", QUDTQK)
+    g.bind("qudtunit", QUDTUNIT)

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -17,6 +17,7 @@ VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
 # QUDT namespaces
 QUDT = Namespace("http://qudt.org/schema/qudt/")
 QUDTQK = Namespace("http://qudt.org/vocab/quantitykind/")
+QUDTDV = Namespace("http://qudt.org/vocab/dimensionvector/")
 UNIT = Namespace("http://qudt.org/vocab/unit/")
 
 A = RDF.type

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import A, OWL, RDFS, SKOS, BRICK, QUDTUNIT
+from .namespaces import A, OWL, RDFS, SKOS, BRICK, QUDTUNIT, QUDT
 
 """
 Defining properties
@@ -151,5 +151,11 @@ properties = {
         SKOS.definition: Literal("The QUDT unit associated with this Point"),
         RDFS.domain: BRICK.Point,
         RDFS.range: QUDTUNIT.Unit,
+    },
+    "associatedQuantityKind": {
+        A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        SKOS.definition: Literal("The QUDT QuantityKind associated with this Quantity"),
+        RDFS.domain: BRICK.Quantity,
+        RDFS.range: QUDT.QuantityKind,
     },
 }

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import A, OWL, RDFS, SKOS, BRICK
+from .namespaces import A, OWL, RDFS, SKOS, BRICK, QUDTUNIT
 
 """
 Defining properties
@@ -145,5 +145,11 @@ properties = {
         SKOS.definition: Literal("The tag is associated with the given class"),
         RDFS.domain: BRICK.Tag,
         RDFS.range: OWL.Class,
+    },
+    "hasUnit": {
+        A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        SKOS.definition: Literal("The QUDT unit associated with this Point"),
+        RDFS.domain: BRICK.Point,
+        RDFS.range: QUDTUNIT.Unit,
     },
 }

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import A, OWL, RDFS, SKOS, BRICK, VCARD, QUDTUNIT, QUDT
+from .namespaces import A, OWL, RDFS, SKOS, BRICK, VCARD, UNIT, QUDT
 
 """
 Defining properties
@@ -156,7 +156,7 @@ properties = {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         SKOS.definition: Literal("The QUDT unit associated with this Point"),
         RDFS.domain: BRICK.Point,
-        RDFS.range: QUDTUNIT.Unit,
+        RDFS.range: UNIT.Unit,
     },
     "associatedQuantityKind": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -158,10 +158,4 @@ properties = {
         RDFS.domain: BRICK.Point,
         RDFS.range: UNIT.Unit,
     },
-    "associatedQuantityKind": {
-        A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        SKOS.definition: Literal("The QUDT QuantityKind associated with this Quantity"),
-        RDFS.domain: BRICK.Quantity,
-        RDFS.range: QUDT.QuantityKind,
-    },
 }

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -47,7 +47,7 @@ quantitykind_extensions = {
 
 quantity_definitions = {
     "Air_Quality": {
-        "subclasses": {
+        "subconcepts": {
             "CO2_Level": {OWL.sameAs: QUDTQK["Concentration"]},
             "PM10_Level": {OWL.sameAs: QUDTQK["Concentration"]},
             "PM25_Level": {OWL.sameAs: QUDTQK["Concentration"]},
@@ -66,10 +66,10 @@ quantity_definitions = {
     "Grains": {},
     "Power": {
         OWL.sameAs: QUDTQK["Power"],
-        "subclasses": {
+        "subconcepts": {
             "Electric_Power": {
                 OWL.sameAs: QUDTQK["ElectricPower"],
-                "subclasses": {
+                "subconcepts": {
                     "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
                         OWL.sameAs: [QUDTQK["ActivePower"], BRICK["Real_Power"]],
@@ -85,15 +85,15 @@ quantity_definitions = {
                     "Tracks the highest (peak) observed power in some interval"
                 ),
             },
-            "Thermal_Power": {},
+            "Thermal_Power": {OWL.sameAs: QUDTQK["ThermalPower"]},
         },
     },
     "Cloudage": {},
     "Current": {
-        "subclasses": {
+        "subconcepts": {
             "Electric_Current": {
                 OWL.sameAs: QUDTQK["ElectricCurrent"],
-                "subclasses": {
+                "subconcepts": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},
                     "Current_Imbalance": {},
@@ -104,7 +104,7 @@ quantity_definitions = {
         },
     },
     "Voltage": {
-        "subclasses": {
+        "subconcepts": {
             "Voltage_Magnitude": {OWL.sameAs: QUDTQK["Voltage"]},
             "Voltage_Angle": {},
             "Voltage_Imbalance": {},
@@ -112,20 +112,20 @@ quantity_definitions = {
     },
     "Daytime": {},
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
-    "Direction": {"subclasses": {"Wind_Direction": {}}},
+    "Direction": {"subconcepts": {"Wind_Direction": {}}},
     "Energy": {
-        "subclasses": {
+        "subconcepts": {
             "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
-    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subclasses": {"Flow_Loss": {}}},
+    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subconcepts": {"Flow_Loss": {}}},
     "Frequency": {
         OWL.sameAs: QUDTQK["Frequency"],
-        "subclasses": {"Alternating_Current_Frequency": {}},
+        "subconcepts": {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
-        "subclasses": {
+        "subconcepts": {
             "Relative_Humidity": {OWL.sameAs: QUDTQK["RelativeHumidity"]},
             "Absolute_Humidity": {OWL.sameAs: QUDTQK["AbsoluteHumidity"]},
         }
@@ -133,10 +133,10 @@ quantity_definitions = {
     "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
     "Irradiance": {
         OWL.sameAs: QUDTQK["Irradiance"],
-        "subclasses": {"Solar_Irradiance": {}},
+        "subconcepts": {"Solar_Irradiance": {}},
     },
     "Level": {
-        "subclasses": {
+        "subconcepts": {
             "CO2_Level": {},
             "PM10_Level": {},
             "PM25_Level": {},
@@ -145,18 +145,18 @@ quantity_definitions = {
     },
     "Luminance": {
         OWL.sameAs: QUDTQK["Luminance"],
-        "subclasses": {
+        "subconcepts": {
             "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
             "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
         },
     },
-    "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
+    "Occupancy": {"subconcepts": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
     "Position": {},
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
         OWL.sameAs: QUDTQK["Pressure"],
-        "subclasses": {
+        "subconcepts": {
             "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},
             "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
@@ -165,11 +165,11 @@ quantity_definitions = {
             },
         },
     },
-    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subclasses": {"Solar_Radiance": {}}},
-    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
+    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subconcepts": {"Solar_Radiance": {}}},
+    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subconcepts": {"Wind_Speed": {}}},
     "Temperature": {
         OWL.sameAs: QUDTQK["ThermodynamicTemperature"],
-        "subclasses": {
+        "subconcepts": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
             "Dry_Bulb_Temperature": {},
@@ -178,7 +178,7 @@ quantity_definitions = {
     },
     "Time": {
         OWL.sameAs: QUDTQK["Time"],
-        "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
+        "subconcepts": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
     "Torque": {OWL.sameAs: QUDTQK["Torque"]},
     "Weather_Condition": {},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,6 @@
+import brickschema
 from rdflib import Literal
-from .namespaces import SKOS, OWL, BRICK, QUDTQK
+from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDT
 
 
 quantity_definitions = {
@@ -65,13 +66,9 @@ quantity_definitions = {
     "Voltage": {
         OWL.equivalentClass: QUDTQK["Voltage"],
         "subclasses": {
-            "Electric_Voltage": {
-                "subclasses": {
-                    "Voltage_Magnitude": {},
-                    "Voltage_Angle": {},
-                    "Voltage_Imbalance": {},
-                },
-            },
+            "Voltage_Magnitude": {},
+            "Voltage_Angle": {},
+            "Voltage_Imbalance": {},
         },
     },
     "Daytime": {},
@@ -158,3 +155,18 @@ quantity_definitions = {
     "Torque": {OWL.equivalentClass: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }
+
+
+def associate_units(outputG):
+    g = brickschema.graph.Graph()
+    g.g.bind("qudt", QUDT)
+    for triple in outputG:
+        g.add(triple)
+    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+    unit_map = g.query(
+        "SELECT ?quant ?unit WHERE {\
+        ?quant a brick:Quantity .\
+        ?quant owl:equivalentClass/qudt:applicableUnit ?unit . }"
+    )
+    for brickquant, unit in unit_map:
+        outputG.add((brickquant, QUDT.applicableUnit, unit))

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -11,32 +11,30 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {OWL.equivalentClass: QUDTQK["Angle"]},
-    "Conductivity": {OWL.equivalentClass: QUDTQK["Conductivity"]},
-    "Capacity": {OWL.equivalentClass: QUDTQK["Capacity"]},
+    "Angle": {OWL.sameAs: QUDTQK["Angle"]},
+    "Conductivity": {OWL.sameAs: QUDTQK["Conductivity"]},
+    "Capacity": {OWL.sameAs: QUDTQK["Capacity"]},
     "Enthalpy": {
         SKOS.definition: Literal(
             "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
         ),
-        OWL.equivalentClass: QUDTQK["Enthalpy"],
+        OWL.sameAs: QUDTQK["Enthalpy"],
     },
     "Grains": {},
     "Power": {
-        OWL.equivalentClass: QUDTQK["Power"],
+        OWL.sameAs: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                OWL.equivalentClass: QUDTQK["ElectricPower"],
+                OWL.sameAs: QUDTQK["ElectricPower"],
                 "subclasses": {
-                    "Apparent_Power": {OWL.equivalentClass: QUDTQK["ApparentPower"]},
+                    "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
-                        OWL.equivalentClass: [
-                            BRICK["Real_Power"],
-                            QUDTQK["ActivePower"],
-                        ]
+                        OWL.sameAs: QUDTQK["ActivePower"],
+                        OWL.equivalentClass: BRICK["Real_Power"],
                     },
                     "Real_Power": {},
-                    "Reactive_Power": {OWL.equivalentClass: QUDTQK["ReactivePower"]},
-                    "Complex_Power": {OWL.equivalentClass: QUDTQK["ComplexPower"]},
+                    "Reactive_Power": {OWL.sameAs: QUDTQK["ReactivePower"]},
+                    "Complex_Power": {OWL.sameAs: QUDTQK["ComplexPower"]},
                 },
             },
             "Peak_Power": {
@@ -51,7 +49,7 @@ quantity_definitions = {
     "Current": {
         "subclasses": {
             "Electric_Current": {
-                OWL.equivalentClass: QUDTQK["ElectricCurrent"],
+                OWL.sameAs: QUDTQK["ElectricCurrent"],
                 "subclasses": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},
@@ -63,7 +61,7 @@ quantity_definitions = {
         },
     },
     "Voltage": {
-        OWL.equivalentClass: QUDTQK["Voltage"],
+        OWL.sameAs: QUDTQK["Voltage"],
         "subclasses": {
             "Electric_Voltage": {
                 "subclasses": {
@@ -75,32 +73,29 @@ quantity_definitions = {
         },
     },
     "Daytime": {},
-    "Dewpoint": {OWL.equivalentClass: QUDTQK["DewPointTemperature"]},
+    "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
-        OWL.equivalentClass: QUDTQK["Energy"],
+        OWL.sameAs: QUDTQK["Energy"],
         "subclasses": {
             "Electric_Energy": {},
-            "Thermal_Energy": {OWL.equivalentClass: QUDTQK["ThermalEnergy"]},
+            "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
-    "Flow": {
-        OWL.equivalentClass: QUDTQK["VolumeFlowRate"],
-        "subclasses": {"Flow_Loss": {}},
-    },
+    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subclasses": {"Flow_Loss": {}}},
     "Frequency": {
-        OWL.equivalentClass: QUDTQK["Frequency"],
+        OWL.sameAs: QUDTQK["Frequency"],
         "subclasses": {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
         "subclasses": {
-            "Relative_Humidity": {OWL.equivalentClass: QUDTQK["RelativeHumidity"]},
-            "Absolute_Humidity": {OWL.equivalentClass: QUDTQK["AbsoluteHumidity"]},
+            "Relative_Humidity": {OWL.sameAs: QUDTQK["RelativeHumidity"]},
+            "Absolute_Humidity": {OWL.sameAs: QUDTQK["AbsoluteHumidity"]},
         }
     },
-    "Illuminance": {OWL.equivalentClass: QUDTQK["Illuminance"]},
+    "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
     "Irradiance": {
-        OWL.equivalentClass: QUDTQK["Irradiance"],
+        OWL.sameAs: QUDTQK["Irradiance"],
         "subclasses": {"Solar_Irradiance": {}},
     },
     "Level": {
@@ -112,39 +107,32 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        OWL.equivalentClass: QUDTQK["Luminance"],
+        OWL.sameAs: QUDTQK["Luminance"],
         "subclasses": {
-            "Luminous_Flux": {OWL.equivalentClass: QUDTQK["LuminousFlux"]},
-            "Luminous_Intensity": {OWL.equivalentClass: QUDTQK["LuminousIntensity"]},
+            "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
+            "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
         },
     },
     "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
     "Position": {},
-    "Power_Factor": {OWL.equivalentClass: QUDTQK["PowerFactor"]},
+    "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        OWL.equivalentClass: QUDTQK["Pressure"],
+        OWL.sameAs: QUDTQK["Pressure"],
         "subclasses": {
-            "Atmospheric_Pressure": {
-                OWL.equivalentClass: QUDTQK["AtmosphericPressure"]
-            },
+            "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},
-            "Static_Pressure": {OWL.equivalentClass: QUDTQK["StaticPressure"]},
+            "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
             "Velocity_Pressure": {
-                OWL.equivalentClass: [
-                    QUDTQK["DynamicPressure"],
-                    BRICK["Dynamic_Pressure"],
-                ]
+                OWL.sameAs: QUDTQK["DynamicPressure"],
+                OWL.equivalentClass: BRICK["Dynamic_Pressure"],
             },
         },
     },
-    "Radiance": {
-        OWL.equivalentClass: QUDTQK["Radiance"],
-        "subclasses": {"Solar_Radiance": {}},
-    },
-    "Speed": {OWL.equivalentClass: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
+    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subclasses": {"Solar_Radiance": {}}},
+    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
     "Temperature": {
-        OWL.equivalentClass: QUDTQK["Temperature"],
+        OWL.sameAs: QUDTQK["Temperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
@@ -153,9 +141,9 @@ quantity_definitions = {
         },
     },
     "Time": {
-        OWL.equivalentClass: QUDTQK["Time"],
+        OWL.sameAs: QUDTQK["Time"],
         "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
-    "Torque": {OWL.equivalentClass: QUDTQK["Torque"]},
+    "Torque": {OWL.sameAs: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -34,7 +34,7 @@ Each is a qudt:QuantityKind
 """
 quantity_definitions = {
     "Air_Quality": {
-        "subconcepts": {
+        SKOS.narrower: {
             "CO2_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
@@ -86,7 +86,7 @@ quantity_definitions = {
     },
     "Mass": {
         OWL.sameAs: QUDTQK["Mass"],
-        "subconcepts": {
+        SKOS.narrower: {
             "GrainsOfMoisture": {
                 QUDT.applicableUnit: UNIT.GRAIN,
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
@@ -100,7 +100,7 @@ quantity_definitions = {
         },
     },
     "Phasor": {
-        "subconcepts": {
+        SKOS.related: {
             "PhasorAngle": {
                 QUDT.applicableUnit: [
                     UNIT.ARCMIN,
@@ -144,10 +144,10 @@ quantity_definitions = {
     },
     "Power": {
         OWL.sameAs: QUDTQK["Power"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Electric_Power": {
                 OWL.sameAs: QUDTQK["ElectricPower"],
-                "subconcepts": {
+                SKOS.narrower: {
                     "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
                         OWL.sameAs: [QUDTQK["ActivePower"], BRICK["Real_Power"]],
@@ -194,91 +194,65 @@ quantity_definitions = {
         RDFS.label: Literal("Cloudage"),
         SKOS.broader: QUDTQK.Dimensionless,
     },
-    "Current": {
-        "subconcepts": {
-            "Electric_Current": {
-                OWL.sameAs: QUDTQK["ElectricCurrent"],
-                "subconcepts": {
-                    "Current_Angle": {
-                        SKOS.definition: Literal(
-                            "The angle of the phasor representing a measurement of electric current"
-                        ),
-                        QUDT.applicableUnit: [
-                            UNIT.ARCMIN,
-                            UNIT.ARCSEC,
-                            UNIT.DEG,
-                            UNIT.GON,
-                            UNIT.GRAD,
-                            UNIT.MIL,
-                            UNIT.RAD,
-                            UNIT.MicroRAD,
-                            UNIT.MilliRAD,
-                            UNIT.MilliARCSEC,
-                            UNIT.REV,
-                        ],
-                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                        SKOS.definition: Literal("Angle of current phasor"),
-                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                        RDFS.label: Literal("CurrentAngle"),
-                        SKOS.broader: BRICK.PhasorAngle,
-                    },
-                    "Current_Magnitude": {
-                        SKOS.definition: Literal(
-                            "The magnitude of the phasor representing a measurement of electric current"
-                        ),
-                        QUDT.applicableUnit: [
-                            UNIT.A,
-                            UNIT.MilliA,
-                            UNIT.MicroA,
-                            UNIT.KiloA,
-                        ],
-                        SKOS.definition: Literal("Magnitude of current phasor"),
-                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                        RDFS.label: Literal("CurrentMagnitude"),
-                        SKOS.broader: BRICK.PhasorMagnitude,
-                    },
-                    "Current_Imbalance": {
-                        SKOS.definition: Literal(
-                            "The percent deviation from average current"
-                        ),
-                        QUDT.applicableUnit: [UNIT.PERCENT],
-                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                        RDFS.label: Literal("CurrentImbalance"),
-                        SKOS.broader: BRICK.Dimensionless,
-                    },
-                    "Current_Total_Harmonic_Distortion": {
-                        SKOS.definition: Literal(
-                            "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)"
-                        ),
-                        QUDT.applicableUnit: [UNIT.PERCENT, UNIT.DeciB_M],
-                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                        RDFS.label: Literal("CurrentTotalHarmonicDistortion"),
-                        SKOS.broader: BRICK.Dimensionless,
-                    },
-                    "Alternating_Current_Frequency": {
-                        QUDT.applicableUnit: [
-                            QUDT.GigaHZ,
-                            QUDT.MegaHZ,
-                            QUDT.KiloHZ,
-                            QUDT.HZ,
-                        ],
-                        SKOS.definition: Literal(
-                            "The frequency of the oscillations of alternating current"
-                        ),
-                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T-1D0"],
-                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                        RDFS.label: Literal("Alternating_Current_Frequency"),
-                        SKOS.broader: QUDTQK.Frequency,
-                    },
-                },
+    "Electric_Current": {
+        OWL.sameAs: QUDTQK["ElectricCurrent"],
+        SKOS.related: {
+            "Current_Angle": {
+                SKOS.definition: Literal(
+                    "The angle of the phasor representing a measurement of electric current"
+                ),
+                QUDT.applicableUnit: [
+                    UNIT.ARCMIN,
+                    UNIT.ARCSEC,
+                    UNIT.DEG,
+                    UNIT.GON,
+                    UNIT.GRAD,
+                    UNIT.MIL,
+                    UNIT.RAD,
+                    UNIT.MicroRAD,
+                    UNIT.MilliRAD,
+                    UNIT.MilliARCSEC,
+                    UNIT.REV,
+                ],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                SKOS.definition: Literal("Angle of current phasor"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("CurrentAngle"),
+                SKOS.broader: BRICK.PhasorAngle,
+            },
+            "Current_Imbalance": {
+                SKOS.definition: Literal("The percent deviation from average current"),
+                QUDT.applicableUnit: [UNIT.PERCENT],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("CurrentImbalance"),
+                SKOS.broader: BRICK.Dimensionless,
+            },
+            "Current_Total_Harmonic_Distortion": {
+                SKOS.definition: Literal(
+                    "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)"
+                ),
+                QUDT.applicableUnit: [UNIT.PERCENT, UNIT.DeciB_M],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("CurrentTotalHarmonicDistortion"),
+                SKOS.broader: BRICK.Dimensionless,
+            },
+            "Alternating_Current_Frequency": {
+                QUDT.applicableUnit: [QUDT.GigaHZ, QUDT.MegaHZ, QUDT.KiloHZ, QUDT.HZ],
+                SKOS.definition: Literal(
+                    "The frequency of the oscillations of alternating current"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T-1D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Alternating_Current_Frequency"),
+                SKOS.broader: QUDTQK.Frequency,
             },
         },
     },
     "Voltage": {
-        "subconcepts": {
-            "Voltage_Magnitude": {OWL.sameAs: QUDTQK["Voltage"]},
+        OWL.sameAs: QUDTQK["Voltage"],
+        SKOS.related: {
             "Voltage_Angle": {
                 SKOS.definition: Literal(
                     "The angle of the phasor representing a measurement of electric voltage"
@@ -314,7 +288,7 @@ quantity_definitions = {
     },
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {
-        "subconcepts": {
+        SKOS.narrower: {
             "Wind_Direction": {
                 QUDT.applicableUnit: [
                     UNIT.ARCMIN,
@@ -337,7 +311,7 @@ quantity_definitions = {
         }
     },
     "Energy": {
-        "subconcepts": {
+        SKOS.narrower: {
             "Electric_Energy": {
                 QUDT.applicableUnit: [UNIT.J],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-2D0"],
@@ -353,7 +327,7 @@ quantity_definitions = {
     },
     "Flow": {
         OWL.sameAs: QUDTQK["VolumeFlowRate"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Flow_Loss": {
                 QUDT.applicableUnit: [UNIT["M3-PER-SEC"]],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L3I0M0H0T-1D0"],
@@ -368,10 +342,10 @@ quantity_definitions = {
     },
     "Frequency": {
         OWL.sameAs: QUDTQK["Frequency"],
-        "subconcepts": {"Alternating_Current_Frequency": {}},
+        SKOS.narrower: {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
-        "subconcepts": {
+        SKOS.narrower: {
             "Relative_Humidity": {OWL.sameAs: QUDTQK["RelativeHumidity"]},
             "Absolute_Humidity": {OWL.sameAs: QUDTQK["AbsoluteHumidity"]},
         }
@@ -390,7 +364,7 @@ quantity_definitions = {
         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
         RDFS.label: Literal("Irradiance"),
         SKOS.broader: QUDTQK.PowerPerArea,
-        "subconcepts": {
+        SKOS.narrower: {
             "Solar_Irradiance": {
                 QUDT.applicableUnit: [
                     UNIT["W-PER-M2"],
@@ -426,7 +400,7 @@ quantity_definitions = {
             "Amount of substance in a container; typically measured in height"
         ),
         SKOS.broader: QUDTQK.Length,
-        "subconcepts": {
+        SKOS.narrower: {
             "Precipitation": {
                 QUDT.applicableUnit: [
                     UNIT["CentiM"],
@@ -451,13 +425,13 @@ quantity_definitions = {
     },
     "Luminance": {
         OWL.sameAs: QUDTQK["Luminance"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
             "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
         },
     },
     "Occupancy": {
-        "subconcepts": {
+        SKOS.narrower: {
             "Occupancy_Count": {
                 QUDT.applicableUnit: [UNIT["People"]],
                 SKOS.definition: Literal("Number of people in an area"),
@@ -488,7 +462,7 @@ quantity_definitions = {
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Pressure": {
         OWL.sameAs: QUDTQK["Pressure"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},
             "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
@@ -499,7 +473,7 @@ quantity_definitions = {
     },
     "Radiance": {
         OWL.sameAs: QUDTQK["Radiance"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Solar_Radiance": {
                 QUDT.applicableUnit: [UNIT["W-PER-M2-SR"]],
                 SKOS.definition: Literal(
@@ -514,7 +488,7 @@ quantity_definitions = {
     "Speed": {
         # TODO: fan speed is not meter/sec
         OWL.sameAs: QUDTQK["Speed"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Wind_Speed": {
                 QUDT.applicableUnit: [
                     UNIT["M-PER-HR"],
@@ -538,7 +512,7 @@ quantity_definitions = {
     },
     "Temperature": {
         OWL.sameAs: QUDTQK["ThermodynamicTemperature"],
-        "subconcepts": {
+        SKOS.narrower: {
             "Operative_Temperature": {
                 QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
                 SKOS.definition: Literal(
@@ -584,7 +558,7 @@ quantity_definitions = {
     "Time": {
         OWL.sameAs: QUDTQK["Time"],
         # TODO: what are these?
-        "subconcepts": {"Acceleration_Time": {}, "Deceleration_Time": {}},
+        SKOS.narrower: {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
     "Torque": {OWL.sameAs: QUDTQK["Torque"]},
     # TODO: https://ci.mines-stetienne.fr/seas/WeatherOntology-0.9#AirTemperature ?

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import SKOS, OWL, BRICK
+from .namespaces import SKOS, OWL, BRICK, QUDTQK
 
 
 quantity_definitions = {
@@ -11,30 +11,38 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {},
-    "Conductivity": {},
-    "Capacity": {},
+    "Angle": {OWL.equivalentClass: QUDTQK["Angle"]},
+    "Conductivity": {OWL.equivalentClass: QUDTQK["Conductivity"]},
+    "Capacity": {OWL.equivalentClass: QUDTQK["Capacity"]},
     "Enthalpy": {
         SKOS.definition: Literal(
             "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
         ),
+        OWL.equivalentClass: QUDTQK["Enthalpy"],
     },
     "Grains": {},
     "Power": {
+        OWL.equivalentClass: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
+                OWL.equivalentClass: QUDTQK["ElectricPower"],
                 "subclasses": {
-                    "Apparent_Power": {},
-                    "Active_Power": {OWL.equivalentClass: BRICK["Real_Power"]},
+                    "Apparent_Power": {OWL.equivalentClass: QUDTQK["ApparentPower"]},
+                    "Active_Power": {
+                        OWL.equivalentClass: [
+                            BRICK["Real_Power"],
+                            QUDTQK["ActivePower"],
+                        ]
+                    },
                     "Real_Power": {},
-                    "Reactive_Power": {},
-                    "Complex_Power": {},
+                    "Reactive_Power": {OWL.equivalentClass: QUDTQK["ReactivePower"]},
+                    "Complex_Power": {OWL.equivalentClass: QUDTQK["ComplexPower"]},
                 },
             },
             "Peak_Power": {
                 SKOS.definition: Literal(
                     "Tracks the highest (peak) observed power in some interval"
-                ),
+                )
             },
             "Thermal_Power": {},
         },
@@ -43,6 +51,7 @@ quantity_definitions = {
     "Current": {
         "subclasses": {
             "Electric_Current": {
+                OWL.equivalentClass: QUDTQK["ElectricCurrent"],
                 "subclasses": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -35,36 +35,42 @@ Each is a qudt:QuantityKind
 quantity_definitions = {
     "Air_Quality": {
         "subconcepts": {
-            "CO2_Level": {
+            "CO2_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                SKOS.definition: Literal("The concentration ratio of some substance"),
+                SKOS.definition: Literal("The concentration of CO2 in air"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("Concentration"),
+                RDFS.label: Literal("CO2Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
             },
-            "PM10_Level": {
+            "PM10_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                SKOS.definition: Literal("The concentration ratio of some substance"),
+                SKOS.definition: Literal(
+                    "The concentration of particulates with diameter of 10 microns or less in air"
+                ),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("Concentration"),
+                RDFS.label: Literal("PM10Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
             },
-            "PM25_Level": {
+            "PM25_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                SKOS.definition: Literal("The concentration ratio of some substance"),
+                SKOS.definition: Literal(
+                    "The concentration of particulates with diameter of 25 microns or less in air"
+                ),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("Concentration"),
+                RDFS.label: Literal("PM25Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
             },
-            "TVOC_Level": {
+            "TVOC_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                SKOS.definition: Literal("The concentration ratio of some substance"),
+                SKOS.definition: Literal(
+                    "The concentration of total volatile organic compounds in air"
+                ),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("Concentration"),
+                RDFS.label: Literal("TVOCConcentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
             },
         },
@@ -81,11 +87,11 @@ quantity_definitions = {
     "Mass": {
         OWL.sameAs: QUDTQK["Mass"],
         "subconcepts": {
-            "Grains": {
+            "GrainsOfMoisture": {
                 QUDT.applicableUnit: UNIT.GRAIN,
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("Grains"),
+                RDFS.label: Literal("GrainsOfMoisture"),
                 SKOS.broader: QUDTQK.Mass,
             }
         },
@@ -161,7 +167,13 @@ quantity_definitions = {
                 ),
             },
             "Thermal_Power": {
-                QUDT.applicableUnit: [UNIT.MilliW, UNIT.W, UNIT.KiloW, UNIT.MegaW],
+                QUDT.applicableUnit: [
+                    UNIT.MilliW,
+                    UNIT.W,
+                    UNIT.KiloW,
+                    UNIT.MegaW,
+                    UNIT.BTU_IT,
+                ],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("ThermalPower"),
@@ -323,7 +335,16 @@ quantity_definitions = {
     },
     "Energy": {
         "subconcepts": {
-            "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
+            "Electric_Energy": {
+                QUDT.applicableUnit: [UNIT.J],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-2D0"],
+                SKOS.definition: Literal(
+                    "A form of energy resulting from the flow of electrical charge"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("ElectricEnergy"),
+                SKOS.broader: QUDTQK["Energy"],
+            },
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,7 +1,7 @@
 from brickschema.graph import Graph
 from brickschema.inference import BrickInferenceSession
-from rdflib import Literal
-from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDT
+from rdflib import Literal, URIRef
+from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDTDV, QUDT, UNIT
 
 
 g = Graph()
@@ -29,13 +29,29 @@ def get_units(brick_quantity):
         yield r
 
 
+"""
+Each is a qudt:QuantityKind
+"""
+# TODO: define these on QUDTQK namespace
+quantitykind_extensions = {
+    "Concentration": {
+        QUDT.applicableUnit: [UNIT.PPM],
+        QUDT.hasDimensionVector: QUDTDV.A0E0L0I0M0H0T0D1,
+        QUDT.plainTextDescription: Literal("The concentration ratio of some substance"),
+        RDFS.isDefinedBy: URIRef(str(QUDTQK).strip("/")),
+        RDFS.label: Literal("Concentration"),
+        SKOS.broader: QUDTQK.Dimensionless,
+    },
+}
+
+
 quantity_definitions = {
     "Air_Quality": {
         "subclasses": {
-            "CO2_Level": {},
-            "PM10_Level": {},
-            "PM25_Level": {},
-            "TVOC_Level": {},
+            "CO2_Level": {OWL.sameAs: QUDTQK["Concentration"]},
+            "PM10_Level": {OWL.sameAs: QUDTQK["Concentration"]},
+            "PM25_Level": {OWL.sameAs: QUDTQK["Concentration"]},
+            "TVOC_Level": {OWL.sameAs: QUDTQK["Concentration"]},
         },
     },
     "Angle": {OWL.sameAs: QUDTQK["Angle"]},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -22,10 +22,10 @@ quantity_definitions = {
     },
     "Grains": {},
     "Power": {
-        OWL.sameAs: QUDTQK["Power"],
+        # OWL.sameAs: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                OWL.sameAs: QUDTQK["ElectricPower"],
+                # OWL.sameAs: QUDTQK["ElectricPower"],
                 "subclasses": {
                     "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
@@ -76,7 +76,7 @@ quantity_definitions = {
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
-        OWL.sameAs: QUDTQK["Energy"],
+        # OWL.sameAs: QUDTQK["Energy"],
         "subclasses": {
             "Electric_Energy": {},
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
@@ -118,7 +118,7 @@ quantity_definitions = {
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        OWL.sameAs: QUDTQK["Pressure"],
+        # OWL.sameAs: QUDTQK["Pressure"],
         "subclasses": {
             "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -32,167 +32,49 @@ def get_units(brick_quantity):
 """
 Each is a qudt:QuantityKind
 """
-# TODO: define these on QUDTQK namespace
-quantitykind_extensions = {
-    "Cloudage": {
-        # TODO: define Okta
-        QUDT.applicableUnit: [UNIT.Okta],
-        QUDT.plainTextDescription: Literal(
-            "The fraction of the sky obscured by clouds when observed from a particular location"
-        ),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("Cloudage"),
-        SKOS.broader: QUDTQK.Dimensionless,
-    },
-    "Concentration": {
-        QUDT.applicableUnit: [UNIT.PPM],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-        QUDT.plainTextDescription: Literal("The concentration ratio of some substance"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("Concentration"),
-        SKOS.broader: QUDTQK.Dimensionless,
-    },
-    "CurrentAngle": {
-        QUDT.applicableUnit: [
-            UNIT.ARCMIN,
-            UNIT.ARCSEC,
-            UNIT.DEG,
-            UNIT.GON,
-            UNIT.GRAD,
-            UNIT.MIL,
-            UNIT.RAD,
-            UNIT.MicroRAD,
-            UNIT.MilliRAD,
-            UNIT.MilliARCSEC,
-            UNIT.REV,
-        ],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-        QUDT.plainTextDescription: Literal("Angle of current phasor"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("CurrentAngle"),
-        SKOS.broader: QUDTQK.PhasorAngle,
-        # TODO: units?
-    },
-    "CurrentMagnitude": {
-        QUDT.applicableUnit: [UNIT.A, UNIT.MilliA, UNIT.MicroA, UNIT.KiloA],
-        QUDT.plainTextDescription: Literal("Magnitude of current phasor"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("CurrentMagnitude"),
-        SKOS.broader: QUDTQK.PhasorMagnitude,
-    },
-    "Irradiance": {
-        QUDT.applicableUnit: [
-            UNIT["W-PER-M2"],
-            UNIT["W-PER-IN2"],
-            UNIT["W-PER-FT2"],
-            UNIT["W-PER-CeniM2"],
-        ],
-        QUDT.plainTextDescription: Literal(
-            "The power per unit area of electromagnetic radiation incident on a surface"
-        ),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("Irradiance"),
-        SKOS.broader: QUDTQK.PowerPerArea,
-    },
-    "PhasorAngle": {
-        QUDT.applicableUnit: [
-            UNIT.ARCMIN,
-            UNIT.ARCSEC,
-            UNIT.DEG,
-            UNIT.GON,
-            UNIT.GRAD,
-            UNIT.MIL,
-            UNIT.RAD,
-            UNIT.MicroRAD,
-            UNIT.MilliRAD,
-            UNIT.MilliARCSEC,
-            UNIT.REV,
-        ],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-        QUDT.plainTextDescription: Literal("Angle component of a phasor"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("PhasorAngle"),
-        SKOS.broader: QUDTQK.PlaneAngle,
-    },
-    "PhasorMagnitude": {
-        QUDT.applicableUnit: [
-            UNIT.ARCMIN,
-            UNIT.ARCSEC,
-            UNIT.DEG,
-            UNIT.GON,
-            UNIT.GRAD,
-            UNIT.MIL,
-            UNIT.RAD,
-            UNIT.MicroRAD,
-            UNIT.MilliRAD,
-            UNIT.MilliARCSEC,
-            UNIT.REV,
-        ],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-        QUDT.plainTextDescription: Literal("Magnitude component of a phasor"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("PhasorMagnitude"),
-        # TODO: finish
-    },
-    "Position": {
-        QUDT.applicableUnit: [UNIT["PERCENT"]],
-        QUDT.plainTextDescription: Literal("The fraction of the full range of motion"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("Position"),
-        SKOS.broader: QUDTQK.DimensionlessRatio,
-    },
-    "SolarIrradiance": {
-        QUDT.applicableUnit: [
-            UNIT["W-PER-M2"],
-            UNIT["W-PER-IN2"],
-            UNIT["W-PER-FT2"],
-            UNIT["W-PER-CeniM2"],
-        ],
-        QUDT.plainTextDescription: Literal(
-            "The power per unit area of solar electromagnetic radiation incident on a surface"
-        ),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("SolarIrradiance"),
-        SKOS.broader: QUDTQK.Irradiance,
-    },
-    "ThermalPower": {
-        QUDT.applicableUnit: [UNIT.MilliW, UNIT.W, UNIT.KiloW, UNIT.MegaW],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("ThermalPower"),
-        SKOS.broader: QUDTQK.Power,
-    },
-    "VoltageAngle": {
-        QUDT.applicableUnit: [
-            UNIT.ARCMIN,
-            UNIT.ARCSEC,
-            UNIT.DEG,
-            UNIT.GON,
-            UNIT.GRAD,
-            UNIT.MIL,
-            UNIT.RAD,
-            UNIT.MicroRAD,
-            UNIT.MilliRAD,
-            UNIT.MilliARCSEC,
-            UNIT.REV,
-        ],
-        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-        QUDT.plainTextDescription: Literal("Angle of voltage phasor"),
-        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-        RDFS.label: Literal("VoltageAngle"),
-        SKOS.broader: QUDTQK.PhasorAngle,
-        # TODO: units?
-    },
-}
-
-
 quantity_definitions = {
     "Air_Quality": {
         "subconcepts": {
-            "CO2_Level": {OWL.sameAs: QUDTQK["Concentration"]},
-            "PM10_Level": {OWL.sameAs: QUDTQK["Concentration"]},
-            "PM25_Level": {OWL.sameAs: QUDTQK["Concentration"]},
-            "TVOC_Level": {OWL.sameAs: QUDTQK["Concentration"]},
+            "CO2_Level": {
+                QUDT.applicableUnit: [UNIT.PPM],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal(
+                    "The concentration ratio of some substance"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Concentration"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
+            "PM10_Level": {
+                QUDT.applicableUnit: [UNIT.PPM],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal(
+                    "The concentration ratio of some substance"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Concentration"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
+            "PM25_Level": {
+                QUDT.applicableUnit: [UNIT.PPM],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal(
+                    "The concentration ratio of some substance"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Concentration"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
+            "TVOC_Level": {
+                QUDT.applicableUnit: [UNIT.PPM],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal(
+                    "The concentration ratio of some substance"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Concentration"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
         },
     },
     "Angle": {OWL.sameAs: QUDTQK["Angle"]},
@@ -207,6 +89,50 @@ quantity_definitions = {
     "Mass": {
         OWL.sameAs: QUDTQK["Mass"],
         "subconcepts": {"Grains": {QUDT.applicableUnit: UNIT.GRAINS}},
+    },
+    "Phasor": {
+        "subconcepts": {
+            "PhasorAngle": {
+                QUDT.applicableUnit: [
+                    UNIT.ARCMIN,
+                    UNIT.ARCSEC,
+                    UNIT.DEG,
+                    UNIT.GON,
+                    UNIT.GRAD,
+                    UNIT.MIL,
+                    UNIT.RAD,
+                    UNIT.MicroRAD,
+                    UNIT.MilliRAD,
+                    UNIT.MilliARCSEC,
+                    UNIT.REV,
+                ],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal("Angle component of a phasor"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("PhasorAngle"),
+                SKOS.broader: QUDTQK.PlaneAngle,
+            },
+            "PhasorMagnitude": {
+                QUDT.applicableUnit: [
+                    UNIT.ARCMIN,
+                    UNIT.ARCSEC,
+                    UNIT.DEG,
+                    UNIT.GON,
+                    UNIT.GRAD,
+                    UNIT.MIL,
+                    UNIT.RAD,
+                    UNIT.MicroRAD,
+                    UNIT.MilliRAD,
+                    UNIT.MilliARCSEC,
+                    UNIT.REV,
+                ],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal("Magnitude component of a phasor"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("PhasorMagnitude"),
+                # TODO: finish
+            },
+        },
     },
     "Power": {
         OWL.sameAs: QUDTQK["Power"],
@@ -229,10 +155,24 @@ quantity_definitions = {
                     "Tracks the highest (peak) observed power in some interval"
                 ),
             },
-            "Thermal_Power": {OWL.sameAs: QUDTQK["ThermalPower"]},
+            "Thermal_Power": {
+                QUDT.applicableUnit: [UNIT.MilliW, UNIT.W, UNIT.KiloW, UNIT.MegaW],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("ThermalPower"),
+                SKOS.broader: QUDTQK.Power,
+            },
         },
     },
-    "Cloudage": {OWL.sameAs: QUDTQK["Cloudage"]},
+    "Cloudage": {
+        QUDT.applicableUnit: [UNIT.Okta],
+        QUDT.plainTextDescription: Literal(
+            "The fraction of the sky obscured by clouds when observed from a particular location"
+        ),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Cloudage"),
+        SKOS.broader: QUDTQK.Dimensionless,
+    },
     "Current": {
         "subconcepts": {
             "Electric_Current": {
@@ -242,13 +182,41 @@ quantity_definitions = {
                         SKOS.definition: Literal(
                             "The angle of the phasor representing a measurement of electric current"
                         ),
-                        OWL.sameAs: QUDTQK["CurrentAngle"],
+                        QUDT.applicableUnit: [
+                            UNIT.ARCMIN,
+                            UNIT.ARCSEC,
+                            UNIT.DEG,
+                            UNIT.GON,
+                            UNIT.GRAD,
+                            UNIT.MIL,
+                            UNIT.RAD,
+                            UNIT.MicroRAD,
+                            UNIT.MilliRAD,
+                            UNIT.MilliARCSEC,
+                            UNIT.REV,
+                        ],
+                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                        QUDT.plainTextDescription: Literal("Angle of current phasor"),
+                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                        RDFS.label: Literal("CurrentAngle"),
+                        SKOS.broader: BRICK.PhasorAngle,
                     },
                     "Current_Magnitude": {
                         SKOS.definition: Literal(
                             "The magnitude of the phasor representing a measurement of electric current"
                         ),
-                        OWL.sameAs: QUDTQK["CurrentMagnitude"],
+                        QUDT.applicableUnit: [
+                            UNIT.A,
+                            UNIT.MilliA,
+                            UNIT.MicroA,
+                            UNIT.KiloA,
+                        ],
+                        QUDT.plainTextDescription: Literal(
+                            "Magnitude of current phasor"
+                        ),
+                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                        RDFS.label: Literal("CurrentMagnitude"),
+                        SKOS.broader: BRICK.PhasorMagnitude,
                     },
                     "Current_Imbalance": {},
                     "Current_Total_Harmonic_Distortion": {},
@@ -264,7 +232,25 @@ quantity_definitions = {
                 SKOS.definition: Literal(
                     "The angle of the phasor representing a measurement of electric voltage"
                 ),
-                OWL.sameAs: QUDTQK["VoltageAngle"],
+                QUDT.applicableUnit: [
+                    UNIT.ARCMIN,
+                    UNIT.ARCSEC,
+                    UNIT.DEG,
+                    UNIT.GON,
+                    UNIT.GRAD,
+                    UNIT.MIL,
+                    UNIT.RAD,
+                    UNIT.MicroRAD,
+                    UNIT.MilliRAD,
+                    UNIT.MilliARCSEC,
+                    UNIT.REV,
+                ],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                QUDT.plainTextDescription: Literal("Angle of voltage phasor"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("VoltageAngle"),
+                SKOS.broader: BRICK.PhasorAngle,
+                # TODO: units?
             },
             "Voltage_Imbalance": {},
         },
@@ -294,8 +280,34 @@ quantity_definitions = {
     },
     "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
     "Irradiance": {
-        OWL.sameAs: QUDTQK["Irradiance"],
-        "subconcepts": {"Solar_Irradiance": {OWL.sameAs: QUDTQK["SolarIrradiance"]}},
+        QUDT.applicableUnit: [
+            UNIT["W-PER-M2"],
+            UNIT["W-PER-IN2"],
+            UNIT["W-PER-FT2"],
+            UNIT["W-PER-CeniM2"],
+        ],
+        QUDT.plainTextDescription: Literal(
+            "The power per unit area of electromagnetic radiation incident on a surface"
+        ),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Irradiance"),
+        SKOS.broader: QUDTQK.PowerPerArea,
+        "subconcepts": {
+            "Solar_Irradiance": {
+                QUDT.applicableUnit: [
+                    UNIT["W-PER-M2"],
+                    UNIT["W-PER-IN2"],
+                    UNIT["W-PER-FT2"],
+                    UNIT["W-PER-CeniM2"],
+                ],
+                QUDT.plainTextDescription: Literal(
+                    "The power per unit area of solar electromagnetic radiation incident on a surface"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("SolarIrradiance"),
+                SKOS.broader: BRICK.Irradiance,
+            }
+        },
     },
     "Level": {
         "subconcepts": {
@@ -313,7 +325,13 @@ quantity_definitions = {
         },
     },
     "Occupancy": {"subconcepts": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
-    "Position": {OWL.sameAs: QUDTQK["Position"]},
+    "Position": {
+        QUDT.applicableUnit: [UNIT["PERCENT"]],
+        QUDT.plainTextDescription: Literal("The fraction of the full range of motion"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Position"),
+        SKOS.broader: QUDTQK.DimensionlessRatio,
+    },
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -38,9 +38,7 @@ quantity_definitions = {
             "CO2_Level": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal(
-                    "The concentration ratio of some substance"
-                ),
+                SKOS.definition: Literal("The concentration ratio of some substance"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
@@ -48,9 +46,7 @@ quantity_definitions = {
             "PM10_Level": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal(
-                    "The concentration ratio of some substance"
-                ),
+                SKOS.definition: Literal("The concentration ratio of some substance"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
@@ -58,9 +54,7 @@ quantity_definitions = {
             "PM25_Level": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal(
-                    "The concentration ratio of some substance"
-                ),
+                SKOS.definition: Literal("The concentration ratio of some substance"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
@@ -68,9 +62,7 @@ quantity_definitions = {
             "TVOC_Level": {
                 QUDT.applicableUnit: [UNIT.PPM],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal(
-                    "The concentration ratio of some substance"
-                ),
+                SKOS.definition: Literal("The concentration ratio of some substance"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("Concentration"),
                 SKOS.broader: QUDTQK.Dimensionless,
@@ -88,7 +80,15 @@ quantity_definitions = {
     },
     "Mass": {
         OWL.sameAs: QUDTQK["Mass"],
-        "subconcepts": {"Grains": {QUDT.applicableUnit: UNIT.GRAINS}},
+        "subconcepts": {
+            "Grains": {
+                QUDT.applicableUnit: UNIT.GRAIN,
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Grains"),
+                SKOS.broader: QUDTQK.Mass,
+            }
+        },
     },
     "Phasor": {
         "subconcepts": {
@@ -107,7 +107,7 @@ quantity_definitions = {
                     UNIT.REV,
                 ],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal("Angle component of a phasor"),
+                SKOS.definition: Literal("Angle component of a phasor"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("PhasorAngle"),
                 SKOS.broader: QUDTQK.PlaneAngle,
@@ -127,10 +127,9 @@ quantity_definitions = {
                     UNIT.REV,
                 ],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal("Magnitude component of a phasor"),
+                SKOS.definition: Literal("Magnitude component of a phasor"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("PhasorMagnitude"),
-                # TODO: finish
             },
         },
     },
@@ -144,7 +143,9 @@ quantity_definitions = {
                     "Active_Power": {
                         OWL.sameAs: [QUDTQK["ActivePower"], BRICK["Real_Power"]],
                     },
-                    "Real_Power": {},
+                    "Real_Power": {
+                        OWL.sameAs: [QUDTQK["ActivePower"], BRICK["Active_Power"]],
+                    },
                     "Reactive_Power": {OWL.sameAs: QUDTQK["ReactivePower"]},
                     "Complex_Power": {OWL.sameAs: QUDTQK["ComplexPower"]},
                 },
@@ -165,8 +166,9 @@ quantity_definitions = {
         },
     },
     "Cloudage": {
+        # TODO: define Okta?
         QUDT.applicableUnit: [UNIT.Okta],
-        QUDT.plainTextDescription: Literal(
+        SKOS.definition: Literal(
             "The fraction of the sky obscured by clouds when observed from a particular location"
         ),
         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
@@ -196,7 +198,7 @@ quantity_definitions = {
                             UNIT.REV,
                         ],
                         QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                        QUDT.plainTextDescription: Literal("Angle of current phasor"),
+                        SKOS.definition: Literal("Angle of current phasor"),
                         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                         RDFS.label: Literal("CurrentAngle"),
                         SKOS.broader: BRICK.PhasorAngle,
@@ -211,16 +213,46 @@ quantity_definitions = {
                             UNIT.MicroA,
                             UNIT.KiloA,
                         ],
-                        QUDT.plainTextDescription: Literal(
-                            "Magnitude of current phasor"
-                        ),
+                        SKOS.definition: Literal("Magnitude of current phasor"),
                         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                         RDFS.label: Literal("CurrentMagnitude"),
                         SKOS.broader: BRICK.PhasorMagnitude,
                     },
-                    "Current_Imbalance": {},
-                    "Current_Total_Harmonic_Distortion": {},
-                    "Alternating_Current_Frequency": {},
+                    "Current_Imbalance": {
+                        SKOS.definition: Literal(
+                            "The percent deviation from average current"
+                        ),
+                        QUDT.applicableUnit: [UNIT.PERCENT],
+                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                        RDFS.label: Literal("CurrentImbalance"),
+                        SKOS.broader: BRICK.Dimensionless,
+                    },
+                    "Current_Total_Harmonic_Distortion": {
+                        SKOS.definition: Literal(
+                            "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)"
+                        ),
+                        QUDT.applicableUnit: [UNIT.PERCENT, UNIT.DeciB_M],
+                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                        RDFS.label: Literal("CurrentTotalHarmonicDistortion"),
+                        SKOS.broader: BRICK.Dimensionless,
+                    },
+                    "Alternating_Current_Frequency": {
+                        QUDT.applicableUnit: [
+                            QUDT.GigaHZ,
+                            QUDT.MegaHZ,
+                            QUDT.KiloHZ,
+                            QUDT.HZ,
+                        ],
+                        SKOS.definition: Literal(
+                            "The frequency of the oscillations of alternating current"
+                        ),
+                        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T-1D0"],
+                        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                        RDFS.label: Literal("Alternating_Current_Frequency"),
+                        SKOS.broader: QUDTQK.Frequency,
+                    },
                 },
             },
         },
@@ -246,19 +278,45 @@ quantity_definitions = {
                     UNIT.REV,
                 ],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
-                QUDT.plainTextDescription: Literal("Angle of voltage phasor"),
+                SKOS.definition: Literal("Angle of voltage phasor"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("VoltageAngle"),
                 SKOS.broader: BRICK.PhasorAngle,
-                # TODO: units?
             },
-            "Voltage_Imbalance": {},
+            # TODO: finish this
+            "Voltage_Imbalance": {
+                SKOS.definition: Literal("The percent deviation from average voltage"),
+                QUDT.applicableUnit: [UNIT.PERCENT],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("VoltageImbalance"),
+                SKOS.broader: BRICK.Dimensionless,
+            },
         },
     },
-    "Daytime": {},
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {
-        "subconcepts": {"Wind_Direction": {OWL.sameAs: QUDTQK["PlaneAngle"]}}
+        "subconcepts": {
+            "Wind_Direction": {
+                QUDT.applicableUnit: [
+                    UNIT.ARCMIN,
+                    UNIT.ARCSEC,
+                    UNIT.DEG,
+                    UNIT.GON,
+                    UNIT.GRAD,
+                    UNIT.MIL,
+                    UNIT.RAD,
+                    UNIT.MicroRAD,
+                    UNIT.MilliRAD,
+                    UNIT.MilliARCSEC,
+                    UNIT.REV,
+                ],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                SKOS.definition: Literal("Direction of wind relative to North"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Wind_Direction"),
+            }
+        }
     },
     "Energy": {
         "subconcepts": {
@@ -266,7 +324,7 @@ quantity_definitions = {
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
-    # define hydralic flow loss? https://en.wikipedia.org/wiki/Friction_loss
+    # TODO: is this https://en.wikipedia.org/wiki/Friction_loss ? need to ask
     "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subconcepts": {"Flow_Loss": {}}},
     "Frequency": {
         OWL.sameAs: QUDTQK["Frequency"],
@@ -286,7 +344,7 @@ quantity_definitions = {
             UNIT["W-PER-FT2"],
             UNIT["W-PER-CeniM2"],
         ],
-        QUDT.plainTextDescription: Literal(
+        SKOS.definition: Literal(
             "The power per unit area of electromagnetic radiation incident on a surface"
         ),
         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
@@ -300,7 +358,7 @@ quantity_definitions = {
                     UNIT["W-PER-FT2"],
                     UNIT["W-PER-CeniM2"],
                 ],
-                QUDT.plainTextDescription: Literal(
+                SKOS.definition: Literal(
                     "The power per unit area of solar electromagnetic radiation incident on a surface"
                 ),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
@@ -310,11 +368,42 @@ quantity_definitions = {
         },
     },
     "Level": {
+        QUDT.applicableUnit: [
+            UNIT["CentiM"],
+            UNIT["DeciM"],
+            UNIT["MilliM"],
+            UNIT["MicroM"],
+            UNIT["KiloM"],
+            UNIT["M"],
+            UNIT["IN"],
+            UNIT["FT"],
+            UNIT["YD"],
+        ],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L1I0M0H0T0D0"],
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Level"),
+        SKOS.broader: QUDTQK.Length,
         "subconcepts": {
-            "CO2_Level": {},
-            "PM10_Level": {},
-            "PM25_Level": {},
-            "TVOC_Level": {},
+            "Precipitation": {
+                QUDT.applicableUnit: [
+                    UNIT["CentiM"],
+                    UNIT["DeciM"],
+                    UNIT["MilliM"],
+                    UNIT["MicroM"],
+                    UNIT["KiloM"],
+                    UNIT["M"],
+                    UNIT["IN"],
+                    UNIT["FT"],
+                    UNIT["YD"],
+                ],
+                SKOS.definition: Literal(
+                    "Amount of atmospheric water vapor fallen including rain, sleet, snow, and hail (https://project-haystack.dev/doc/lib-phScience/precipitation)"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L1I0M0H0T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Precipitation"),
+                SKOS.broader: QUDTQK.Length,
+            },
         },
     },
     "Luminance": {
@@ -324,16 +413,36 @@ quantity_definitions = {
             "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
         },
     },
-    "Occupancy": {"subconcepts": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
+    "Occupancy": {
+        "subconcepts": {
+            "Occupancy_Count": {
+                QUDT.applicableUnit: [UNIT["People"]],
+                SKOS.definition: Literal("Number of people in an area"),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Occupancy_Count"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
+            "Occupancy_Percentage": {
+                QUDT.applicableUnit: [UNIT["PERCENT"]],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                SKOS.definition: Literal(
+                    "Percent of total occupancy of space that is occupied"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Occupancy_Percentage"),
+                SKOS.broader: QUDTQK.Dimensionless,
+            },
+        }
+    },
     "Position": {
         QUDT.applicableUnit: [UNIT["PERCENT"]],
-        QUDT.plainTextDescription: Literal("The fraction of the full range of motion"),
+        SKOS.definition: Literal("The fraction of the full range of motion"),
         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
         RDFS.label: Literal("Position"),
-        SKOS.broader: QUDTQK.DimensionlessRatio,
+        SKOS.broader: QUDTQK.Dimensionless,
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
     },
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
-    "Precipitation": {},
     "Pressure": {
         OWL.sameAs: QUDTQK["Pressure"],
         "subconcepts": {
@@ -345,21 +454,97 @@ quantity_definitions = {
             },
         },
     },
-    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subconcepts": {"Solar_Radiance": {}}},
-    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subconcepts": {"Wind_Speed": {}}},
+    "Radiance": {
+        OWL.sameAs: QUDTQK["Radiance"],
+        "subconcepts": {
+            "Solar_Radiance": {
+                QUDT.applicableUnit: [UNIT["W-PER-M2-SR"]],
+                SKOS.definition: Literal(
+                    "The amount of light that passes through or is emitted from the sun and falls withi na given solid angle in a specified direction",
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Solar_Radiance"),
+                SKOS.broader: QUDTQK.Radiance,
+            }
+        },
+    },
+    "Speed": {
+        # TODO: fan speed is not meter/sec
+        OWL.sameAs: QUDTQK["Speed"],
+        "subconcepts": {
+            "Wind_Speed": {
+                QUDT.applicableUnit: [
+                    UNIT["M-PER-HR"],
+                    UNIT["KiloM-PER-HR"],
+                    UNIT["FT-PER-HR"],
+                    UNIT["MI-PER-HR"],
+                    UNIT["M-PER-SEC"],
+                    UNIT["KiloM-PER-SEC"],
+                    UNIT["FT-PER-SEC"],
+                    UNIT["MI-PER-SEC"],
+                ],
+                SKOS.definition: Literal(
+                    "Measured speed of wind, caused by air moving from high to low pressure",
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L1I0M0H0T-1D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Wind_Speed"),
+                SKOS.broader: QUDTQK.Speed,
+            }
+        },
+    },
     "Temperature": {
         OWL.sameAs: QUDTQK["ThermodynamicTemperature"],
+        # TODO: finish
         "subconcepts": {
-            "Operative_Temperature": {},
-            "Radiant_Temperature": {},
-            "Dry_Bulb_Temperature": {},
-            "Wet_Bulb_Temperature": {},
+            "Operative_Temperature": {
+                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
+                SKOS.definition: Literal(
+                    "The uniform temperature of an imaginary black enclosure in which an occupant would exchange the same amount of heat by radiation plus convection as in the actual nonuniform environment (https://en.wikipedia.org/wiki/Operative_temperature)"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Operative_Temperature"),
+                SKOS.broader: QUDTQK.ThermodynamicTemperature,
+            },
+            "Radiant_Temperature": {
+                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
+                SKOS.definition: Literal(
+                    "the uniform temperature of an imaginary enclosure in which the radiant heat transfer from the human body is equal to the radiant heat transfer in the actual non-uniform enclosure. (https://en.wikipedia.org/wiki/Mean_radiant_temperature)"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Radiant_Temperature"),
+                SKOS.broader: QUDTQK.ThermodynamicTemperature,
+            },
+            "Dry_Bulb_Temperature": {
+                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
+                SKOS.definition: Literal(
+                    "The temperature of air measured by a thermometer freely exposed to the air, but shielded from radiation and moisture. (https://en.wikipedia.org/wiki/Dry-bulb_temperature)"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Dry_Bulb_Temperature"),
+                SKOS.broader: QUDTQK.ThermodynamicTemperature,
+            },
+            "Wet_Bulb_Temperature": {
+                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
+                SKOS.definition: Literal(
+                    "The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)"
+                ),
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("Wet_Bulb_Temperature"),
+                SKOS.broader: QUDTQK.ThermodynamicTemperature,
+            },
         },
     },
     "Time": {
         OWL.sameAs: QUDTQK["Time"],
+        # TODO: what are these?
         "subconcepts": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
     "Torque": {OWL.sameAs: QUDTQK["Torque"]},
+    # TODO: https://ci.mines-stetienne.fr/seas/WeatherOntology-0.9#AirTemperature ?
     "Weather_Condition": {},
 }

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -494,7 +494,6 @@ quantity_definitions = {
     },
     "Temperature": {
         OWL.sameAs: QUDTQK["ThermodynamicTemperature"],
-        # TODO: finish
         "subconcepts": {
             "Operative_Temperature": {
                 QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -12,32 +12,36 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {OWL.equivalentClass: QUDTQK["Angle"]},
-    "Conductivity": {OWL.equivalentClass: QUDTQK["Conductivity"]},
-    "Capacity": {OWL.equivalentClass: QUDTQK["Capacity"]},
+    "Angle": {BRICK.associatedQuantityKind: QUDTQK["Angle"]},
+    "Conductivity": {BRICK.associatedQuantityKind: QUDTQK["Conductivity"]},
+    "Capacity": {BRICK.associatedQuantityKind: QUDTQK["Capacity"]},
     "Enthalpy": {
         SKOS.definition: Literal(
             "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
         ),
-        OWL.equivalentClass: QUDTQK["Enthalpy"],
+        BRICK.associatedQuantityKind: QUDTQK["Enthalpy"],
     },
     "Grains": {},
     "Power": {
-        OWL.equivalentClass: QUDTQK["Power"],
+        BRICK.associatedQuantityKind: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                OWL.equivalentClass: QUDTQK["ElectricPower"],
+                BRICK.associatedQuantityKind: QUDTQK["ElectricPower"],
                 "subclasses": {
-                    "Apparent_Power": {OWL.equivalentClass: QUDTQK["ApparentPower"]},
+                    "Apparent_Power": {
+                        BRICK.associatedQuantityKind: QUDTQK["ApparentPower"]
+                    },
                     "Active_Power": {
-                        OWL.equivalentClass: [
-                            QUDTQK["ActivePower"],
-                            BRICK["Real_Power"],
-                        ],
+                        OWL.equivalentClass: BRICK["Real_Power"],
+                        BRICK.associatedQuantityKind: QUDTQK["ActivePower"],
                     },
                     "Real_Power": {},
-                    "Reactive_Power": {OWL.equivalentClass: QUDTQK["ReactivePower"]},
-                    "Complex_Power": {OWL.equivalentClass: QUDTQK["ComplexPower"]},
+                    "Reactive_Power": {
+                        BRICK.associatedQuantityKind: QUDTQK["ReactivePower"]
+                    },
+                    "Complex_Power": {
+                        BRICK.associatedQuantityKind: QUDTQK["ComplexPower"]
+                    },
                 },
             },
             "Peak_Power": {
@@ -52,7 +56,7 @@ quantity_definitions = {
     "Current": {
         "subclasses": {
             "Electric_Current": {
-                OWL.equivalentClass: QUDTQK["ElectricCurrent"],
+                BRICK.associatedQuantityKind: QUDTQK["ElectricCurrent"],
                 "subclasses": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},
@@ -64,7 +68,7 @@ quantity_definitions = {
         },
     },
     "Voltage": {
-        OWL.equivalentClass: QUDTQK["Voltage"],
+        BRICK.associatedQuantityKind: QUDTQK["Voltage"],
         "subclasses": {
             "Voltage_Magnitude": {},
             "Voltage_Angle": {},
@@ -72,31 +76,35 @@ quantity_definitions = {
         },
     },
     "Daytime": {},
-    "Dewpoint": {OWL.equivalentClass: QUDTQK["DewPointTemperature"]},
+    "Dewpoint": {BRICK.associatedQuantityKind: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
         "subclasses": {
-            "Electric_Energy": {OWL.equivalentClass: QUDTQK["Energy"]},
-            "Thermal_Energy": {OWL.equivalentClass: QUDTQK["ThermalEnergy"]},
+            "Electric_Energy": {BRICK.associatedQuantityKind: QUDTQK["Energy"]},
+            "Thermal_Energy": {BRICK.associatedQuantityKind: QUDTQK["ThermalEnergy"]},
         },
     },
     "Flow": {
-        OWL.equivalentClass: QUDTQK["VolumeFlowRate"],
+        BRICK.associatedQuantityKind: QUDTQK["VolumeFlowRate"],
         "subclasses": {"Flow_Loss": {}},
     },
     "Frequency": {
-        OWL.equivalentClass: QUDTQK["Frequency"],
+        BRICK.associatedQuantityKind: QUDTQK["Frequency"],
         "subclasses": {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
         "subclasses": {
-            "Relative_Humidity": {OWL.equivalentClass: QUDTQK["RelativeHumidity"]},
-            "Absolute_Humidity": {OWL.equivalentClass: QUDTQK["AbsoluteHumidity"]},
+            "Relative_Humidity": {
+                BRICK.associatedQuantityKind: QUDTQK["RelativeHumidity"]
+            },
+            "Absolute_Humidity": {
+                BRICK.associatedQuantityKind: QUDTQK["AbsoluteHumidity"]
+            },
         }
     },
-    "Illuminance": {OWL.equivalentClass: QUDTQK["Illuminance"]},
+    "Illuminance": {BRICK.associatedQuantityKind: QUDTQK["Illuminance"]},
     "Irradiance": {
-        OWL.equivalentClass: QUDTQK["Irradiance"],
+        BRICK.associatedQuantityKind: QUDTQK["Irradiance"],
         "subclasses": {"Solar_Irradiance": {}},
     },
     "Level": {
@@ -108,39 +116,42 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        OWL.equivalentClass: QUDTQK["Luminance"],
+        BRICK.associatedQuantityKind: QUDTQK["Luminance"],
         "subclasses": {
-            "Luminous_Flux": {OWL.equivalentClass: QUDTQK["LuminousFlux"]},
-            "Luminous_Intensity": {OWL.equivalentClass: QUDTQK["LuminousIntensity"]},
+            "Luminous_Flux": {BRICK.associatedQuantityKind: QUDTQK["LuminousFlux"]},
+            "Luminous_Intensity": {
+                BRICK.associatedQuantityKind: QUDTQK["LuminousIntensity"]
+            },
         },
     },
     "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
     "Position": {},
-    "Power_Factor": {OWL.equivalentClass: QUDTQK["PowerFactor"]},
+    "Power_Factor": {BRICK.associatedQuantityKind: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        OWL.equivalentClass: QUDTQK["Pressure"],
+        BRICK.associatedQuantityKind: QUDTQK["Pressure"],
         "subclasses": {
             "Atmospheric_Pressure": {
-                OWL.equivalentClass: QUDTQK["AtmosphericPressure"]
+                BRICK.associatedQuantityKind: QUDTQK["AtmosphericPressure"]
             },
             "Dynamic_Pressure": {},
-            "Static_Pressure": {OWL.equivalentClass: QUDTQK["StaticPressure"]},
+            "Static_Pressure": {BRICK.associatedQuantityKind: QUDTQK["StaticPressure"]},
             "Velocity_Pressure": {
-                OWL.equivalentClass: [
-                    QUDTQK["DynamicPressure"],
-                    BRICK["Dynamic_Pressure"],
-                ],
+                OWL.equivalentClass: BRICK["Dynamic_Pressure"],
+                BRICK.associatedQuantityKind: QUDTQK["DynamicPressure"],
             },
         },
     },
     "Radiance": {
-        OWL.equivalentClass: QUDTQK["Radiance"],
+        BRICK.associatedQuantityKind: QUDTQK["Radiance"],
         "subclasses": {"Solar_Radiance": {}},
     },
-    "Speed": {OWL.equivalentClass: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
+    "Speed": {
+        BRICK.associatedQuantityKind: QUDTQK["Speed"],
+        "subclasses": {"Wind_Speed": {}},
+    },
     "Temperature": {
-        OWL.equivalentClass: QUDTQK["Temperature"],
+        BRICK.associatedQuantityKind: QUDTQK["Temperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
@@ -149,10 +160,10 @@ quantity_definitions = {
         },
     },
     "Time": {
-        OWL.equivalentClass: QUDTQK["Time"],
+        BRICK.associatedQuantityKind: QUDTQK["Time"],
         "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
-    "Torque": {OWL.equivalentClass: QUDTQK["Torque"]},
+    "Torque": {BRICK.associatedQuantityKind: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }
 
@@ -163,10 +174,11 @@ def associate_units(outputG):
     for triple in outputG:
         g.add(triple)
     g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
     unit_map = g.query(
         "SELECT ?quant ?unit WHERE {\
         ?quant a brick:Quantity .\
-        ?quant owl:equivalentClass/qudt:applicableUnit ?unit . }"
+        ?quant brick:associatedQuantityKind/qudt:applicableUnit ?unit . }"
     )
     for brickquant, unit in unit_map:
         outputG.add((brickquant, QUDT.applicableUnit, unit))

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import SKOS, OWL, BRICK, QUDTQK, QUDT
+from .namespaces import SKOS, OWL, BRICK, QUDTQK
 
 
 quantity_definitions = {
@@ -11,30 +11,32 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {OWL.sameAs: QUDTQK["Angle"]},
-    "Conductivity": {OWL.sameAs: QUDTQK["Conductivity"]},
-    "Capacity": {OWL.sameAs: QUDTQK["Capacity"]},
+    "Angle": {OWL.equivalentClass: QUDTQK["Angle"]},
+    "Conductivity": {OWL.equivalentClass: QUDTQK["Conductivity"]},
+    "Capacity": {OWL.equivalentClass: QUDTQK["Capacity"]},
     "Enthalpy": {
         SKOS.definition: Literal(
             "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
         ),
-        OWL.sameAs: QUDTQK["Enthalpy"],
+        OWL.equivalentClass: QUDTQK["Enthalpy"],
     },
     "Grains": {},
     "Power": {
-        # OWL.sameAs: QUDTQK["Power"],
+        OWL.equivalentClass: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                # OWL.sameAs: QUDTQK["ElectricPower"],
+                OWL.equivalentClass: QUDTQK["ElectricPower"],
                 "subclasses": {
-                    "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
+                    "Apparent_Power": {OWL.equivalentClass: QUDTQK["ApparentPower"]},
                     "Active_Power": {
-                        OWL.sameAs: QUDTQK["ActivePower"],
-                        OWL.equivalentClass: BRICK["Real_Power"],
+                        OWL.equivalentClass: [
+                            QUDTQK["ActivePower"],
+                            BRICK["Real_Power"],
+                        ],
                     },
                     "Real_Power": {},
-                    "Reactive_Power": {OWL.sameAs: QUDTQK["ReactivePower"]},
-                    "Complex_Power": {OWL.sameAs: QUDTQK["ComplexPower"]},
+                    "Reactive_Power": {OWL.equivalentClass: QUDTQK["ReactivePower"]},
+                    "Complex_Power": {OWL.equivalentClass: QUDTQK["ComplexPower"]},
                 },
             },
             "Peak_Power": {
@@ -49,7 +51,7 @@ quantity_definitions = {
     "Current": {
         "subclasses": {
             "Electric_Current": {
-                OWL.sameAs: QUDTQK["ElectricCurrent"],
+                OWL.equivalentClass: QUDTQK["ElectricCurrent"],
                 "subclasses": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},
@@ -61,7 +63,7 @@ quantity_definitions = {
         },
     },
     "Voltage": {
-        OWL.sameAs: QUDTQK["Voltage"],
+        OWL.equivalentClass: QUDTQK["Voltage"],
         "subclasses": {
             "Electric_Voltage": {
                 "subclasses": {
@@ -73,28 +75,31 @@ quantity_definitions = {
         },
     },
     "Daytime": {},
-    "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
+    "Dewpoint": {OWL.equivalentClass: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
         "subclasses": {
-            "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
-            "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
+            "Electric_Energy": {OWL.equivalentClass: QUDTQK["Energy"]},
+            "Thermal_Energy": {OWL.equivalentClass: QUDTQK["ThermalEnergy"]},
         },
     },
-    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subclasses": {"Flow_Loss": {}}},
+    "Flow": {
+        OWL.equivalentClass: QUDTQK["VolumeFlowRate"],
+        "subclasses": {"Flow_Loss": {}},
+    },
     "Frequency": {
-        OWL.sameAs: QUDTQK["Frequency"],
+        OWL.equivalentClass: QUDTQK["Frequency"],
         "subclasses": {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
         "subclasses": {
-            "Relative_Humidity": {OWL.sameAs: QUDTQK["RelativeHumidity"]},
-            "Absolute_Humidity": {OWL.sameAs: QUDTQK["AbsoluteHumidity"]},
+            "Relative_Humidity": {OWL.equivalentClass: QUDTQK["RelativeHumidity"]},
+            "Absolute_Humidity": {OWL.equivalentClass: QUDTQK["AbsoluteHumidity"]},
         }
     },
-    "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
+    "Illuminance": {OWL.equivalentClass: QUDTQK["Illuminance"]},
     "Irradiance": {
-        OWL.sameAs: QUDTQK["Irradiance"],
+        OWL.equivalentClass: QUDTQK["Irradiance"],
         "subclasses": {"Solar_Irradiance": {}},
     },
     "Level": {
@@ -106,32 +111,39 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        OWL.sameAs: QUDTQK["Luminance"],
+        OWL.equivalentClass: QUDTQK["Luminance"],
         "subclasses": {
-            "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
-            "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
+            "Luminous_Flux": {OWL.equivalentClass: QUDTQK["LuminousFlux"]},
+            "Luminous_Intensity": {OWL.equivalentClass: QUDTQK["LuminousIntensity"]},
         },
     },
     "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
     "Position": {},
-    "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
+    "Power_Factor": {OWL.equivalentClass: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        # OWL.sameAs: QUDTQK["Pressure"],
+        OWL.equivalentClass: QUDTQK["Pressure"],
         "subclasses": {
-            "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
+            "Atmospheric_Pressure": {
+                OWL.equivalentClass: QUDTQK["AtmosphericPressure"]
+            },
             "Dynamic_Pressure": {},
-            "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
+            "Static_Pressure": {OWL.equivalentClass: QUDTQK["StaticPressure"]},
             "Velocity_Pressure": {
-                OWL.sameAs: QUDTQK["DynamicPressure"],
-                OWL.equivalentClass: BRICK["Dynamic_Pressure"],
+                OWL.equivalentClass: [
+                    QUDTQK["DynamicPressure"],
+                    BRICK["Dynamic_Pressure"],
+                ],
             },
         },
     },
-    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subclasses": {"Solar_Radiance": {}}},
-    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
+    "Radiance": {
+        OWL.equivalentClass: QUDTQK["Radiance"],
+        "subclasses": {"Solar_Radiance": {}},
+    },
+    "Speed": {OWL.equivalentClass: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
     "Temperature": {
-        OWL.sameAs: QUDTQK["Temperature"],
+        OWL.equivalentClass: QUDTQK["Temperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
@@ -140,9 +152,9 @@ quantity_definitions = {
         },
     },
     "Time": {
-        OWL.sameAs: QUDTQK["Time"],
+        OWL.equivalentClass: QUDTQK["Time"],
         "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
-    "Torque": {OWL.sameAs: QUDTQK["Torque"]},
+    "Torque": {OWL.equivalentClass: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import SKOS, OWL, BRICK, QUDTQK
+from .namespaces import SKOS, OWL, BRICK, QUDTQK, QUDT
 
 
 quantity_definitions = {
@@ -76,9 +76,8 @@ quantity_definitions = {
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
-        # OWL.sameAs: QUDTQK["Energy"],
         "subclasses": {
-            "Electric_Energy": {},
+            "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -36,11 +36,17 @@ Each is a qudt:QuantityKind
 quantitykind_extensions = {
     "Concentration": {
         QUDT.applicableUnit: [UNIT.PPM],
-        QUDT.hasDimensionVector: QUDTDV.A0E0L0I0M0H0T0D1,
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
         QUDT.plainTextDescription: Literal("The concentration ratio of some substance"),
         RDFS.isDefinedBy: URIRef(str(QUDTQK).strip("/")),
         RDFS.label: Literal("Concentration"),
         SKOS.broader: QUDTQK.Dimensionless,
+    },
+    "ThermalPower": {
+        QUDT.applicableUnit: [UNIT.MilliW, UNIT.W, UNIT.KiloW, UNIT.MegaW],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
+        RDFS.isDefinedBy: URIRef(str(QUDTQK).strip("/")),
+        RDFS.label: Literal("ThermalPower"),
     },
 }
 
@@ -63,7 +69,10 @@ quantity_definitions = {
         ),
         OWL.sameAs: QUDTQK["Enthalpy"],
     },
-    "Grains": {},
+    "Mass": {
+        OWL.sameAs: QUDTQK["Mass"],
+        "subconcepts": {"Grains": {QUDT.applicableUnit: UNIT.GRAINS}},
+    },
     "Power": {
         OWL.sameAs: QUDTQK["Power"],
         "subconcepts": {

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -92,6 +92,9 @@ quantity_definitions = {
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("GrainsOfMoisture"),
+                SKOS.definition: Literal(
+                    "Mass of moisture per pround of air, measured in grains of water"
+                ),
                 SKOS.broader: QUDTQK.Mass,
             }
         },

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -34,7 +34,7 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {RDFS.seeAlso: QUDTQK["Angle"], OWL.sameAs: QUDTQK["Angle"]},
+    "Angle": {OWL.sameAs: QUDTQK["Angle"]},
     "Conductivity": {OWL.sameAs: QUDTQK["Conductivity"]},
     "Capacity": {OWL.sameAs: QUDTQK["Capacity"]},
     "Enthalpy": {
@@ -45,10 +45,10 @@ quantity_definitions = {
     },
     "Grains": {},
     "Power": {
-        # OWL.sameAs: QUDTQK["Power"],
+        OWL.sameAs: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                # OWL.sameAs: QUDTQK["ElectricPower"],
+                OWL.sameAs: QUDTQK["ElectricPower"],
                 "subclasses": {
                     "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
@@ -124,7 +124,7 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        # OWL.sameAs: QUDTQK["Luminance"],
+        OWL.sameAs: QUDTQK["Luminance"],
         "subclasses": {
             "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
             "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
@@ -135,7 +135,7 @@ quantity_definitions = {
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        # OWL.sameAs: QUDTQK["Pressure"],
+        OWL.sameAs: QUDTQK["Pressure"],
         "subclasses": {
             "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},
@@ -148,7 +148,7 @@ quantity_definitions = {
     "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subclasses": {"Solar_Radiance": {}}},
     "Speed": {OWL.sameAs: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
     "Temperature": {
-        OWL.sameAs: QUDTQK["Temperature"],
+        OWL.sameAs: QUDTQK["ThermodynamicTemperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -419,6 +419,9 @@ quantity_definitions = {
         QUDT.hasDimensionVector: QUDTDV["A0E0L1I0M0H0T0D0"],
         RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
         RDFS.label: Literal("Level"),
+        SKOS.definition: Literal(
+            "Amount of substance in a container; typically measured in height"
+        ),
         SKOS.broader: QUDTQK.Length,
         "subconcepts": {
             "Precipitation": {

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -34,19 +34,154 @@ Each is a qudt:QuantityKind
 """
 # TODO: define these on QUDTQK namespace
 quantitykind_extensions = {
+    "Cloudage": {
+        # TODO: define Okta
+        QUDT.applicableUnit: [UNIT.Okta],
+        QUDT.plainTextDescription: Literal(
+            "The fraction of the sky obscured by clouds when observed from a particular location"
+        ),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Cloudage"),
+        SKOS.broader: QUDTQK.Dimensionless,
+    },
     "Concentration": {
         QUDT.applicableUnit: [UNIT.PPM],
         QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
         QUDT.plainTextDescription: Literal("The concentration ratio of some substance"),
-        RDFS.isDefinedBy: URIRef(str(QUDTQK).strip("/")),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
         RDFS.label: Literal("Concentration"),
         SKOS.broader: QUDTQK.Dimensionless,
+    },
+    "CurrentAngle": {
+        QUDT.applicableUnit: [
+            UNIT.ARCMIN,
+            UNIT.ARCSEC,
+            UNIT.DEG,
+            UNIT.GON,
+            UNIT.GRAD,
+            UNIT.MIL,
+            UNIT.RAD,
+            UNIT.MicroRAD,
+            UNIT.MilliRAD,
+            UNIT.MilliARCSEC,
+            UNIT.REV,
+        ],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+        QUDT.plainTextDescription: Literal("Angle of current phasor"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("CurrentAngle"),
+        SKOS.broader: QUDTQK.PhasorAngle,
+        # TODO: units?
+    },
+    "CurrentMagnitude": {
+        QUDT.applicableUnit: [UNIT.A, UNIT.MilliA, UNIT.MicroA, UNIT.KiloA],
+        QUDT.plainTextDescription: Literal("Magnitude of current phasor"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("CurrentMagnitude"),
+        SKOS.broader: QUDTQK.PhasorMagnitude,
+    },
+    "Irradiance": {
+        QUDT.applicableUnit: [
+            UNIT["W-PER-M2"],
+            UNIT["W-PER-IN2"],
+            UNIT["W-PER-FT2"],
+            UNIT["W-PER-CeniM2"],
+        ],
+        QUDT.plainTextDescription: Literal(
+            "The power per unit area of electromagnetic radiation incident on a surface"
+        ),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Irradiance"),
+        SKOS.broader: QUDTQK.PowerPerArea,
+    },
+    "PhasorAngle": {
+        QUDT.applicableUnit: [
+            UNIT.ARCMIN,
+            UNIT.ARCSEC,
+            UNIT.DEG,
+            UNIT.GON,
+            UNIT.GRAD,
+            UNIT.MIL,
+            UNIT.RAD,
+            UNIT.MicroRAD,
+            UNIT.MilliRAD,
+            UNIT.MilliARCSEC,
+            UNIT.REV,
+        ],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+        QUDT.plainTextDescription: Literal("Angle component of a phasor"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("PhasorAngle"),
+        SKOS.broader: QUDTQK.PlaneAngle,
+    },
+    "PhasorMagnitude": {
+        QUDT.applicableUnit: [
+            UNIT.ARCMIN,
+            UNIT.ARCSEC,
+            UNIT.DEG,
+            UNIT.GON,
+            UNIT.GRAD,
+            UNIT.MIL,
+            UNIT.RAD,
+            UNIT.MicroRAD,
+            UNIT.MilliRAD,
+            UNIT.MilliARCSEC,
+            UNIT.REV,
+        ],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+        QUDT.plainTextDescription: Literal("Magnitude component of a phasor"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("PhasorMagnitude"),
+        # TODO: finish
+    },
+    "Position": {
+        QUDT.applicableUnit: [UNIT["PERCENT"]],
+        QUDT.plainTextDescription: Literal("The fraction of the full range of motion"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("Position"),
+        SKOS.broader: QUDTQK.DimensionlessRatio,
+    },
+    "SolarIrradiance": {
+        QUDT.applicableUnit: [
+            UNIT["W-PER-M2"],
+            UNIT["W-PER-IN2"],
+            UNIT["W-PER-FT2"],
+            UNIT["W-PER-CeniM2"],
+        ],
+        QUDT.plainTextDescription: Literal(
+            "The power per unit area of solar electromagnetic radiation incident on a surface"
+        ),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("SolarIrradiance"),
+        SKOS.broader: QUDTQK.Irradiance,
     },
     "ThermalPower": {
         QUDT.applicableUnit: [UNIT.MilliW, UNIT.W, UNIT.KiloW, UNIT.MegaW],
         QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
-        RDFS.isDefinedBy: URIRef(str(QUDTQK).strip("/")),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
         RDFS.label: Literal("ThermalPower"),
+        SKOS.broader: QUDTQK.Power,
+    },
+    "VoltageAngle": {
+        QUDT.applicableUnit: [
+            UNIT.ARCMIN,
+            UNIT.ARCSEC,
+            UNIT.DEG,
+            UNIT.GON,
+            UNIT.GRAD,
+            UNIT.MIL,
+            UNIT.RAD,
+            UNIT.MicroRAD,
+            UNIT.MilliRAD,
+            UNIT.MilliARCSEC,
+            UNIT.REV,
+        ],
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+        QUDT.plainTextDescription: Literal("Angle of voltage phasor"),
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("VoltageAngle"),
+        SKOS.broader: QUDTQK.PhasorAngle,
+        # TODO: units?
     },
 }
 
@@ -97,14 +232,24 @@ quantity_definitions = {
             "Thermal_Power": {OWL.sameAs: QUDTQK["ThermalPower"]},
         },
     },
-    "Cloudage": {},
+    "Cloudage": {OWL.sameAs: QUDTQK["Cloudage"]},
     "Current": {
         "subconcepts": {
             "Electric_Current": {
                 OWL.sameAs: QUDTQK["ElectricCurrent"],
                 "subconcepts": {
-                    "Current_Angle": {},
-                    "Current_Magnitude": {},
+                    "Current_Angle": {
+                        SKOS.definition: Literal(
+                            "The angle of the phasor representing a measurement of electric current"
+                        ),
+                        OWL.sameAs: QUDTQK["CurrentAngle"],
+                    },
+                    "Current_Magnitude": {
+                        SKOS.definition: Literal(
+                            "The magnitude of the phasor representing a measurement of electric current"
+                        ),
+                        OWL.sameAs: QUDTQK["CurrentMagnitude"],
+                    },
                     "Current_Imbalance": {},
                     "Current_Total_Harmonic_Distortion": {},
                     "Alternating_Current_Frequency": {},
@@ -115,19 +260,27 @@ quantity_definitions = {
     "Voltage": {
         "subconcepts": {
             "Voltage_Magnitude": {OWL.sameAs: QUDTQK["Voltage"]},
-            "Voltage_Angle": {},
+            "Voltage_Angle": {
+                SKOS.definition: Literal(
+                    "The angle of the phasor representing a measurement of electric voltage"
+                ),
+                OWL.sameAs: QUDTQK["VoltageAngle"],
+            },
             "Voltage_Imbalance": {},
         },
     },
     "Daytime": {},
     "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
-    "Direction": {"subconcepts": {"Wind_Direction": {}}},
+    "Direction": {
+        "subconcepts": {"Wind_Direction": {OWL.sameAs: QUDTQK["PlaneAngle"]}}
+    },
     "Energy": {
         "subconcepts": {
             "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
+    # define hydralic flow loss? https://en.wikipedia.org/wiki/Friction_loss
     "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subconcepts": {"Flow_Loss": {}}},
     "Frequency": {
         OWL.sameAs: QUDTQK["Frequency"],
@@ -142,7 +295,7 @@ quantity_definitions = {
     "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
     "Irradiance": {
         OWL.sameAs: QUDTQK["Irradiance"],
-        "subconcepts": {"Solar_Irradiance": {}},
+        "subconcepts": {"Solar_Irradiance": {OWL.sameAs: QUDTQK["SolarIrradiance"]}},
     },
     "Level": {
         "subconcepts": {
@@ -160,7 +313,7 @@ quantity_definitions = {
         },
     },
     "Occupancy": {"subconcepts": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
-    "Position": {},
+    "Position": {OWL.sameAs: QUDTQK["Position"]},
     "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -101,7 +101,7 @@ quantity_definitions = {
     },
     "Phasor": {
         SKOS.related: {
-            "PhasorAngle": {
+            "Phasor_Angle": {
                 QUDT.applicableUnit: [
                     UNIT.ARCMIN,
                     UNIT.ARCSEC,
@@ -121,7 +121,7 @@ quantity_definitions = {
                 RDFS.label: Literal("PhasorAngle"),
                 SKOS.broader: QUDTQK.PlaneAngle,
             },
-            "PhasorMagnitude": {
+            "Phasor_Magnitude": {
                 QUDT.applicableUnit: [
                     UNIT.ARCMIN,
                     UNIT.ARCSEC,
@@ -218,7 +218,7 @@ quantity_definitions = {
                 SKOS.definition: Literal("Angle of current phasor"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("CurrentAngle"),
-                SKOS.broader: BRICK.PhasorAngle,
+                SKOS.broader: BRICK.Phasor_Angle,
             },
             "Current_Imbalance": {
                 SKOS.definition: Literal("The percent deviation from average current"),
@@ -274,7 +274,7 @@ quantity_definitions = {
                 SKOS.definition: Literal("Angle of voltage phasor"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("VoltageAngle"),
-                SKOS.broader: BRICK.PhasorAngle,
+                SKOS.broader: BRICK.Phasor_Angle,
             },
             "Voltage_Imbalance": {
                 SKOS.definition: Literal("The percent deviation from average voltage"),

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,6 +1,28 @@
-import brickschema
+from brickschema.graph import Graph
+from brickschema.inference import BrickInferenceSession
 from rdflib import Literal
 from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDT
+
+
+g = Graph()
+g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+g.load_file("support/VOCAB_QUDT-UNITS-ALL-v2.1.ttl")
+g.g.bind("qudt", QUDT)
+g.g.bind("qudtqk", QUDTQK)
+sess = BrickInferenceSession()
+g = sess.expand(g)
+
+
+def get_units(brick_quantity):
+    res = g.query(
+        f"""SELECT ?unit ?symbol WHERE {{
+                    <{brick_quantity}> qudt:applicableUnit ?unit .
+                    ?unit qudt:symbol ?symbol .
+                    FILTER(isLiteral(?symbol))
+                    }}"""
+    )
+    for r in res:
+        yield r
 
 
 quantity_definitions = {
@@ -12,42 +34,37 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Angle": {BRICK.associatedQuantityKind: QUDTQK["Angle"]},
-    "Conductivity": {BRICK.associatedQuantityKind: QUDTQK["Conductivity"]},
-    "Capacity": {BRICK.associatedQuantityKind: QUDTQK["Capacity"]},
+    "Angle": {RDFS.seeAlso: QUDTQK["Angle"], OWL.sameAs: QUDTQK["Angle"]},
+    "Conductivity": {OWL.sameAs: QUDTQK["Conductivity"]},
+    "Capacity": {OWL.sameAs: QUDTQK["Capacity"]},
     "Enthalpy": {
         SKOS.definition: Literal(
             "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
         ),
-        BRICK.associatedQuantityKind: QUDTQK["Enthalpy"],
+        OWL.sameAs: QUDTQK["Enthalpy"],
     },
     "Grains": {},
     "Power": {
-        BRICK.associatedQuantityKind: QUDTQK["Power"],
+        # OWL.sameAs: QUDTQK["Power"],
         "subclasses": {
             "Electric_Power": {
-                BRICK.associatedQuantityKind: QUDTQK["ElectricPower"],
+                # OWL.sameAs: QUDTQK["ElectricPower"],
                 "subclasses": {
-                    "Apparent_Power": {
-                        BRICK.associatedQuantityKind: QUDTQK["ApparentPower"]
-                    },
+                    "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
+                        OWL.sameAs: QUDTQK["ActivePower"],
                         OWL.equivalentClass: BRICK["Real_Power"],
-                        BRICK.associatedQuantityKind: QUDTQK["ActivePower"],
                     },
                     "Real_Power": {},
-                    "Reactive_Power": {
-                        BRICK.associatedQuantityKind: QUDTQK["ReactivePower"]
-                    },
-                    "Complex_Power": {
-                        BRICK.associatedQuantityKind: QUDTQK["ComplexPower"]
-                    },
+                    "Reactive_Power": {OWL.sameAs: QUDTQK["ReactivePower"]},
+                    "Complex_Power": {OWL.sameAs: QUDTQK["ComplexPower"]},
                 },
             },
             "Peak_Power": {
+                OWL.sameAs: QUDTQK["ElectricPower"],
                 SKOS.definition: Literal(
                     "Tracks the highest (peak) observed power in some interval"
-                )
+                ),
             },
             "Thermal_Power": {},
         },
@@ -56,7 +73,7 @@ quantity_definitions = {
     "Current": {
         "subclasses": {
             "Electric_Current": {
-                BRICK.associatedQuantityKind: QUDTQK["ElectricCurrent"],
+                OWL.sameAs: QUDTQK["ElectricCurrent"],
                 "subclasses": {
                     "Current_Angle": {},
                     "Current_Magnitude": {},
@@ -68,43 +85,35 @@ quantity_definitions = {
         },
     },
     "Voltage": {
-        BRICK.associatedQuantityKind: QUDTQK["Voltage"],
         "subclasses": {
-            "Voltage_Magnitude": {},
+            "Voltage_Magnitude": {OWL.sameAs: QUDTQK["Voltage"]},
             "Voltage_Angle": {},
             "Voltage_Imbalance": {},
         },
     },
     "Daytime": {},
-    "Dewpoint": {BRICK.associatedQuantityKind: QUDTQK["DewPointTemperature"]},
+    "Dewpoint": {OWL.sameAs: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
     "Energy": {
         "subclasses": {
-            "Electric_Energy": {BRICK.associatedQuantityKind: QUDTQK["Energy"]},
-            "Thermal_Energy": {BRICK.associatedQuantityKind: QUDTQK["ThermalEnergy"]},
+            "Electric_Energy": {OWL.sameAs: QUDTQK["Energy"]},
+            "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
-    "Flow": {
-        BRICK.associatedQuantityKind: QUDTQK["VolumeFlowRate"],
-        "subclasses": {"Flow_Loss": {}},
-    },
+    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subclasses": {"Flow_Loss": {}}},
     "Frequency": {
-        BRICK.associatedQuantityKind: QUDTQK["Frequency"],
+        OWL.sameAs: QUDTQK["Frequency"],
         "subclasses": {"Alternating_Current_Frequency": {}},
     },
     "Humidity": {
         "subclasses": {
-            "Relative_Humidity": {
-                BRICK.associatedQuantityKind: QUDTQK["RelativeHumidity"]
-            },
-            "Absolute_Humidity": {
-                BRICK.associatedQuantityKind: QUDTQK["AbsoluteHumidity"]
-            },
+            "Relative_Humidity": {OWL.sameAs: QUDTQK["RelativeHumidity"]},
+            "Absolute_Humidity": {OWL.sameAs: QUDTQK["AbsoluteHumidity"]},
         }
     },
-    "Illuminance": {BRICK.associatedQuantityKind: QUDTQK["Illuminance"]},
+    "Illuminance": {OWL.sameAs: QUDTQK["Illuminance"]},
     "Irradiance": {
-        BRICK.associatedQuantityKind: QUDTQK["Irradiance"],
+        OWL.sameAs: QUDTQK["Irradiance"],
         "subclasses": {"Solar_Irradiance": {}},
     },
     "Level": {
@@ -116,42 +125,32 @@ quantity_definitions = {
         },
     },
     "Luminance": {
-        BRICK.associatedQuantityKind: QUDTQK["Luminance"],
+        # OWL.sameAs: QUDTQK["Luminance"],
         "subclasses": {
-            "Luminous_Flux": {BRICK.associatedQuantityKind: QUDTQK["LuminousFlux"]},
-            "Luminous_Intensity": {
-                BRICK.associatedQuantityKind: QUDTQK["LuminousIntensity"]
-            },
+            "Luminous_Flux": {OWL.sameAs: QUDTQK["LuminousFlux"]},
+            "Luminous_Intensity": {OWL.sameAs: QUDTQK["LuminousIntensity"]},
         },
     },
     "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
     "Position": {},
-    "Power_Factor": {BRICK.associatedQuantityKind: QUDTQK["PowerFactor"]},
+    "Power_Factor": {OWL.sameAs: QUDTQK["PowerFactor"]},
     "Precipitation": {},
     "Pressure": {
-        BRICK.associatedQuantityKind: QUDTQK["Pressure"],
+        # OWL.sameAs: QUDTQK["Pressure"],
         "subclasses": {
-            "Atmospheric_Pressure": {
-                BRICK.associatedQuantityKind: QUDTQK["AtmosphericPressure"]
-            },
+            "Atmospheric_Pressure": {OWL.sameAs: QUDTQK["AtmosphericPressure"]},
             "Dynamic_Pressure": {},
-            "Static_Pressure": {BRICK.associatedQuantityKind: QUDTQK["StaticPressure"]},
+            "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
             "Velocity_Pressure": {
+                OWL.sameAs: QUDTQK["DynamicPressure"],
                 OWL.equivalentClass: BRICK["Dynamic_Pressure"],
-                BRICK.associatedQuantityKind: QUDTQK["DynamicPressure"],
             },
         },
     },
-    "Radiance": {
-        BRICK.associatedQuantityKind: QUDTQK["Radiance"],
-        "subclasses": {"Solar_Radiance": {}},
-    },
-    "Speed": {
-        BRICK.associatedQuantityKind: QUDTQK["Speed"],
-        "subclasses": {"Wind_Speed": {}},
-    },
+    "Radiance": {OWL.sameAs: QUDTQK["Radiance"], "subclasses": {"Solar_Radiance": {}}},
+    "Speed": {OWL.sameAs: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
     "Temperature": {
-        BRICK.associatedQuantityKind: QUDTQK["Temperature"],
+        OWL.sameAs: QUDTQK["Temperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
@@ -160,25 +159,9 @@ quantity_definitions = {
         },
     },
     "Time": {
-        BRICK.associatedQuantityKind: QUDTQK["Time"],
+        OWL.sameAs: QUDTQK["Time"],
         "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
-    "Torque": {BRICK.associatedQuantityKind: QUDTQK["Torque"]},
+    "Torque": {OWL.sameAs: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }
-
-
-def associate_units(outputG):
-    g = brickschema.graph.Graph()
-    g.g.bind("qudt", QUDT)
-    for triple in outputG:
-        g.add(triple)
-    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
-    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
-    unit_map = g.query(
-        "SELECT ?quant ?unit WHERE {\
-        ?quant a brick:Quantity .\
-        ?quant brick:associatedQuantityKind/qudt:applicableUnit ?unit . }"
-    )
-    for brickquant, unit in unit_map:
-        outputG.add((brickquant, QUDT.applicableUnit, unit))

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -63,6 +63,7 @@ quantity_definitions = {
         },
     },
     "Voltage": {
+        OWL.equivalentClass: QUDTQK["Voltage"],
         "subclasses": {
             "Electric_Voltage": {
                 "subclasses": {
@@ -74,14 +75,34 @@ quantity_definitions = {
         },
     },
     "Daytime": {},
-    "Dewpoint": {},
+    "Dewpoint": {OWL.equivalentClass: QUDTQK["DewPointTemperature"]},
     "Direction": {"subclasses": {"Wind_Direction": {}}},
-    "Energy": {"subclasses": {"Electric_Energy": {}, "Thermal_Energy": {}}},
-    "Flow": {"subclasses": {"Flow_Loss": {}}},
-    "Frequency": {"subclasses": {"Alternating_Current_Frequency": {}}},
-    "Humidity": {"subclasses": {"Relative_Humidity": {}}},
-    "Illuminance": {},
-    "Irradiance": {"subclasses": {"Solar_Irradiance": {}}},
+    "Energy": {
+        OWL.equivalentClass: QUDTQK["Energy"],
+        "subclasses": {
+            "Electric_Energy": {},
+            "Thermal_Energy": {OWL.equivalentClass: QUDTQK["ThermalEnergy"]},
+        },
+    },
+    "Flow": {
+        OWL.equivalentClass: QUDTQK["VolumeFlowRate"],
+        "subclasses": {"Flow_Loss": {}},
+    },
+    "Frequency": {
+        OWL.equivalentClass: QUDTQK["Frequency"],
+        "subclasses": {"Alternating_Current_Frequency": {}},
+    },
+    "Humidity": {
+        "subclasses": {
+            "Relative_Humidity": {OWL.equivalentClass: QUDTQK["RelativeHumidity"]},
+            "Absolute_Humidity": {OWL.equivalentClass: QUDTQK["AbsoluteHumidity"]},
+        }
+    },
+    "Illuminance": {OWL.equivalentClass: QUDTQK["Illuminance"]},
+    "Irradiance": {
+        OWL.equivalentClass: QUDTQK["Irradiance"],
+        "subclasses": {"Solar_Irradiance": {}},
+    },
     "Level": {
         "subclasses": {
             "CO2_Level": {},
@@ -90,21 +111,40 @@ quantity_definitions = {
             "TVOC_Level": {},
         },
     },
-    "Luminance": {"subclasses": {"Luminous_Flux": {}, "Luminous_Intensity": {}}},
-    "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
-    "Position": {},
-    "Power_Factor": {},
-    "Precipitation": {},
-    "Pressure": {
+    "Luminance": {
+        OWL.equivalentClass: QUDTQK["Luminance"],
         "subclasses": {
-            "Atmospheric_Pressure": {},
-            "Static_Pressure": {},
-            "Velocity_Pressure": {},
+            "Luminous_Flux": {OWL.equivalentClass: QUDTQK["LuminousFlux"]},
+            "Luminous_Intensity": {OWL.equivalentClass: QUDTQK["LuminousIntensity"]},
         },
     },
-    "Radiance": {"subclasses": {"Solar_Radiance": {}}},
-    "Speed": {"subclasses": {"Wind_Speed": {}}},
+    "Occupancy": {"subclasses": {"Occupancy_Count": {}, "Occupancy_Percentage": {}}},
+    "Position": {},
+    "Power_Factor": {OWL.equivalentClass: QUDTQK["PowerFactor"]},
+    "Precipitation": {},
+    "Pressure": {
+        OWL.equivalentClass: QUDTQK["Pressure"],
+        "subclasses": {
+            "Atmospheric_Pressure": {
+                OWL.equivalentClass: QUDTQK["AtmosphericPressure"]
+            },
+            "Dynamic_Pressure": {},
+            "Static_Pressure": {OWL.equivalentClass: QUDTQK["StaticPressure"]},
+            "Velocity_Pressure": {
+                OWL.equivalentClass: [
+                    QUDTQK["DynamicPressure"],
+                    BRICK["Dynamic_Pressure"],
+                ]
+            },
+        },
+    },
+    "Radiance": {
+        OWL.equivalentClass: QUDTQK["Radiance"],
+        "subclasses": {"Solar_Radiance": {}},
+    },
+    "Speed": {OWL.equivalentClass: QUDTQK["Speed"], "subclasses": {"Wind_Speed": {}}},
     "Temperature": {
+        OWL.equivalentClass: QUDTQK["Temperature"],
         "subclasses": {
             "Operative_Temperature": {},
             "Radiant_Temperature": {},
@@ -112,7 +152,10 @@ quantity_definitions = {
             "Wet_Bulb_Temperature": {},
         },
     },
-    "Time": {"subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}}},
-    "Torque": {},
+    "Time": {
+        OWL.equivalentClass: QUDTQK["Time"],
+        "subclasses": {"Acceleration_Time": {}, "Deceleration_Time": {}},
+    },
+    "Torque": {OWL.equivalentClass: QUDTQK["Torque"]},
     "Weather_Condition": {},
 }

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -283,7 +283,6 @@ quantity_definitions = {
                 RDFS.label: Literal("VoltageAngle"),
                 SKOS.broader: BRICK.PhasorAngle,
             },
-            # TODO: finish this
             "Voltage_Imbalance": {
                 SKOS.definition: Literal("The percent deviation from average voltage"),
                 QUDT.applicableUnit: [UNIT.PERCENT],

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -14,6 +14,10 @@ g = sess.expand(g)
 
 
 def get_units(brick_quantity):
+    """
+    Fetches the QUDT unit and symbol (as a Literal) from the QUDT ontology so
+    in order to avoid having to pull the full QUDT ontology into Brick
+    """
     res = g.query(
         f"""SELECT ?unit ?symbol WHERE {{
                     <{brick_quantity}> qudt:applicableUnit ?unit .

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -151,7 +151,10 @@ quantity_definitions = {
                 },
             },
             "Peak_Power": {
-                OWL.sameAs: QUDTQK["ElectricPower"],
+                QUDT.applicableUnit: [UNIT.KiloW, UNIT.MegaW, UNIT.MilliW, UNIT.W],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("PeakPower"),
                 SKOS.definition: Literal(
                     "Tracks the highest (peak) observed power in some interval"
                 ),

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -459,7 +459,7 @@ quantity_definitions = {
             "Solar_Radiance": {
                 QUDT.applicableUnit: [UNIT["W-PER-M2-SR"]],
                 SKOS.definition: Literal(
-                    "The amount of light that passes through or is emitted from the sun and falls withi na given solid angle in a specified direction",
+                    "The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction",
                 ),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 RDFS.label: Literal("Solar_Radiance"),

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -151,6 +151,7 @@ quantity_definitions = {
                 },
             },
             "Peak_Power": {
+                SKOS.broader: QUDTQK.Power,
                 QUDT.applicableUnit: [UNIT.KiloW, UNIT.MegaW, UNIT.MilliW, UNIT.W],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L2I0M1H0T-3D0"],
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -327,8 +327,21 @@ quantity_definitions = {
             "Thermal_Energy": {OWL.sameAs: QUDTQK["ThermalEnergy"]},
         },
     },
-    # TODO: is this https://en.wikipedia.org/wiki/Friction_loss ? need to ask
-    "Flow": {OWL.sameAs: QUDTQK["VolumeFlowRate"], "subconcepts": {"Flow_Loss": {}}},
+    "Flow": {
+        OWL.sameAs: QUDTQK["VolumeFlowRate"],
+        "subconcepts": {
+            "Flow_Loss": {
+                QUDT.applicableUnit: [UNIT["M3-PER-SEC"]],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L3I0M0H0T-1D0"],
+                SKOS.definition: Literal(
+                    "The amount of flow rate that is lost during distribution"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("FlowLoss"),
+                SKOS.broader: BRICK.Flow,
+            },
+        },
+    },
     "Frequency": {
         OWL.sameAs: QUDTQK["Frequency"],
         "subconcepts": {"Alternating_Current_Frequency": {}},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -52,8 +52,7 @@ quantity_definitions = {
                 "subclasses": {
                     "Apparent_Power": {OWL.sameAs: QUDTQK["ApparentPower"]},
                     "Active_Power": {
-                        OWL.sameAs: QUDTQK["ActivePower"],
-                        OWL.equivalentClass: BRICK["Real_Power"],
+                        OWL.sameAs: [QUDTQK["ActivePower"], BRICK["Real_Power"]],
                     },
                     "Real_Power": {},
                     "Reactive_Power": {OWL.sameAs: QUDTQK["ReactivePower"]},
@@ -142,8 +141,7 @@ quantity_definitions = {
             "Dynamic_Pressure": {},
             "Static_Pressure": {OWL.sameAs: QUDTQK["StaticPressure"]},
             "Velocity_Pressure": {
-                OWL.sameAs: QUDTQK["DynamicPressure"],
-                OWL.equivalentClass: BRICK["Dynamic_Pressure"],
+                OWL.sameAs: [QUDTQK["DynamicPressure"], BRICK["Dynamic_Pressure"]],
             },
         },
     },

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -178,7 +178,11 @@ def define_classes_narrower(definitions, parent, typeclass, pun_classes=False):
         ]
         for propname in other_properties:
             propval = defn[propname]
-            G.add((classname, propname, propval))
+            if isinstance(propval, list):
+                for pv in propval:
+                    G.add((classname, propname, pv))
+            else:
+                G.add((classname, propname, propval))
 
 
 def define_classes(definitions, parent, pun_classes=False):

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -6,7 +6,7 @@ from rdflib.collection import Collection
 
 from bricksrc.ontology import define_ontology
 
-from bricksrc.namespaces import BRICK, RDF, OWL, RDFS, TAG, SOSA, SKOS, QUDT
+from bricksrc.namespaces import BRICK, RDF, OWL, RDFS, TAG, SOSA, SKOS, QUDT, QUDTQK
 from bricksrc.namespaces import bind_prefixes
 
 from bricksrc.setpoint import setpoint_definitions
@@ -23,7 +23,7 @@ from bricksrc.equipment import (
     security_subclasses,
 )
 from bricksrc.substances import substances
-from bricksrc.quantities import quantity_definitions, get_units
+from bricksrc.quantities import quantity_definitions, get_units, quantitykind_extensions
 from bricksrc.properties import properties
 from bricksrc.tags import tags
 
@@ -280,6 +280,19 @@ def define_properties(definitions, superprop=None):
                 G.add((BRICK[prop], propname, propval))
 
 
+def define_quantitykind_extensions(defs):
+    """
+    Defines extensions to QUDT's QuantityKinds
+    """
+    for quantitykind, defn in defs.items():
+        G.add((QUDTQK[quantitykind], A, QUDT.QuantityKind))
+        for propname, propvals in defn.items():
+            if not isinstance(propvals, list):
+                propvals = [propvals]
+            for propval in propvals:
+                G.add((QUDTQK[quantitykind], propname, propval))
+
+
 logging.info("Beginning BRICK Ontology compilation")
 # handle ontology definition
 define_ontology(G)
@@ -350,6 +363,7 @@ define_classes(substances, BRICK.Substance, pun_classes=True)
 
 # this defines the SKOS-based concept hierarchy for BRICK Quantities
 define_concept_hierarchy(quantity_definitions, BRICK.Quantity)
+define_quantitykind_extensions(quantitykind_extensions)
 
 # for all Quantities, copy part of the QUDT unit definitions over
 res = G.query(

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -23,7 +23,7 @@ from bricksrc.equipment import (
     security_subclasses,
 )
 from bricksrc.substances import substances
-from bricksrc.quantities import quantity_definitions, get_units, quantitykind_extensions
+from bricksrc.quantities import quantity_definitions, get_units
 from bricksrc.properties import properties
 from bricksrc.tags import tags
 
@@ -280,6 +280,7 @@ def define_properties(definitions, superprop=None):
                 G.add((BRICK[prop], propname, propval))
 
 
+# TODO: remove
 def define_quantitykind_extensions(defs):
     """
     Defines extensions to QUDT's QuantityKinds
@@ -363,7 +364,6 @@ define_classes(substances, BRICK.Substance, pun_classes=True)
 
 # this defines the SKOS-based concept hierarchy for BRICK Quantities
 define_concept_hierarchy(quantity_definitions, BRICK.Quantity)
-define_quantitykind_extensions(quantitykind_extensions)
 
 # for all Quantities, copy part of the QUDT unit definitions over
 res = G.query(

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -339,12 +339,13 @@ G.add((BRICK.Substance, A, OWL.Class))
 G.add((BRICK.Substance, RDFS.subClassOf, SKOS.Concept))
 
 # We make the punning explicit here. Any subclass of brick:Substance
-# or brick:Quantity is itself a substance or quantity. There is one canonical
-# instance of each class, which is indicated by referencing the class itself.
+# is itself a substance or quantity. There is one canonical instance of
+# each class, which is indicated by referencing the class itself.
 #
 #    bldg:tmp1      a           brick:Air_Temperature_Sensor;
 #               brick:measures  brick:Air ,
 #                               brick:Temperature .
+#
 # This makes Substance metaclasses.
 define_classes(substances, BRICK.Substance, pun_classes=True)
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -172,7 +172,11 @@ def define_classes(definitions, parent, pun_classes=False):
         ]
         for propname in other_properties:
             propval = defn[propname]
-            G.add((classname, propname, propval))
+            if isinstance(propval, list):
+                for pv in propval:
+                    G.add((classname, propname, pv))
+            else:
+                G.add((classname, propname, propval))
 
 
 def define_properties(definitions, superprop=None):

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -23,7 +23,7 @@ from bricksrc.equipment import (
     security_subclasses,
 )
 from bricksrc.substances import substances
-from bricksrc.quantities_sameas import quantity_definitions, get_units
+from bricksrc.quantities import quantity_definitions, get_units
 from bricksrc.properties import properties
 from bricksrc.tags import tags
 

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -121,7 +121,7 @@ def add_tags(klass, definition):
     intersection_classes[klass] = tuple(sorted(definition))
 
 
-def define_concept_hierarchy(definitions, typeclass, broader=None):
+def define_concept_hierarchy(definitions, typeclasses, broader=None):
     """
     Generates triples to define the SKOS hierarchy of concepts given by
     'definitions', which are all instances of the class given by 'typeclass'.
@@ -131,7 +131,8 @@ def define_concept_hierarchy(definitions, typeclass, broader=None):
     """
     for concept, defn in definitions.items():
         concept = BRICK[concept]
-        G.add((concept, A, typeclass))
+        for typeclass in typeclasses:
+            G.add((concept, A, typeclass))
         # mark broader concept if one exists
         if broader is not None:
             G.add((concept, SKOS.broader, broader))
@@ -157,7 +158,9 @@ def define_concept_hierarchy(definitions, typeclass, broader=None):
         # this is a nested dictionary
         subconceptdef = defn.get("subconcepts", {})
         assert isinstance(subconceptdef, dict)
-        define_concept_hierarchy(subconceptdef, BRICK.Quantity, broader=concept)
+        define_concept_hierarchy(
+            subconceptdef, [BRICK.Quantity, QUDT.QuantityKind], broader=concept
+        )
 
         # handle 'parents' subconcepts (links outside of tree-based hierarchy)
         parents = defn.get("parents", [])
@@ -363,7 +366,7 @@ G.add((BRICK.Substance, A, OWL.Class))
 define_classes(substances, BRICK.Substance, pun_classes=True)
 
 # this defines the SKOS-based concept hierarchy for BRICK Quantities
-define_concept_hierarchy(quantity_definitions, BRICK.Quantity)
+define_concept_hierarchy(quantity_definitions, [BRICK.Quantity, QUDT.QuantityKind])
 
 # for all Quantities, copy part of the QUDT unit definitions over
 res = G.query(

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -336,7 +336,6 @@ G.add((BRICK.Quantity, RDFS.subClassOf, SKOS.Concept))
 G.add((BRICK.Substance, RDFS.subClassOf, SOSA.FeatureOfInterest))
 G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Substance, A, OWL.Class))
-G.add((BRICK.Substance, RDFS.subClassOf, SKOS.Concept))
 
 # We make the punning explicit here. Any subclass of brick:Substance
 # is itself a substance or quantity. There is one canonical instance of

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -18,7 +18,7 @@ from bricksrc.parameter import parameter_definitions
 from bricksrc.location import location_subclasses
 from bricksrc.equipment import equipment_subclasses, hvac_subclasses, valve_subclasses
 from bricksrc.substances import substances
-from bricksrc.quantities import quantity_definitions
+from bricksrc.quantities import quantity_definitions, associate_units
 from bricksrc.properties import properties
 from bricksrc.tags import tags
 
@@ -281,6 +281,10 @@ G.add((BRICK.Substance, A, OWL.Class))
 # This makes Substance and Quantity metaclasses.
 define_classes(substances, BRICK.Substance, pun_classes=True)
 define_classes(quantity_definitions, BRICK.Quantity, pun_classes=True)
+
+# associate QUDT units using QUDT.applicableUnit by following the
+# owl.equivalentClass constructions in bricksrc/quantities.py
+associate_units(G)
 
 logging.info("Finishing Tag definitions")
 # declares that all tags are pairwise different; i.e. no two tags refer

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -155,11 +155,11 @@ def define_concept_hierarchy(definitions, typeclass, broader=None):
 
         # define class structure
         # this is a nested dictionary
-        subclassdef = defn.get("subclasses", {})
-        assert isinstance(subclassdef, dict)
-        define_concept_hierarchy(subclassdef, BRICK.Quantity, broader=concept)
+        subconceptdef = defn.get("subconcepts", {})
+        assert isinstance(subconceptdef, dict)
+        define_concept_hierarchy(subconceptdef, BRICK.Quantity, broader=concept)
 
-        # handle 'parents' subclasses (links outside of tree-based hierarchy)
+        # handle 'parents' subconcepts (links outside of tree-based hierarchy)
         parents = defn.get("parents", [])
         assert isinstance(parents, list)
         for _parent in parents:
@@ -167,7 +167,7 @@ def define_concept_hierarchy(definitions, typeclass, broader=None):
 
         # all other key-value pairs in the definition are
         # property-object pairs
-        expected_properties = ["parents", "tags", "substances", "subclasses"]
+        expected_properties = ["parents", "tags", "substances", "subconcepts"]
         other_properties = [
             prop for prop in defn.keys() if prop not in expected_properties
         ]

--- a/shacl/BrickShape.ttl
+++ b/shacl/BrickShape.ttl
@@ -1,17 +1,21 @@
 @prefix brick: <https://brickschema.org/schema/1.1/Brick#> .
 @prefix bsh: <https://brickschema.org/schema/1.1/BrickShape#> .
-@prefix dcterms: <http://purl.org/dc/terms#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sdo: <http://schema.org#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix sosa: <http://www.w3.org/ns/sosa#> .
-@prefix tag: <https://brickschema.org/schema/1.1/BrickTag#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bsh:associatedQuantityKindDomainShape a sh:NodeShape ;
+    sh:class brick:Quantity ;
+    sh:message "Property associatedQuantityKind has subject with incorrect type" ;
+    sh:targetSubjectsOf brick:associatedQuantityKind .
+
+bsh:associatedQuantityKindRangeShape a sh:NodeShape ;
+    sh:property [ sh:class qudt:QuantityKind ;
+            sh:message "Property associatedQuantityKind has object with incorrect type" ;
+            sh:path brick:associatedQuantityKind ] ;
+    sh:targetSubjectsOf brick:associatedQuantityKind .
 
 bsh:feedsAirHasInputSubstanceShape a sh:NodeShape ;
     sh:property [ sh:class brick:Air ;
@@ -82,6 +86,17 @@ bsh:hasTagRangeShape a sh:NodeShape ;
             sh:message "Property hasTag has object with incorrect type" ;
             sh:path brick:hasTag ] ;
     sh:targetSubjectsOf brick:hasTag .
+
+bsh:hasUnitDomainShape a sh:NodeShape ;
+    sh:class brick:Point ;
+    sh:message "Property hasUnit has subject with incorrect type" ;
+    sh:targetSubjectsOf brick:hasUnit .
+
+bsh:hasUnitRangeShape a sh:NodeShape ;
+    sh:property [ sh:class unit:Unit ;
+            sh:message "Property hasUnit has object with incorrect type" ;
+            sh:path brick:hasUnit ] ;
+    sh:targetSubjectsOf brick:hasUnit .
 
 bsh:isAssociatedWithDomainShape a sh:NodeShape ;
     sh:class brick:Tag ;

--- a/shacl/BrickShape.ttl
+++ b/shacl/BrickShape.ttl
@@ -1,21 +1,9 @@
 @prefix brick: <https://brickschema.org/schema/1.1/Brick#> .
 @prefix bsh: <https://brickschema.org/schema/1.1/BrickShape#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix qudt: <http://qudt.org/schema/qudt/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
-
-bsh:associatedQuantityKindDomainShape a sh:NodeShape ;
-    sh:class brick:Quantity ;
-    sh:message "Property associatedQuantityKind has subject with incorrect type" ;
-    sh:targetSubjectsOf brick:associatedQuantityKind .
-
-bsh:associatedQuantityKindRangeShape a sh:NodeShape ;
-    sh:property [ sh:class qudt:QuantityKind ;
-            sh:message "Property associatedQuantityKind has object with incorrect type" ;
-            sh:path brick:associatedQuantityKind ] ;
-    sh:targetSubjectsOf brick:associatedQuantityKind .
 
 bsh:feedsAirHasInputSubstanceShape a sh:NodeShape ;
     sh:property [ sh:class brick:Air ;

--- a/support/SCHEMA_QUDT-v2.1.ttl
+++ b/support/SCHEMA_QUDT-v2.1.ttl
@@ -1,0 +1,3215 @@
+# baseURI: http://qudt.org/2.1/schema/qudt
+# imports: http://www.linkedmodel.org/schema/dtype
+# imports: http://www.linkedmodel.org/schema/vaem
+# imports: http://www.w3.org/2004/02/skos/core
+
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dtype: <http://www.linkedmodel.org/schema/dtype#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qudt.type: <http://qudt.org/vocab/type/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
+@prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+dct:abstract
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy dct: ;
+  rdfs:label "abstract" ;
+  rdfs:range xsd:string ;
+.
+dct:author
+  a rdf:Property ;
+  rdfs:range xsd:string ;
+.
+dct:contributor
+  a rdf:Property ;
+  rdfs:label "contributor" ;
+  rdfs:range xsd:string ;
+.
+dct:created
+  a rdf:Property ;
+  rdfs:label "created" ;
+  rdfs:range xsd:date ;
+.
+dct:creator
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "creator" ;
+  rdfs:range xsd:string ;
+.
+dct:description
+  a rdf:Property ;
+  a owl:AnnotationProperty ;
+  rdfs:label "description" ;
+.
+dct:modified
+  a rdf:Property ;
+  rdfs:label "modified" ;
+  rdfs:range xsd:date ;
+.
+dct:rights
+  a owl:AnnotationProperty ;
+  rdfs:label "rights" ;
+  rdfs:range xsd:string ;
+.
+dct:source
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy dct: ;
+  rdfs:label "source" ;
+  rdfs:range xsd:anyURI ;
+.
+dct:subject
+  a owl:AnnotationProperty ;
+  rdfs:label "subject" ;
+  rdfs:range xsd:string ;
+.
+dct:title
+  a owl:AnnotationProperty ;
+  rdfs:label "title" ;
+  rdfs:range xsd:string ;
+.
+<http://qudt.org/2.1/schema/qudt>
+  a owl:Ontology ;
+  vaem:hasGraphMetadata vaem:GMD_QUDT-SCHEMA ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Schema - Version 2.1.2" ;
+  owl:imports <http://www.linkedmodel.org/schema/dtype> ;
+  owl:imports <http://www.linkedmodel.org/schema/vaem> ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt> ;
+.
+qudt:Aspect
+  a qudt:AspectClass ;
+  rdfs:comment "An aspect is an abstract type class that defines properties that can be reused."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Aspect" ;
+  rdfs:subClassOf owl:Thing ;
+.
+qudt:AspectClass
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Aspect Class" ;
+  rdfs:subClassOf rdfs:Class ;
+.
+qudt:BaseDimensionMagnitude
+  a owl:Class ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dimensional_analysis"^^xsd:anyURI ;
+  qudt:informativeReference "http://web.mit.edu/2.25/www/pdf/DA_unified.pdf"^^xsd:anyURI ;
+  rdfs:comment """<p class=\"lm-para\">A <em>Dimension</em> expresses a magnitude for a base quantiy kind such as mass, length and time.</p>
+<p class=\"lm-para\">DEPRECATED - each exponent is expressed as a property. Keep until a validaiton of this has been done.</p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Base Dimension Magnitude" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty qudt:hasBaseQuantityKind ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:float ;
+      owl:onProperty qudt:vectorMagnitude ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:int ;
+      owl:onProperty qudt:hasBaseQuantityKind ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:int ;
+      owl:onProperty qudt:vectorMagnitude ;
+    ] ;
+.
+qudt:BaseUnit
+  a owl:Class ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Base-Units"^^xsd:anyURI ;
+  qudt:informativeReference "http://dbpedia.org/resource/Category:SI_base_units"^^xsd:anyURI ;
+  rdfs:comment "A <em>Base Unit</em> is a unit adopted by convention for a base quantity."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Base Unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:BigEndian
+  a qudt:EndianType ;
+  dtype:literal "big" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Big Endian" ;
+.
+qudt:BinaryPrefixUnit
+  a owl:Class ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Binary_prefix"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Binary_prefix"^^xsd:anyURI ;
+  rdfs:comment "A <em>Binary Prefix Unit</em> is a unit prefix for multiples of units in data processing, data transmission, and digital information, notably the bit and the byte, to indicate multiplication by a power of 2."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Binary Prefix Unit" ;
+  rdfs:subClassOf qudt:PrefixUnit ;
+.
+qudt:BinaryScaledUnit
+  a owl:Class ;
+  rdfs:comment "A <em>Binary Scaled Unit</em> specifies a binary multipler for scaling."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Binary scaled unit" ;
+  rdfs:subClassOf qudt:ScaledUnit ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:BinaryPrefixUnit ;
+      owl:onProperty qudt:hasPrefixUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasPrefixUnit ;
+    ] ;
+.
+qudt:BitEncodingType
+  a owl:Class ;
+  dct:description "A bit encoding is a correspondence between the two possible values of a bit, 0 or 1, and some interpretation. For example, in a boolean encoding, a bit denotes a truth value, where 0 corresponds to False and 1 corresponds to True." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Bit Encoding" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:BooleanEncoding
+  a qudt:BooleanEncodingType ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Boolean Encoding" ;
+.
+qudt:BooleanEncodingType
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Boolean encoding type" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:ByteEncodingType
+  a owl:Class ;
+  dct:description "This class contains the various ways that information may be encoded into bytes." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Byte Encoding" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:CGS-Unit
+  a owl:Class ;
+  qudt:citation "http://scienceworld.wolfram.com/physics/cgs.html" ;
+  qudt:citation "https://en.wikipedia.org/wiki/Centimetre%E2%80%93gram%E2%80%93second_system_of_units" ;
+  qudt:citation "https://www.unc.edu/~rowlett/units/cgsmks.html" ;
+  rdfs:comment """<p>The C.G.S. System of Units defined four units of measure as a basic set from which all otherC.G.S units are derived. These are: </p>
+<ol>
+<li>length: cm = centimetre; </li>
+<li>mass: g = gram;</li>
+<li> time: s = second; </li>
+<li> luminous intensity: cd = candela, originally new candle.</li>
+</ol>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS Unit" ;
+  rdfs:subClassOf qudt:NonSI-Unit ;
+.
+qudt:CT_COUNTABLY-INFINITE
+  a qudt:CardinalityType ;
+  dct:description "A set of numbers is called countably infinite if there is a way to enumerate them.  Formally this is done with a bijection function that associates each number in the set with exactly one of the positive integers.  The set of all fractions is also countably infinite.  In other words, any set \\(X\\) that has the same cardinality as the set of the natural numbers, or \\(| X | \\; =  \\; | \\mathbb N | \\; = \\; \\aleph0\\), is said to be a countably infinite set."^^qudt:LatexString ;
+  qudt:informativeReference "http://www.math.vanderbilt.edu/~schectex/courses/infinity.pdf"^^xsd:anyURI ;
+  qudt:literal "countable" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Countably Infinite Cardinality Type" ;
+.
+qudt:CT_FINITE
+  a qudt:CardinalityType ;
+  dct:description "Any set \\(X\\) with cardinality less than that of the natural numbers, or \\(| X | \\\\; <  \\; | \\\\mathbb N | \\), is said to be a finite set."^^qudt:LatexString ;
+  qudt:literal "finite" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Finite Cardinality Type" ;
+.
+qudt:CT_UNCOUNTABLE
+  a qudt:CardinalityType ;
+  dct:description "Any set with cardinality greater than that of the natural numbers, or \\(| X | \\; >  \\; | \\mathbb N | \\),  for example \\(| R| \\; =  \\;  c  \\; > |\\mathbb N |\\), is said to be uncountable."^^qudt:LatexString ;
+  qudt:literal "uncountable" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Uncountable Cardinality Type" ;
+.
+qudt:CardinalityType
+  a owl:Class ;
+  dct:description "In mathematics, the cardinality of a set is a measure of the number of elements of the set.  For example, the set \\(A = {2, 4, 6}\\) contains 3 elements, and therefore \\(A\\) has a cardinality of 3. There are two approaches to cardinality – one which compares sets directly using bijections and injections, and another which uses cardinal numbers."^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cardinal_number"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cardinality"^^xsd:anyURI ;
+  qudt:plainTextDescription "In mathematics, the cardinality of a set is a measure of the number of elements of the set.  For example, the set 'A = {2, 4, 6}' contains 3 elements, and therefore 'A' has a cardinality of 3. There are two approaches to cardinality – one which compares sets directly using bijections and injections, and another which uses cardinal numbers." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Cardinality Type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  owl:oneOf (
+      qudt:CT_COUNTABLY-INFINITE
+      qudt:CT_FINITE
+    ) ;
+.
+qudt:CharEncoding
+  a qudt:BooleanEncodingType ;
+  a qudt:CharEncodingType ;
+  dc:description "7 bits of 1 octet" ;
+  qudt:bytes 1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Char Encoding" ;
+.
+qudt:CharEncodingType
+  a owl:Class ;
+  dct:description "The class of all character encoding schemes, each of which defines a rule or algorithm for encoding character data as a sequence of bits or bytes." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Char Encoding Type" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:Citation
+  a owl:Class ;
+  rdfs:comment "Provides a simple way of making citations."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Citation" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:url ;
+    ] ;
+.
+qudt:Comment
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Comment" ;
+  rdfs:subClassOf qudt:Verifiable ;
+  rdfs:subClassOf owl:Thing ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty dct:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:rationale ;
+    ] ;
+.
+qudt:Concept
+  a owl:Class ;
+  rdfs:comment "The root class for all QUDT concepts."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Concept" ;
+  rdfs:subClassOf owl:Thing ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Rule ;
+      owl:onProperty qudt:hasRule ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty dct:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:plainTextDescription ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:abbreviation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:id ;
+    ] ;
+.
+qudt:ConstantValue
+  a owl:Class ;
+  rdfs:comment "Used to specify the values of a constant."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Constant value" ;
+  rdfs:subClassOf qudt:QuantityValue ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:exactConstant ;
+    ] ;
+.
+qudt:CountingUnit
+  a owl:Class ;
+  rdfs:comment "Used for all units that express counts. Examples are Atomic Number, Number, Number per Year, Percent and Sample per Second."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Counting Unit" ;
+  rdfs:subClassOf qudt:DimensionlessUnit ;
+  rdfs:subClassOf qudt:ResourceUnit ;
+.
+qudt:CurrencyUnit
+  a owl:Class ;
+  rdfs:comment "Currency Units have their own subclass of unit because: (a) they have additonal properites such as 'country' and (b) their URIs do not conform to the same rules as other units."^^rdf:HTML ;
+  rdfs:comment "Used for all units that express currency."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Currency Unit" ;
+  rdfs:subClassOf qudt:DimensionlessUnit ;
+  rdfs:subClassOf qudt:ResourceUnit ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:DataEncoding
+  a owl:Class ;
+  rdfs:comment "<p><em>Data Encoding</em> expresses the properties that specify how data is represented at the bit and byte level. These properties are applicable to describing raw data.</p>"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Data Encoding" ;
+  rdfs:subClassOf qudt:Aspect ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Encoding ;
+      owl:onProperty qudt:encoding ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:EndianType ;
+      owl:onProperty qudt:bitOrder ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bitOrder ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:byteOrder ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:encoding ;
+    ] ;
+.
+qudt:Datatype
+  a owl:Class ;
+  dct:description "A data type is a definition of a set of values (for example, \"all integers between 0 and 10\"), and the allowable operations on those values; the meaning of the data; and the way values of that type can be stored. Some types are primitive - built-in to the language, with no visible internal structure - e.g. Boolean; others are composite - constructed from one or more other types (of either kind) - e.g. lists, arrays, structures, unions. Object-oriented programming extends this with classes which encapsulate both the structure of a type and the operations that can be performed on it. Some languages provide strong typing, others allow implicit type conversion and/or explicit type conversion." ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data_type"^^xsd:anyURI ;
+  qudt:informativeReference "http://foldoc.org/data+type"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.princeton.edu/~achaney/tmve/wiki100k/docs/Data_type.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Datatype" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:CardinalityType ;
+      owl:onProperty qudt:cardinality ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Datatype ;
+      owl:onProperty qudt:basis ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:OrderedType ;
+      owl:onProperty qudt:orderedType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:ansiSQLName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:basis ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bounded ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:cName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:cardinality ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:id ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:javaName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:jsName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:matlabName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:microsoftSQLServerName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:mySQLName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:odbcName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:oleDBName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:oracleSQLName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:orderedType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:protocolBuffersName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:pythonName ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:vbName ;
+    ] ;
+.
+qudt:DateTimeStringEncodingType
+  a owl:Class ;
+  dct:description "Date Time encodings are logical encodings for expressing date/time quantities as strings by applying unambiguous formatting and parsing rules." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Date Time String Encoding Type" ;
+  rdfs:subClassOf qudt:StringEncodingType ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:allowedPattern ;
+    ] ;
+.
+qudt:DecimalPrefixUnit
+  a owl:Class ;
+  rdfs:comment "A <em>Decimal Prefix Unit</em> is a unit prefix for multiples of units that are powers of 10."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Decimal Prefix Unit" ;
+  rdfs:subClassOf qudt:PrefixUnit ;
+.
+qudt:DecimalScaledUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Decimal scaled unit" ;
+  rdfs:subClassOf qudt:ScaledUnit ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:DecimalPrefixUnit ;
+      owl:onProperty qudt:hasPrefixUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasPrefixUnit ;
+    ] ;
+.
+qudt:DerivedCoherentUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Derived coherent unit" ;
+  rdfs:subClassOf qudt:DerivedUnit ;
+  owl:disjointWith qudt:DerivedNonCoherentUnit ;
+.
+qudt:DerivedNonCoherentUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Derived non coherent unit" ;
+  rdfs:subClassOf qudt:DerivedUnit ;
+  owl:disjointWith qudt:DerivedCoherentUnit ;
+.
+qudt:DerivedUnit
+  a owl:Class ;
+  a owl:DeprecatedClass ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Category:SI_derived_units"^^xsd:anyURI ;
+  rdfs:comment "A DerivedUnit is a type specification for units that are derived from other units."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Derived Unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:DimensionlessUnit
+  a owl:Class ;
+  rdfs:comment "A Dimensionless Unit is a quantity for which all the exponents of the factors corresponding to the base quantities in its quantity dimension are zero."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Dimensionless Unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:Discipline
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Discipline" ;
+  rdfs:subClassOf qudt:Concept ;
+.
+qudt:DomainSpecificUnit
+  a owl:Class ;
+  rdfs:comment "A domain-specific unit is a categorization of how units may be associated with an area of science, engineering or other discipline."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Domain-specific Unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:DoublePrecisionEncoding
+  a qudt:FloatingPointEncodingType ;
+  qudt:bytes 64 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Single Precision Real Encoding" ;
+.
+qudt:Encoding
+  a owl:Class ;
+  dct:description "An encoding is a rule or algorithm that is used to convert data from a native, or unspecified form into a specific form that satisfies the encoding rules. Examples of encodings include character encodings, such as UTF-8." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Encoding" ;
+  rdfs:subClassOf skos:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bits ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bytes ;
+    ] ;
+.
+qudt:EndianType
+  a owl:Class ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Endianness"^^xsd:anyURI ;
+  qudt:plainTextDescription "In computing, endianness is the ordering used to represent some kind of data as a sequence of smaller units. Typical cases are the order in which integer values are stored as bytes in computer memory (relative to a given memory addressing scheme) and the transmission order over a network or other medium. When specifically talking about bytes, endianness is also referred to simply as byte order.  Most computer processors simply store integers as sequences of bytes, so that, conceptually, the encoded value can be obtained by simple concatenation. For an 'n-byte' integer value this allows 'n!' (n factorial) possible representations (one for each byte permutation). The two most common of them are: increasing numeric significance with increasing memory addresses, known as little-endian, and its opposite, called big-endian." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Endian Type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  owl:oneOf (
+      qudt.type:LittleEndian
+      qudt.type:BigEndian
+    ) ;
+.
+qudt:EnumeratedValue
+  a owl:Class ;
+  dct:Description """<p>This class is for all enumerated and/or coded values.  For example, it contains the dimension objects that are the basis elements in some abstract vector space associated with a quantity kind system. Another use is for the base dimensions for quantity systems. Each quantity kind system that defines a base set has a corresponding ordered enumeration whose elements are the dimension objects for the base quantity kinds. The order of the dimensions in the enumeration determines the canonical order of the basis elements in the corresponding abstract vector space.</p>
+
+<p>An enumeration is a set of literals from which a single value is selected. Each literal can have a tag as an integer within a standard encoding appropriate to the range of integer values. Consistency of enumeration types will allow them, and the enumerated values, to be referred to unambiguously either through symbolic name or encoding. Enumerated values are also controlled vocabularies and as such need to be standardized. Without this consistency enumeration literals can be stated differently and result in  data conflicts and misinterpretations.</p>
+
+<p>The tags are a set of positive whole numbers, not necessarily contiguous and having no numerical significance, each corresponding to the associated literal identifier. An order attribute can also be given on the enumeration elements. An enumeration can itself be a member of an enumeration. This allows enumerations to be enumerated in a selection. Enumerations are also subclasses of Scalar Datatype. This allows them to be used as the reference of a datatype specification.</p>"""^^rdf:HTML ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Enumeration"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Enumerated Value" ;
+  rdfs:subClassOf qudt:Datatype ;
+  rdfs:subClassOf dtype:EnumeratedValue ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:abbreviation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:description ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:symbol ;
+    ] ;
+.
+qudt:Enumeration
+  a owl:Class ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Enumeration"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Enumerated_type"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Enumeration"^^xsd:anyURI ;
+  rdfs:comment """<p>An enumeration is a set of literals from which a single value is selected. Each literal can have a tag as an integer within a standard encoding appropriate to the range of integer values. Consistency of enumeration types will allow them, and the enumerated values, to be referred to unambiguously either through symbolic name or encoding. Enumerated values are also controlled vocabularies and as such need to be standardized. Without this consistency enumeration literals can be stated differently and result in  data conflicts and misinterpretations.</p>
+
+<p>The tags are a set of positive whole numbers, not necessarily contiguous and having no numerical significance, each corresponding to the associated literal identifier. An order attribute can also be given on the enumeration elements. An enumeration can itself be a member of an enumeration. This allows enumerations to be enumerated in a selection. Enumerations are also subclasses of <em>Scalar Datatype</em>. This allows them to be used as the reference of a datatype specification.</p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Enumeration" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf dtype:Enumeration ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:EnumeratedValue ;
+      owl:onProperty qudt:default ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:EnumeratedValue ;
+      owl:onProperty qudt:element ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:abbreviation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:default ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:element ;
+    ] ;
+.
+qudt:EnumerationScale
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Enumeration scale" ;
+  rdfs:subClassOf qudt:Scale ;
+  rdfs:subClassOf dtype:Enumeration ;
+.
+qudt:Figure
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Figure" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:imageLocation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:figureCaption ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:figureLabel ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:height ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:image ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:landscape ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:width ;
+    ] ;
+.
+qudt:FloatingPointEncodingType
+  a owl:Class ;
+  dct:description "A \"Encoding\" with the following instance(s): \"Double Precision Encoding\", \"Single Precision Real Encoding\"." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Floating Point Encoding" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:IEEE754_1985RealEncoding
+  a qudt:FloatingPointEncodingType ;
+  qudt:bytes 32 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "IEEE 754 1985 Real Encoding" ;
+.
+qudt:ISO8601-UTCDateTime-BasicFormat
+  a qudt:DateTimeStringEncodingType ;
+  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}.[0-9]+Z" ;
+  qudt:allowedPattern "[0-9]{4}[0-9]{2}[0-9]{2}T[0-9]{2}[0-9]{2}[0-9]{2}Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ISO 8601 UTC Date Time - Basic Format" ;
+.
+qudt:ImperialUnit
+  a owl:Class ;
+  rdfs:comment "British/Imperial units where these are not aligned to international customary units." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Imperial Unit" ;
+  rdfs:subClassOf qudt:NonSI-Unit ;
+.
+qudt:IntegerEncodingType
+  a owl:Class ;
+  dct:description "The encoding scheme for integer types" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Integer Encoding" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:International-CustomaryUnit
+  a owl:Class ;
+  rdfs:comment "Customary units defined in terms of exact multiplers with SI metric units, as specified in the 1959 International Yard and Pound agreement." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Customary Unit" ;
+  rdfs:subClassOf qudt:NonSI-Unit ;
+.
+qudt:IntervalScale
+  a owl:Class ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Level_of_measurement"^^xsd:anyURI ;
+  rdfs:comment """<p>The interval type allows for the degree of difference between items, but not the ratio between them. Examples include temperature with the Celsius scale, which has two defined points (the freezing and boiling point of water at specific conditions) and then separated into 100 intervals, date when measured from an arbitrary epoch (such as AD), percentage such as a percentage return on a stock,[16] location in Cartesian coordinates, and direction measured in degrees from true or magnetic north. Ratios are not meaningful since 20 °C cannot be said to be \"twice as hot\" as 10 °C, nor can multiplication/division be carried out between any two dates directly. However, ratios of differences can be expressed; for example, one difference can be twice another. Interval type variables are sometimes also called \"scaled variables\", but the formal mathematical term is an affine space (in this case an affine line).</p>
+<p>Characteristics: median, percentile &amp; Monotonic increasing (order (&lt;) &amp; totally ordered set</p>"""^^rdf:HTML ;
+  rdfs:comment "median, percentile & Monotonic increasing (order (<)) & totally ordered set"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Interval scale" ;
+  rdfs:seeAlso qudt:NominalScale ;
+  rdfs:seeAlso qudt:OrdinalScale ;
+  rdfs:seeAlso qudt:RatioScale ;
+  rdfs:subClassOf qudt:Scale ;
+.
+qudt:LatexString
+  a rdfs:Datatype ;
+  rdfs:comment "A type of string in which some characters may be wrapped with '\\(' and '\\) characters for LaTeX rendering." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Latex String" ;
+  rdfs:subClassOf xsd:string ;
+.
+qudt:LittleEndian
+  a qudt:EndianType ;
+  dtype:literal "little" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Little Endian" ;
+.
+qudt:LogarithmicUnit
+  a owl:Class ;
+  rdfs:comment "Logarithmic units are abstract mathematical units that can be used to express any quantities (physical or mathematical) that are defined on a logarithmic scale, that is, as being proportional to the value of a logarithm function. Examples of logarithmic units include common units of information and entropy, such as the bit, and the byte, as well as units of relative signal strength magnitude such as the decibel."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Logarithmic Unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:LongUnsignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 8 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Long Unsigned Integer Encoding" ;
+.
+qudt:MKS-Unit
+  a owl:Class ;
+  qudt:citation "http://scienceworld.wolfram.com/physics/MKS.html" ;
+  qudt:citation "https://en.wikipedia.org/wiki/MKS_system_of_units" ;
+  rdfs:comment "The MKS system of units is a physical system of units that expresses any given measurement using fundamental units of the metre, kilogram, and/or second (MKS)."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "MKS-Unit" ;
+  rdfs:subClassOf qudt:NonSI-Unit ;
+.
+qudt:MathFunctionType
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Math Function Type" ;
+  rdfs:subClassOf qudt:Concept ;
+.
+qudt:NIST_SP811_Comment
+  a owl:Class ;
+  dc:description "National Institute of Standards and Technology (NIST) Special Publication 811 Comments on some quantities and their units" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "NIST SP~811 Comment" ;
+  rdfs:subClassOf qudt:Comment ;
+.
+qudt:NominalScale
+  a owl:Class ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Level_of_measurement"^^xsd:anyURI ;
+  rdfs:comment "A nominal scale differentiates between items or subjects based only on their names or (meta-)categories and other qualitative classifications they belong to; thus dichotomous data involves the construction of classifications as well as the classification of items. Discovery of an exception to a classification can be viewed as progress. Numbers may be used to represent the variables but the numbers do not have numerical value or relationship: For example, a Globally unique identifier. Examples of these classifications include gender, nationality, ethnicity, language, genre, style, biological species, and form. In a university one could also use hall of affiliation as an example."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Nominal scale" ;
+  rdfs:seeAlso qudt:IntervalScale ;
+  rdfs:seeAlso qudt:OrdinalScale ;
+  rdfs:seeAlso qudt:RatioScale ;
+  rdfs:subClassOf qudt:Scale ;
+.
+qudt:NonSI-Unit
+  a owl:Class ;
+  rdfs:comment "<p class=\"lm-para\">A parent class for all units that are not SI Units</p>"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Non-SI Unit" ;
+  rdfs:subClassOf qudt:StandardsUnit ;
+.
+qudt:OctetEncoding
+  a qudt:BooleanEncodingType ;
+  a qudt:ByteEncodingType ;
+  qudt:bytes 1 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "OCTET Encoding" ;
+.
+qudt:OrderedType
+  a owl:Class ;
+  dct:description "Describes how a data or information structure is ordered." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Ordered type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  owl:oneOf (
+      qudt:Unordered
+      qudt:PartiallyOrdered
+      qudt:TotallyOrdered
+    ) ;
+.
+qudt:OrdinalScale
+  a owl:Class ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Level_of_measurement"^^xsd:anyURI ;
+  rdfs:comment "The ordinal type allows for rank order (1st, 2nd, 3rd, etc.) by which data can be sorted, but still does not allow for relative degree of difference between them. Examples include, on one hand, dichotomous data with dichotomous (or dichotomized) values such as 'sick' vs. 'healthy' when measuring health, 'guilty' vs. 'innocent' when making judgments in courts, 'wrong/false' vs. 'right/true' when measuring truth value, and, on the other hand, non-dichotomous data consisting of a spectrum of values, such as 'completely agree', 'mostly agree', 'mostly disagree', 'completely disagree' when measuring opinion."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Ordinal scale" ;
+  rdfs:seeAlso qudt:IntervalScale ;
+  rdfs:seeAlso qudt:NominalScale ;
+  rdfs:seeAlso qudt:RatioScale ;
+  rdfs:subClassOf qudt:Scale ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:order ;
+    ] ;
+.
+qudt:Organization
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Organization" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:url ;
+    ] ;
+.
+qudt:PartiallyOrdered
+  a qudt:OrderedType ;
+  qudt:literal "partial" ;
+  qudt:plainTextDescription "Partial ordered structure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Partially Ordered" ;
+.
+qudt:PhysicalConstant
+  a owl:Class ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Physical_constant"^^xsd:anyURI ;
+  rdfs:comment "A physical constant is a physical quantity that is generally believed to be both universal in nature and constant in time. It can be contrasted with a mathematical constant, which is a fixed numerical value but does not directly involve any physical measurement. There are many physical constants in science, some of the most widely recognized being the speed of light in vacuum c, Newton's gravitational constant G, Planck's constant h, the electric permittivity of free space ε0, and the elementary charge e. Physical constants can take many dimensional forms, or may be dimensionless depending on the system of quantities and units used."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Physical Constant" ;
+  rdfs:subClassOf qudt:Quantity ;
+.
+qudt:PrefixUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Prefix unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:Quantifiable
+  a owl:Class ;
+  rdfs:comment "<p><em>Quantifiable</em> ascribes to some thing the capability of being measured, observed, or counted.</p>"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantifiable" ;
+  rdfs:subClassOf qudt:Aspect ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Datatype ;
+      owl:onProperty qudt:dataType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:unit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:valueUnion ;
+      owl:onProperty qudt:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:double ;
+      owl:onProperty qudt:relativeStandardUncertainty ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:double ;
+      owl:onProperty qudt:standardUncertainty ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:int ;
+      owl:onProperty qudt:unit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:dataType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:relativeStandardUncertainty ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:standardUncertainty ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:value ;
+    ] ;
+.
+qudt:Quantity
+  a owl:Class ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quantity"^^xsd:anyURI ;
+  rdfs:comment """<p class=\"lm-para\">A <b>quantity</b> is the measurement of an observable property of a particular object, event, or physical system. A quantity is always associated with the context of measurement (i.e. the thing measured, the measured value, the accuracy of measurement, etc.) whereas the underlying <b>quantity kind</b> is independent of any particular measurement. Thus, length is a quantity kind while the height of a rocket is a specific quantity of length; its magnitude that may be expressed in meters, feet, inches, etc. Examples of physical quantities include physical constants, such as the speed of light in a vacuum, Planck's constant, the electric permittivity of free space, and the fine structure constant. </p>
+
+<p class=\"lm-para\">In other words, quantities are quantifiable aspects of the world, such as the duration of a movie, the distance between two points, velocity of a car, the pressure of the atmosphere, and a person's weight; and units are used to describe their numerical measure.
+
+<p class=\"lm-para\">Many <b>quantity kinds</b> are related to each other by various physical laws, and as a result, the associated units of some quantity kinds can be expressed as products (or ratios) of powers of other quantity kinds (e.g., momentum is mass times velocity and velocity is defined as distance divided by time). In this way, some quantities can be calculated from other measured quantities using their associations to the quantity kinds in these expressions. These quantity kind relationships are also discussed in dimensional analysis. Those that cannot be so expressed can be regarded as \"fundamental\" in this sense.</p>
+<p class=\"lm-para\">A quantity is distinguished from a \"quantity kind\" in that the former carries a value and the latter is a type specifier.</p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf qudt:Quantifiable ;
+  rdfs:subClassOf qudt:Verifiable ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      dct:description "a reference to the dimension that quantifies the property"^^rdf:HTML ;
+      owl:allValuesFrom qudt:QuantityValue ;
+      owl:onProperty qudt:quantityValue ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:DataEncoding ;
+      owl:onProperty qudt:dataEncoding ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty qudt:hasQuantityKind ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dataEncoding ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexDefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:mathMLdefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasQuantityKind ;
+    ] ;
+.
+qudt:QuantityKind
+  a owl:Class ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=112-01-04"^^xsd:anyURI ;
+  rdfs:comment "A <b>Quantity Kind</b> is any observable property that can be  measured and quantified numerically. Familiar examples include physical properties such as length, mass, time, force, energy, power, electric charge, etc. Less familiar examples include currency, interest rate, price to earning ratio, and information capacity."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity Kind" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf qudt:Verifiable ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty qudt:generalization ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty skos:broader ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKindDimensionVector ;
+      owl:onProperty qudt:hasDimensionVector ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKindDimensionVector_SI ;
+      owl:onProperty qudt:dimensionVectorForSI ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:SystemOfQuantityKinds ;
+      owl:onProperty qudt:isQuantityKindOf ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:generalization ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseCGSUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseISOUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseImperialUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseSIUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseUSCustomaryUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionVectorForSI ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexDefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:mathMLdefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "4"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onClass qudt:QuantityKindDimensionVector ;
+      owl:onProperty qudt:qkdvDenominator ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onClass qudt:QuantityKindDimensionVector ;
+      owl:onProperty qudt:qkdvNumerator ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableCGSUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableISOUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableImperialUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableSIUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableUSCustomaryUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:applicableUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:expression ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexSymbol ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:symbol ;
+    ] ;
+.
+qudt:QuantityKindDimensionVector
+  a owl:Class ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dimensional_analysis"^^xsd:anyURI ;
+  qudt:informativeReference "http://web.mit.edu/2.25/www/pdf/DA_unified.pdf"^^xsd:anyURI ;
+  rdfs:comment """<p class=\"lm-para\">A  <em>Quantity Kind Dimension Vector</em> describes the dimensionality of a quantity kind in the context of a system of units. In the SI system of units, the dimensions of a quantity kind are expressed as a product of the basic physical dimensions mass (\\(M\\)), length (\\(L\\)), time (\\(T\\)) current (\\(I\\)), amount of substance (\\(N\\)), luminous intensity (\\(J\\)) and absolute temperature (\\(\\theta\\)) as \\(dim \\, Q = L^{\\alpha} \\, M^{\\beta} \\, T^{\\gamma} \\, I ^{\\delta} \\, \\theta ^{\\epsilon} \\, N^{\\eta} \\, J ^{\\nu}\\).</p>
+
+<p class=\"lm-para\">The rational powers of the dimensional exponents, \\(\\alpha, \\, \\beta, \\, \\gamma, \\, \\delta, \\, \\epsilon, \\, \\eta, \\, \\nu\\), are positive, negative, or zero.</p>
+
+<p class=\"lm-para\">For example, the dimension of the physical quantity kind \\(\\it{speed}\\) is \\(\\boxed{length/time}\\), \\(L/T\\) or \\(LT^{-1}\\), and the dimension of the physical quantity kind force is \\(\\boxed{mass \\times acceleration}\\) or \\(\\boxed{mass \\times (length/time)/time}\\), \\(ML/T^2\\) or \\(MLT^{-2}\\) respectively.</p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity Kind Dimension Vector" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForAmountOfSubstance ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForElectricCurrent ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForLength ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForLuminousIntensity ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForMass ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForThermodynamicTemperature ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionExponentForTime ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dimensionlessExponent ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:baseUnitDimensions ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexDefinition ;
+    ] ;
+.
+qudt:QuantityKindDimensionVector_CGS
+  a owl:Class ;
+  rdfs:comment "A <em>CGS Dimension Vector</em> is used to specify the dimensions for a C.G.S. quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector ;
+.
+qudt:QuantityKindDimensionVector_CGS-EMU
+  a owl:Class ;
+  rdfs:comment "A <em>CGS EMU Dimension Vector</em> is used to specify the dimensions for EMU C.G.S. quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS EMU Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector_CGS ;
+.
+qudt:QuantityKindDimensionVector_CGS-ESU
+  a owl:Class ;
+  rdfs:comment "A <em>CGS ESU Dimension Vector</em> is used to specify the dimensions for ESU C.G.S. quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS ESU Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector_CGS ;
+.
+qudt:QuantityKindDimensionVector_CGS-GAUSS
+  a owl:Class ;
+  rdfs:comment "A <em>CGS GAUSS Dimension Vector</em> is used to specify the dimensions for Gaussioan C.G.S. quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS GAUSS Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector_CGS ;
+.
+qudt:QuantityKindDimensionVector_CGS-LH
+  a owl:Class ;
+  rdfs:comment "A <em>CGS LH Dimension Vector</em> is used to specify the dimensions for Lorentz-Heaviside C.G.S. quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "CGS LH Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector_CGS ;
+.
+qudt:QuantityKindDimensionVector_ISO
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ISO Dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector ;
+.
+qudt:QuantityKindDimensionVector_Imperial
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Imperial dimension vector" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector ;
+.
+qudt:QuantityKindDimensionVector_SI
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity Kind Dimension vector (SI)" ;
+  rdfs:subClassOf qudt:QuantityKindDimensionVector ;
+.
+qudt:QuantityType
+  a owl:Class ;
+  dct:description "\\(\\textit{Quantity Type}\\) is an enumeration of quanity kinds. It specializes \\(\\boxed{dtype:EnumeratedValue}\\) by constrinaing \\(\\boxed{dtype:value}\\) to instances of \\(\\boxed{qudt:QuantityKind}\\)."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty dtype:value ;
+    ] ;
+.
+qudt:QuantityValue
+  a owl:Class ;
+  rdfs:comment "A <i>Quantity Value</i> expresses the magnitude and kind of a quantity and is given by the product of a numerical value <code>n</code> and a unit of measure <code>U</code>. The number multiplying the unit is referred to as the numerical value of the quantity expressed in that unit. Refer to <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html\">NIST SP 811 section 7</a> for more on quantity values."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Quantity value" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf qudt:Quantifiable ;
+.
+qudt:RatioScale
+  a owl:Class ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Level_of_measurement"^^xsd:anyURI ;
+  rdfs:comment "The ratio type takes its name from the fact that measurement is the estimation of the ratio between a magnitude of a continuous quantity and a unit magnitude of the same kind (Michell, 1997, 1999). A ratio scale possesses a meaningful (unique and non-arbitrary) zero value. Most measurement in the physical sciences and engineering is done on ratio scales. Examples include mass, length, duration, plane angle, energy and electric charge. In contrast to interval scales, ratios are now meaningful because having a non-arbitrary zero point makes it meaningful to say, for example, that one object has \"twice the length\" of another (= is \"twice as long\"). Very informally, many ratio scales can be described as specifying \"how much\" of something (i.e. an amount or magnitude) or \"how many\" (a count). The Kelvin temperature scale is a ratio scale because it has a unique, non-arbitrary zero point called absolute zero."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Ratio scale" ;
+  rdfs:seeAlso qudt:IntervalScale ;
+  rdfs:seeAlso qudt:NominalScale ;
+  rdfs:seeAlso qudt:OrdinalScale ;
+  rdfs:subClassOf qudt:Scale ;
+.
+qudt:Rule
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Rule" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf qudt:Verifiable ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:RuleType ;
+      owl:onProperty qudt:ruleType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:example ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:rationale ;
+    ] ;
+.
+qudt:RuleType
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Rule Type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+.
+qudt:SI-Unit
+  a owl:Class ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Category:SI_units"^^xsd:anyURI ;
+  rdfs:comment "The International System of Units (SI) defines seven units of measure as a basic set from which all other SI units are derived. These SI base units and their physical quantities are: metre for length kilogram for mass second for time ampere for electric current kelvin for temperature candela for luminous intensity mole for the amount of substance. The SI base quantities form a set of mutually independent dimensions as required by dimensional analysis commonly employed in science and technology."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "SI Unit" ;
+  rdfs:subClassOf qudt:StandardsUnit ;
+.
+qudt:SIGNED
+  a qudt:SignednessType ;
+  dtype:literal "signed" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Signed" ;
+.
+qudt:SOU_CGS
+  a qudt:SystemOfUnits ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Centimetre–gram–second_system_of_units"^^xsd:anyURI ;
+  rdfs:label "CGS System of Units" ;
+.
+qudt:SOU_IMPERIAL
+  a qudt:SystemOfUnits ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Imperial_units"^^xsd:anyURI ;
+  rdfs:label "Imperial System of Units" ;
+.
+qudt:SOU_NATURAL_UNITS
+  a qudt:SystemOfUnits ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Natural_units"^^xsd:anyURI ;
+  rdfs:comment """<p>In physics, natural units are physical units of measurement based only on universal physical constants. For example the elementary charge e is a natural unit of electric charge, or the speed of light c is a natural unit of speed.</p>
+<p>A purely natural system of units is defined in such a way that some set of selected universal physical constants are normalized to unity; that is, their numerical values in terms of these units become exactly 1.</p>
+<p>Examples are Planck Units and Atomic Units. Atomic units (au or a.u.) form a system of natural units which is especially convenient for atomic physics calculations. There are two different kinds of atomic units, which one might name Hartree atomic units and Rydberg atomic units, which differ in the choice of the unit of mass and charge.</p>
+<p>Planck units are unique among systems of natural units, because they are not defined in terms of properties of any prototype, physical object, or even elementary particle.</p>"""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "System of Natural Units" ;
+.
+qudt:SOU_SI
+  a qudt:SystemOfUnits ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/International_System_of_Units"^^xsd:anyURI ;
+  rdfs:label "SI International System of Units" ;
+.
+qudt:SOU_USCS
+  a qudt:SystemOfUnits ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/United_States_customary_units"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "US Customary System of Units" ;
+.
+qudt:ScalarDatatype
+  a owl:Class ;
+  dct:description "Scalar data types are those that have a single value. The permissible values are defined over a domain that may be integers, float, character or boolean. Often a scalar data type is referred to as a primitive data type." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Scalar Datatype" ;
+  rdfs:subClassOf qudt:Datatype ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom rdfs:Datatype ;
+      owl:onProperty qudt:rdfsDatatype ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bits ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:bytes ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:length ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:maxExclusive ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:maxInclusive ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:minExclusive ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:minInclusive ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:rdfsDatatype ;
+    ] ;
+.
+qudt:Scale
+  a owl:Class ;
+  rdfs:comment "Scales (also called \"scales of measurement\" or \"levels of measurement\")  are expressions that typically refer to the theory of scale types."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Scale" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:MathsFunctionType ;
+      owl:onProperty qudt:permissibleMaths ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:ScaleType ;
+      owl:onProperty qudt:scaleType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:TransformType ;
+      owl:onProperty qudt:permissibleTransformation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dataStructure ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:scaleType ;
+    ] ;
+.
+qudt:ScaleType
+  a owl:Class ;
+  qudt:plainTextDescription "Scales, or scales of measurement (or categorization) provide ways of quantifying measurements, values and other enumerated values according to a normative frame of reference.  Four different types of scales are typically used. These are interval, nominal, ordinal and ratio scales." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Scale type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:MathsFunctionType ;
+      owl:onProperty qudt:permissibleMaths ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:TransformType ;
+      owl:onProperty qudt:permissibleTransformation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dataStructure ;
+    ] ;
+.
+qudt:ScaledUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Scaled unit" ;
+  rdfs:subClassOf qudt:Unit ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:isScalingOf ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:isScalingOf ;
+    ] ;
+.
+qudt:ShortSignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 2 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Short Signed Integer Encoding" ;
+.
+qudt:ShortUnsignedIntegerEncoding
+  a qudt:BooleanEncodingType ;
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 2 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Short Unsigned Integer Encoding" ;
+.
+qudt:SignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 4 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Signed Integer Encoding" ;
+.
+qudt:SignednessType
+  a owl:Class ;
+  dct:description "Specifics whether a value should be signed or unsigned." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Signedness type" ;
+  rdfs:subClassOf qudt:EnumeratedValue ;
+  owl:oneOf (
+      qudt:SIGNED
+      qudt:UNSIGNED
+    ) ;
+.
+qudt:SinglePrecisionRealEncoding
+  a qudt:FloatingPointEncodingType ;
+  qudt:bytes 32 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Single Precision Real Encoding" ;
+.
+qudt:StandardsUnit
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Standards unit" ;
+  rdfs:subClassOf qudt:Unit ;
+.
+qudt:Statement
+  a rdfs:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Statement" ;
+  rdfs:subClassOf rdf:Statement ;
+.
+qudt:StringEncodingType
+  a owl:Class ;
+  dct:description "A \"Encoding\" with the following instance(s): \"UTF-16 String\", \"UTF-8 Encoding\"." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "String Encoding Type" ;
+  rdfs:subClassOf qudt:Encoding ;
+.
+qudt:StructuredDatatype
+  a owl:Class ;
+  dct:description "A \"Structured Datatype\", in contrast to scalar data types, is used to characterize classes of more complex data structures, such as linked or indexed lists, trees, ordered trees, and multi-dimensional file formats." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Structured Data Type" ;
+  rdfs:subClassOf qudt:Datatype ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality 1 ;
+      owl:onProperty qudt:elementType ;
+    ] ;
+.
+qudt:Symbol
+  a owl:Class ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Symbol" ;
+  rdfs:subClassOf qudt:Concept ;
+.
+qudt:SystemOfQuantityKinds
+  a owl:Class ;
+  rdfs:comment "A system of quantity kinds is a set of one or more quantity kinds together with a set of zero or more algebraic equations that define relationships between quantity kinds in the set. In the physical sciences, the equations relating quantity kinds are typically physical laws and definitional relations, and constants of proportionality. Examples include Newton’s First Law of Motion, Coulomb’s Law, and the definition of velocity as the instantaneous change in position.  In almost all cases, the system identifies a subset of base quantity kinds. The base set is chosen so that all other quantity kinds of interest can be derived from the base quantity kinds and the algebraic equations. If the unit system is explicitly associated with a quantity kind system, then the unit system must define at least one unit for each quantity kind.  From a scientific point of view, the division of quantities into base quantities and derived quantities is a matter of convention."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "System of Quantity Kinds" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Enumeration ;
+      owl:onProperty qudt:baseDimensionEnumeration ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty qudt:hasQuantityKind ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:SystemOfUnits ;
+      owl:onProperty qudt:hasUnitSystem ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:baseDimensionEnumeration ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:hasQuantityKind ;
+    ] ;
+.
+qudt:SystemOfUnits
+  a owl:Class ;
+  qudt:informativeReference "http://dbpedia.org/resource/Category:Systems_of_units"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.ieeeghn.org/wiki/index.php/System_of_Measurement_Units"^^xsd:anyURI ;
+  rdfs:comment "A system of units is a set of units which are chosen as the reference scales for some set of quantity kinds together with the definitions of each unit. Units may be defined by experimental observation or by proportion to another unit not included in the system. If the unit system is explicitly associated with a quantity kind system, then the unit system must define at least one unit for each quantity kind."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "System of Units" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:BaseUnit ;
+      owl:onProperty qudt:hasBaseUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:DerivedUnit ;
+      owl:onProperty qudt:hasDerivedCoherentUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:DerivedUnit ;
+      owl:onProperty qudt:hasDerivedUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:PhysicalConstant ;
+      owl:onProperty qudt:applicablePhysicalConstant ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:hasAllowedUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:hasCoherentUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:hasDefinedUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:Unit ;
+      owl:onProperty qudt:hasUnit ;
+    ] ;
+.
+qudt:TotallyOrdered
+  a qudt:OrderedType ;
+  qudt:literal "total" ;
+  qudt:plainTextDescription "Totally ordered structure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Totally Ordered" ;
+.
+qudt:UCUMci
+  a rdfs:Datatype ;
+  rdfs:comment "Lexical pattern for the case-insensitive version of UCUM code" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "case-insensitive UCUM code" ;
+  rdfs:subClassOf rdfs:Resource ;
+  owl:onDatatype xsd:string ;
+  owl:withRestrictions (
+      [
+        xsd:pattern "[\\x21-\\x60,\\x7b-\\x7e]+" ;
+      ]
+    ) ;
+.
+qudt:UCUMci-term
+  a rdfs:Datatype ;
+  rdfs:comment "Lexical pattern for the terminal symbols in the case-insensitive version of UCUM code" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "case-insensitive UCUM term" ;
+  rdfs:subClassOf rdfs:Resource ;
+  owl:onDatatype xsd:string ;
+  owl:withRestrictions (
+      [
+        xsd:pattern "[\\x21,\\x23-\\x27,\\x2a,\\x2c,\\x30-\\x3c,\\x3e-\\x5a,\\x5c,\\x5e-\\x60,\\x7c,\\x7e]+" ;
+      ]
+    ) ;
+.
+qudt:UCUMcs
+  a rdfs:Datatype ;
+  rdfs:comment "Lexical pattern for the case-sensitive version of UCUM code" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "case-sensitive UCUM code" ;
+  rdfs:subClassOf rdfs:Resource ;
+  owl:onDatatype xsd:string ;
+  owl:withRestrictions (
+      [
+        xsd:pattern "[\\x21-\\x7e]+" ;
+      ]
+    ) ;
+.
+qudt:UCUMcs-term
+  a rdfs:Datatype ;
+  rdfs:comment "Lexical pattern for the terminal symbols in the case-sensitive version of UCUM code" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "case-sensitive UCUM terminal" ;
+  rdfs:subClassOf rdfs:Resource ;
+  owl:onDatatype xsd:string ;
+  owl:withRestrictions (
+      [
+        xsd:pattern "[\\x21,\\x23-\\x27,\\x2a,\\x2c,\\x30-\\x3c,\\x3e-\\x5a,\\x5c,\\x5e-\\x7a,\\x7c,\\x7e]+" ;
+      ]
+    ) ;
+.
+qudt:UNSIGNED
+  a qudt:SignednessType ;
+  dtype:literal "unsigned" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Unsigned" ;
+.
+qudt:US-CustomaryUnit
+  a owl:Class ;
+  rdfs:comment "Customary units used in USA not including those aligned to the SI system as specified in the 1960 agreement" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "US-Customary unit" ;
+  rdfs:subClassOf qudt:NonSI-Unit ;
+.
+qudt:US-SurveyUnit
+  a owl:Class ;
+  rdfs:comment """US survey units (length and area) are defined slightly different to the International Customary units agreed in 1960. They retain earlier multipliers relative to the metre:
+1 mile = 5280 feet
+1 foot = 1200/3297 metres
+1 inch = 1/12 foot""" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "US-Survey unit" ;
+  rdfs:subClassOf qudt:StandardsUnit ;
+.
+qudt:UTF16-StringEncoding
+  a qudt:StringEncodingType ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "UTF-16 String" ;
+.
+qudt:UTF8-StringEncoding
+  a qudt:StringEncodingType ;
+  qudt:bytes 8 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "UTF-8 Encoding" ;
+.
+qudt:Unit
+  a owl:Class ;
+  qudt:informativeReference "http://dbpedia.org/resource/Category:Units_of_measure"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.allmeasures.com/Fullconversion.asp"^^xsd:anyURI ;
+  rdfs:comment "A unit of measure, or unit, is a particular quantity value that has been chosen as a scale for measuring other quantities the same kind (more generally of equivalent dimension). For example, the meter is a quantity of length that has been rigorously defined and standardized by the BIPM (International Board of Weights and Measures). Any measurement of the length can be expressed as a number multiplied by the unit meter. More formally, the value of a physical quantity Q with respect to a unit (U) is expressed as the scalar multiple of a real number (n) and U, as  \\(Q = nU\\)."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Unit" ;
+  rdfs:subClassOf qudt:Concept ;
+  rdfs:subClassOf qudt:Verifiable ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:QuantityKind ;
+      owl:onProperty qudt:hasQuantityKind ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:SystemOfUnits ;
+      owl:onProperty qudt:isUnitOfSystem ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:UCUMci-term ;
+      owl:onProperty qudt:ucumCaseInsensitiveCode ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom qudt:UCUMcs-term ;
+      owl:onProperty qudt:ucumCaseSensitiveCode ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:string ;
+      owl:onProperty qudt:iec61360Code ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:string ;
+      owl:onProperty qudt:ucumCode ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:abbreviation ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:conversionMultiplier ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:int ;
+      owl:onProperty qudt:conversionOffset ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:mathMLdefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:uneceCommonCode ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:expression ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexDefinition ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:latexSymbol ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:siUnitsExpression ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:symbol ;
+    ] ;
+.
+qudt:Unordered
+  a qudt:OrderedType ;
+  qudt:literal "unordered" ;
+  qudt:plainTextDescription "Unordered structure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Unordered" ;
+.
+qudt:UnsignedIntegerEncoding
+  a qudt:IntegerEncodingType ;
+  qudt:bytes 4 ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Unsigned Integer Encoding" ;
+.
+qudt:Verifiable
+  a qudt:AspectClass ;
+  rdfs:comment "An aspect class that holds properties that provide external knowledge and specifications of a given resource." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Verifiable" ;
+  rdfs:subClassOf qudt:Aspect ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:dbpediaMatch ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:informativeReference ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:isoNormativeReference ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:isoNormativeReference ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:normativeReference ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty qudt:normativeReference ;
+    ] ;
+.
+qudt:Wikipedia
+  a qudt:Organization ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Wikipedia" ;
+.
+qudt:abbreviation
+  a owl:DatatypeProperty ;
+  dct:description "An abbreviation for a unit is a short ASCII string that is used in place of the full name for the unit in contexts where non-ASCII characters would be problematic, or where using the abbreviation will enhance readability. When a power of abase unit needs to be expressed, such as squares this can be done using abbreviations rather than symbols. For example, <em>sq ft</em> means <em>square foot</em>, and <em>cu ft</em> means <em>cubic foot</em>."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "abbreviation" ;
+  rdfs:range xsd:string ;
+.
+qudt:acronym
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "acronym" ;
+  rdfs:range xsd:string ;
+.
+qudt:allowedPattern
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+.
+qudt:ansiSQLName
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ANSI SQL Name" ;
+  rdfs:range xsd:string ;
+.
+qudt:applicableCGSUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable CGS unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicableISOUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable ISO unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicableImperialUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable Imperial unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicablePhysicalConstant
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable physical constant" ;
+.
+qudt:applicablePlanckUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable Planck unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicableSIUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable SI unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicableUSCustomaryUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable US Customary unit" ;
+  rdfs:range qudt:Unit ;
+  rdfs:subPropertyOf qudt:applicableUnit ;
+.
+qudt:applicableUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "applicable unit" ;
+  rdfs:range qudt:Unit ;
+.
+qudt:baseCGSUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "<em>qudt:baseCGSUnitDimensions</em> is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units in the CGS System."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base CGS unit dimensions" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:baseUnitDimensions ;
+.
+qudt:baseDimensionEnumeration
+  a owl:FunctionalProperty ;
+  a owl:ObjectProperty ;
+  dct:description "This property associates a system of quantities with an enumeration that enumerates the base dimensions of the system in canonical order."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base dimension enumeration" ;
+  rdfs:range qudt:Enumeration ;
+.
+qudt:baseISOUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "<strong>qudt:baseISOUnitDimensions</strong> is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units in the ISO System."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base ISO unit dimensions" ;
+  rdfs:range qudt:LatexString ;
+  rdfs:subPropertyOf qudt:baseUnitDimensions ;
+.
+qudt:baseImperialUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "<strong>qudt:baseImperialUnitDimensions</strong> is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units in the Imperial System."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base Imperial unit dimensions" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:baseUnitDimensions ;
+.
+qudt:baseSIUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "<strong>qudt:baseSIUnitDimensions</strong> is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units. For example, in the SI system \\(capacitance\\) has the unit \\(Farad\\) and base unit dimensions of \\(C^2 \\cdot s^2 / (kg \\cdot m^2)\\)."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base SI unit dimensions" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:baseUnitDimensions ;
+.
+qudt:baseUSCustomaryUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "\"qudt:baseUSCustomaryUnitDimensions\" is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units in the US Customary System."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base US Customary unit dimensions" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:baseUnitDimensions ;
+.
+qudt:baseUnitDimensions
+  a owl:DatatypeProperty ;
+  dct:description "\"qudt:baseUnitDimensions\" is a string datatype property expressing the dimensions of a unit, or quantity, as a vector over the base units."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base unit dimensions" ;
+  rdfs:range xsd:string ;
+.
+qudt:basis
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "basis" ;
+.
+qudt:belongsToSystemOfQuantities
+  a owl:ObjectProperty ;
+  rdfs:domain qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "belongs to system of quantities" ;
+  rdfs:range qudt:SystemOfQuantityKinds ;
+.
+qudt:bitOrder
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "bit order" ;
+  rdfs:range qudt:EndianType ;
+.
+qudt:bits
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "bits" ;
+  rdfs:range xsd:integer ;
+.
+qudt:bounded
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "bounded" ;
+.
+qudt:byteOrder
+  a owl:ObjectProperty ;
+  dct:description "Byte order is an enumeration of two values: 'Big Endian' and 'Little Endian' and is used to denote whether the most signiticant byte is either first or last, respectively." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "byte order" ;
+  rdfs:range qudt:EndianType ;
+.
+qudt:bytes
+  a rdf:Property ;
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "bytes" ;
+  rdfs:range xsd:integer ;
+.
+qudt:cName
+  a rdf:Property ;
+  rdfs:comment "Datatype name in the C programming language" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "C Language name" ;
+  rdfs:range xsd:string ;
+.
+qudt:cardinality
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "cardinality" ;
+.
+qudt:categorizedAs
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "categorized as" ;
+.
+qudt:citation
+  a owl:AnnotationProperty ;
+  qudt:plainTextDescription "Used to provide an annotation for an informative reference." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "citation" ;
+  rdfs:range xsd:string ;
+.
+qudt:code
+  a owl:DatatypeProperty ;
+  dct:description "A code is a string that uniquely identifies a QUDT concept.  The code is constructed from the designator."^^rdf:HTML ;
+  rdfs:domain qudt:Concept ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "code" ;
+.
+qudt:coherentUnitSystem
+  a owl:FunctionalProperty ;
+  a owl:ObjectProperty ;
+  dct:description "<p>A system of units is coherent with respect to a system of quantities and equations if the system of units is chosen in such a way that the equations between numerical values have exactly the same form (including the numerical factors) as the corresponding equations between the quantities. In such a coherent system, no numerical factor other than the number 1 ever occurs in the expressions for the derived units in terms of the base units. For example, the \\(newton\\) and the \\(joule\\). These two are, respectively, the force that causes one kilogram to be accelerated at 1 metre per (1) second per (1) second, and the work done by 1 newton acting over 1 metre. Being coherent refers to this consistent use of 1. In the old c.g.s. system , with its base units the centimetre and the gram, the corresponding coherent units were the dyne and the erg, respectively the force that causes 1 gram to be accelerated at 1 centimetre per (1) second per (1) second, and the work done by 1 dyne acting over 1 centimetre. So \\(1\\,newton = 10^5 dyne\\), \\(1 joule = 10^7 erg\\), making each of the four compatible in a decimal sense within its respective other system, but not coherent therein.</p>"^^qudt:LatexString ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Coherence_(units_of_measurement)"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "coherent unit system" ;
+  rdfs:subPropertyOf qudt:hasUnitSystem ;
+.
+qudt:conversionCoefficient
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "conversion coefficient" ;
+  rdfs:range xsd:double ;
+.
+qudt:conversionMultiplier
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "conversion multiplier" ;
+  rdfs:range xsd:double ;
+.
+qudt:conversionOffset
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "conversion offset" ;
+  rdfs:range xsd:double ;
+.
+qudt:currencyExponent
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  dct:description "The currency exponent indicates the number of decimal places between a major currency unit and its minor currency unit. For example, the US dollar is the major currency unit of the United States, and the US cent is the minor currency unit. Since one cent is 1/100 of a dollar, the US dollar has a currency exponent of 2. However, the Japanese Yen has no minor currency units, so the yen has a currency exponent of 0."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "currency exponent" ;
+  rdfs:range xsd:integer ;
+.
+qudt:dataEncoding
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "data encoding" ;
+  rdfs:range qudt:DataEncoding ;
+.
+qudt:dataStructure
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "data structure" ;
+  rdfs:range xsd:string ;
+.
+qudt:dataType
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "datatype" ;
+.
+qudt:dbpediaMatch
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dbpedia match" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:default
+  a owl:ObjectProperty ;
+  dct:description "The default element in an enumeration"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "default" ;
+.
+qudt:definitionReference
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "definition reference" ;
+.
+qudt:denominatorDimensionVector
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "denominator dimension vector" ;
+  rdfs:range qudt:QuantityKindDimensionVector ;
+.
+qudt:derivedQuantityKindOfSystem
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "derived quantity kind of system" ;
+  rdfs:subPropertyOf qudt:isQuantityKindOf ;
+  owl:inverseOf qudt:systemDerivedQuantityKind ;
+.
+qudt:description
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "qudt description" ;
+  rdfs:range rdf:HTML ;
+  rdfs:subPropertyOf dct:description ;
+.
+qudt:dimensionExponent
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent" ;
+  rdfs:range dtype:numericUnion ;
+.
+qudt:dimensionExponentForAmountOfSubstance
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for amount of substance" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForElectricCurrent
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for electric current" ;
+  rdfs:range xsd:integer ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForLength
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for length" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForLuminousIntensity
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for luminous intensity" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForMass
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for mass" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForThermodynamicTemperature
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for thermodynamic temperature" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionExponentForTime
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension exponent for time" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:dimensionInverse
+  a owl:FunctionalProperty ;
+  a owl:InverseFunctionalProperty ;
+  a owl:ObjectProperty ;
+  a owl:SymmetricProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension inverse" ;
+  owl:inverseOf qudt:dimensionInverse ;
+.
+qudt:dimensionVectorForSI
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimension vector for SI" ;
+  rdfs:range qudt:QuantityKindDimensionVector_SI ;
+.
+qudt:dimensionlessExponent
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "dimensionless exponent" ;
+  rdfs:subPropertyOf qudt:dimensionExponent ;
+.
+qudt:element
+  a owl:ObjectProperty ;
+  dct:description "An element of an enumeration"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "element" ;
+.
+qudt:elementKind
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "element kind" ;
+.
+qudt:elementType
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "element type" ;
+.
+qudt:encoding
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "encoding" ;
+.
+qudt:exactConstant
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "exact constant" ;
+  rdfs:range xsd:boolean ;
+.
+qudt:exactMatch
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "exact match" ;
+  rdfs:range qudt:Unit ;
+.
+qudt:example
+  a owl:AnnotationProperty ;
+  rdfs:comment "The 'qudt:example' property is used to annotate an instance of a class with a reference to a concept that is an example. The type of this property is 'rdf:Property'. This allows both scalar and object ranges."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "example" ;
+.
+qudt:expression
+  a owl:AnnotationProperty ;
+  dct:description "An 'expression' is a finite combination of symbols that are well-formed according to rules that apply to units of measure, quantity kinds and their dimensions."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "expression" ;
+.
+qudt:fieldCode
+  a owl:AnnotationProperty ;
+  qudt:plainTextDescription "A field code is a generic property for representing unique codes that make up other identifers. For example each QuantityKind class caries a domain code as its field code." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "field code" ;
+  rdfs:range xsd:string ;
+.
+qudt:figure
+  a owl:AnnotationProperty ;
+  dct:description "Provides a link to an image."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "figure" ;
+  rdfs:range qudt:Figure ;
+.
+qudt:figureCaption
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "figure caption" ;
+  rdfs:range xsd:string ;
+.
+qudt:figureLabel
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "figure label" ;
+  rdfs:range xsd:string ;
+.
+qudt:floatPercentage
+  a rdfs:Datatype ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "float percentage" ;
+  rdfs:subClassOf xsd:float ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+      owl:onDatatype xsd:float ;
+      owl:withRestrictions (
+          [
+            xsd:minInclusive "0.00"^^xsd:float ;
+          ]
+          [
+            xsd:maxInclusive "100.00"^^xsd:float ;
+          ]
+        ) ;
+    ] ;
+.
+qudt:generalization
+  a owl:ObjectProperty ;
+  dct:description """This property relates a quantity kind to its generalization. A quantity kind, PARENT, is a generalization of the quantity kind CHILD only if:
+
+1. PARENT and CHILD have the same dimensions in every system of quantities;
+2. Every unit that is a measure of quantities of kind CHILD is also a valid measure of quantities of kind PARENT."""^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "generalization" ;
+  owl:inverseOf qudt:specialization ;
+.
+qudt:guidance
+  a owl:AnnotationProperty ;
+  rdfs:domain qudt:Concept ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "guidance" ;
+  rdfs:range rdf:HTML ;
+.
+qudt:hasAllowedUnit
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit system with a unit of measure that is not defined by or part of the system, but is allowed for use within the system. An allowed unit must be convertible to some dimensionally eqiuvalent unit that is defined by the system."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "allowed unit" ;
+  rdfs:subPropertyOf qudt:hasUnit ;
+.
+qudt:hasBaseQuantityKind
+  a owl:FunctionalProperty ;
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has base quantity kind" ;
+  rdfs:subPropertyOf qudt:hasQuantityKind ;
+  owl:inverseOf qudt:isBaseQuantityKindOfSystem ;
+.
+qudt:hasBaseUnit
+  a owl:ObjectProperty ;
+  dct:description "This property relates a system of units to a base unit defined within the system. The base units of a system are used to define the derived units of the system by expressing the derived units as products of the base units raised to a rational power."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "base unit" ;
+  rdfs:subPropertyOf qudt:hasCoherentUnit ;
+  owl:inverseOf qudt:isBaseUnitOfSystem ;
+.
+qudt:hasCoherentUnit
+  a owl:ObjectProperty ;
+  dct:description "A coherent unit of measurement for a unit system is a defined unit that may be expressed as a product of powers of the system's base units with the proportionality factor of one."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "coherent unit" ;
+  rdfs:subPropertyOf qudt:hasDefinedUnit ;
+  owl:inverseOf qudt:isCoherentUnitOfSystem ;
+.
+qudt:hasDefinedUnit
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit system with a unit of measure that is defined by the system."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "defined unit" ;
+  rdfs:subPropertyOf qudt:hasUnit ;
+.
+qudt:hasDenominatorPart
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has quantity kind dimension vector denominator part" ;
+.
+qudt:hasDerivedCoherentUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "derived coherent unit" ;
+  rdfs:subPropertyOf qudt:hasCoherentUnit ;
+  rdfs:subPropertyOf qudt:hasDerivedUnit ;
+  owl:inverseOf qudt:isDerivedCoherentUnitOfSystem ;
+.
+qudt:hasDerivedNonCoherentUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has coherent derived unit" ;
+  rdfs:subPropertyOf qudt:hasDerivedUnit ;
+  owl:inverseOf qudt:isDerivedNonCoherentUnitOfSystem ;
+.
+qudt:hasDerivedUnit
+  a owl:ObjectProperty ;
+  dct:description "This property relates a system of units to a unit of measure that is defined within the system in terms of the base units for the system. That is, the derived unit is defined as a product of the base units for the system raised to some rational power."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "derived unit" ;
+.
+qudt:hasDimension
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has dimension" ;
+.
+qudt:hasDimensionVector
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has dimension vector" ;
+  rdfs:range qudt:QuantityKindDimensionVector ;
+.
+qudt:hasNonCoherentUnit
+  a owl:DeprecatedProperty ;
+  a owl:ObjectProperty ;
+  dct:description "A coherent unit of measurement for a unit system is a defined unit that may be expressed as a product of powers of the system's base units with the proportionality factor of one."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has non-coherent unit" ;
+  rdfs:subPropertyOf qudt:hasDefinedUnit ;
+  owl:inverseOf qudt:isCoherentUnitOfSystem ;
+.
+qudt:hasNumeratorPart
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has quantity kind dimension vector numerator part" ;
+.
+qudt:hasPrefixUnit
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "prefix unit" ;
+  rdfs:subPropertyOf qudt:hasDefinedUnit ;
+.
+qudt:hasQuantity
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has quantity" ;
+  rdfs:range qudt:Quantity ;
+.
+qudt:hasQuantityKind
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has quantity kind" ;
+  rdfs:range qudt:QuantityKind ;
+  owl:inverseOf qudt:isQuantityKindOf ;
+.
+qudt:hasReferenceQuantityKind
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has reference quantity kind" ;
+.
+qudt:hasRule
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has rule" ;
+.
+qudt:hasUnit
+  a owl:ObjectProperty ;
+  dct:description "This property relates a system of units with a unit of measure that is either a) defined by the system, or b) accepted for use by the system and is convertible to a unit of equivalent dimension that is defined by the system. Systems of units may distinguish between base and derived units. Base units are the units which measure the base quantities for the corresponding system of quantities. The base units are used to define units for all other quantities as products of powers of the base units. Such units are called derived units for the system."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has unit" ;
+  owl:inverseOf qudt:isUnitOfSystem ;
+.
+qudt:hasUnitSystem
+  a owl:FunctionalProperty ;
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has unit system" ;
+.
+qudt:hasVocabulary
+  a owl:AnnotationProperty ;
+  qudt:plainTextDescription "Used to relate a class to one or more graphs where vocabularies for the class are defined." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "has vocabulary" ;
+  rdfs:range owl:Ontology ;
+.
+qudt:height
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "height" ;
+  rdfs:range xsd:string ;
+.
+qudt:id
+  a owl:DatatypeProperty ;
+  dct:description "The \"qudt:id\" is an identifier string that uniquely identifies a QUDT concept.  The identifier is constructed using a prefix. For example, units are coded using the pattern: \"UCCCENNNN\", where \"CCC\" is a numeric code or a category and \"NNNN\" is a digit string for a member element of that category. For scaled units there may be an addition field that has the format \"QNN\" where \"NN\" is a digit string representing an exponent power, and \"Q\" is a qualifier that indicates with the code \"P\" that the power is a positive decimal exponent, or the code \"N\" for a negative decimal exponent, or the code \"B\" for binary positive exponents."^^rdf:HTML ;
+  rdfs:domain qudt:Concept ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "qudt id" ;
+  rdfs:range xsd:string ;
+.
+qudt:iec61360Code
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "iec-61360 code" ;
+  rdfs:range xsd:string ;
+.
+qudt:image
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "image" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:imageLocation
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "image location" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:informativeReference
+  a owl:AnnotationProperty ;
+  dct:description "Provides a way to reference a source that provided useful but non-normative information."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "informative reference" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:integerPercentage
+  a rdfs:Datatype ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "integer percentage" ;
+  rdfs:subClassOf xsd:integer ;
+  owl:equivalentClass [
+      a rdfs:Datatype ;
+      rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+      owl:onDatatype xsd:integer ;
+      owl:withRestrictions (
+          [
+            xsd:minInclusive 0 ;
+          ]
+          [
+            xsd:maxInclusive 100 ;
+          ]
+        ) ;
+    ] ;
+.
+qudt:isAllowedUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure with a unit system that does not define the unit, but allows its use within the system. An allowed unit must be convertible to some dimensionally eqiuvalent unit that is defined by the system."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "allowed unit of system" ;
+  rdfs:subPropertyOf qudt:isUnitOfSystem ;
+  owl:inverseOf qudt:hasAllowedUnit ;
+.
+qudt:isBaseQuantityKindOfSystem
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is base quantity kind of system" ;
+  rdfs:subPropertyOf qudt:isQuantityKindOf ;
+  owl:inverseOf qudt:hasBaseQuantityKind ;
+.
+qudt:isBaseUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure to the system of units in which it is defined as a base unit for the system. The base units of a system are used to define the derived units of the system by expressing the derived units as products of the base units raised to a rational power."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is base unit of system" ;
+  rdfs:subPropertyOf qudt:isCoherentUnitOfSystem ;
+  owl:inverseOf qudt:hasBaseUnit ;
+.
+qudt:isCoherentUnitOfSystem
+  a owl:DeprecatedProperty ;
+  a owl:ObjectProperty ;
+  dct:description "A coherent unit of measurement for a unit system is a defined unit that may be expressed as a product of powers of the system's base units with the proportionality factor of one. A system of units is coherent with respect to a system of quantities and equations if the system of units is chosen in such a way that the equations between numerical values have exactly the same form (including the numerical factors) as the corresponding equations between the quantities. For example, the 'newton' and the 'joule'. These two are, respectively, the force that causes one kilogram to be accelerated at 1 metre per second per  second, and the work done by 1 newton acting over 1 metre. Being coherent refers to this consistent use of 1. In the old c.g.s. system , with its base units the centimetre and the gram, the corresponding coherent units were the dyne and the erg, respectively the force that causes 1 gram to be accelerated at 1 centimetre per second per second, and the work done by 1 dyne acting over 1 centimetre. So \\(1 newton = 10^5\\,dyne\\), \\(1 joule = 10^7\\,erg\\), making each of the four compatible in a decimal sense within its respective other system, but not coherent therein."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is coherent unit of system" ;
+  rdfs:range qudt:DerivedCoherentUnit ;
+  rdfs:subPropertyOf qudt:isDefinedUnitOfSystem ;
+  owl:inverseOf qudt:hasCoherentUnit ;
+.
+qudt:isDefinedUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure with the unit system that defines the unit."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "defined unit of system" ;
+  rdfs:subPropertyOf qudt:isUnitOfSystem ;
+  owl:inverseOf qudt:hasDefinedUnit ;
+.
+qudt:isDerivedCoherentUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure to the unit system in which the unit is derived from the system's base units with a proportionality constant of one."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is coherent derived unit of system" ;
+  rdfs:subPropertyOf qudt:isCoherentUnitOfSystem ;
+  rdfs:subPropertyOf qudt:isDerivedUnitOfSystem ;
+  owl:inverseOf qudt:hasDerivedCoherentUnit ;
+.
+qudt:isDerivedNonCoherentUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure to the unit system in which the unit is derived from the system's base units without proportionality constant of one."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is non-coherent derived unit of system" ;
+  rdfs:range qudt:DerivedNonCoherentUnit ;
+  rdfs:subPropertyOf qudt:isDerivedUnitOfSystem ;
+  owl:inverseOf qudt:hasDerivedNonCoherentUnit ;
+.
+qudt:isDerivedUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure to the system of units in which it is defined as a derived unit. That is, the derived unit is defined as a product of the base units for the system raised to some rational power."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is derived unit of system" ;
+  rdfs:subPropertyOf qudt:isUnitOfSystem ;
+  owl:inverseOf qudt:hasDerivedUnit ;
+.
+qudt:isDimensionInSystem
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is dimension in system" ;
+.
+qudt:isMetricUnit
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is metric unit" ;
+  rdfs:range xsd:boolean ;
+.
+qudt:isQuantityKindOf
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is quantity kind of" ;
+  owl:inverseOf qudt:hasQuantityKind ;
+.
+qudt:isScalingOf
+  a owl:ObjectProperty ;
+  a owl:TransitiveProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is scaling of" ;
+.
+qudt:isUnitOfSystem
+  a owl:ObjectProperty ;
+  dct:description "This property relates a unit of measure with a system of units that either a) defines the unit or b) allows the unit to be used within the system."^^rdf:HTML ;
+  rdfs:domain qudt:Unit ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "is unit of system" ;
+  rdfs:range qudt:SystemOfUnits ;
+  owl:inverseOf qudt:hasUnit ;
+.
+qudt:isoNormativeReference
+  a owl:AnnotationProperty ;
+  dct:description "Provides a way to reference the ISO unit definition."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "normative reference (ISO)" ;
+  rdfs:range xsd:anyURI ;
+  rdfs:subPropertyOf qudt:normativeReference ;
+.
+qudt:javaName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "java name" ;
+  rdfs:range xsd:string ;
+.
+qudt:jsName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Javascript name" ;
+  rdfs:range xsd:string ;
+.
+qudt:landscape
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "landscape" ;
+  rdfs:range xsd:boolean ;
+.
+qudt:latexDefinition
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "latex definition" ;
+  rdfs:range qudt:LatexString ;
+.
+qudt:latexSymbol
+  a owl:DatatypeProperty ;
+  dct:description "The symbol is a glyph that is used to represent some concept, typically a unit or a quantity, in a compact form. For example, the symbol for an Ohm is \\(ohm\\). This contrasts with 'unit:abbreviation', which gives a short alphanumeric abbreviation for the unit, 'ohm' for Ohm."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "latex symbol" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:literal ;
+.
+qudt:length
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "length" ;
+  rdfs:range xsd:integer ;
+.
+qudt:literal
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "literal" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf dtype:literal ;
+.
+qudt:lowerBound
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "lower bound" ;
+.
+qudt:mathDefinition
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "math definition" ;
+  rdfs:range xsd:string ;
+.
+qudt:mathMLdefinition
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "mathML definition" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:mathDefinition ;
+.
+qudt:matlabName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "matlab name" ;
+  rdfs:range xsd:string ;
+.
+qudt:maxExclusive
+  a owl:DatatypeProperty ;
+  dct:description "maxExclusive is the exclusive upper bound of the value space for a datatype with the ordered property. The value of maxExclusive must be in the value space of the base type or be equal to {value} in {base type definition}." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "max exclusive" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:upperBound ;
+.
+qudt:maxInclusive
+  a owl:DatatypeProperty ;
+  dct:description "maxInclusive is the inclusive upper bound of the value space for a datatype with the ordered property. The value of maxInclusive must be in the value space of the base type." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "max inclusive" ;
+  rdfs:subPropertyOf qudt:upperBound ;
+.
+qudt:microsoftSQLServerName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Microsoft SQL Server name" ;
+  rdfs:range xsd:string ;
+.
+qudt:minExclusive
+  a rdf:Property ;
+  a owl:DatatypeProperty ;
+  dct:description "minExclusive is the exclusive lower bound of the value space for a datatype with the ordered property. The value of minExclusive must be in the value space of the base type or be equal to {value} in {base type definition}." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "min exclusive" ;
+  rdfs:subPropertyOf qudt:lowerBound ;
+.
+qudt:minInclusive
+  a owl:DatatypeProperty ;
+  dct:description "minInclusive is the inclusive lower bound of the value space for a datatype with the ordered property. The value of minInclusive must be in the value space of the base type." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "min inclusive" ;
+  rdfs:subPropertyOf qudt:lowerBound ;
+.
+qudt:mySQLName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "MySQL name" ;
+  rdfs:range xsd:string ;
+.
+qudt:negativeDeltaLimit
+  a owl:DatatypeProperty ;
+  dct:description "A negative change limit between consecutive sample values for a parameter. The Negative Delta may be the encoded value or engineering units value depending on whether or not a Calibrator is defined."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "negative delta limit" ;
+  rdfs:range xsd:string ;
+.
+qudt:normativeReference
+  a owl:AnnotationProperty ;
+  dct:description "Provides a way to reference information that is an authorative source providing a standard definition"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "normative reference" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:numeratorDimensionVector
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "numerator dimension vector" ;
+  rdfs:range qudt:QuantityKindDimensionVector ;
+.
+qudt:numericValue
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "numeric value" ;
+  rdfs:range dtype:numericUnion ;
+.
+qudt:odbcName
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ODBC name" ;
+  rdfs:range xsd:string ;
+.
+qudt:oleDBName
+  a owl:DatatypeProperty ;
+  dct:description "OLE DB (Object Linking and Embedding, Database, sometimes written as OLEDB or OLE-DB), an API designed by Microsoft, allows accessing data from a variety of sources in a uniform manner. The API provides a set of interfaces implemented using the Component Object Model (COM); it is otherwise unrelated to OLE. " ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/OLE_DB"^^xsd:anyURI ;
+  qudt:informativeReference "http://msdn.microsoft.com/en-us/library/windows/desktop/ms714931(v=vs.85).aspx"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "OLE DB name" ;
+  rdfs:range xsd:string ;
+.
+qudt:omUnit
+  a owl:ObjectProperty ;
+  rdfs:domain qudt:Unit ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "om unit" ;
+.
+qudt:onlineReference
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "online reference" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:oracleSQLName
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ORACLE SQL name" ;
+  rdfs:range xsd:string ;
+.
+qudt:order
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "order" ;
+  rdfs:range xsd:nonNegativeInteger ;
+.
+qudt:orderedType
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ordered type" ;
+.
+qudt:outOfScope
+  a owl:AnnotationProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "out of scope" ;
+  rdfs:range xsd:boolean ;
+.
+qudt:permissibleMaths
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "permissible maths" ;
+.
+qudt:permissibleTransformation
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "permissible transformation" ;
+.
+qudt:plainTextDescription
+  a owl:DatatypeProperty ;
+  dct:description "A plain text description is used to provide a description with only simple ASCII characters for cases where LaTeX , HTML or other markup would not be appropriate."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "description (plain text)" ;
+  rdfs:range xsd:string ;
+.
+qudt:positiveDeltaLimit
+  a owl:DatatypeProperty ;
+  dct:description "A positive change limit between consecutive sample values for a parameter. The Positive Delta may be the encoded value or engineering units value depending on whether or not a Calibrator is defined."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Positive delta limit" ;
+  rdfs:range xsd:string ;
+.
+qudt:protocolBuffersName
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "protocol buffers name" ;
+  rdfs:range xsd:string ;
+.
+qudt:pythonName
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "python name" ;
+  rdfs:range xsd:string ;
+.
+qudt:qkdvDenominator
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "denominator dimension vector" ;
+  rdfs:range qudt:QuantityKindDimensionVector ;
+.
+qudt:qkdvNumerator
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "numerator dimension vector" ;
+  rdfs:range qudt:QuantityKindDimensionVector ;
+.
+qudt:quantity
+  a owl:ObjectProperty ;
+  dct:description "a property to relate an observable thing with a quantity (qud:Quantity)"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "quantity" ;
+.
+qudt:quantityValue
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "quantity value" ;
+  rdfs:range qudt:QuantityValue ;
+.
+qudt:rationale
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "rationale" ;
+  rdfs:range rdf:HTML ;
+.
+qudt:rdfsDatatype
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "rdfs datatype" ;
+.
+qudt:reference
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "reference" ;
+.
+qudt:referenceUnit
+  a owl:FunctionalProperty ;
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "reference unit" ;
+.
+qudt:relativeStandardUncertainty
+  a owl:DatatypeProperty ;
+  dct:description "The relative standard uncertainty of a measurement is the (absolute) standard uncertainty divided by the magnitude of the exact value."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "relative standard uncertainty" ;
+  rdfs:range xsd:double ;
+.
+qudt:relevantQuantityKind
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "relevant quantity kind" ;
+  rdfs:range qudt:QuantityKind ;
+.
+qudt:ruleType
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "rule type" ;
+.
+qudt:scaleType
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "scale type" ;
+.
+qudt:siUnitsExpression
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "si units expression" ;
+  rdfs:range xsd:string ;
+.
+qudt:specialization
+  a owl:ObjectProperty ;
+  dct:description "This property relates a quantity kind to its specialization(s). For example, linear velocity and angular velocity are both specializations of velocity."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "specialization" ;
+  owl:inverseOf qudt:generalization ;
+.
+qudt:standardUncertainty
+  a owl:DatatypeProperty ;
+  dct:description "The standard uncertainty of a quantity is the estimated standard deviation of the mean taken from a series of measurements."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "standard uncertainty" ;
+  rdfs:range xsd:double ;
+.
+qudt:symbol
+  a owl:DatatypeProperty ;
+  dct:description "The symbol is a glyph that is used to represent some concept, typically a unit or a quantity, in a compact form. For example, the symbol for an Ohm is \\(ohm\\). This contrasts with 'unit:abbreviation', which gives a short alphanumeric abbreviation for the unit, 'ohm' for Ohm."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "symbol" ;
+  rdfs:range xsd:string ;
+  rdfs:subPropertyOf qudt:literal ;
+.
+qudt:systemDefinition
+  a owl:ObjectProperty ;
+  a owl:TransitiveProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "system definition" ;
+.
+qudt:systemDerivedQuantityKind
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "system derived quantity kind" ;
+  rdfs:subPropertyOf qudt:hasQuantityKind ;
+  owl:inverseOf qudt:derivedQuantityKindOfSystem ;
+.
+qudt:systemDimension
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "system dimension" ;
+.
+qudt:ucumCaseInsensitiveCode
+  a owl:DatatypeProperty ;
+  dct:description "<em>ucumCode</em> associates a QUDT unit with a UCUM case-insensitive code."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ucum case-insensitive code" ;
+  rdfs:subPropertyOf qudt:ucumCode ;
+.
+qudt:ucumCaseSensitiveCode
+  a owl:DatatypeProperty ;
+  dct:description "<em>ucumCode</em> associates a QUDT unit with with a UCUM case-sensitive code."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ucum case-sensitive code" ;
+  rdfs:subPropertyOf qudt:ucumCode ;
+.
+qudt:ucumCode
+  a owl:DatatypeProperty ;
+  dct:description "<p><em>ucumCode</em> associates a QUDT unit with its UCUM counterpart.</p><p>In SHACL the values are derived from specifi ucum properties using 'sh:values'.</p>"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "ucum code" ;
+  rdfs:subPropertyOf skos:notation ;
+.
+qudt:uneceCommonCode
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "unece common code" ;
+  rdfs:range xsd:string ;
+.
+qudt:unit
+  a owl:ObjectProperty ;
+  dct:description "A reference to the unit of measure of a quantity (variable or constant) of interest."^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "unit" ;
+  rdfs:range qudt:Unit ;
+  owl:inverseOf qudt:unitFor ;
+.
+qudt:unitFor
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "unit for" ;
+  owl:inverseOf qudt:unit ;
+.
+qudt:upperBound
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "upper bound" ;
+  rdfs:range xsd:anySimpleType ;
+.
+qudt:url
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "url" ;
+  rdfs:range xsd:anyURI ;
+.
+qudt:value
+  a owl:ObjectProperty ;
+  dct:description "A property to relate an observable thing with a value that can be of any simple XSD type"^^rdf:HTML ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "value" ;
+.
+qudt:valueQuantity
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "value for quantity" ;
+  owl:inverseOf qudt:quantityValue ;
+.
+qudt:valueUnion
+  a rdfs:Datatype ;
+  dct:description "A datatype that is the union of numeric xsd data types. \"numericUnion\" is equivalent to the xsd specification that uses an xsd:union of memberTypes=\"xsd:decimal xsd:double xsd:float xsd:integer\"." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "value union" ;
+  rdfs:subClassOf rdfs:Resource ;
+  owl:equivalentClass [
+      a owl:Class ;
+      owl:unionOf (
+          xsd:anySimpleType
+          dtype:EnumeratedValue
+        ) ;
+    ] ;
+.
+qudt:vbName
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "Vusal Basic name" ;
+  rdfs:range xsd:string ;
+.
+qudt:vectorMagnitude
+  a owl:DatatypeProperty ;
+  a owl:FunctionalProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "vector magnitude" ;
+  rdfs:range xsd:float ;
+.
+qudt:width
+  a owl:DatatypeProperty ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "width" ;
+  rdfs:range xsd:string ;
+.
+voag:QUDT-SchemaCatalogEntry
+  a vaem:CatalogEntry ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Schema Catalog Entry" ;
+.
+voag:supersededBy
+  a owl:ObjectProperty ;
+  rdfs:isDefinedBy <http://voag.linkedmodel.org/schema/voag> ;
+  rdfs:label "superseded by" ;
+.
+<http://www.linkedmodel.org/schema/dtype>
+  vaem:namespace "http://www.linkedmodel.org/schema/dtype#"^^xsd:anyURI ;
+  vaem:namespacePrefix "dtype" ;
+.
+vaem:GMD_QUDT-SCHEMA
+  a vaem:GraphMetaData ;
+  dct:author "Ralph Hodgson" ;
+  dct:contributor "Daniel Mekonnen" ;
+  dct:contributor "David Price" ;
+  dct:contributor "Jack Hodges" ;
+  dct:contributor "James E. Masters" ;
+  dct:contributor "Simon Cox" ;
+  dct:contributor "Steve Ray" ;
+  dct:created "2011-04-20"^^xsd:date ;
+  dct:creator "Ralph Hodgson" ;
+  dct:description """<p class=\"lm-para\">The QUDT, or \"Quantity, Unit, Dimension and Type\" schema defines the base classes properties, and restrictions used for modeling physical quantities, units of measure, and their dimensions in various measurement systems. The goal of the QUDT ontology is to provide a unified model of, measurable quantities, units for measuring different kinds of quantities, the numerical values of quantities in different units of measure and the data structures and data types used to store and manipulate these objects in software.</p>
+
+<p class=\"lm-para\">Except for unit prefixes, all units are specified in separate vocabularies. Descriptions are provided in both HTML and LaTeX formats. A quantity is a measure of an observable phenomenon, that, when associated with something, becomes a property of that thing; a particular object, event, or physical system. </p>
+
+<p class=\"lm-para\">A quantity has meaning in the context of a measurement (i.e. the thing measured, the measured value, the accuracy of measurement, etc.) whereas the underlying quantity kind is independent of any particular measurement. Thus, length is a quantity kind while the height of a rocket is a specific quantity of length; its magnitude that may be expressed in meters, feet, inches, etc.  Or, as stated at Wikipedia, in the language of measurement, quantities are quantifiable aspects of the world, such as time, distance, velocity, mass, momentum, energy, and weight, and units are used to describe their measure. Many of these quantities are related to each other by various physical laws, and as a result the units of some of the quantities can be expressed as products (or ratios) of powers of other units (e.g., momentum is mass times velocity and velocity is measured in distance divided by time).</p>"""^^rdf:HTML ;
+  dct:modified "2020-04-06T12:30:51.335-07:00"^^xsd:dateTime ;
+  dct:rights "The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available at https://creativecommons.org/licenses/by/4.0/. Attribution should be made to QUDT.org" ;
+  dct:subject "QUDT" ;
+  dct:title "QUDT Schema - Version 2.1.2" ;
+  qudt:informativeReference "http://unitsofmeasure.org/trac"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.bipm.org/en/publications/si-brochure"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.bipm.org/utils/common/documents/jcgm/JCGM_200_2008.pdf"^^xsd:anyURI ;
+  qudt:informativeReference "https://books.google.com/books?id=pIlCAAAAIAAJ&dq=dimensional+analysis&hl=en"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.nist.gov/physical-measurement-laboratory/special-publication-811"^^xsd:anyURI ;
+  vaem:graphName "qudt" ;
+  vaem:graphTitle "Quantities, Units, Dimensions and Types (QUDT) Schema - Version 2.1.2" ;
+  vaem:hasGraphRole vaem:SchemaGraph ;
+  vaem:hasOwner vaem:QUDT ;
+  vaem:hasSteward vaem:QUDT ;
+  vaem:intent "Specifies the schema for quantities, units and dimensions. Types are defined in other schemas." ;
+  vaem:isMetadataFor <http://qudt.org/2.1/schema/qudt> ;
+  vaem:latestPublishedVersion "http://www.qudt.org/doc/2020/04/DOC_SCHEMA-QUDT-v2.1.html"^^xsd:anyURI ;
+  vaem:logo "http://www.linkedmodel.org/lib/lm/images/logos/qudt_logo-300x110.png"^^xsd:anyURI ;
+  vaem:namespace "http://qudt.org/schema/qudt/" ;
+  vaem:namespacePrefix "qudt" ;
+  vaem:owner "qudt.org" ;
+  vaem:previousPublishedVersion "http://www.qudt.org/doc/2019/10/DOC_SCHEMA-QUDT-v2.1.html"^^xsd:anyURI ;
+  vaem:revision "2.1.2" ;
+  vaem:turtleFileURL "http://qudt.org/2.1/schema/qudt"^^xsd:anyURI ;
+  vaem:usesNonImportedResource dct:abstract ;
+  vaem:usesNonImportedResource dct:author ;
+  vaem:usesNonImportedResource dct:contributor ;
+  vaem:usesNonImportedResource dct:created ;
+  vaem:usesNonImportedResource dct:description ;
+  vaem:usesNonImportedResource dct:modified ;
+  vaem:usesNonImportedResource dct:rights ;
+  vaem:usesNonImportedResource dct:source ;
+  vaem:usesNonImportedResource dct:subject ;
+  vaem:usesNonImportedResource dct:title ;
+  vaem:usesNonImportedResource voag:QUDT-Attribution ;
+  vaem:withAttributionTo voag:QUDT-Attribution ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT Schema - Version 2.1.2" ;
+  owl:versionIRI <http://qudt.org/2.1/schema/qudt> ;
+.
+vaem:QUDT
+  a vaem:Party ;
+  dct:description "QUDT is a non-profit organization that governs the QUDT ontologies."^^rdf:HTML ;
+  vaem:graphName "qudt.org" ;
+  vaem:website "http:/www.qudt.org"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/schema/qudt> ;
+  rdfs:label "QUDT" ;
+.
+prov:wasDerivedFrom
+  a rdf:Property ;
+  rdfs:isDefinedBy <http://www.w3.org/ns/prov> ;
+  rdfs:label "was derived from" ;
+  rdfs:range qudt:Concept ;
+.

--- a/support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -1,0 +1,8890 @@
+# baseURI: http://qudt.org/2.1/vocab/quantitykind
+# imports: http://qudt.org/2.1/schema/qudt
+# imports: http://qudt.org/2.1/vocab/constant
+# imports: http://qudt.org/2.1/vocab/dimensionvector
+# imports: http://qudt.org/2.1/vocab/unit
+
+@prefix constant: <http://qudt.org/vocab/constant/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mc: <http://www.linkedmodel.org/owl/schema/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
+@prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://qudt.org/2.1/vocab/quantitykind>
+  a owl:Ontology ;
+  vaem:hasGraphMetadata vaem:GMD_QUDT-QUANTITY-KINDS-ALL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "QUDT VOCAB Quantity Kinds r2.1.2" ;
+  owl:imports <http://qudt.org/2.1/schema/qudt> ;
+  owl:imports <http://qudt.org/2.1/vocab/constant> ;
+  owl:imports <http://qudt.org/2.1/vocab/dimensionvector> ;
+  owl:imports <http://qudt.org/2.1/vocab/unit> ;
+  owl:versionIRI <http://qudt.org/2.1/vocab/quantitykind> ;
+.
+quantitykind:AbsoluteActivity
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Absolute Activity\" is the exponential of the ratio of the chemical potential to \\(RT\\) where \\(R\\) is the gas constant and \\(T\\) the thermodynamic temperature."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://goldbook.iupac.org/A00019.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\lambda_B = e^{\\frac{\\mu_B}{RT}}\\), where \\(\\mu_B\\) is the chemical potential of substance \\(B\\), \\(R\\) is the molar gas constant, and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\lambda_B\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Absolute Activity" ;
+  skos:broader quantitykind:InverseVolume ;
+.
+quantitykind:AbsoluteHumidity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Absolute Humidity\" is an amount of water vapor, usually discussed per unit volume. Absolute humidity in air ranges from zero to roughly 30 grams per cubic meter when the air is saturated at \\(30 ^\\circ C\\). The absolute humidity changes as air temperature or pressure changes. This is very inconvenient for chemical engineering calculations, e.g. for clothes dryers, where temperature can vary considerably. As a result, absolute humidity is generally defined in chemical engineering as mass of water vapor per unit mass of dry air, also known as the mass mixing ratio, which is much more rigorous for heat and mass balance calculations. Mass of water per unit volume as in the equation above would then be defined as volumetric humidity. Because of the potential confusion."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:generalization quantitykind:Density ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Humidity"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Humidity#Absolute_humidity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(AH = \\frac{\\mathcal{M}_\\omega}{\\vee_{net}}\\),
+where \\(\\mathcal{M}_\\omega\\) is the mass of water vapor per unit volume of total air and \\(\\vee_{net}\\) is water vapor mixture."""^^qudt:LatexString ;
+  qudt:symbol "AH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Absolute Humidity" ;
+  rdfs:seeAlso quantitykind:RelativeHumidity ;
+  skos:broader quantitykind:Density ;
+.
+quantitykind:AbsorbedDose
+  a qudt:QuantityKind ;
+  dcterms:description "\"Absorbed Dose\" (also known as Total Ionizing Dose, TID) is a measure of the energy deposited in a medium by ionizing radiation. It is equal to the energy deposited per unit mass of medium, and so has the unit \\(J/kg\\), which is given the special name Gray (\\(Gy\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:GRAY ;
+  qudt:applicableUnit unit:RAD_R ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Absorbed_dose"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Absorbed_dose"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(D = \\frac{d\\bar{\\varepsilon}}{dm}\\), where \\(d\\bar{\\varepsilon}\\) is the mean energy imparted by ionizing radiation to an element of irradiated matter with the mass \\(dm\\)."^^qudt:LatexString ;
+  qudt:symbol "D" ;
+  rdfs:comment "Note that the absorbed dose is not a good indicator of the likely biological effect. 1 Gy of alpha radiation would be much more biologically damaging than 1 Gy of photon radiation for example. Appropriate weighting factors can be applied reflecting the different relative biological effects to find the equivalent dose. The risk of stoctic effects due to radiation exposure can be quantified using the effective dose, which is a weighted average of the equivalent dose to each organ depending upon its radiosensitivity. When ionising radiation is used to treat cancer, the doctor will usually prescribe the radiotherapy treatment in Gy. When risk from ionising radiation is being discussed, a related unit, the Sievert is used." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Absorbed Dose" ;
+  skos:broader quantitykind:SpecificEnergy ;
+.
+quantitykind:AbsorbedDoseRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:GRAY-PER-SEC ;
+  qudt:baseUnitDimensions "L^2/T^3" ;
+  qudt:baseUnitDimensions "m^2/s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-3D0> ;
+  qudt:informativeReference "http://www.answers.com/topic/absorbed-dose-rate"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\dot{D} = \\frac{dD}{dt}\\), where \\(dD\\) is the increment of absorbed dose during time interval with duration \\(dt\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\dot{D}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Absorbed Dose Rate\" is the absorbed dose of ionizing radiation imparted at a given location per unit of time (second, minute, hour, or day)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Absorbed Dose Rate" ;
+.
+quantitykind:Absorptance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Absorptance"^^xsd:anyURI ;
+  qudt:informativeReference "https://www.researchgate.net/post/Absorptance_or_absorbance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha = \\frac{\\Phi_a}{\\Phi_m}\\), where \\(\\Phi_a\\) is the absorbed radiant flux or the absorbed luminous flux, and \\(\\Phi_m\\) is the radiant flux or luminous flux of the incident radiation."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Absorptance is the ratio of the radiation absorbed by a surface to that incident upon it. Also known as absorbance." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Absorptance" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Absorbance> ;
+.
+quantitykind:Acceleration
+  a qudt:QuantityKind ;
+  dcterms:description "Acceleration is the (instantaneous) rate of change of velocity. Acceleration may be either linear acceleration, or angular acceleration. It is a vector quantity with dimension \\(length/time^{2}\\) for linear acceleration, or in the case of angular acceleration, with dimension \\(angle/time^{2}\\). In SI units, linear acceleration is measured in \\(meters/second^{2}\\) (\\(m \\cdot s^{-2}\\)) and angular acceleration is measured in \\(radians/second^{2}\\). In physics, any increase or decrease in speed is referred to as acceleration and similarly, motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M-PER-SEC2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Acceleration"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acceleration"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Acceleration" ;
+.
+quantitykind:AccelerationOfGravity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The acceleration of freely falling bodies under the influence of terrestrial gravity, equal to approximately 9.81 meters (32 feet) per second per second." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Acceleration Of Gravity" ;
+.
+quantitykind:AcceptorDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M0H0T0D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Acceptor Density\" is the number per volume of acceptor levels." ;
+  qudt:symbol "n_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Acceptor Density" ;
+.
+quantitykind:AcceptorIonizationEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ionization_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Acceptor Ionization Energy\" is the ionization energy of an acceptor." ;
+  qudt:symbol "E_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Acceptor Ionization Energy" ;
+  skos:broader quantitykind:IonizationEnergy ;
+  skos:closeMatch quantitykind:DonorIonizationEnergy ;
+.
+quantitykind:AcousticImpedance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA-SEC-PER-M3 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acoustic_impedance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z_a= \\frac{p}{q} = \\frac{p}{vS}\\), where \\(p\\) is the sound pressure, \\(q\\) is the sound volume velocity, \\(v\\) is sound particle velocity, and \\(S\\) is the surface area through which an acoustic wave of frequence \\(f\\) propagates."^^qudt:LatexString ;
+  qudt:plainTextDescription "Acoustic impedance at a surface is the complex quotient of the average sound pressure over that surface by the sound volume flow rate through that surface." ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Acoustic Impediance" ;
+.
+quantitykind:Action
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Action_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S = \\int Ldt\\), where \\(L\\) is the Lagrange function and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:plainTextDescription """An action is usually an integral over time. But for action pertaining to fields, it may be integrated over spatial variables as well. In some cases, the action is integrated along the path followed by the physical system.  If the action is represented as an integral over time, taken a the path of the system between the initial time and the final time of the development of the system.
+The evolution of a physical system between two states is determined by requiring the action be minimized or, more generally, be stationary for small perturbations about the true evolution. This requirement leads to differential equations that describe the true evolution. Conversely, an action principle is a method for reformulating differential equations of motion for a physical system as an equivalent integral equation. Although several variants have been defined (see below), the most commonly used action principle is Hamilton's principle.""" ;
+  qudt:symbol "S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Action" ;
+.
+quantitykind:ActionTime
+  a qudt:QuantityKind ;
+  rdfs:comment "Action Time (sec)" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Action Time" ;
+.
+quantitykind:ActivePower
+  a qudt:QuantityKind ;
+  dcterms:description "\\(Active Power\\) is, under periodic conditions, the mean value, taken over one period \\(T\\), of the instantaneous power \\(p\\). In complex notation, \\(P = \\mathbf{Re} \\; \\underline{S}\\), where \\(\\underline{S}\\) is \\(\\textit{complex power}\\)\"."^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-42"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(P = \\frac{1}{T}\\int_{0}^{T} pdt\\), where \\(T\\) is the period and \\(p\\) is instantaneous power."^^qudt:LatexString ;
+  qudt:symbol "P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Active Power" ;
+  rdfs:seeAlso quantitykind:ComplexPower ;
+  rdfs:seeAlso quantitykind:InstantaneousPower ;
+.
+quantitykind:Activity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Activity\" is the number of decays per unit time of a radioactive sample, the term used to characterise the number of nuclei which disintegrate in a radioactive substance per unit time. Activity is usually measured in Becquerels (\\(Bq\\)), where 1 \\(Bq\\) is 1 disintegration per second, in honor of the scientist Henri Becquerel."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BQ ;
+  qudt:applicableUnit unit:Ci ;
+  qudt:applicableUnit unit:MicroCi ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Radioactive_decay"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_number"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radioactive_decay"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radioactive_decay#Radioactive_decay_rates"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(A = Z + N\\), where \\(Z\\) is the atomic number and \\(N\\) is the neutron number.
+
+Variation \\(dN\\) of spontaneous number of nuclei \\(N\\) in a particular energy state, in a sample of radionuclide, due to spontaneous nuclear transitions from this state during an infinitesimal time interval, divided by its duration \\(dt\\), thus \\(A = -\\frac{dN}{dt}\\)."""^^qudt:LatexString ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Activity" ;
+  skos:broader quantitykind:StochasticProcess ;
+.
+quantitykind:ActivityCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Activity_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(f_B = \\frac{\\lambda_B}{(\\lambda_B^*x_B)}\\), where \\(\\lambda_B\\) the absolute activity of substance \\(B\\), \\(\\lambda_B^*\\) is the absolute activity of the pure substance \\(B\\) at the same temperature and pressure, and \\(x_B\\) is the amount-of-substance fraction of substance \\(B\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "An \"Activity Coefficient\" is a factor used in thermodynamics to account for deviations from ideal behaviour in a mixture of chemical substances. In an ideal mixture, the interactions between each pair of chemical species are the same (or more formally, the enthalpy change of solution is zero) and, as a result, properties of the mixtures can be expressed directly in terms of simple concentrations or partial pressures of the substances present e.g. Raoult's law. Deviations from ideality are accommodated by modifying the concentration by an activity coefficient. " ;
+  qudt:symbol "f_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Activity Coefficient" ;
+.
+quantitykind:ActivityConcentration
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BQ-PER-M3 ;
+  qudt:informativeReference "http://www.euronuclear.org/info/encyclopedia/activityconcentration.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c_A = \\frac{A}{V}\\), where \\(A\\) is the activity of a sample and \\(V\\) is its volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Activity Concentration\", also known as volume activity, and activity density, is ." ;
+  qudt:symbol "c_A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Activity Concentration" ;
+.
+quantitykind:ActivityThresholds
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_t\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Activity Thresholds\" are thresholds of sensitivity for radioactivity." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Activity Thresholds" ;
+.
+quantitykind:Adaptation
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Adaptation\" is the recovery of visual ability following exposure to light (dark adaptation)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Adaptation" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Neural_adaptation#Visual> ;
+.
+quantitykind:Admittance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Admittance\" is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of the impedance (\\(Z\\)). "^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Admittance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-51"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\underline{Y} = \\frac{1}{\\underline{Z}}\\), where \\(\\underline{Z}\\) is impedance."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\underline{Y}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Admittance" ;
+  rdfs:seeAlso quantitykind:Impedance ;
+.
+quantitykind:AmbientPressure
+  a qudt:QuantityKind ;
+  dcterms:description """The ambient pressure on an object is the pressure of the surrounding medium, such as a gas or liquid, which comes into contact with the object.
+The SI unit of pressure is the pascal (Pa), which is a very small unit relative to atmospheric pressure on Earth, so kilopascals (\\(kPa\\)) are more commonly used in this context. """^^qudt:LatexString ;
+  qudt:symbol "p_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ambient Pressure" ;
+.
+quantitykind:AmountOfSubstance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Amount of Substance\" is a standards-defined quantity that measures the size of an ensemble of elementary entities, such as atoms, molecules, electrons, and other particles. It is sometimes referred to as chemical amount. The International System of Units (SI) defines the amount of substance to be proportional to the number of elementary entities present. The SI unit for amount of substance is \\(mole\\). It has the unit symbol \\(mol\\). The mole is defined as the amount of substance that contains an equal number of elementary entities as there are atoms in 0.012kg of the isotope carbon-12. This number is called Avogadro's number and has the value \\(6.02214179(30) \\times 10\\). The only other unit of amount of substance in current use is the \\(pound-mole\\) with the symbol \\(lb-mol\\), which is sometimes used in chemical engineering in the United States. One \\(pound-mole\\) is exactly \\(453.59237 mol\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:IU ;
+  qudt:applicableUnit unit:MOL ;
+  qudt:baseUnitDimensions "M" ;
+  qudt:baseUnitDimensions "mol" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Amount_of_substance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Amount_of_substance"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance" ;
+.
+quantitykind:AmountOfSubstanceConcentrationOfB
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L-3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Amount_of_substance_concentration"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(C_B = \\frac{n_B}{V}\\), where \\(n_B\\) is the amount of substance \\(B\\) and \\(V\\) is the volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Amount of Substance of Concentration of B\" is defined as the amount of a constituent divided by the volume of the mixture." ;
+  qudt:symbol "C_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance of Concentration of B" ;
+.
+quantitykind:AmountOfSubstanceFractionOfB
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Amount_fraction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(x_B = \\frac{n_B}{n}\\), where \\(n_B\\) is the amount of substance \\(B\\) and \\(n\\) is the total amount of substance."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Amount of Substance of Fraction of B\" is defined as tthe amount of a constituent divided by the total amount of all constituents in a mixture." ;
+  qudt:symbol "X_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance of Fraction of B" ;
+.
+quantitykind:AmountOfSubstancePerUnitMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM ;
+  qudt:baseUnitDimensions "N/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M-1H0T0D0> ;
+  vaem:todo "fix the numerator and denominator dimensions" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance per Unit Mass" ;
+  skos:broader quantitykind:Concentration ;
+.
+quantitykind:AmountOfSubstancePerUnitVolume
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-PER-M3 ;
+  qudt:applicableUnit unit:MilliMOL-PER-L ;
+  qudt:baseUnitDimensions "M/L^3" ;
+  qudt:baseUnitDimensions "mol/m^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L-3I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.ask.com/answers/72367781/what-is-defined-as-the-amount-of-substance-per-unit-of-volume"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Molar_concentration"^^xsd:anyURI ;
+  qudt:plainTextDescription "The amount of substance per unit volume is called the molar density. Molar density is an intensive property of a substance and depends on the temperature and pressure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Amount of Substance per Unit Volume" ;
+  skos:broader quantitykind:Concentration ;
+.
+quantitykind:Angle
+  a qudt:QuantityKind ;
+  dcterms:description "The inclination to each other of two intersecting lines, measured by the arc of a circle intercepted between the two lines forming the angle, the center of the circle being the point of intersection.  An acute angle is less than \\(90^\\circ\\), a right angle \\(90^\\circ\\); an obtuse angle, more than \\(90^\\circ\\) but less than \\(180^\\circ\\); a straight angle, \\(180^\\circ\\); a reflex angle, more than \\(180^\\circ\\) but less than \\(360^\\circ\\); a perigon, \\(360^\\circ\\). Any angle not a multiple of \\(90^\\circ\\) is an oblique angle. If the sum of two angles is \\(90^\\circ\\), they are complementary angles; if \\(180^\\circ\\), supplementary angles; if \\(360^\\circ\\), explementary angles."^^qudt:LatexString ;
+  qudt:applicableUnit unit:MIN_Angle ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angle"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angle" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:AngleOfAttack
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Angle of attack  is the angle between the oncoming air or relative wind and a reference line on the airplane or wing." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angle Of Attack" ;
+.
+quantitykind:AngleOfOpticalRotation
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Optical_rotation"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Angle of Optical Rotation\" is the angle through which plane-polarized light is rotated clockwise, as seen when facing the light source, in passing through an optically active medium." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angle of Optical Rotation" ;
+.
+quantitykind:AngularAcceleration
+  a qudt:QuantityKind ;
+  dcterms:description "Angular acceleration is the rate of change of angular velocity over time. Measurement of the change made in the rate of change of an angle that a spinning object undergoes per unit time. It is a vector quantity.  Also called Rotational acceleration. In SI units, it is measured in radians per second squared (\\(rad/s^2\\)), and is usually denoted by the Greek letter alpha."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DEG-PER-SEC2 ;
+  qudt:applicableUnit unit:RAD-PER-SEC2 ;
+  qudt:applicableUnit unit:REV-PER-SEC2 ;
+  qudt:baseCGSUnitDimensions "U/T^2" ;
+  qudt:baseSIUnitDimensions "\\(/s^2\\)"^^qudt:LatexString ;
+  qudt:baseUnitDimensions "U/T^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_acceleration"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-2D1> ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T2D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Acceleration" ;
+  skos:broader quantitykind:Acceleration ;
+.
+quantitykind:AngularCross-Section
+  a qudt:QuantityKind ;
+  dcterms:description "\"Angular Cross-section\" is the cross-section for ejecting or scattering a particle into an elementary cone, divided by the solid angle \\(d\\Omega\\) of that cone."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M2-PER-SR ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sigma = \\int \\sigma_\\Omega d\\Omega\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma_\\Omega\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Cross-section" ;
+  skos:broader quantitykind:CrossSection ;
+  skos:closeMatch quantitykind:SpectralCross-Section ;
+.
+quantitykind:AngularDistance
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Angular distance travelled by orbiting vehicle measured from the azimuth of closest approach." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Distance" ;
+.
+quantitykind:AngularFrequency
+  a qudt:QuantityKind ;
+  dcterms:description "\"Angular frequency\", symbol \\(\\omega\\) (also referred to by the terms angular speed, radial frequency, circular frequency, orbital frequency, radian frequency, and pulsatance) is a scalar measure of rotation rate. Angular frequency (or angular speed) is the magnitude of the vector quantity angular velocity."^^qudt:LatexString ;
+  qudt:applicableUnit unit:HZ ;
+  qudt:applicableUnit unit:PlanckFrequency_Ang ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_frequency"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Angular_frequency"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\omega = 2\\pi f\\), where \\(f\\) is frequency."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\(\\omega\\)\\)"^^qudt:LatexString ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Frequency" ;
+  skos:broader quantitykind:Frequency ;
+.
+quantitykind:AngularImpulse
+  a qudt:QuantityKind ;
+  dcterms:description "The Angular Impulse, also known as angular momentum, is the moment of linear momentum around a point. It is defined as\\(H = \\int Mdt\\), where \\(M\\) is the moment of force and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-M2-PER-SEC ;
+  qudt:applicableUnit unit:N-M-SEC ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/AngularMomentum"^^xsd:anyURI ;
+  qudt:exactMatch quantitykind:AngularMomentum ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-1D0> ;
+  qudt:informativeReference "http://emweb.unl.edu/NEGAHBAN/EM373/note13/note.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:symbol "H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Impulse" ;
+.
+quantitykind:AngularMeasurement
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ARCMIN ;
+  qudt:applicableUnit unit:MilliARCSEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Measurement" ;
+.
+quantitykind:AngularMomentum
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ERG-SEC ;
+  qudt:applicableUnit unit:EV-SEC ;
+  qudt:applicableUnit unit:FT-LB_F-SEC ;
+  qudt:applicableUnit unit:J-SEC ;
+  qudt:applicableUnit unit:KiloGM-M2-PER-SEC ;
+  qudt:applicableUnit unit:N-M-SEC ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/T" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_momentum"^^xsd:anyURI ;
+  qudt:generalization quantitykind:Momentum ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Angular_momentum"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L = I\\omega\\), where \\(I\\) is the moment of inertia, and \\(\\omega\\) is the angular velocity."^^qudt:LatexString ;
+  qudt:plainTextDescription "Angular Momentum of an object rotating about some reference point is the measure of the extent to which the object will continue to rotate about that point unless acted upon by an external torque. In particular, if a point mass rotates about an axis, then the angular momentum with respect to a point on the axis is related to the mass of the object, the velocity and the distance of the mass to the axis. While the motion associated with linear momentum has no absolute frame of reference, the rotation associated with angular momentum is sometimes spoken of as being measured relative to the fixed stars.  \\textit{Angular Momentum}, \\textit{Moment of Momentum}, or \\textit{Rotational Momentum\", is a vector quantity that represents the product of a body's rotational inertia and rotational velocity about a particular axis." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Momentum" ;
+  skos:broader quantitykind:Momentum ;
+.
+quantitykind:AngularReciprocalLatticeVector
+  a qudt:QuantityKind ;
+  dcterms:description "\"Angular Reciprocal Lattice Vector\" is a vector whose scalar products with all fundamental lattice vectors are integral multiples of \\(2\\pi\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://www.matter.org.uk/diffraction/geometry/lattice_vectors.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Reciprocal Lattice Vector" ;
+  skos:broader quantitykind:LatticeVector ;
+.
+quantitykind:AngularVelocity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG-PER-HR ;
+  qudt:applicableUnit unit:DEG-PER-MIN ;
+  qudt:applicableUnit unit:DEG-PER-SEC ;
+  qudt:applicableUnit unit:RAD-PER-HR ;
+  qudt:applicableUnit unit:RAD-PER-MIN ;
+  qudt:applicableUnit unit:RAD-PER-SEC ;
+  qudt:applicableUnit unit:REV-PER-HR ;
+  qudt:applicableUnit unit:REV-PER-MIN ;
+  qudt:applicableUnit unit:REV-PER-SEC ;
+  qudt:baseUnitDimensions "/s" ;
+  qudt:baseUnitDimensions "U/T" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angular_velocity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D1> ;
+  qudt:plainTextDescription "The change of angle per unit time; specifically, in celestial mechanics, the change in angle of the radius vector per unit time." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T1D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Velocity" ;
+  skos:broader quantitykind:Velocity ;
+.
+quantitykind:AngularWavenumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:applicableUnit unit:RAD-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Wavenumber"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(k = \\frac{2\\pi}{\\lambda}= \\frac{2\\pi\\upsilon}{\\upsilon_p}=\\frac{\\omega}{\\upsilon_p}\\), where \\(\\upsilon\\) is the frequency of the wave, \\(\\lambda\\) is the wavelength, \\(\\omega = 2\\pi \\upsilon\\) is the angular frequency of the wave, and \\(\\upsilon_p\\) is the phase velocity of the wave.
+
+Alternatively:
+
+\\(k = \\frac{p}{\\hbar}\\), where \\(p\\) is the linear momentum of quasi free electrons in an electron gas and \\(\\hbar\\) is the reduced Planck constant (\\(h\\) divided by \\(2\\pi\\)); for phonons, its magnitude is \\(k = \\frac{2\\pi}{\\lambda}\\), where \\(\\lambda\\) is the wavelength of the lattice vibrations."""^^qudt:LatexString ;
+  qudt:plainTextDescription "\"wavenumber\" is the spatial frequency of a wave - the number of waves that exist over a specified distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector." ;
+  qudt:symbol "k" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Angular Wave Number" ;
+  rdfs:label "Angular Wavenumber" ;
+.
+quantitykind:ApogeeRadius
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Apogee radius of an elliptical orbit" ;
+  qudt:symbol "r_2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Apogee Radius" ;
+.
+quantitykind:ApparentPower
+  a qudt:QuantityKind ;
+  dcterms:description "\"Apparent Power\" is the product of the rms voltage \\(U\\) between the terminals of a two-terminal element or two-terminal circuit and the rms electric current I in the element or circuit. Under sinusoidal conditions, the apparent power is the modulus of the complex power."^^qudt:LatexString ;
+  qudt:applicableUnit unit:V-A ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-41"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\left | \\underline{S} \\right | =  UI\\), where \\(U\\) is rms value of voltage and \\(I\\) is rms value of electric current."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\left | \\underline{S} \\right |\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Apparent Power" ;
+  rdfs:seeAlso quantitykind:ElectricCurrent ;
+  rdfs:seeAlso quantitykind:Voltage ;
+.
+quantitykind:Area
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:AC ;
+  qudt:applicableUnit unit:ARE ;
+  qudt:applicableUnit unit:BARN ;
+  qudt:applicableUnit unit:CentiM2 ;
+  qudt:applicableUnit unit:FT2 ;
+  qudt:applicableUnit unit:HA ;
+  qudt:applicableUnit unit:IN2 ;
+  qudt:applicableUnit unit:M2 ;
+  qudt:applicableUnit unit:MI2 ;
+  qudt:applicableUnit unit:MIL_Circ ;
+  qudt:applicableUnit unit:PlanckArea ;
+  qudt:applicableUnit unit:YD2 ;
+  qudt:baseCGSUnitDimensions "cm^2" ;
+  qudt:baseSIUnitDimensions "\\(m^2\\)"^^qudt:LatexString ;
+  qudt:baseUnitDimensions "L^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Area"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0> ;
+  qudt:plainTextDescription "Area is a quantity expressing the two-dimensional size of a defined part of a surface, typically a region bounded by a closed curve." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area" ;
+.
+quantitykind:AreaAngle
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-SR ;
+  qudt:baseUnitDimensions "L^2 \\cdot U" ;
+  qudt:baseUnitDimensions "m^2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area Angle" ;
+.
+quantitykind:AreaPerTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:baseImperialUnitDimensions "\\(ft^2/s\\)"^^qudt:LatexString ;
+  qudt:baseSIUnitDimensions "\\(m^2/s\\)"^^qudt:LatexString ;
+  qudt:baseUSCustomaryUnitDimensions "\\(L^2/T\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area per Time" ;
+.
+quantitykind:AreaTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FT2-DEG_F ;
+  qudt:applicableUnit unit:M2-K ;
+  qudt:baseUnitDimensions "K \\cdot m^2" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot L^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area Temperature" ;
+.
+quantitykind:AreaThermalExpansion
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-K ;
+  qudt:baseUnitDimensions "L^2/\\Theta" ;
+  qudt:baseUnitDimensions "m^2/K" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/area_thermal_expansion"^^xsd:anyURI ;
+  qudt:plainTextDescription "When the temperature of a substance changes, the energy that is stored in the intermolecular bonds between atoms changes. When the stored energy increases, so does the length of the molecular bonds. As a result, solids typically expand in response to heating and contract on cooling; this dimensional response to temperature change is expressed by its coefficient of thermal expansion." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area Thermal Expansion" ;
+.
+quantitykind:AreaTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CentiM2-MIN ;
+  qudt:applicableUnit unit:CentiM2-SEC ;
+  qudt:applicableUnit unit:HR-FT2 ;
+  qudt:applicableUnit unit:SEC-FT2 ;
+  qudt:baseUnitDimensions "L^2 \\cdot T" ;
+  qudt:baseUnitDimensions "m^2 \\cdot s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area Time" ;
+.
+quantitykind:AreaTimeTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:FT2-SEC-DEG_F ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H1T1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Area Time Temperature" ;
+.
+quantitykind:Asset
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "An Asset is an economic resource owned by a business or company. Simply stated, assets are things of value that can be readily converted into cash (although cash itself is also considered an asset)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Asset" ;
+.
+quantitykind:AtmosphericPressure
+  a qudt:QuantityKind ;
+  dcterms:description "The pressure exerted by the weight of the air above it at any point on the earth's surface. At sea level the atmosphere will support a column of mercury about \\(760 mm\\) high. This decreases with increasing altitude. The standard value for the atmospheric pressure at sea level in SI units is \\(101,325 pascals\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Atmospheric_pressure"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/views/ENTRY.html?subview=Main&entry=t83.e178"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Atmospheric Pressure" ;
+  skos:broader quantitykind:Pressure ;
+.
+quantitykind:AtomScatteringFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://reference.iucr.org/dictionary/Atomic_scattering_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(f = \\frac{E_a}{E_e}\\), where \\(E_a\\) is the radiation amplitude scattered by the atom and \\(E_e\\) is the radiation ampliture scattered by a single electron."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Atom Scattering Factor\" is measure of the scattering power of an isolated atom." ;
+  qudt:symbol "f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Atom Scattering Factor" ;
+.
+quantitykind:AtomicCharge
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.answers.com/topic/atomic-charge"^^xsd:anyURI ;
+  qudt:plainTextDescription "The electric charge of an ion, equal to the number of electrons the atom has gained or lost in its ionization multiplied by the charge on one electron." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Atomic Charge" ;
+.
+quantitykind:AtomicMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Atomic Mass\" is the mass of a specific isotope, most often expressed in unified atomic mass units." ;
+  qudt:symbol "m_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Atomic Mass" ;
+.
+quantitykind:AtomicNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_number"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Atomic Number\", also known as the proton number, is the number of protons found in the nucleus of an atom and therefore identical to the charge number of the nucleus. A nuclide is a species of atom with specified numbers of protons and neutrons. Nuclides with the same value of Z but different values of N are called isotopes of an element. The ordinal number of an element in the periodic table is equal to the atomic number. The atomic number equals the charge of the nucleus in units of the elementary charge." ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Atomic Number" ;
+.
+quantitykind:AttenuationCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Attenuation_coefficient"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(F(x) = Ae^{-\\alpha x} \\cos{[\\beta (x - x_0)]}\\), then \\(\\alpha\\) is the attenuation coefficient and \\(\\beta\\) is the phase coefficient."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The attenuation coefficient is a quantity that characterizes how easily a material or medium can be penetrated by a beam of light, sound, particles, or other energy or matter. A large attenuation coefficient means that the beam is quickly \"attenuated\" (weakened) as it passes through the medium, and a small attenuation coefficient means that the medium is relatively transparent to the beam. The Attenuation Coefficient is also called linear attenuation coefficient, narrow beam attenuation coefficient, or absorption coefficient." ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Attenuation Coefficient" ;
+.
+quantitykind:AuditoryThresholds
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_a\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Auditory Thresholds\" is the thresholds of sensitivity to auditory signals and other input to the ear or the sense of hearing." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Auditory Thresholds" ;
+.
+quantitykind:AuxillaryMagneticField
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-M ;
+  qudt:applicableUnit unit:AT-PER-IN ;
+  qudt:applicableUnit unit:AT-PER-M ;
+  qudt:applicableUnit unit:OERSTED ;
+  qudt:applicableUnit unit:T_Ab ;
+  qudt:exactMatch quantitykind:MagneticFieldStrength ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-1I0M0H0T0D0> ;
+  qudt:latexSymbol "H"^^qudt:LatexString ;
+  qudt:plainTextDescription "Magnetic Fields surround magnetic materials and electric currents and are detected by the force they exert on other magnetic materials and moving electric charges. The electric and magnetic fields are two interrelated aspects of a single object, called the electromagnetic field. A pure electric field in one reference frame is observed as a combination of both an electric field and a magnetic field in a moving reference frame. The Auxillary Magnetic Field, H characterizes how the true Magnetic Field B influences the organization of magnetic dipoles in a given medium." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Auxillary Magnetic Field" ;
+  skos:broader quantitykind:ElectricCurrentPerUnitLength ;
+  skos:broader quantitykind:LinearElectricCurrent ;
+.
+quantitykind:AverageLogarithmicEnergyDecrement
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://everything2.com/title/Average+logarithmic+energy+decrement+per+collision"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\xi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Average Logarithmic Energy Decrement\" is a measure of the amount of energy a neutron loses upon colliding with various nuclei. It is the average value of the increase in lethargy in elastic collisions between neutrons and nuclei whose kinetic energy is negligible compared with that of the neutrons." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Average Logarithmic Energy Decrement" ;
+.
+quantitykind:AverageSpecificImpulse
+  a qudt:QuantityKind ;
+  rdfs:comment "Avg Specific Impulse (lbf-sec/lbm) " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Average Specific Impulse" ;
+  skos:broader quantitykind:SpecificImpulse ;
+.
+quantitykind:AverageVacuumThrust
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Average Vacuum Thrust" ;
+  skos:altLabel "AVT" ;
+  skos:broader quantitykind:VacuumThrust ;
+.
+quantitykind:BendingMomentOfForce
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:N-M ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Torque"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bending_moment"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(M_b = M \\cdot e_Q\\), where \\(M\\) is the momentof force and \\(e_Q\\) is a unit vector directed along a \\(Q-axis\\) with respect to which the torque is considered."^^qudt:LatexString ;
+  qudt:plainTextDescription "A bending moment exists in a structural element when a moment is applied to the element so that the element bends. It is the component of moment of force perpendicular to the longitudinal axis of a beam or a shaft." ;
+  qudt:symbol "M_b" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Bending Moment of Force" ;
+  skos:broader quantitykind:MomentOfForce ;
+.
+quantitykind:BevelGearPitchAngle
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Pitch angle in bevel gears is the angle between an element of a pitch cone and its axis. In external and internal bevel gears, the pitch angles are respectively less than and greater than 90 degrees." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Bevel Gear Pitch Angle" ;
+.
+quantitykind:BindingFraction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/binding+fraction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(b = \\frac{B_r}{A}\\), where \\(B_r\\) is the relative mass defect and \\(A\\) is the nucleon number."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Binding Fraction\" is the ratio of the binding energy of a nucleus to the atomic mass number." ;
+  qudt:symbol "b" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Binding Fraction" ;
+.
+quantitykind:BloodGlucoseLevel
+  a qudt:QuantityKind ;
+  dcterms:description """<p>The blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and other animals. Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times. The body tightly regulates blood glucose levels as a part of metabolic homeostasis. Glucose is stored in skeletal muscle and liver cells in the form of glycogen;[2] in fasted individuals, blood glucose is maintained at a constant level at the expense of glycogen stores in the liver and skeletal muscle. [Wikipedia]</p>
+
+<p>There are two main methods of describing concentrations: by weight, and by molecular count. Weights are in grams, molecular counts in moles. A mole is 6.022*10^23 molecules.) In both cases, the
+unit is usually modified by \\(milli-\\) or \\(micro-\\) or other prefix, and is always \\(per\\) some volume, often a liter. Conversion factors depend on the molecular weight of the substance in question.</p>
+
+<p>\\(mmol/l\\) is millimoles/liter, and is the world standard unit for measuring glucose in blood. Specifically, it is the designated SI (Systeme International) unit. \"World standard\"is not universal; not only the US but a number of other countries use mg/dl. A mole is about 6*10^23 molecules.</p>
+
+<p>\\(mg/dl\\) (milligrams/deciliter) is the traditional unit for measuring bG (blood glucose). There is trend toward using \\(mmol/L\\) however mg/dl is much in practice. Some use is made of \\(mmol/L\\) as
+the primary unit with \\(mg/dl\\) quoated in parentheses. This acknowledges the large base of health care providers, researchers and patients who are already familiar with \\(mg/dl|).</p>"""^^qudt:LatexString ;
+  qudt:applicableUnit unit:MilliGM-PER-DeciL ;
+  qudt:applicableUnit unit:MilliMOL-PER-L ;
+  qudt:informativeReference "http://www.faqs.org/faqs/diabetes/faq/part1/section-9.html"^^xsd:anyURI ;
+  rdfs:comment "citation: https://en.wikipedia.org/wiki/Blood_sugar_level" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Blood Glucose Level" ;
+  rdfs:seeAlso quantitykind:SystolicBloodPressure ;
+.
+quantitykind:BodyMassIndex
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textit{Body Mass Index}\\), BMI, is an index of weight for height, calculated as: \\(BMI = \\frac{M_{body}}{H}\\), where \\(M_{body}\\) is body mass in kg, and \\(H\\) is height in metre. The BMI has been used as a guideline for defining whether a person is overweight because it minimizes the effect of height, but it does not take into consideration other important factors, such as age and body build. The BMI has also been used as an indicator of obesity on the assumption that the higher the index, the greater the level of body fat."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T0D0> ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198631477.001.0001/acref-9780198631477-e-254"^^xsd:anyURI ;
+  qudt:symbol "BMI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Body Mass Index" ;
+  skos:altLabel "BMI" ;
+.
+quantitykind:BraggAngle
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://reference.iucr.org/dictionary/Bragg_angle"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(2d\\sin{\\vartheta} = n\\lambda \\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\vartheta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Bragg Angle\" describes the condition for a plane wave to be diffracted from a family of lattice planes, the angle between the wavevector of the incident plane wave, and the lattice planes." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Bragg Angle" ;
+.
+quantitykind:Breadth
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Length"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wiktionary.org/wiki/breadth"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Breadth\" is the extent or measure of how broad or wide something is." ;
+  qudt:symbol "b" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Breadth" ;
+.
+quantitykind:BucklingFactor
+  a qudt:QuantityKind ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Buckling Factor" ;
+.
+quantitykind:BulkModulus
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bulk_modulus"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(K = \\frac{p}{\\vartheta}\\), where \\(\\p\\) is pressure and \\(\\vartheta\\) is volume strain."^^qudt:LatexString ;
+  qudt:plainTextDescription "The bulk modulus of a substance measures the substance's resistance to uniform compression. It is defined as the ratio of the infinitesimal pressure increase to the resulting relative decrease of the volume." ;
+  qudt:symbol "K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Bulk Modulus" ;
+.
+quantitykind:BurgersVector
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Burgers_vector"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Burgers Vector\" is the vector characterizing a dislocation, i.e. the closing vector in a Burgers circuit encircling a dislocation line." ;
+  qudt:symbol "b" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Burgers Vector" ;
+.
+quantitykind:BurnRate
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Burn Rate" ;
+.
+quantitykind:BurnTime
+  a qudt:QuantityKind ;
+  qudt:symbol "t" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Burn Time" ;
+.
+quantitykind:CENTER-OF-GRAVITY_X
+  a qudt:QuantityKind ;
+  qudt:symbol "cg" ;
+  qudt:url "http://www.grc.nasa.gov/WWW/k-12/airplane/cg.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Center of Gravity in the X axis" ;
+.
+quantitykind:CENTER-OF-GRAVITY_Y
+  a qudt:QuantityKind ;
+  qudt:symbol "cg" ;
+  qudt:url "http://www.grc.nasa.gov/WWW/k-12/airplane/cg.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Center of Gravity in the Y axis" ;
+.
+quantitykind:CENTER-OF-GRAVITY_Z
+  a qudt:QuantityKind ;
+  qudt:symbol "cg" ;
+  qudt:url "http://www.grc.nasa.gov/WWW/k-12/airplane/cg.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Center of Gravity in the X axis" ;
+.
+quantitykind:CENTER-OF-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The point at which the distributed mass of a composite body can be acted upon by a force without inducing any rotation of the composite body." ;
+  qudt:symbol "R" ;
+  qudt:url "http://en.wikipedia.org/wiki/Center_of_mass"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Center of Mass (CoM)"^^rdfs:Literal ;
+  skos:altLabel "COM" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:CONTRACT-END-ITEM-SPECIFICATION-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Contractual mass requirement of a delivered item. Note that The term 'control mass' is sometimes utilized as a limit in lieu of CEI mass when a CEI mass does not exist. The term 'Interface Control Document Mass' is another alternative for specifying a contractual mass requirement." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Contract End Item (CEI) Specification Mass"^^rdfs:Literal ;
+  skos:altLabel "CEI" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:CONTROL-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The upper design gross mass limit of a system at a specified mission event against which margins are calculated after accounting for basic masses of flight hardware, MGA, and uncertainties. It may include propellants, crew, and cargo." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Control Mass"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:CanonicalPartitionFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Partition_function_(statistical_mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z = \\sum_r e^{-\\frac{E_r}{kT}}\\), where the sum is over all quantum states consistent with given energy, volume, external fields, and content, \\(E_r\\) is the energy in the \\(rth\\) quantum state, \\(k\\) is the Boltzmann constant, and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:plainTextDescription "A \"Canonical Partition Function\" applies to a canonical ensemble, in which the system is allowed to exchange heat with the environment at fixed temperature, volume, and number of particles." ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Canonical Partition Function" ;
+.
+quantitykind:Capacitance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FARAD ;
+  qudt:applicableUnit unit:FARAD_Ab ;
+  qudt:applicableUnit unit:FARAD_Stat ;
+  qudt:applicableUnit unit:MicroFARAD ;
+  qudt:applicableUnit unit:NanoFARAD ;
+  qudt:applicableUnit unit:PicoFARAD ;
+  qudt:baseUnitDimensions "A^2 \\cdot s^4/kg \\cdot m^2" ;
+  qudt:baseUnitDimensions "I^2 \\cdot T^4/L^2 \\cdot M" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Capacitance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T4D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(C = Q/U\\), where \\(Q\\) is electric charge and \\(V\\) is voltage."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Capacitance\" is the ability of a body to hold an electrical charge; it is quantified as the amount of electric charge stored for a given electric potential. Capacitance is a scalar-valued quantity." ;
+  qudt:symbol "C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Capacitance" ;
+.
+quantitykind:Capacity
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Capacity"^^xsd:anyURI ;
+  qudt:plainTextDescription "In computer operations, (a) the largest quantity which can be stored, processed, or transferred; (b) the largest number of digits or characters which may regularly be processed; (c) the upper and lower limits of the quantities which may be processed. In other contexts, the amount of material that  can be stored, such as fuel or food." ;
+  qudt:symbol "TBD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Capacity" ;
+.
+quantitykind:CarrierLifetIme
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Carrier_lifetime"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\tau, \\tau_n, \\tau_p\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Carrier LifetIme\" is a time constant for recombination or trapping of minority charge carriers in semiconductors." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Carrier LifetIme" ;
+.
+quantitykind:CartesianCoordinates
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cartesian_coordinate_system"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Cartesian Coordinates\" specify each point uniquely in a plane by a pair of numerical coordinates, which are the signed distances from the point to two fixed perpendicular directed lines, measured in the same unit of length. " ;
+  qudt:symbol "x, y, z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cartesian Coordinates" ;
+.
+quantitykind:CartesianVolume
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Volume"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(V = \\int\\int\\int dxdydz\\), where \\(x\\), \\(y\\), and \\(z\\) are cartesian coordinates."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Volume\" is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains." ;
+  qudt:symbol "V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume" ;
+  skos:closeMatch quantitykind:Volume ;
+.
+quantitykind:CatalyticActivity
+  a qudt:QuantityKind ;
+  dcterms:description "An index of the actual or potential activity of a catalyst. The catalytic activity of an enzyme or an enzyme-containing preparation is defined as the property measured by the increase in the rate of conversion of a specified chemical reaction that the enzyme produces in a specified assay system. Catalytic activity is an extensive quantity and is a property of the enzyme, not of the reaction mixture; it is thus conceptually different from rate of conversion although measured by and equidimensional with it. The unit for catalytic activity is the \\(katal\\); it may also be expressed in mol \\(s^{-1}\\). Dimensions: \\(N T^{-1}\\). Former terms such as catalytic ability, catalytic amount, and enzymic activity are no er recommended. Derived quantities are molar catalytic activity, specific catalytic activity, and catalytic activity concentration. Source(s): <a href=\"http://www.answers.com/topic/catalytic-activity-biochemistry\">www.answers.com</a>"^^qudt:LatexString ;
+  qudt:applicableUnit unit:KAT ;
+  qudt:baseUnitDimensions "M/T" ;
+  qudt:baseUnitDimensions "mol/s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Catalysis"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Catalytic Activity" ;
+.
+quantitykind:CelciusTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG_C ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition """\"Celcius Temperature\", the thermodynamic temperature \\(T_0\\), is exactly \\SI{0.01}{\\kelvin below the thermodynamic temperature of the triple point of water.
+
+\\(t = T - T_0\\), where \\(T\\) is Thermodynamic Temperature and \\(T_0 = 273.15 K\\)."""^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Celcius Temperature\", the thermodynamic temperature T_0, is exactly 0.01 kelvin below the thermodynamic temperature of the triple point of water." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Celcius temperature" ;
+  prov:wasDerivedFrom quantitykind:ThermodynamicTemperature ;
+.
+quantitykind:CharacteristicAcousticImpedance
+  a qudt:QuantityKind ;
+  dcterms:description "Characteristic impedance at a point in a non-dissipative medium and for a plane progressive wave, the quotient of the sound pressure \\(p\\) by the component of the sound particle velocity \\(v\\) in the direction of the wave propagation."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PA-SEC-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acoustic_impedance#Characteristic_acoustic_impedance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z_c = pc\\), where \\(p\\) is the sound pressure and \\(c\\) is the phase speed of sound."^^qudt:LatexString ;
+  qudt:symbol "Z" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Characteristic Acoustic Impedance" ;
+  skos:broader quantitykind:AcousticImpedance ;
+.
+quantitykind:CharacteristicVelocity
+  a qudt:QuantityKind ;
+  dcterms:description "Characteristic velocity or \\(c^{*}\\) is a measure of the combustion performance of a rocket engine independent of nozzle performance, and is used to compare different propellants and propulsion systems."^^qudt:LatexString ;
+  qudt:symbol "c^{*}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Characteristic Velocity" ;
+.
+quantitykind:ChargeNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Charge Number\", or just valance of an ion is the coefficient that, when multiplied by the elementary charge, gives the ion's charge." ;
+  qudt:symbol "z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Charge Number" ;
+.
+quantitykind:ChemicalAffinity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-MOL ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Chemical_affinity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(A = -\\sum \\nu_b\\mu_B\\), where \\(\\nu_b\\) is the stoichiometric number of substance \\(B\\) and \\(\\mu_B\\) is the chemical potential of substance \\(B\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "In chemical physics and physical chemistry, \"Chemical Affinity\" is the electronic property by which dissimilar chemical species are capable of forming chemical compounds. Chemical affinity can also refer to the tendency of an atom or compound to combine by chemical reaction with atoms or compounds of unlike composition." ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Chemical Affinity" ;
+.
+quantitykind:ChemicalPotential
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-MOL ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Chemical_potential"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu_B = (\\frac{\\partial G}{\\partial n_B})_{T,p,n_i}\\), where \\(G\\) is Gibbs energy, and \\(n_B\\) is the amount of substance \\(B\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu_B\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Chemical Potential\", also known as partial molar free energy, is a form of potential energy that can be absorbed or released during a chemical reaction." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Chemical Potential" ;
+.
+quantitykind:Circulation
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Circulation_%28fluid_dynamics%29"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In fluid dynamics, circulation is the line integral around a closed curve of the fluid velocity. It has dimensions of length squared over time." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Circulation" ;
+  skos:broader quantitykind:AreaPerTime ;
+.
+quantitykind:ClosestApproachRadius
+  a qudt:QuantityKind ;
+  qudt:symbol "r_o" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Closest Approach Radius" ;
+.
+quantitykind:CoefficientOfHeatTransfer
+  a qudt:QuantityKind ;
+  qudt:applicableImperialUnit unit:BTU_IT-PER-FT2-HR-DEG_F ;
+  qudt:applicableImperialUnit unit:BTU_IT-PER-FT2-SEC-DEG_F ;
+  qudt:applicableSIUnit unit:W-PER-M2-K ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT2-SEC-DEG_F ;
+  qudt:applicableUnit unit:W-PER-M2-K ;
+  qudt:baseUnitDimensions "M/\\Theta \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg/K \\cdot s^3" ;
+  qudt:expression "\\(heat-xfer-coeff\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H-1T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_transfer_coefficient"^^xsd:anyURI ;
+  qudt:latexDefinition """\"Coefficient of Heat Transfer\", in thermodynamics and in mechanical and chemical engineering, is used in calculating the heat transfer, typically by convection or phase transition between a fluid and a solid. The heat transfer coefficient is the proportionality coefficient between the heat flux, that is heat flow per unit area, \\(q/A\\), and the thermodynamic driving force for the flow of heat (that is, the temperature difference, \\( \\bigtriangleup T \\)).  Areic heat flow rate divided by thermodynamic temperature difference. In building technology, the \\textit{Coefficient of Heat Transfer}, is often called \\textit{thermal transmittance}, with the symbol \\(U\\). \\textit{Coefficient of Heat Transfer}, has SI units in watts per squared meter kelvin: \\(W/(m^{2\" \\cdot K)\\) .
+
+\\(K = \\frac{\\varphi}{T}\\), where \\(\\varphi\\) is areic heat flow rate and \\(T\\) is thermodynamic temperature difference."""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\kappa\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Coefficient of Heat Transfer\", in thermodynamics and in mechanical and chemical engineering, is used in calculating the heat transfer, typically by convection or phase transition between a fluid and a solid. The heat transfer coefficient is the proportionality coefficient between the heat flux, that is heat flow per unit area, q/A, and the thermodynamic driving force for the flow of heat (that is, the temperature difference, (Delta T).  Areic heat flow rate divided by thermodynamic temperature difference. In building technology, the \"Coefficient of Heat Transfer\", is often called \"thermal transmittance}\" with the symbol \"U\". It has SI units in watts per squared meter kelvin." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Coefficient of Heat Transfer" ;
+  rdfs:label "Coefficient of heat transfer" ;
+.
+quantitykind:Coercivity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Coercivity}, also referred to as \\textit(Coercive Field Strength), is the magnetic field strength to be applied to bring the magnetic flux density in a substance from its remaining magnetic flux density to zero. This is defined as the coercive field strength in a substance when either the magnetic flux density or the magnetic polarization and magnetization is brought from its value at magnetic saturation to zero by monotonic reduction of the applied magnetic field strength. The quantity which is brought to zero should be stated, and the appropriate symbol used: \\(H_{cB}\\), \\(H_{cJ}\\) or \\(H_{cM}\\) for the coercivity relating to the magnetic flux density, the magnetic polarization or the magnetization respectively, where \\(H_{cJ} = H_{cM\"\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-PER-M ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-69"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:symbol "H_{c,B}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Coercivity" ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+.
+quantitykind:ColdReceptorThreshold
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_c\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Cold Receptor Threshold\" is the threshold of cold-sensitive free nerve-ending." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cold Receptor Threshold" ;
+.
+quantitykind:CombinedNonEvaporativeHeatTransferCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2-K ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H-1T-3D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(h = h_r + h_c + h_k\\), where \\(h_r\\) is the linear radiative heat transfer coefficient, \\(h_c\\) is the convective heat transfer coefficient, and \\(h_k\\) is the conductive heat transfer coefficient."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Combined Non Evaporative Heat Transfer Coefficient\" is the " ;
+  qudt:symbol "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Combined Non Evaporative Heat Transfer Coefficient" ;
+.
+quantitykind:CombustionChamberTemperature
+  a qudt:QuantityKind ;
+  qudt:symbol "T_c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Combustion Chamber Temperature" ;
+.
+quantitykind:ComplexPower
+  a qudt:QuantityKind ;
+  dcterms:description "\"Complex Power\", under sinusoidal conditions, is the product of the phasor \\(U\\) representing the voltage between the terminals of a linear two-terminal element or two-terminal circuit and the complex conjugate of the phasor \\(I\\) representing the electric current in the element or circuit."^^qudt:LatexString ;
+  qudt:applicableUnit unit:V-A ;
+  qudt:expression "\\(complex-power\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-39"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\underline{S} = \\underline{U}\\underline{I^*}\\), where \\(\\underline{U}\\) is voltage phasor and \\(\\underline{I^*}\\) is the complex conjugage of the current phasor."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\underline{S}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Complex Power" ;
+  rdfs:seeAlso quantitykind:ElectricCurrentPhasor ;
+  rdfs:seeAlso quantitykind:VoltagePhasor ;
+.
+quantitykind:Compressibility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-PA ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Compressibility"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\chi = -(\\frac{\\1}{V})\\frac{dV}{d\\rho}\\), where \\(V\\) is volume and \\(p\\) is pressure."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\chi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Compressibility is a measure of the relative volume change of a fluid or solid as a response to a pressure (or mean stress) change." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Compressibility" ;
+.
+quantitykind:CompressibilityFactor
+  a qudt:QuantityKind ;
+  dcterms:description "The compressibility factor (\\(Z\\)) is a useful thermodynamic property for modifying the ideal gas law to account for the real gas behaviour. The closer a gas is to a phase change, the larger the deviations from ideal behavior. It is simply defined as the ratio of the molar volume of a gas to the molar volume of an ideal gas at the same temperature and pressure. Values for compressibility are calculated using equations of state (EOS), such as the virial equation and van der Waals equation. The compressibility factor for specific gases can be obtained, with out calculation, from compressibility charts. These charts are created by plotting Z as a function of pressure at constant temperature."^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Compressibility Factor" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:Concentration
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Concentration"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Concentration"^^xsd:anyURI ;
+  qudt:plainTextDescription "In chemistry, concentration is defined as the abundance of a constituent divided by the total volume of a mixture. Furthermore, in chemistry, four types of mathematical description can be distinguished: mass concentration, molar concentration, number concentration, and volume concentration. The term concentration can be applied to any kind of chemical mixture, but most frequently it refers to solutes in solutions." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Concentration" ;
+.
+quantitykind:Conductance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Conductance}, for a resistive two-terminal element or two-terminal circuit with terminals A and B, quotient of the electric current i in the element or circuit by the voltage \\(u_{AB}\\) between the terminals: \\(G = \\frac{1}{R\"\\), where the electric current is taken as positive if its direction is from A to B and negative in the opposite case. The conductance of an element or circuit is the inverse of its resistance."^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-2I0M-1H0T3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-06"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(G = Re\\underline{Y}\\), where \\(\\underline{Y}\\) is admittance.
+
+Alternatively:
+
+\\(G = \\frac{1}{R}\\), where \\(R\\) is resistance."""^^qudt:LatexString ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Conductance" ;
+  rdfs:seeAlso quantitykind:Admittance ;
+.
+quantitykind:ConductionSpeed
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Conduction Speed\" is the speed of impulses in nerve fibers." ;
+  qudt:symbol "c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Conduction Speed" ;
+.
+quantitykind:ConductiveHeatTransfer
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi_k\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Conductive Heat Transfer\" is proportional to temperature gradient and area of contact." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Conductive Heat Transfer" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Heat_transfer#Conduction> ;
+.
+quantitykind:Conductivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:S-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-03"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{J} = \\sigma \\mathbf{E}\\), where \\(\\mathbf{J}\\) is electric current density, and \\(\\mathbf{E}\\) is electric field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Conductivity\" is a scalar or tensor quantity the product of which by the electric field strength in a medium is equal to the electric current density. For an isotropic medium the conductivity is a scalar quantity; for an anisotropic medium it is a tensor quantity." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Conductivity" ;
+  rdfs:seeAlso quantitykind:ElectricCurrentDensity ;
+  rdfs:seeAlso quantitykind:ElectricFieldStrength ;
+.
+quantitykind:ConvectiveHeatTransfer
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi_c\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Convective Heat Transfer\" is convective heat transfer coefficient multiplied by temperature difference and exchange area. " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Convective Heat Transfer" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Heat_transfer#Convection> ;
+.
+quantitykind:CouplingFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=161-03-18"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "For inductive coupling between two inductive elements, \\(k = \\frac{\\left | L_{mn} \\right |}{\\sqrt{L_m L_n}}\\), where \\(L_m\\) and \\(L_n\\) are their self inductances, and \\(L_{mn}\\) is their mutual inductance."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Coupling Factor\" is the ratio of an electromagnetic quantity, usually voltage or current, appearing at a specified location of a given circuit to the corresponding quantity at a specified location in the circuit from which energy is transferred by coupling." ;
+  qudt:symbol "k" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Coupling Factor" ;
+.
+quantitykind:CrossSection
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cross-Section" ;
+.
+quantitykind:CrossSectionalArea
+  a qudt:QuantityKind ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cross-sectional Area" ;
+.
+quantitykind:CubicElectricDipoleMomentPerSquareEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C3-M-PER-J2 ;
+  qudt:baseUnitDimensions "A^3 \\cdot s^7/kg^2 \\cdot m" ;
+  qudt:baseUnitDimensions "I^3 \\cdot T^7/L \\cdot M^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E3L-1I0M-2H0T7D0> ;
+  qudt:plainTextDescription "\"Cubic Electric Dipole Moment per Square Energy\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cubic Electric Dipole Moment per Square Energy" ;
+.
+quantitykind:CubicExpansionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-K ;
+  qudt:expression "\\(cubic-exp-coef\\)"^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_V = \\frac{1}{V} \\; \\frac{dV}{dT}\\), where \\(V\\) is \\(volume\\) and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_v\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Cubic Expansion Coefficient" ;
+.
+quantitykind:CurieTemperature
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curie_temperature"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Curie Temperature\" is the critical thermodynamic temperature of a ferromagnet." ;
+  qudt:symbol "T_C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Curie Temperature" ;
+  skos:closeMatch quantitykind:NeelTemperature ;
+  skos:closeMatch quantitykind:SuperconductionTransitionTemperature ;
+.
+quantitykind:Currency
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:AFN ;
+  qudt:applicableUnit unit:AMD ;
+  qudt:applicableUnit unit:ARS ;
+  qudt:applicableUnit unit:AUD ;
+  qudt:applicableUnit unit:AWG ;
+  qudt:applicableUnit unit:AZN ;
+  qudt:applicableUnit unit:BBD ;
+  qudt:applicableUnit unit:BDT ;
+  qudt:applicableUnit unit:BHD ;
+  qudt:applicableUnit unit:BSD ;
+  qudt:applicableUnit unit:BYR ;
+  qudt:applicableUnit unit:BelizeDollar ;
+  qudt:applicableUnit unit:BermudaDollar ;
+  qudt:applicableUnit unit:BolivianMvdol ;
+  qudt:applicableUnit unit:Boliviano ;
+  qudt:applicableUnit unit:BrazilianReal ;
+  qudt:applicableUnit unit:BruneiDollar ;
+  qudt:applicableUnit unit:BulgarianLev ;
+  qudt:applicableUnit unit:BurundianFranc ;
+  qudt:applicableUnit unit:CAD ;
+  qudt:applicableUnit unit:CapeVerdeEscudo ;
+  qudt:applicableUnit unit:CaymanIslandsDollar ;
+  qudt:applicableUnit unit:Cedi ;
+  qudt:applicableUnit unit:ChileanPeso ;
+  qudt:applicableUnit unit:ColombianPeso ;
+  qudt:applicableUnit unit:ComoroFranc ;
+  qudt:applicableUnit unit:ConvertibleMark ;
+  qudt:applicableUnit unit:CordobaOro ;
+  qudt:applicableUnit unit:CostaRicanColon ;
+  qudt:applicableUnit unit:CroatianKuna ;
+  qudt:applicableUnit unit:CubanPeso ;
+  qudt:applicableUnit unit:CyprusPound ;
+  qudt:applicableUnit unit:CzechKoruna ;
+  qudt:applicableUnit unit:DZD ;
+  qudt:applicableUnit unit:Dalasi ;
+  qudt:applicableUnit unit:DanishKrone ;
+  qudt:applicableUnit unit:Deka ;
+  qudt:applicableUnit unit:Denar ;
+  qudt:applicableUnit unit:DjiboutiFranc ;
+  qudt:applicableUnit unit:Dobra ;
+  qudt:applicableUnit unit:DominicanPeso ;
+  qudt:applicableUnit unit:EastCaribbeanDollar ;
+  qudt:applicableUnit unit:EgyptianPound ;
+  qudt:applicableUnit unit:EthiopianBirr ;
+  qudt:applicableUnit unit:Euro ;
+  qudt:applicableUnit unit:EuropeanCompositeUnit ;
+  qudt:applicableUnit unit:EuropeanMonetaryUnit ;
+  qudt:applicableUnit unit:EuropeanUnitOfAccount17 ;
+  qudt:applicableUnit unit:EuropeanUnitOfAccount9 ;
+  qudt:applicableUnit unit:FalklandIslandsPound ;
+  qudt:applicableUnit unit:FijiDollar ;
+  qudt:applicableUnit unit:Flight ;
+  qudt:applicableUnit unit:Forint ;
+  qudt:applicableUnit unit:FrancCongolais ;
+  qudt:applicableUnit unit:GibraltarPound ;
+  qudt:applicableUnit unit:Gold-OunceTroy ;
+  qudt:applicableUnit unit:GoldFranc ;
+  qudt:applicableUnit unit:Guarani ;
+  qudt:applicableUnit unit:GuineaFranc ;
+  qudt:applicableUnit unit:GuyanaDollar ;
+  qudt:applicableUnit unit:HaitiGourde ;
+  qudt:applicableUnit unit:HeartBeat ;
+  qudt:applicableUnit unit:HongKongDollar ;
+  qudt:applicableUnit unit:Hryvnia ;
+  qudt:applicableUnit unit:IcelandKrona ;
+  qudt:applicableUnit unit:IndianRupee ;
+  qudt:applicableUnit unit:IranianRial ;
+  qudt:applicableUnit unit:IraqiDinar ;
+  qudt:applicableUnit unit:JamaicanDollar ;
+  qudt:applicableUnit unit:JapaneseYen ;
+  qudt:applicableUnit unit:JordanianDinar ;
+  qudt:applicableUnit unit:KenyanShilling ;
+  qudt:applicableUnit unit:KiloGM-SEC2 ;
+  qudt:applicableUnit unit:Kina ;
+  qudt:applicableUnit unit:Kroon ;
+  qudt:applicableUnit unit:KuwaitiDinar ;
+  qudt:applicableUnit unit:Kwanza ;
+  qudt:applicableUnit unit:Kyat ;
+  qudt:applicableUnit unit:LaoKip ;
+  qudt:applicableUnit unit:Lari ;
+  qudt:applicableUnit unit:LatvianLats ;
+  qudt:applicableUnit unit:LebanesePound ;
+  qudt:applicableUnit unit:Lek ;
+  qudt:applicableUnit unit:Lempira ;
+  qudt:applicableUnit unit:Leone ;
+  qudt:applicableUnit unit:LiberianDollar ;
+  qudt:applicableUnit unit:LibyanDinar ;
+  qudt:applicableUnit unit:Lilangeni ;
+  qudt:applicableUnit unit:LithuanianLitas ;
+  qudt:applicableUnit unit:Loti ;
+  qudt:applicableUnit unit:MDOLLAR-PER-FLIGHT ;
+  qudt:applicableUnit unit:MalagasyAriary ;
+  qudt:applicableUnit unit:MalawiKwacha ;
+  qudt:applicableUnit unit:MalaysianRinggit ;
+  qudt:applicableUnit unit:MalteseLira ;
+  qudt:applicableUnit unit:Manat ;
+  qudt:applicableUnit unit:MauritiusRupee ;
+  qudt:applicableUnit unit:Metical ;
+  qudt:applicableUnit unit:MexicanPeso ;
+  qudt:applicableUnit unit:MexicanUnidadDeInversion ;
+  qudt:applicableUnit unit:MillionUSD ;
+  qudt:applicableUnit unit:MillionUSD-PER-YR ;
+  qudt:applicableUnit unit:MoldovanLeu ;
+  qudt:applicableUnit unit:MoroccanDirham ;
+  qudt:applicableUnit unit:Naira ;
+  qudt:applicableUnit unit:Nakfa ;
+  qudt:applicableUnit unit:NamibianDollar ;
+  qudt:applicableUnit unit:NepaleseRupee ;
+  qudt:applicableUnit unit:NetherlandsAntillianGuilder ;
+  qudt:applicableUnit unit:NewIsraeliShekel ;
+  qudt:applicableUnit unit:NewTaiwanDollar ;
+  qudt:applicableUnit unit:NewTurkishLira ;
+  qudt:applicableUnit unit:NewZealandDollar ;
+  qudt:applicableUnit unit:Ngultrum ;
+  qudt:applicableUnit unit:NorthKoreanWon ;
+  qudt:applicableUnit unit:NorwegianKrone ;
+  qudt:applicableUnit unit:NuevoSol ;
+  qudt:applicableUnit unit:OmaniRial ;
+  qudt:applicableUnit unit:Ouguiya ;
+  qudt:applicableUnit unit:PAB ;
+  qudt:applicableUnit unit:PER-H ;
+  qudt:applicableUnit unit:Paanga ;
+  qudt:applicableUnit unit:PakistanRupee ;
+  qudt:applicableUnit unit:Palladium-OunceTroy ;
+  qudt:applicableUnit unit:Pataca ;
+  qudt:applicableUnit unit:PhilippinePeso ;
+  qudt:applicableUnit unit:Pico ;
+  qudt:applicableUnit unit:Platinum-OunceTroy ;
+  qudt:applicableUnit unit:PoundSterling ;
+  qudt:applicableUnit unit:Pula ;
+  qudt:applicableUnit unit:QatariRial ;
+  qudt:applicableUnit unit:Quetzal ;
+  qudt:applicableUnit unit:Riel ;
+  qudt:applicableUnit unit:RomanianNeLeu ;
+  qudt:applicableUnit unit:Rufiyaa ;
+  qudt:applicableUnit unit:Rupiah ;
+  qudt:applicableUnit unit:RussianRuble ;
+  qudt:applicableUnit unit:RwandaFranc ;
+  qudt:applicableUnit unit:SaintHelenaPound ;
+  qudt:applicableUnit unit:SamoanTala ;
+  qudt:applicableUnit unit:SaudiRiyal ;
+  qudt:applicableUnit unit:SerbianDinar ;
+  qudt:applicableUnit unit:SeychellesRupee ;
+  qudt:applicableUnit unit:Silver-OunceTroy ;
+  qudt:applicableUnit unit:SingaporeDollar ;
+  qudt:applicableUnit unit:SlovakKoruna ;
+  qudt:applicableUnit unit:SolomonIslandsDollar ;
+  qudt:applicableUnit unit:Som ;
+  qudt:applicableUnit unit:SomaliShilling ;
+  qudt:applicableUnit unit:Somoni ;
+  qudt:applicableUnit unit:SouthAfricanRand ;
+  qudt:applicableUnit unit:SouthKoreanWon ;
+  qudt:applicableUnit unit:SpecialDrawingRights ;
+  qudt:applicableUnit unit:SriLankaRupee ;
+  qudt:applicableUnit unit:SudanesePound ;
+  qudt:applicableUnit unit:SurinamDollar ;
+  qudt:applicableUnit unit:SwedishKrona ;
+  qudt:applicableUnit unit:SwissFranc ;
+  qudt:applicableUnit unit:SyrianPound ;
+  qudt:applicableUnit unit:THB ;
+  qudt:applicableUnit unit:TanzanianShilling ;
+  qudt:applicableUnit unit:Tenge ;
+  qudt:applicableUnit unit:TrinidadAndTobagoDollar ;
+  qudt:applicableUnit unit:Tugrik ;
+  qudt:applicableUnit unit:TunisianDinar ;
+  qudt:applicableUnit unit:UAEDirham ;
+  qudt:applicableUnit unit:UICFranc ;
+  qudt:applicableUnit unit:USDollar ;
+  qudt:applicableUnit unit:USDollar-NextDay ;
+  qudt:applicableUnit unit:USDollar-SameDay ;
+  qudt:applicableUnit unit:UgandaShilling ;
+  qudt:applicableUnit unit:UnidadDeValorReal ;
+  qudt:applicableUnit unit:UnidadesDeFormento ;
+  qudt:applicableUnit unit:UruguayPeso ;
+  qudt:applicableUnit unit:UzbekistanSom ;
+  qudt:applicableUnit unit:Vatu ;
+  qudt:applicableUnit unit:VenezuelanBolvar ;
+  qudt:applicableUnit unit:VietnameseDong ;
+  qudt:applicableUnit unit:WIREuro ;
+  qudt:applicableUnit unit:WIRFranc ;
+  qudt:applicableUnit unit:XAF ;
+  qudt:applicableUnit unit:XOF ;
+  qudt:applicableUnit unit:XPF ;
+  qudt:applicableUnit unit:YemeniRial ;
+  qudt:applicableUnit unit:YuanRenminbi ;
+  qudt:applicableUnit unit:ZambianKwacha ;
+  qudt:applicableUnit unit:ZimbabweDollar ;
+  qudt:applicableUnit unit:Zloty ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Currency"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Currency"^^xsd:anyURI ;
+  qudt:plainTextDescription "In economics, currency is a generally accepted medium of exchange. These are usually the coins and banknotes of a particular government, which comprise the physical aspects of a nation's money supply. The other part of a nation's money supply consists of bank deposits (sometimes called deposit money), ownership of which can be transferred by means of cheques, debit cards, or other forms of money transfer. Deposit money and currency are money in the sense that both are acceptable as a means of payment." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Currency" ;
+  skos:broader quantitykind:Asset ;
+.
+quantitykind:CurrentLinkage
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:expression "\\(current-linkage\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-60"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Current Linkage\" is the net electric current through a surface delimited by a closed loop." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Current Linkage" ;
+.
+quantitykind:Curvature
+  a qudt:QuantityKind ;
+  dcterms:description "The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point. The magnitude of curvature at points on physical curves can be measured in \\(diopters\\) (also spelled \\(dioptre\\)) — this is the convention in optics."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DIOPTER ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Curvature"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curvature"^^xsd:anyURI ;
+  qudt:plainTextDescription """The canonical example of extrinsic curvature is that of a circle, which has curvature equal to the inverse of its radius everywhere. Smaller circles bend more sharply, and hence have higher curvature. The curvature of a smooth curve is defined as the curvature of its osculating circle at each point. The osculating circle of a sufficiently smooth plane curve at a given point on the curve is the circle whose center lies on the inner normal line and whose curvature is the same as that of the given curve at that point. This circle is tangent to the curve at the given point.
+That is, given a point P on a smooth curve C, the curvature of C at P is defined to be 1/R where R is the radius of the osculating circle of C at P. The magnitude of curvature at points on physical curves can be measured in diopters (also spelled dioptre) — this is the convention in optics. [Wikipedia],""" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Curvature" ;
+.
+quantitykind:CurvatureFromRadius
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curvature"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\kappa = \\frac{1}{\\rho}\\), where \\(\\rho\\) is the radius of the curvature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\kappa\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In mathematics \"Curvature\" is the amount by which a geometric object deviates from being flat, or straight in the case of a line, but this is defined in different ways depending on the context." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Curvature" ;
+  skos:closeMatch quantitykind:Curvature ;
+.
+quantitykind:CyclotronAngularFrequency
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electron_cyclotron_resonance"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\omega_c = \\frac{\\left | q \\right |}{m}B\\), where \\(q\\) is the electric charge, \\(m\\) is its mass, and \\(B\\) is the magnetic flux density."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\omega_c\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Cyclotron Angular Frequency\" describes angular momentum vector precession about the external field axis with an angular frequency." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Larmor Angular Frequency" ;
+  skos:broader quantitykind:AngularFrequency ;
+.
+quantitykind:DELTA-V
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\bigtriangleup-v\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The change in translational velocity including all losses for a propulsive system or module. Delta-V losses include, but are not limited to, gravity losses and steering losses." ;
+  qudt:url "http://en.wikipedia.org/wiki/Delta-v"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Delta-V"^^rdfs:Literal ;
+.
+quantitykind:DRY-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Mass of a system without the propellants, pressurants, reserve or residual fluids, personnel and personnel provisions, and cargo." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dry Mass"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:DataRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloBIT-PER-SEC ;
+  qudt:applicableUnit unit:MegaBIT-PER-SEC ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Data_rate"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:plainTextDescription "The frequency derived from the period of time required to transmit one bit. This represents the amount of data transferred per second by a communications channel or a computing or storage device. Data rate is measured in units of bits per second (written \"b/s\" or \"bps\"), bytes per second (Bps), or baud. When applied to data rate, the multiplier prefixes \"kilo-\", \"mega-\", \"giga-\", etc. (and their abbreviations, \"k\", \"M\", \"G\", etc.) always denote powers of 1000. For example, 64 kbps is 64,000 bits per second. This contrasts with units of storage which use different prefixes to denote multiplication by powers of 1024, for example 1 kibibit = 1024 bits." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Data Rate" ;
+  skos:broader quantitykind:InformationFlowRate ;
+.
+quantitykind:Debye-WallerFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Debye–Waller_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(u = R - R_0\\), where \\(R\\) is the particle position vector and \\(R_0\\) is the equilibrium position vector of a particle."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Debye-Waller Factor\" (DWF), named after Peter Debye and Ivar Waller, is used in condensed matter physics to describe the attenuation of x-ray scattering or coherent neutron scattering caused by thermal motion. Also, a factor by which the intensity of a diffraction line is reduced because of the lattice vibrations." ;
+  qudt:symbol "D, B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Debye-Waller Factor" ;
+.
+quantitykind:DebyeAngularFrequency
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://lamp.tu-graz.ac.at/~hadley/ss1/phonons/table/dosdebye.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\omega_b\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Debye Angular Frequency\" is the cut-off angular frequency in the Debye model of the vibrational spectrum of a solid." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Debye Angular Frequency" ;
+.
+quantitykind:DebyeAngularWavenumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:RAD-PER-M ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Debye Angular Wavenumber\" is the cut-off angular wavenumber in the Debye model of the vibrational spectrum of a solid." ;
+  qudt:symbol "q_D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Debye Angular Wavenumber" ;
+.
+quantitykind:DebyeTemperature
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Debye_model"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Theta_D = \\frac{\\hbar\\omega_D}{k}\\), where \\(k\\) is the Boltzmann constant, \\(\\hbar\\) is the reduced Planck constant, and \\(\\omega_D\\) is the Debye angular frequency."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Theta_D\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Debye Temperature\" is the temperature at which the highest-frequency mode (and hence all modes) are excited." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Debye Temperature" ;
+.
+quantitykind:DecayConstant
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Exponential_decay"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.britannica.com/EBchecked/topic/154945/decay-constant"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "Relative variation \\(\\frac{dN}{N}\\) of the number \\(N\\) of atoms or nuclei in a system, due to spontaneous emission from these atoms or nuclei during an infinitesimal time interval, divided by its duration \\(dt\\), thus \\(\\lambda = -\\frac{1}{N}\\frac{dN}{dt}\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\lambda\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Decay Constant\" is the proportionality between the size of a population of radioactive atoms and the rate at which the population decreases because of radioactive decay." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Decay Constant" ;
+.
+quantitykind:DegreeOfDissociation
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Faraday_constant"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dissociation_(chemistry)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Degree of Dissociation\" is the fraction of original solute molecules that have dissociated." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Degree of Dissociation" ;
+.
+quantitykind:Density
+  a qudt:QuantityKind ;
+  dcterms:description "The mass density or density of a material is defined as its mass per unit volume. The symbol most often used for density is \\(\\rho\\).  Mathematically, density is defined as mass divided by volume: \\(\\rho = m/V\\), where \\(\\rho\\) is the density, \\(m\\) is the mass, and \\(V\\) is the volume. In some cases, density is also defined as its weight per unit volume, although this quantity is more properly called specific weight."^^qudt:LatexString ;
+  qudt:applicableUnit unit:GRAIN-PER-GAL ;
+  qudt:applicableUnit unit:KiloGM-PER-M3 ;
+  qudt:applicableUnit unit:LB_M-PER-FT3 ;
+  qudt:applicableUnit unit:LB_M-PER-GAL ;
+  qudt:applicableUnit unit:LB_M-PER-IN3 ;
+  qudt:applicableUnit unit:LB_M-PER-M3 ;
+  qudt:applicableUnit unit:LB_M-PER-YD3 ;
+  qudt:applicableUnit unit:MilliGM-PER-DeciL ;
+  qudt:applicableUnit unit:OZ_M_PER-GAL ;
+  qudt:applicableUnit unit:OZ_M_PER-IN3 ;
+  qudt:applicableUnit unit:PlanckDensity ;
+  qudt:applicableUnit unit:SLUG-PER-FT3 ;
+  qudt:applicableUnit unit:TON_LONG-PER-YD3 ;
+  qudt:applicableUnit unit:TON_SHORT-PER-YD3 ;
+  qudt:baseUnitDimensions "M/L^3" ;
+  qudt:baseUnitDimensions "kg/m^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Density"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Density"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho = m/V\\), where \\(\\rho\\) is the density, \\(m\\) is the mass, and \\(V\\) is the volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Density" ;
+.
+quantitykind:DensityInCombustionChamber
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\rho_c\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Density In Combustion Chamber" ;
+.
+quantitykind:DensityOfStates
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:SEC-PER-RAD-M3 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Density_of_states"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Density of States\" is the number of vibrational modes in an infinitesimal interval of angular frequency divided by the range of that interval and by volume." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Density of States" ;
+  rdfs:label "Density of states" ;
+.
+quantitykind:DensityOfTheExhaustGases
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Density Of The Exhaust Gases" ;
+.
+quantitykind:DewPointTemperature
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Dew Point Temperature\" is the temperature at which vapour in air reaches saturation." ;
+  qudt:symbol "T_d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dew Point Temperature" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:Diameter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Diameter"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Diameter"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(d = 2r\\), where \\(r\\) is the radius of the circle."^^qudt:LatexString ;
+  qudt:plainTextDescription "In classical geometry, the \"Diameter\" of a circle is any straight line segment that passes through the center of the circle and whose endpoints lie on the circle. " ;
+  qudt:symbol "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Diameter" ;
+.
+quantitykind:DiffusionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_diffusivity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(C_B \\left \\langle \\nu_B \\right \\rangle = -D grad C_B\\), where \\(C_B\\) the local molecular concentration of substance \\(B\\) in the mixture and \\(\\left \\langle \\nu_B \\right \\rangle\\) is the local average velocity of the molecules of \\(B\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Diffusion Coefficient\" is a proportionality constant between the molar flux due to molecular diffusion and the gradient in the concentration of the species (or the driving force for diffusion). Diffusivity is encountered in Fick's law and numerous other equations of physical chemistry." ;
+  qudt:symbol "D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Diffusion Coefficient" ;
+.
+quantitykind:Dimensionless
+  a qudt:QuantityKind ;
+  dcterms:description "In dimensional analysis, a dimensionless quantity or quantity of dimension one is a quantity without an associated physical dimension. It is thus a \"pure\" number, and as such always has a dimension of 1. Dimensionless quantities are widely used in mathematics, physics, engineering, economics, and in everyday life (such as in counting). Numerous well-known quantities, such as \\(\\pi\\), \\(\\epsilon\\), and \\(\\psi\\), are dimensionless. By contrast, non-dimensionless quantities are measured in units of length, area, time, etc. Dimensionless quantities are often defined as products or ratios of quantities that are not dimensionless, but whose dimensions cancel out when their powers are multiplied."^^qudt:LatexString ;
+  qudt:applicableUnit unit:Atto ;
+  qudt:applicableUnit unit:BYTE ;
+  qudt:applicableUnit unit:Centi ;
+  qudt:applicableUnit unit:DECADE ;
+  qudt:applicableUnit unit:Deca ;
+  qudt:applicableUnit unit:Deci ;
+  qudt:applicableUnit unit:Exa ;
+  qudt:applicableUnit unit:Exbi ;
+  qudt:applicableUnit unit:Femto ;
+  qudt:applicableUnit unit:Gibi ;
+  qudt:applicableUnit unit:Giga ;
+  qudt:applicableUnit unit:GigaBYTE ;
+  qudt:applicableUnit unit:Hecto ;
+  qudt:applicableUnit unit:Kibi ;
+  qudt:applicableUnit unit:Kilo ;
+  qudt:applicableUnit unit:KiloBYTE ;
+  qudt:applicableUnit unit:KiloBYTE-PER-SEC ;
+  qudt:applicableUnit unit:Mebi ;
+  qudt:applicableUnit unit:Mega ;
+  qudt:applicableUnit unit:MegaBYTE ;
+  qudt:applicableUnit unit:MegaBYTE_Memory ;
+  qudt:applicableUnit unit:Micro ;
+  qudt:applicableUnit unit:Milli ;
+  qudt:applicableUnit unit:NP ;
+  qudt:applicableUnit unit:NUM ;
+  qudt:applicableUnit unit:Nano ;
+  qudt:applicableUnit unit:OCT ;
+  qudt:applicableUnit unit:Pebi ;
+  qudt:applicableUnit unit:PebiBYTE ;
+  qudt:applicableUnit unit:Peta ;
+  qudt:applicableUnit unit:PetaBYTE ;
+  qudt:applicableUnit unit:Tebi ;
+  qudt:applicableUnit unit:Tera ;
+  qudt:applicableUnit unit:TeraBYTE ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:applicableUnit unit:Yobi ;
+  qudt:applicableUnit unit:Yocto ;
+  qudt:applicableUnit unit:Yotta ;
+  qudt:applicableUnit unit:Zebi ;
+  qudt:applicableUnit unit:Zepto ;
+  qudt:applicableUnit unit:Zetta ;
+  qudt:baseUnitDimensions "" ;
+  qudt:baseUnitDimensions "U" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dimensionless_quantity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dimensionless_quantity"^^xsd:anyURI ;
+  qudt:symbol "U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dimensionless" ;
+.
+quantitykind:DimensionlessRatio
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DeciB_M ;
+  qudt:applicableUnit unit:GR ;
+  qudt:applicableUnit unit:MACH ;
+  qudt:applicableUnit unit:PERCENT ;
+  qudt:applicableUnit unit:PPB ;
+  qudt:applicableUnit unit:PPM ;
+  qudt:applicableUnit unit:PPTH ;
+  qudt:applicableUnit unit:PPTR ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dimensionless Ratio" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:Displacement
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Displacement_(vector)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Delta r =  R_f - R_i\\), where \\(R_f\\) is the final position and \\(R_i\\) is the initial position."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Delta r\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Displacement\" is the shortest distance from the initial to the final position of a point P." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Displacement" ;
+.
+quantitykind:DisplacementCurrent
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Displacement_current"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I_D= \\int_S J_D \\cdot e_n dA\\), over a surface \\(S\\), where \\(J_D\\) is displacement current density and \\(e_n dA\\) is the vector surface element."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Displacement Current\" is a quantity appearing in Maxwell's equations that is defined in terms of the rate of change of electric displacement field. Displacement current has the units of electric current density, and it has an associated magnetic field just as actual currents do. However it is not an electric current of moving charges, but a time-varying electric field. In materials, there is also a contribution from the slight motion of charges bound in atoms, dielectric polarization." ;
+  qudt:symbol "I_D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Displacement Current" ;
+  rdfs:seeAlso quantitykind:ElectricFluxDensity ;
+.
+quantitykind:DisplacementCurrentDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Displacement Current Density}\\) is the time rate of change of the \\(\\textit{Electric Flux Density}\\). This is a measure of how quickly the electric field changes if we observe it as a function of time. This is different than if we look at how the electric field changes spatially, that is, over a region of space for a fixed amount of time."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-PER-M2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_flux"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.maxwells-equations.com/math/partial-electric-flux.php"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J_D = \\frac{\\partial D}{\\partial t}\\), where \\(D\\) is electric flux density and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(J_D\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Displacement Current Density" ;
+  rdfs:seeAlso quantitykind:ElectricFluxDensity ;
+.
+quantitykind:Dissipance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dissipation_factor"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\delta = \\frac{\\P_d}{\\P_i}\\), where \\(\\P_d\\) is the dissipated sound power, and \\(\\P_i\\) is the incident sound power."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\delta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Dissipance, or dissipation factor for sound power, is the ratio of dissipated sound power to incident sound power. The dissipation factor (DF) is a measure of loss-rate of energy of a mode of oscillation (mechanical, electrical, or electromechanical) in a dissipative system. It is the reciprocal of quality factor, which represents the quality of oscillation." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dissipance" ;
+.
+quantitykind:Distance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Distance"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Distance\" is a numerical description of how far apart objects are. " ;
+  qudt:symbol "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Distance" ;
+.
+quantitykind:DistanceTraveledDuringBurn
+  a qudt:QuantityKind ;
+  qudt:symbol "s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Distance Traveled During a Burn" ;
+.
+quantitykind:DoseEquivalent
+  a qudt:QuantityKind ;
+  dcterms:description "\"Dose Equivalent} (former), or \\textit{Equivalent Absorbed Radiation Dose}, usually shortened to \\textit{Equivalent Dose\", is a computed average measure of the radiation absorbed by a fixed mass of biological tissue, that attempts to account for the different biological damage potential of different types of ionizing radiation. The equivalent dose to a tissue is found by multiplying the absorbed dose, in gray, by a dimensionless \"quality factor\" \\(Q\\), dependent upon radiation type, and by another dimensionless factor \\(N\\), dependent on all other pertinent factors. N depends upon the part of the body irradiated, the time and volume over which the dose was spread, even the species of the subject."^^qudt:LatexString ;
+  qudt:applicableUnit unit:REM ;
+  qudt:applicableUnit unit:SV ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Equivalent_dose"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Equivalent_dose"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "At the point of interest in tissue, \\(H = DQ\\), where \\(D\\) is the absorbed dose and \\(Q\\) is the quality factor at that point."^^qudt:LatexString ;
+  qudt:symbol "H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dose Equivalent" ;
+  skos:broader quantitykind:SpecificEnergy ;
+.
+quantitykind:DoseEquivalentQualityFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Equivalent_dose"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Dose Equivalent Quality Factor\" is a factor in the caculation and measurement of dose equivalent, by which the absorbed dose is to be weighted in order to account for different biological effectiveness of radiations, for radiation protection purposes." ;
+  qudt:symbol "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dose Equivalent Quality Factor" ;
+.
+quantitykind:DragCoefficient
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "In fluid dynamics, the drag coefficient is a dimensionless quantity that is used to quantify the drag or resistance of an object in a fluid environment such as air or water." ;
+  qudt:symbol "C_{D}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Drag Coefficient" ;
+.
+quantitykind:DragForce
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription """In fluid dynamics, drag refers to forces which act on a solid object in the direction of the relative fluid flow velocity. Unlike other resistive forces such as dry friction, which is nearly independent of velocity, drag forces depend on velocity.
+Drag forces always decrease fluid velocity relative to the solid object in the fluid's path.""" ;
+  qudt:symbol "D or F_D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Drag Force" ;
+.
+quantitykind:DryVolume
+  a qudt:QuantityKind ;
+  dcterms:description "Dry measures are units of volume used to measure bulk commodities which are not gas or liquid. They are typically used in agriculture, agronomy, and commodity markets to measure grain, dried beans, and dried and fresh fruit; formerly also salt pork and fish. They are also used in fishing for clams, crabs, etc. and formerly for many other substances (for example coal, cement, lime) which were typically shipped and delivered in a standardized container such as a barrel.  In the original metric system, the unit of dry volume was the stere, but this is not part of the modern metric system; the liter and the cubic meter (\\(m^{3}\\)) are now used. However, the stere is still widely used for firewood."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BU_UK ;
+  qudt:applicableUnit unit:BU_US ;
+  qudt:applicableUnit unit:CORD ;
+  qudt:applicableUnit unit:GAL_US_DRY ;
+  qudt:applicableUnit unit:PINT_US_DRY ;
+  qudt:applicableUnit unit:PK_US_DRY ;
+  qudt:applicableUnit unit:QT_US_DRY ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dry_measure"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dry Volume" ;
+  skos:broader quantitykind:Volume ;
+.
+quantitykind:DynamicFriction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Friction"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Friction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\frac{F}{N}\\), where \\(F\\) is the tangential component of the contact force and \\(N\\) is the normal component of the contact force between two sliding bodies."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Kinetic (or dynamic) friction occurs when two objects are moving relative to each other and rub together (like a sled on the ground)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dynamic Friction" ;
+  skos:broader quantitykind:Friction ;
+.
+quantitykind:DynamicPressure
+  a qudt:QuantityKind ;
+  dcterms:description "Dynamic Pressure (indicated with q, or Q, and sometimes called velocity pressure) is the quantity defined by: \\(q = 1/2 * \\rho v^{2}\\), where (using SI units),  \\(q\\) is dynamic pressure in \\(pascals\\), \\(\\rho\\) is fluid density in \\(kg/m^{3}\\) (for example, density of air) and \\(v \\) is fluid velocity in \\(m/s\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dynamic_pressure"^^xsd:anyURI ;
+  qudt:symbol "q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dynamic Pressure" ;
+  skos:broader quantitykind:Pressure ;
+.
+quantitykind:DynamicViscosity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CentiP ;
+  qudt:applicableUnit unit:LB_F-SEC-PER-FT2 ;
+  qudt:applicableUnit unit:LB_F-SEC-PER-IN2 ;
+  qudt:applicableUnit unit:LB_M-PER-FT-HR ;
+  qudt:applicableUnit unit:LB_M-PER-FT-SEC ;
+  qudt:applicableUnit unit:PA-SEC ;
+  qudt:applicableUnit unit:PA-SEC-PER-M ;
+  qudt:applicableUnit unit:POISE ;
+  qudt:applicableUnit unit:SLUG-PER-FT-SEC ;
+  qudt:baseUnitDimensions "M/L \\cdot T" ;
+  qudt:baseUnitDimensions "kg/m \\cdot s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-1D0> ;
+  qudt:informativeReference "http://dictionary.reference.com/browse/dynamic+viscosity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\tau_x_z = \\eta\\frac{dv_x}{dz}\\), where \\(\\tau_x_z\\) is shear stress in a fluid moving with a velocity gradient \\(\\frac{dv_x}{dz}\\) perpendicular to the plane of shear. "^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "A measure of the molecular frictional resistance of a fluid as calculated using Newton's law." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Dynamic Viscosity" ;
+  skos:broader quantitykind:Viscosity ;
+.
+quantitykind:EarthClosestApproachVehicleVelocity
+  a qudt:QuantityKind ;
+  qudt:symbol "V_o" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Earth Closest Approach Vehicle Velocity" ;
+  skos:broader quantitykind:VehicleVelocity ;
+.
+quantitykind:EccentricityOfOrbit
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\varepsilon\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The orbital eccentricity of an astronomical object is a parameter that determines the amount by which its orbit around another body deviates from a perfect circle. In a two-body problem with inverse-square-law force, every orbit is a Kepler orbit. The eccentricity of this Kepler orbit is a positive number that defines its shape." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Eccentricity Of Orbit" ;
+.
+quantitykind:EffectiveExhaustVelocity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The velocity of an exhaust stream after reduction by effects such as friction, non-axially directed flow, and pressure differences between the inside of the rocket and its surroundings. The effective exhaust velocity is one of two factors determining the thrust, or accelerating force, that a rocket can develop, the other factor being the quantity of reaction mass expelled from the rocket in unit time. In most cases, the effective exhaust velocity is close to the actual exhaust velocity." ;
+  qudt:symbol "v_{e}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Effective Exhaustvelocity" ;
+.
+quantitykind:EffectiveMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Effective_mass_(solid-state_physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(m^* = \\hbar^2k(\\frac{d\\varepsilon}{dk})\\), where \\(\\hbar\\) is the reduced Planck constant, \\(k\\) is the wavenumber, and \\(\\varepsilon\\) is the energy of the electron."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Effective Mass\" is used in the motional equation for electrons in solid state bodies, depending on the wavenumber and corresponding to its velocity and energy level." ;
+  qudt:symbol "m^*" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Effective Mass" ;
+.
+quantitykind:EffectiveMultiplicationFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nuclear_chain_reaction#Effective_neutron_multiplication_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Effective Multiplication Factor\" is the multiplication factor for a finite medium." ;
+  qudt:symbol "k_{eff}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Effective Multiplication Factor" ;
+  skos:broader quantitykind:MultiplicationFactor ;
+  skos:closeMatch quantitykind:InfiniteMultiplicationFactor ;
+.
+quantitykind:Efficiency
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deformation_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\eta = \\frac{P_o_u_t}{P_i_n}\\), where \\(P_o_u_t\\) is the output power and \\(P_i_n\\) is the input power."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\eta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Efficiency is the ratio of output power to input power." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Efficiency" ;
+  skos:broader quantitykind:Strain ;
+.
+quantitykind:EinsteinTransitionProbability
+  a qudt:QuantityKind ;
+  dcterms:description "Given two atomic states of energy \\(E_j\\) and \\(E_k\\).  Let \\(E_j > E_k\\).  Assume the atom is bathed in radiation of energy density \\(u(w)\\).  Transitions between these states can take place in three different ways. Spontaneous, induced/stimulated emission, and induced absorption. \\(A_jk\\) represents the Einstein transition probability for spontaneous emission."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(\\frac{-dN_j}{dt} = A_jkN_j\\), where \\(-dN_j\\) is the number of molecules spontaneously leaving the state j for the state k during a time interval of duration \\(dt\\), \\(N_j\\) is the number of molecules in the state j, and \\(E_j > E_k\\)."^^qudt:LatexString ;
+  qudt:symbol "A_jkN_j" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Einstein Transition Probability" ;
+  skos:exactMatch <http://electron6.phys.utk.edu/qm2/modules/m10/einstein.htm> ;
+.
+quantitykind:ElectricCharge
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Charge\" is a fundamental conserved property of some subatomic particles, which determines their electromagnetic interaction. Electrically charged matter is influenced by, and produces, electromagnetic fields. The electric charge on a body may be positive or negative. Two positively charged bodies experience a mutual repulsive force, as do two negatively charged bodies. A positively charged body and a negatively charged body experience an attractive force. Electric charge is carried by discrete particles and can be positive or negative. The sign convention is such that the elementary electric charge \\(e\\), that is, the charge of the proton, is positive. The SI derived unit of electric charge is the coulomb."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-HR ;
+  qudt:applicableUnit unit:AttoC ;
+  qudt:applicableUnit unit:C ;
+  qudt:applicableUnit unit:C_Ab ;
+  qudt:applicableUnit unit:C_Stat ;
+  qudt:applicableUnit unit:CentiC ;
+  qudt:applicableUnit unit:DecaC ;
+  qudt:applicableUnit unit:DeciC ;
+  qudt:applicableUnit unit:E ;
+  qudt:applicableUnit unit:ElementaryCharge ;
+  qudt:applicableUnit unit:ExaC ;
+  qudt:applicableUnit unit:F ;
+  qudt:applicableUnit unit:FR ;
+  qudt:applicableUnit unit:FemtoC ;
+  qudt:applicableUnit unit:GigaC ;
+  qudt:applicableUnit unit:HectoC ;
+  qudt:applicableUnit unit:KiloC ;
+  qudt:applicableUnit unit:MegaC ;
+  qudt:applicableUnit unit:MicroC ;
+  qudt:applicableUnit unit:MilliC ;
+  qudt:applicableUnit unit:NanoC ;
+  qudt:applicableUnit unit:PetaC ;
+  qudt:applicableUnit unit:PicoC ;
+  qudt:applicableUnit unit:PlanckCharge ;
+  qudt:applicableUnit unit:TeraC ;
+  qudt:applicableUnit unit:YoctoC ;
+  qudt:applicableUnit unit:YottaC ;
+  qudt:applicableUnit unit:ZeptoC ;
+  qudt:applicableUnit unit:ZettaC ;
+  qudt:baseUnitDimensions "A \\cdot s" ;
+  qudt:baseUnitDimensions "I \\cdot T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electric_charge"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electric_charge?oldid=492961669"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(dQ = Idt\\), where \\(I\\) is electric current."^^qudt:LatexString ;
+  qudt:symbol "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge" ;
+  rdfs:seeAlso quantitykind:ElectricCurrent ;
+.
+quantitykind:ElectricChargeDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-M3 ;
+  qudt:expression "\\(charge-density\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-3I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.maxwells-equations.com/pho/charge-density.php"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho = \\frac{dQ}{dV}\\), where \\(Q\\) is electric charge and \\(V\\) is Volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Density" ;
+  rdfs:seeAlso quantitykind:ElectricChargeSurfaceDensity ;
+.
+quantitykind:ElectricChargeLineDensity
+  a qudt:QuantityKind ;
+  dcterms:description "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively. The respective SI units are \\(C \\cdot \\), \\(m^{-1}\\), \\(C \\cdot m^{-2}\\) or \\(C \\cdot m^{-3}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-M ;
+  qudt:baseUnitDimensions "A \\cdot s/m" ;
+  qudt:baseUnitDimensions "I \\cdot T/L" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-1I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\lambda\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Line Density" ;
+.
+quantitykind:ElectricChargeLinearDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-M ;
+  qudt:expression "\\(linear-charge-density\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho_l = \\frac{dQ}{dl}\\), where \\(Q\\) is electric charge and \\(l\\) is length."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_l\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Linear Density" ;
+  rdfs:seeAlso quantitykind:ElectricChargeDensity ;
+.
+quantitykind:ElectricChargePerAmountOfSubstance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Charge Per Amount Of Substance\" is the charge assocated with a given amount of substance. Un the ISO and SI systems this is \\(1 mol\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-MOL ;
+  qudt:applicableUnit unit:C_Stat-PER-MOL ;
+  qudt:baseUnitDimensions "A \\cdot s/mol" ;
+  qudt:baseUnitDimensions "I \\cdot T/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E1L0I0M0H0T1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge per Amount of Substance" ;
+  rdfs:label "Electric charge per amount of substance" ;
+.
+quantitykind:ElectricChargePerArea
+  a qudt:QuantityKind ;
+  dcterms:description "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively. The respective SI units are \\(C \\cdot m^{-1}\\), \\(C \\cdot m^{-2}\\) or \\(C \\cdot m^{-3}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-M2 ;
+  qudt:applicableUnit unit:C_Ab-PER-CentiM2 ;
+  qudt:applicableUnit unit:C_Stat-PER-CentiM2 ;
+  qudt:baseUnitDimensions "A \\cdot s/m^2" ;
+  qudt:baseUnitDimensions "I \\cdot T/L^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric charge per area" ;
+.
+quantitykind:ElectricChargePerMass
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Charge Per Mass\" is the charge associated with a specific mass of a substance. In the SI and ISO systems this is \\(1 kg\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-KiloGM ;
+  qudt:applicableUnit unit:HZ-PER-T ;
+  qudt:applicableUnit unit:MegaHZ-PER-T ;
+  qudt:applicableUnit unit:PER-T-SEC ;
+  qudt:baseUnitDimensions "A \\cdot s/kg" ;
+  qudt:baseUnitDimensions "I \\cdot T/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M-1H0T1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Per Mass" ;
+.
+quantitykind:ElectricChargeSurfaceDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-M2 ;
+  qudt:expression "\\(surface-charge-density\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho_A = \\frac{dQ}{dA}\\), where \\(Q\\) is electric charge and \\(A\\) is Area."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_A\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Surface Density" ;
+  rdfs:seeAlso quantitykind:ElectricChargeDensity ;
+.
+quantitykind:ElectricChargeVolumeDensity
+  a qudt:QuantityKind ;
+  dcterms:description "In electromagnetism, charge density is a measure of electric charge per unit volume of space, in one, two or three dimensions. More specifically: the linear, surface, or volume charge density is the amount of electric charge per unit length, surface area, or volume, respectively. The respective SI units are \\(C \\cdot m^{-1}\\), \\(C \\cdot m^{-2}\\) or \\(C \\cdot m^{-3}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-M3 ;
+  qudt:baseUnitDimensions "A \\cdot s/m^3" ;
+  qudt:baseUnitDimensions "I \\cdot T/L^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-3I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Charge_density"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Charge Volume Density" ;
+.
+quantitykind:ElectricConductivity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Conductivity} or \\textit{Specific Conductance\" is a measure of a material's ability to conduct an electric current. When an electrical potential difference is placed across a conductor, its movable charges flow, giving rise to an electric current. The conductivity \\(\\sigma\\) is defined as the ratio of the electric current density \\(J\\) to the electric field \\(E\\): \\(J = \\sigma E\\). In isotropic materials, conductivity is scalar-valued, however in general, conductivity is a tensor-valued quantity."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A_Ab-CentiM2 ;
+  qudt:applicableUnit unit:MHO ;
+  qudt:applicableUnit unit:MHO_Stat ;
+  qudt:applicableUnit unit:S ;
+  qudt:applicableUnit unit:S_Ab ;
+  qudt:applicableUnit unit:S_Stat ;
+  qudt:baseUnitDimensions "A^2 \\cdot s^3/kg \\cdot m^2" ;
+  qudt:baseUnitDimensions "I^2 \\cdot T^3/L^2 \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0> ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Conductivity" ;
+.
+quantitykind:ElectricCurrent
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:applicableUnit unit:A_Ab ;
+  qudt:applicableUnit unit:A_Stat ;
+  qudt:applicableUnit unit:BIOT ;
+  qudt:applicableUnit unit:KiloA ;
+  qudt:applicableUnit unit:MicroA ;
+  qudt:applicableUnit unit:MilliA ;
+  qudt:applicableUnit unit:NanoA ;
+  qudt:applicableUnit unit:PicoA ;
+  qudt:applicableUnit unit:PlanckCurrent ;
+  qudt:baseUnitDimensions "A" ;
+  qudt:baseUnitDimensions "I" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_current"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Electric Current\" is the flow (movement) of electric charge. The amount of electric current through some surface, for example, a section through a copper conductor, is defined as the amount of electric charge flowing through that surface over time. Current is a scalar-valued quantity. Electric current is one of the base quantities in the International System of Quantities, ISQ, on which the International System of Units, SI, is based. " ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current" ;
+.
+quantitykind:ElectricCurrentDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Current Density\" is a measure of the density of flow of electric charge; it is the electric current per unit area of cross section. Electric current density is a vector-valued quantity. Electric current, \\(I\\), through a surface \\(S\\) is defined as \\(I = \\int_S J \\cdot e_n dA\\), where \\(e_ndA\\) is the vector surface element."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-PER-M2 ;
+  qudt:applicableUnit unit:A_Ab-PER-CentiM2 ;
+  qudt:applicableUnit unit:A_Stat-PER-CentiM2 ;
+  qudt:applicableUnit unit:PlanckCurrentDensity ;
+  qudt:baseUnitDimensions "A/m^2" ;
+  qudt:baseUnitDimensions "I/L^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Current_density"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M0H0T0D0> ;
+  qudt:informativeReference "http://maxwells-equations.com/density/current.php"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J = \\rho v\\), where \\(\\rho\\) is electric current density and \\(v\\) is volume."^^qudt:LatexString ;
+  qudt:symbol "J" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current Density" ;
+.
+quantitykind:ElectricCurrentPerAngle
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-RAD ;
+  qudt:baseUnitDimensions "A" ;
+  qudt:baseUnitDimensions "I/U" ;
+  qudt:plainTextDescription "\"Electric Current Per Angle\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Angle" ;
+.
+quantitykind:ElectricCurrentPerUnitEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-J ;
+  qudt:baseUnitDimensions "A \\cdot s^3/kg \\cdot m^2" ;
+  qudt:baseUnitDimensions "I \\cdot T^3/L^2 \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T3D0> ;
+  qudt:plainTextDescription "\"Electric Current per Unit Energy\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Unit Energy" ;
+.
+quantitykind:ElectricCurrentPerUnitLength
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "A/m" ;
+  qudt:baseUnitDimensions "I/L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current per Unit Length" ;
+.
+quantitykind:ElectricCurrentPerUnitTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-DEG_C ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H-1T0D0> ;
+  qudt:plainTextDescription "\"Electric Current per Unit Temperature\" is used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind/all> ;
+  rdfs:label "Electric Current per Unit Temperature" ;
+.
+quantitykind:ElectricCurrentPhasor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Phasor_(electronics)"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-26"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "When \\(i = \\hat{I} \\cos{(\\omega t + \\alpha)}\\), where \\(i\\) is the electric current, \\(\\omega\\) is angular frequence, \\(t\\) is time, and \\(\\alpha\\) is initial phase, then \\(\\underline{I} = Ie^{ja}\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\underline{I}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Current Phasor\" is a representation of current as a sinusoidal integral quantity using a complex quantity whose argument is equal to the initial phase and whose modulus is equal to the root-mean-square value. A phasor is a constant complex number, usually expressed in exponential form, representing the complex amplitude (magnitude and phase) of a sinusoidal function of time. Phasors are used by electrical engineers to simplify computations involving sinusoids, where they can often reduce a differential equation problem to an algebraic one." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Current Phasor" ;
+.
+quantitykind:ElectricDipoleMoment
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-M ;
+  qudt:applicableUnit unit:Debye ;
+  qudt:baseUnitDimensions "A \\cdot m \\cdot s" ;
+  qudt:baseUnitDimensions "I \\cdot L \\cdot T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L1I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electric_dipole_moment"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(E_p = -p \\cdot E\\), where \\(E_p\\) is the interaction energy of the molecule with electric dipole moment \\(p\\) and an electric field with electric field strength \\(E\\).
+
+\\(p = q(r_+ - r_i)\\), where \\(r_+\\) and \\(r_-\\) are the position vectors to carriers of electric charge \\(a\\) and \\(-q\\), respectively."""^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Dipole Moment\" is a measure of the separation of positive and negative electrical charges in a system of (discrete or continuous) charges. It is a vector-valued quantity. If the system of charges is neutral, that is if the sum of all charges is zero, then the dipole moment of the system is independent of the choice of a reference frame; however in a non-neutral system, such as the dipole moment of a single proton, a dependence on the choice of reference point arises. In such cases it is conventional to choose the reference point to be the center of mass of the system or the center of charge, not some arbitrary origin. This convention ensures that the dipole moment is an intrinsic property of the system. The electric dipole moment of a substance within a domain is the vector sum of electric dipole moments of all electric dipoles included in the domain." ;
+  qudt:symbol "p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Dipole Moment" ;
+.
+quantitykind:ElectricDisplacement
+  a qudt:QuantityKind ;
+  dcterms:description "In a dielectric material the presence of an electric field E causes the bound charges in the material (atomic nuclei and their electrons) to slightly separate, inducing a local electric dipole moment. The Electric Displacement Field, \\(D\\), is a vector field that accounts for the effects of free charges within such dielectric materials. This describes also the charge density on an extended surface that could be causing the field."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-M2 ;
+  qudt:exactMatch quantitykind:ElectricFluxDensity ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M0H0T1D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(D = \\epsilon_0 E + P\\), where \\(\\epsilon_0\\) is the electric constant, \\(E\\) is electric field strength, and \\(P\\) is electric polarization."^^qudt:LatexString ;
+  qudt:symbol "D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Displacement" ;
+  skos:broader quantitykind:ElectricChargePerArea ;
+.
+quantitykind:ElectricDisplacementField
+  a qudt:QuantityKind ;
+  qudt:symbol "D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Displacement Field" ;
+  skos:broader quantitykind:ElectricChargePerArea ;
+.
+quantitykind:ElectricField
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-PER-M ;
+  qudt:applicableUnit unit:V_Ab-PER-CentiM ;
+  qudt:applicableUnit unit:V_Stat-PER-CentiM ;
+  qudt:baseUnitDimensions "L \\cdot M/I \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m/A \\cdot s^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_field"^^xsd:anyURI ;
+  qudt:expression "\\(E\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electric_field"^^xsd:anyURI ;
+  qudt:plainTextDescription "The space surrounding an electric charge or in the presence of a time-varying magnetic field has a property called an electric field. This electric field exerts a force on other electrically charged objects. In the idealized case, the force exerted between two point charges is inversely proportional to the square of the distance between them. (Coulomb's Law)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Field" ;
+.
+quantitykind:ElectricFieldStrength
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Electric Field Strength}\\) is the magnitude and direction of an electric field, expressed by the value of \\(E\\), also referred to as \\(\\color{indigo} {\\textit{electric field intensity}}\\) or simply the electric field."^^qudt:LatexString ;
+  qudt:applicableUnit unit:V-PER-M ;
+  qudt:applicableUnit unit:V_Ab-PER-CentiM ;
+  qudt:applicableUnit unit:V_Stat-PER-CentiM ;
+  qudt:baseUnitDimensions "kg \\cdot m/A \\cdot s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L1I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{E} = \\mathbf{F}/q\\), where \\(\\mathbf{F}\\) is force and \\(q\\) is electric charge, of a test particle at rest."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mathbf{E} \\)"^^qudt:LatexString ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Field Strength" ;
+.
+quantitykind:ElectricFlux
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C ;
+  qudt:applicableUnit unit:V-M ;
+  qudt:applicableUnit unit:V_Stat-CentiM ;
+  qudt:baseUnitDimensions "L^3 \\cdot M/I \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m^3/A \\cdot s^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_flux"^^xsd:anyURI ;
+  qudt:expression "\\(electirc-flux\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L3I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Psi = \\int_S D \\cdot e_n dA\\), over a surface \\(S\\), where \\(D\\) is electric flux density and \\(e_n dA\\) is the vector surface element."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Psi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Flux\" through an area is defined as the electric field multiplied by the area of the surface projected in a plane perpendicular to the field. Electric Flux is a scalar-valued quantity." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Flux" ;
+  rdfs:seeAlso quantitykind:ElectricFluxDensity ;
+.
+quantitykind:ElectricFluxDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Electric Flux Density}\\), also referred to as \\(\\textit{Electric Displacement}\\), is related to electric charge density by the following equation: \\(\\text{div} \\; D = \\rho\\), where \\(\\text{div}\\) denotes the divergence."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-PER-M2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electric_flux"^^xsd:anyURI ;
+  qudt:exactMatch quantitykind:ElectricDisplacement ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M0H0T1D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{D}  = \\epsilon_0 E + P\\), where \\(\\epsilon_0\\) is the electric constant, \\(\\mathbf{E} \\) is electric field strength, and \\(P\\) is electric polarization."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mathbf{D}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Flux Density" ;
+.
+quantitykind:ElectricPolarizability
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-MOL ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Polarizability"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_{i,j} = \\frac{\\partial p_i}{\\partial E_j}\\), where \\(p_i\\) is the cartesian component along the \\(i-axis\\) of the electric dipole moment induced by the applied electric field strength acting on the molecule, and \\(E_j\\) is the component along the \\(j-axis\\) of this electric field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Polarizability\" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which is applied typically by inserting the molecule in a charged parallel-plate capacitor, but may also be caused by the presence of a nearby ion or dipole." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Polarizability" ;
+.
+quantitykind:ElectricPolarization
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-M2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M0H0T1D0> ;
+  qudt:informativeReference "http://www.britannica.com/EBchecked/topic/182690/electric-polarization"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(P =\\frac{dp}{dV}\\), where \\(p\\) is electic charge density and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Polarization\" is the relative shift of positive and negative electric charge in opposite directions within an insulator, or dielectric, induced by an external electric field. Polarization occurs when an electric field distorts the negative cloud of electrons around positive atomic nuclei in a direction opposite the field. This slight separation of charge makes one side of the atom somewhat positive and the opposite side somewhat negative. In some materials whose molecules are permanently polarized by chemical forces, such as water molecules, some of the polarization is caused by molecules rotating into the same alignment under the influence of the electric field. One of the measures of polarization is electric dipole moment, which equals the distance between the slightly shifted centres of positive and negative charge multiplied by the amount of one of the charges. Polarization P in its quantitative meaning is the amount of dipole moment p per unit volume V of a polarized material, P = p/V." ;
+  qudt:symbol "P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Polarization" ;
+  rdfs:seeAlso quantitykind:ElectricChargeDensity ;
+  rdfs:seeAlso quantitykind:ElectricDipoleMoment ;
+.
+quantitykind:ElectricPotential
+  a qudt:QuantityKind ;
+  dcterms:description "The Electric Potential is a scalar valued quantity associated with an electric field. The electric potential \\(\\phi(x)\\) at a point, \\(x\\), is formally defined as the line integral of the electric field taken along a path from x to the point at infinity. If the electric field is static, that is time independent, then the choice of the path is arbitrary; however if the electric field is time dependent, taking the integral a different paths will produce different results."^^qudt:LatexString ;
+  qudt:exactMatch quantitykind:EnergyPerElectricCharge ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(-\\textbf{grad} \\; V = E + \\frac{\\partial A}{\\partial t}\\), where \\(E\\) is electric field strength, \\(A\\) is magentic vector potential and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\(\\phi\\)\\)"^^qudt:LatexString ;
+  qudt:symbol "V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Potential" ;
+  skos:broader quantitykind:EnergyPerElectricCharge ;
+.
+quantitykind:ElectricPotentialDifference
+  a qudt:QuantityKind ;
+  qudt:exactMatch quantitykind:EnergyPerElectricCharge ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(V_{ab} = \\int_{r_a(C)}^{r_b} (E +\\frac{\\partial A}{\\partial t}) \\), where \\(E\\) is electric field strength, \\(A\\) is magentic vector potential,  \\(t\\) is time, and \\(r\\) is position vector along a curve C from a point \\(a\\) to \\(b\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Potential Difference\" is a scalar valued quantity associated with an electric field." ;
+  qudt:symbol "V_{ab}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Potential Difference" ;
+  skos:broader quantitykind:EnergyPerElectricCharge ;
+.
+quantitykind:ElectricPower
+  a qudt:QuantityKind ;
+  dcterms:description "\"Electric Power\" is the rate at which electrical energy is transferred by an electric circuit. In the simple case of direct current circuits, electric power can be calculated as the product of the potential difference in the circuit (V) and the amount of current flowing in the circuit (I): \\(P = VI\\), where \\(P\\) is the power, \\(V\\) is the potential difference, and \\(I\\) is the current. However, in general electric power is calculated by taking the integral of the vector cross-product of the electrical and magnetic fields over a specified area."^^qudt:LatexString ;
+  qudt:applicableSIUnit unit:KiloW ;
+  qudt:applicableSIUnit unit:MegaW ;
+  qudt:applicableSIUnit unit:MilliW ;
+  qudt:applicableSIUnit unit:W ;
+  qudt:applicableUnit unit:KiloW ;
+  qudt:applicableUnit unit:MegaW ;
+  qudt:applicableUnit unit:MilliW ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:latexDefinition "\\(p = ui\\), where \\(u\\) is instantaneous voltage and \\(i\\) is instantaneous electric current."^^qudt:LatexString ;
+  qudt:symbol "P_E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Power" ;
+  skos:broader quantitykind:Power ;
+.
+quantitykind:ElectricPropulsionPropellantMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M_P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Propulsion Propellant Mass" ;
+  skos:broader quantitykind:PropellantMass ;
+.
+quantitykind:ElectricQuadrupoleMoment
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-M2 ;
+  qudt:baseUnitDimensions "A \\cdot m^2 \\cdot s" ;
+  qudt:baseUnitDimensions "I \\cdot L^2 \\cdot T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L2I0M0H0T1D0> ;
+  qudt:plainTextDescription "The Electric Quadrupole Moment is a quantity which describes the effective shape of the ellipsoid of nuclear charge distribution. A non-zero quadrupole moment Q indicates that the charge distribution is not spherically symmetric. By convention, the value of Q is taken to be positive if the ellipsoid is prolate and negative if it is oblate. In general, the electric quadrupole moment is tensor-valued." ;
+  qudt:symbol "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Quadrupole Moment" ;
+.
+quantitykind:ElectricSusceptibility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Permittivity"^^xsd:anyURI ;
+  qudt:expression "\\(e-susceptibility\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\chi = \\frac{P}{(\\epsilon_0 E)}\\), where \\(P\\) is electric polorization, \\(\\epsilon_0\\) is the electric constant, and \\(E\\) is electric field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\chi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electric Susceptibility\" is the ratio of electric polarization to electric field strength, normalized to the electric constant. The definition applies to an isotropic medium. For an anisotropic medium, electric susceptibility is a second order tensor." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electric Susceptibility" ;
+  rdfs:seeAlso quantitykind:ElectricFieldStrength ;
+  rdfs:seeAlso quantitykind:ElectricPolarization ;
+  rdfs:seeAlso quantitykind:PermittivityOfVacuum ;
+.
+quantitykind:ElectricalPowerToMassRatio
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\xi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electrical Power To Mass Ratio" ;
+.
+quantitykind:ElectrolyticConductivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:S-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Conductivity_(electrolytic)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(x = \\frac{J}{E}\\), where \\(J\\) is the electrolytic current density and \\(E\\) is the electric field strength."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electrolytic Conductivity\" of an electrolyte solution is a measure of its ability to conduct electricity." ;
+  qudt:symbol "x" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electrolytic Conductivity" ;
+.
+quantitykind:ElectromagneticEnergyDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Electromagnetic Energy Density}\\), also known as the \\(\\color{indigo} {\\textit{Volumic Electromagnetic Energy}}\\), is the energy associated with an electromagnetic field, per unit volume of the field."^^qudt:LatexString ;
+  qudt:applicableUnit unit:J-PER-M3 ;
+  qudt:exactMatch quantitykind:VolumicElectromagneticEnergy ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-64"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w = (1/2) ( \\mathbf{E} \\cdot \\mathbf{D} + \\mathbf{B} \\cdot \\mathbf{H})\\), where \\(\\mathbf{E}\\) is electric field strength, \\(\\mathbf{D}\\) is electric flux density, \\(\\mathbf{M}\\) is magnetic flux density, and \\(\\mathbf{H}\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:symbol "w" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electromagnetic Energy Density" ;
+  rdfs:seeAlso quantitykind:ElectricFieldStrength ;
+  rdfs:seeAlso quantitykind:ElectricFluxDensity ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:MagneticFluxDensity ;
+.
+quantitykind:ElectromagneticWavePhaseSpeed
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-66"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c  = w/k\\) where \\(w\\) is angular velocity and \\(k\\) is angular wavenumber."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Electromagnetic Wave Phase Speed\" is the ratio of angular velocity and wavenumber." ;
+  qudt:symbol "c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electromagnetic Wave Phase Speed" ;
+.
+quantitykind:ElectromotiveForce
+  a qudt:QuantityKind ;
+  dcterms:description "In physics, electromotive force, or most commonly \\(emf\\) (seldom capitalized), or (occasionally) electromotance is that which tends to cause current (actual electrons and ions) to flow. More formally, \\(emf\\) is the external work expended per unit of charge to produce an electric potential difference across two open-circuited terminals. \"Electromotive Force\" is deprecated in the ISO System of Quantities."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electromotive_force"^^xsd:anyURI ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Electromotive Force" ;
+  skos:broader quantitykind:EnergyPerElectricCharge ;
+.
+quantitykind:ElementaryCharge
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Elementary_charge"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Elementary Charge\" is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron." ;
+  qudt:symbol "e" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Elementary Charge" ;
+  skos:exactMatch quantitykind:AtomicUnitOfCharge ;
+.
+quantitykind:EllipticalOrbitApogeeVelocity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Velocity at apogee for an elliptical orbit velocity" ;
+  qudt:symbol "V_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Elliptical Orbit Apogee Velocity" ;
+  skos:broader quantitykind:VehicleVelocity ;
+.
+quantitykind:EllipticalOrbitPerigeeVelocity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Velocity at apogee for an elliptical orbit velocity." ;
+  qudt:symbol "V_p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Elliptical Orbit Perigee Velocity" ;
+  skos:broader quantitykind:VehicleVelocity ;
+.
+quantitykind:Emissivity
+  a qudt:QuantityKind ;
+  dcterms:description "Emissivity of a material (usually written \\(\\varepsilon\\) or e) is the relative ability of its surface to emit energy by radiation."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(\\varepsilon = \\frac{M}{M_b}\\), where \\(M\\) is the radiant exitance of a thermal radiator and \\(M_b\\) is the radiant exitance of a blackbody at the same temperature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varepsilon\\)"^^qudt:LatexString ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Emissivity" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Emissivity> ;
+.
+quantitykind:Energy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Energy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:plainTextDescription "Energy is the quantity characterizing the ability of a system to do work." ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy" ;
+  rdfs:seeAlso quantitykind:Enthalpy ;
+  rdfs:seeAlso quantitykind:Entropy ;
+  rdfs:seeAlso quantitykind:GibbsEnergy ;
+  rdfs:seeAlso quantitykind:HelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:InternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:EnergyAndWork
+  a qudt:QuantityKind ;
+  dcterms:description """The net work is equal to the change in kinetic energy. This relationship is called the work-energy theorem: \\(Wnet = K. E._f − K. E._o \\), where \\(K. E._f\\) is the final kinetic energy and \\(K. E._o\\) is the original kinetic energy.
+Potential energy, also referred to as stored energy, is the ability of a system to do work due to its position or internal structure.
+Change in potential energy is equal to work. The potential energy equations can also be derived from the integral form of work, \\(\\Delta P. E. = W = \\int  F \\cdot dx\\)."""^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT ;
+  qudt:applicableUnit unit:BTU_TH ;
+  qudt:applicableUnit unit:CAL_IT ;
+  qudt:applicableUnit unit:CAL_TH ;
+  qudt:applicableUnit unit:ERG ;
+  qudt:applicableUnit unit:EV ;
+  qudt:applicableUnit unit:E_h ;
+  qudt:applicableUnit unit:FT-LB_F ;
+  qudt:applicableUnit unit:FT-PDL ;
+  qudt:applicableUnit unit:GigaEV ;
+  qudt:applicableUnit unit:J ;
+  qudt:applicableUnit unit:KiloCAL ;
+  qudt:applicableUnit unit:KiloEV ;
+  qudt:applicableUnit unit:KiloW-HR ;
+  qudt:applicableUnit unit:MegaEV ;
+  qudt:applicableUnit unit:MegaTOE ;
+  qudt:applicableUnit unit:PlanckEnergy ;
+  qudt:applicableUnit unit:QUAD ;
+  qudt:applicableUnit unit:THM_EEC ;
+  qudt:applicableUnit unit:THM_US ;
+  qudt:applicableUnit unit:TOE ;
+  qudt:applicableUnit unit:TonEnergy ;
+  qudt:applicableUnit unit:W-HR ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Energy"^^xsd:anyURI ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Work_%28physics%29"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.cliffsnotes.com/study_guide/Work-and-Energy.topicArticleId-10453,articleId-10418.html"^^xsd:anyURI ;
+  qudt:plainTextDescription "The concepts of work and energy are closely tied to the concept of force because an applied force can do work on an object and cause a change in energy. Energy is defined as the ability to do work. Work is done on an object when an applied force moves it through a distance. Kinetic energy is the energy of an object in motion. The net work is equal to the change in kinetic energy." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy and Work" ;
+  rdfs:label "Energy and work" ;
+.
+quantitykind:EnergyAndWorkPerMassAmountOfSubstance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-LB_M-MOL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy and work per mass amount of substance" ;
+.
+quantitykind:EnergyDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT3 ;
+  qudt:applicableUnit unit:BTU_TH-PER-FT3 ;
+  qudt:applicableUnit unit:ERG-PER-CentiM3 ;
+  qudt:applicableUnit unit:J-PER-M3 ;
+  qudt:baseISOUnitDimensions "\\(m^{-1} \\cdot kg \\cdot s^{-2}\\)" ;
+  qudt:baseImperialUnitDimensions "\\(ft^{-1} \\cdot lb \\cdot s^{-2}\\)"^^qudt:LatexString ;
+  qudt:baseSIUnitDimensions "\\(m^{-1} \\cdot kg \\cdot s^{-2}\\)"^^qudt:LatexString ;
+  qudt:baseUSCustomaryUnitDimensions "\\(L^{-1} \\cdot M \\cdot T^{-2}\\)"^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Energy_density"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Energy_density"^^xsd:anyURI ;
+  qudt:plainTextDescription "Energy density is defined as energy per unit volume. The SI unit for energy density is the joule per cubic meter." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Density" ;
+.
+quantitykind:EnergyDensityOfStates
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-J-M3 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Density_of_states"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho(E) = n_E(E) = \\frac{dN(E)}{dE}\\frac{1}{V}\\), where \\(N(E)\\) is the total number of states with energy less than \\(E\\), and \\(V\\) is the volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Energy Density of States\" refers to electrons or other entities, e.g. phonons. It can, for example, refer to amount of substance instead of volume." ;
+  qudt:symbol "n_E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Density of States" ;
+.
+quantitykind:EnergyExpenditure
+  a qudt:QuantityKind ;
+  dcterms:description """Energy expenditure is dependent on a person's sex, metabolic rate, body-mass composition, the thermic effects of food, and activity level.  The approximate energy expenditure of a man lying in bed is \\(1.0\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\). For slow walking (just over two miles per hour), \\(3.0\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\). For fast steady running (about 10 miles per hour), \\(16.3\\,kilo\\,calorie\\,per\\,hour\\,per\\,kilogram\\).
+Females expend about 10 per cent less energy than males of the same size doing a comparable activity.  For people weighing the same, individuals with a high percentage of body fat usually expend less energy than lean people, because fat is not as metabolically active as muscle."""^^qudt:LatexString ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198631477.001\\).0001/acref-9780198631477-e-594"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Expenditure" ;
+.
+quantitykind:EnergyFluence
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fluence"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Psi = \\frac{dR}{dA}\\), where \\(dR\\) describes the sum of radiant energies, exclusive of rest energy, of all particles incident on a small spherical domain, and \\(dA\\) describes the cross-sectional area of that domain."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Psi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Energy Fluence\" can be used to describe the energy delivered per unit area" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Fluence" ;
+.
+quantitykind:EnergyPerArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-FT2 ;
+  qudt:applicableUnit unit:FT-LB_F-PER-FT2 ;
+  qudt:applicableUnit unit:FT-LB_F-PER-M2 ;
+  qudt:applicableUnit unit:J-PER-M2 ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM2 ;
+  qudt:baseUnitDimensions "M/T^2" ;
+  qudt:baseUnitDimensions "kg/s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.calculator.org/property.aspx?name=energy%20per%20unit%20area"^^xsd:anyURI ;
+  qudt:plainTextDescription "Energy per unit area is a measure of the energy either impinging upon or generated from a given unit of area. This can be a measure of the \"toughness\" of a material, being the amount of energy that needs to be applied per unit area of a crack to cause it to fracture. This is a constant for a given material.." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy per Area" ;
+.
+quantitykind:EnergyPerAreaElectricCharge
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-PER-M2 ;
+  qudt:baseUnitDimensions "M/I \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg/A \\cdot s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L0I0M1H0T-3D0> ;
+  qudt:plainTextDescription "\"Energy Per Area Electric Charge\" is the amount of electric energy associated with a unit of area." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Per Area Electric Charge" ;
+.
+quantitykind:EnergyPerElectricCharge
+  a qudt:QuantityKind ;
+  dcterms:description "Voltage is a representation of the electric potential energy per unit charge. If a unit of electrical charge were placed in a location, the voltage indicates the potential energy of it at that point. In other words, it is a measurement of the energy contained within an electric field, or an electric circuit, at a given point. Voltage is a scalar quantity. The SI unit of voltage is the volt, such that \\(1 volt = 1 joule/coulomb\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PlanckVolt ;
+  qudt:applicableUnit unit:V ;
+  qudt:applicableUnit unit:V_Ab ;
+  qudt:applicableUnit unit:V_Stat ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/I \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/A \\cdot s^3" ;
+  qudt:exactMatch quantitykind:ElectricPotential ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://physics.about.com/od/glossary/g/voltage.htm"^^xsd:anyURI ;
+  qudt:symbol "V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy per Electric Charge" ;
+  rdfs:label "Energy per electric charge" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:EnergyPerSquareMagneticFluxDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-T2 ;
+  qudt:baseUnitDimensions "A^2 \\cdot m^2 \\cdot s^2/kg" ;
+  qudt:baseUnitDimensions "I^2 \\cdot L^2 \\cdot T^2/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L2I0M-1H0T2D0> ;
+  qudt:plainTextDescription "\"Energy Per Square Magnetic Flux Density\" is a measure of energy for a unit of magnetic flux density." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy Per Square Magnetic Flux Density" ;
+.
+quantitykind:EnergyPerTemperature
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/\\Theta \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/K \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Energy per Temperature" ;
+  rdfs:label "Energy per temperature" ;
+.
+quantitykind:Entropy
+  a qudt:QuantityKind ;
+  dcterms:description "When a small amount of heat \\(dQ\\) is received by a system whose thermodynamic temperature is \\(T\\), the entropy of the system increases by \\(dQ/T\\), provided that no irreversible change takes place in the system."^^qudt:LatexString ;
+  qudt:applicableUnit unit:J-PER-K ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Entropy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:symbol "S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Entropy" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:EquilibriumConstant
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Equilibrium_constant"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(K^\\Theta = \\Pi_B(\\lambda_B^\\Theta)^{-\\nu_B}\\), where \\(\\Pi_B\\) denotes the product for all substances \\(B\\), \\(\\lambda_B^\\Theta\\) is the standard absolute activity of substance \\(B\\), and \\(\\nu_B\\) is the stoichiometric number of the substance \\(B\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(K^\\Theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Equlilbrium Constant\", also known as the thermodynamic equilibrium constant, is an expression that gives us a ratio of the products and reactants of a reaction at equilibrium with respect to a specific unit." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Equilibrium Constant" ;
+  rdfs:seeAlso quantitykind:EquilibriumConstantOnConcentrationBasis ;
+  rdfs:seeAlso quantitykind:EquilibriumConstantOnPressureBasis ;
+.
+quantitykind:EquilibriumConstantOnConcentrationBasis
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Equilibrium_constant"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(K_c = \\Pi_B(c_B)^{-\\nu_B}\\), for solutions"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(K_c\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Equlilbrium Constant\", also known as the thermodynamic equilibrium constant, is an expression that gives us a ratio of the products and reactants of a reaction at equilibrium with respect to a specific unit." ;
+  rdfs:comment "The unit is unit:MOL-PER-M3 raised to the N where N is the summation of stoichiometric numbers. I don't know what to do with this." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Equilibrium Constant on Concentration Basis" ;
+  skos:broader quantitykind:EquilibriumConstant ;
+.
+quantitykind:EquilibriumConstantOnPressureBasis
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Equilibrium_constant"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(K_p = \\Pi_B(p_B)^{-\\nu_B}\\), for gases"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(K_p\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Equlilbrium Constant\", also known as the thermodynamic equilibrium constant, is an expression that gives us a ratio of the products and reactants of a reaction at equilibrium with respect to a specific unit." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Equilibrium Constant on Pressure Basis" ;
+  skos:broader quantitykind:EquilibriumConstant ;
+.
+quantitykind:EvaporativeHeatTransfer
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi_e\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Evaporative Heat Transfer\" is " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Evaporative Heat Transfer" ;
+.
+quantitykind:EvaporativeHeatTransferCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2-PA ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Evaporative Heat Transfer Coefficient\" is the areic heat transfer coefficient multiplied by the water vapor pressure difference between skind and the environment, and by the exchange area." ;
+  qudt:symbol "h_e" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Combined Non Evaporative Heat Transfer Coefficient" ;
+.
+quantitykind:ExchangeIntegral
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Exchange_interaction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Exchange Integral\" is the constituent of the interaction energy between the spins of adjacent electrons in matter arising from the overlap of electron state functions." ;
+  qudt:symbol "K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exchange Integral" ;
+.
+quantitykind:ExhaustGasMeanMolecularWeight
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exhaust Gas Mean Molecular Weight" ;
+.
+quantitykind:ExhaustGasesSpecificHeat
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Specific heat of exhaust gases at constant pressure." ;
+  qudt:symbol "c_p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exhaust Gases Specific Heat" ;
+.
+quantitykind:ExhaustStreamPower
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exhaust Stream Power" ;
+.
+quantitykind:ExitPlaneCrossSectionalArea
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Cross-sectional area at exit plane of nozzle" ;
+  qudt:symbol "A_{e}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exit Plane Cross-sectional Area" ;
+.
+quantitykind:ExitPlanePressure
+  a qudt:QuantityKind ;
+  qudt:symbol "p_{e}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exit Plane Pressure" ;
+  skos:broader quantitykind:Pressure ;
+.
+quantitykind:ExitPlaneTemperature
+  a qudt:QuantityKind ;
+  qudt:symbol "T_e" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exit Plane Temperature" ;
+.
+quantitykind:ExpansionRatio
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Expansion Ratio" ;
+.
+quantitykind:Exposure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-KiloGM ;
+  qudt:applicableUnit unit:R ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Exposure"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M-1H0T1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Exposure_%28photography%29"^^xsd:anyURI ;
+  qudt:informativeReference "http://hps.org/publicinformation/ate/faqs/gammaandexposure.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "For X-or gamma radiation, \\(X = \\frac{dQ}{dm}\\), where \\(dQ\\) is the absolute value of the mean total electric charge of the ions of the same sign produced in dry air when all the electrons and positrons liberated or created by photons in an element of air are completely stopped in air, and \\(dm\\) is the mass of that element."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Exposure\" reflects the extent of ionization events taking place when air is irradiated by ionizing photons (gamma radiation and/or x rays). In photography, exposure is the amount of light allowed to fall on each area unit of a photographic medium (photographic film or image sensor) during the process of taking a photograph. Exposure is measured in lux seconds, and can be computed from exposure value (EV) and scene luminance in a specified region." ;
+  qudt:symbol "X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exposure" ;
+  skos:broader quantitykind:ElectricChargePerMass ;
+.
+quantitykind:ExposureRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C-PER-KiloGM-SEC ;
+  qudt:informativeReference "http://hps.org/publicinformation/ate/faqs/gammaandexposure.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\dot{X} = \\frac{dX}{dt}\\), where \\(X\\) is the increment of exposure during time interval with duration \\(t\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\dot{X}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Exposure Rate\" expresses the rate of charge production per unit mass of air and is commonly expressed in roentgens per hour (R/h) or milliroentgens per hour (mR/h)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Exposure Rate" ;
+  skos:broader quantitykind:Kerma ;
+.
+quantitykind:ExtentOfReaction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Extent_of_reaction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(dn_B = \\nu_B d\\xi\\), where \\(n_B\\) is the amount of substance \\(B\\) and \\(\\nu_B\\) is the stoichiometric number of substance \\(B\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\xi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In physical chemistry, the \"Extent of Reaction\" is a quantity that measures the extent in which the reaction proceeds." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Extent of Reaction" ;
+.
+quantitykind:FLIGHT-PERFORMANCE-RESERVE-PROPELLANT-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A quantity of propellant, at a nominal mixture ratio, along with fuel bias that is set aside from total propellant loaded to cover for statistical variations of flight hardware characteristics and environment conditions on the day of launch. The launch vehicle is designed to accommodate the maximum FPR loading." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Flight Performance Reserve Propellant Mass" ;
+  skos:altLabel "FPR" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:FUEL-BIAS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "An additional quantity of fuel to ensure depletion of high-weight oxidizer before fuel for systems with high-oxidizer mixing ratios (e.g., 6:1). This practice allows for more efficient propellant utilization." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fuel Bias"^^rdfs:Literal ;
+.
+quantitykind:FastFissionFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Four_factor_formula"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Fast Fission Factor\" in an infinite medium, is the ratio of the mean number of neutrons produced by fission due to neutrons of all energies to the mean number of neutrons produced by fissions due to thermal neutrons only." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fast Fission Factor" ;
+.
+quantitykind:FermiAngularWavenumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:RAD-PER-M ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heavy_fermion"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "k_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fermi Angular Wavenumber" ;
+.
+quantitykind:FermiEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fermi_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Fermi Energy\" in a metal is the highest occupied energy level at zero thermodynamic temperature." ;
+  qudt:symbol "E_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fermi Energy" ;
+.
+quantitykind:FermiTemperature
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fermi_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(T_F = \\frac{E_F}{k}\\), where \\(E_F\\) is the Fermi energy and \\(k\\) is the Boltzmann constant."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Fermi Temperature\" is the temperature associated with the Fermi energy." ;
+  qudt:symbol "T_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fermi Temperature" ;
+.
+quantitykind:FinalOrCurrentVehicleMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Final Or Current Vehicle Mass" ;
+.
+quantitykind:FirstMomentOfArea
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The first moment of area is the summation of area times distance to an axis. It is a measure of the distribution of the area of a shape in relationship to an axis." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "First Moment of Area" ;
+  skos:broader quantitykind:Volume ;
+.
+quantitykind:FirstStageMassRatio
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Mass ratio for the first stage of a multistage launcher." ;
+  qudt:symbol "R_1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "First Stage Mass Ratio" ;
+  skos:broader quantitykind:MassRatio ;
+.
+quantitykind:FissionCoreRadiusToHeightRatio
+  a qudt:QuantityKind ;
+  qudt:symbol "R/H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fission Core Radius To Height Ratio" ;
+.
+quantitykind:FissionFuelUtilizationFactor
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fission Fuel Utilization Factor" ;
+.
+quantitykind:FissionMultiplicationFactor
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The number of fission neutrons produced per absorption in the fuel." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fission Multiplication Factor" ;
+.
+quantitykind:FlightPathAngle
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Flight path angle is defined in two different ways. To the aerodynamicist, it is the angle between the flight path vector (where the airplane is going) and the local atmosphere. To the flight crew, it is normally known as the angle between the flight path vector and the horizon, also known as the climb (or descent) angle." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Flight Path Angle" ;
+.
+quantitykind:Force
+  a qudt:QuantityKind ;
+  dcterms:description "\"Force\" is an influence that causes mass to accelerate. It may be experienced as a lift, a push, or a pull. Force is defined by Newton's Second Law as \\(F = m \\times a \\), where \\(F\\) is force, \\(m\\) is mass and \\(a\\) is acceleration. Net force is mathematically equal to the time rate of change of the momentum of the body on which it acts. Since momentum is a vector quantity (has both a magnitude and direction), force also is a vector quantity."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DYN ;
+  qudt:applicableUnit unit:KIP_F ;
+  qudt:applicableUnit unit:KiloGM_F ;
+  qudt:applicableUnit unit:KiloP ;
+  qudt:applicableUnit unit:LB_F ;
+  qudt:applicableUnit unit:MegaLB_F ;
+  qudt:applicableUnit unit:N ;
+  qudt:applicableUnit unit:OZ_F ;
+  qudt:applicableUnit unit:PDL ;
+  qudt:applicableUnit unit:PlanckForce ;
+  qudt:baseUnitDimensions "L \\cdot M/T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Force"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Force"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(F = \\frac{dp}{dt}\\), where \\(F\\) is the resultant force acting on a body, \\(p\\) is momentum of a body, and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:symbol "F" ;
+  qudt:url "http://en.wikipedia.org/wiki/Force"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force" ;
+.
+quantitykind:ForceMagnitude
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ERG ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://wiki.answers.com/Q/What_is_magnitude_of_force"^^xsd:anyURI ;
+  qudt:plainTextDescription "The 'magnitude' of a force is its 'size' or 'strength', regardless of the direction in which it acts." ;
+  qudt:symbol "U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force Magnitude" ;
+.
+quantitykind:ForcePerArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ATM ;
+  qudt:applicableUnit unit:ATM_T ;
+  qudt:applicableUnit unit:BAR ;
+  qudt:applicableUnit unit:CM_H2O ;
+  qudt:applicableUnit unit:CentiBAR ;
+  qudt:applicableUnit unit:DYN-PER-CentiM2 ;
+  qudt:applicableUnit unit:DeciBAR ;
+  qudt:applicableUnit unit:FT_Water ;
+  qudt:applicableUnit unit:HectoPA ;
+  qudt:applicableUnit unit:IN_AQ ;
+  qudt:applicableUnit unit:IN_HG ;
+  qudt:applicableUnit unit:KIP_F-PER-IN2 ;
+  qudt:applicableUnit unit:KiloBAR ;
+  qudt:applicableUnit unit:KiloGM_F-PER-CentiM2 ;
+  qudt:applicableUnit unit:KiloPA ;
+  qudt:applicableUnit unit:KiloPA_A ;
+  qudt:applicableUnit unit:LB_F-PER-FT2 ;
+  qudt:applicableUnit unit:LB_F-PER-IN2 ;
+  qudt:applicableUnit unit:MegaBAR ;
+  qudt:applicableUnit unit:MicroTORR ;
+  qudt:applicableUnit unit:MilliBAR ;
+  qudt:applicableUnit unit:MilliM_HG ;
+  qudt:applicableUnit unit:MilliM_HGA ;
+  qudt:applicableUnit unit:MilliTORR ;
+  qudt:applicableUnit unit:N-PER-M2 ;
+  qudt:applicableUnit unit:PA ;
+  qudt:applicableUnit unit:PDL-PER-FT2 ;
+  qudt:applicableUnit unit:PlanckPressure ;
+  qudt:applicableUnit unit:TORR ;
+  qudt:baseUnitDimensions "M/L \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg/m \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.thefreedictionary.com/force+per+unit+area"^^xsd:anyURI ;
+  qudt:outOfScope true ;
+  qudt:plainTextDescription "The force applied to a unit area of surface; measured in pascals (SI unit) or in dynes (cgs unit)" ;
+  qudt:symbol "p" ;
+  qudt:url "http://en.wikipedia.org/wiki/Pressure"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force Per Area" ;
+  skos:broader quantitykind:Force ;
+.
+quantitykind:ForcePerAreaTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_F-PER-IN2-SEC ;
+  qudt:applicableUnit unit:PA-PER-HR ;
+  qudt:applicableUnit unit:PA-PER-MIN ;
+  qudt:applicableUnit unit:PA-PER-SEC ;
+  qudt:baseUnitDimensions "M/L \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg/m \\cdot s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force Per Area Time" ;
+.
+quantitykind:ForcePerElectricCharge
+  a qudt:QuantityKind ;
+  dcterms:description "The electric field depicts the force exerted on other electrically charged objects by the electrically charged particle the field is surrounding. The electric field is a vector field with SI units of newtons per coulomb (\\(N C^{-1}\\)) or, equivalently, volts per metre (\\(V m^{-1}\\) ). The SI base units of the electric field are \\(kg m s^{-3} A^{-1}\\). The strength or magnitude of the field at a given point is defined as the force that would be exerted on a positive test charge of 1 coulomb placed at that point"^^qudt:LatexString ;
+  qudt:applicableUnit unit:N-PER-C ;
+  qudt:baseUnitDimensions "L \\cdot M/I \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m/A \\cdot s^3" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electric_field"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force per Electric Charge" ;
+.
+quantitykind:ForcePerLength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_F-PER-FT ;
+  qudt:applicableUnit unit:LB_F-PER-IN ;
+  qudt:applicableUnit unit:N-PER-M ;
+  qudt:baseUnitDimensions "M/T^2" ;
+  qudt:baseUnitDimensions "kg/s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Force per Length" ;
+.
+quantitykind:FractionalMass_Stage1
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Fractional mass allocated to stage 1" ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fractional Mass (Stage 1)" ;
+.
+quantitykind:FractionalMass_Stage2
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Fractional mass allocated to stage 2" ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fractional Mass (Stage 2)" ;
+.
+quantitykind:FractionalMass_Stage3
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Fractional mass allocated to stage 3" ;
+  qudt:symbol "C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fractional Mass (Stage 3)" ;
+.
+quantitykind:FractionallMass_Stages1-3
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Fraction of propellant and structural mass assigned to stages 1, 2 and 3." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fractional Mass (Stages 1 through 3)" ;
+.
+quantitykind:Frequency
+  a qudt:QuantityKind ;
+  dcterms:description "\"Frequency\" is the number of occurrences of a repeating event per unit time. The repetition of the events may be periodic (that is. the length of time between event repetitions is fixed) or aperiodic (i.e. the length of time between event repetitions varies). Therefore, we distinguish between periodic and aperiodic frequencies. In the SI system, periodic frequency is measured in hertz (Hz) or multiples of hertz, while aperiodic frequency is measured in becquerel (Bq).  In spectroscopy, \\(\\nu\\) is mostly used. Light passing through different media keeps its frequency, but not its wavelength or wavenumber."^^qudt:LatexString ;
+  qudt:applicableUnit unit:GigaHZ ;
+  qudt:applicableUnit unit:HZ ;
+  qudt:applicableUnit unit:KiloHZ ;
+  qudt:applicableUnit unit:MegaHZ ;
+  qudt:applicableUnit unit:NUM-PER-YR ;
+  qudt:applicableUnit unit:PER-HR ;
+  qudt:applicableUnit unit:PER-MIN ;
+  qudt:applicableUnit unit:PER-SEC ;
+  qudt:applicableUnit unit:PlanckFrequency ;
+  qudt:applicableUnit unit:SAMPLE-PER-SEC ;
+  qudt:baseUnitDimensions "/T" ;
+  qudt:baseUnitDimensions "/s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Frequency"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:latexDefinition """\\(f = 1/T\\), where \\(T\\) is a period.
+
+Alternatively,
+
+\\(\\nu = 1/T\\)"""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\nu, f\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Frequency" ;
+.
+quantitykind:Friction
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Friction"^^xsd:anyURI ;
+  qudt:generalization quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Friction"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Friction\" is the force of two surfaces In contact, or the force of a medium acting on a moving object (that is air on an aircraft). When contacting surfaces move relative to each other, the friction between the two objects converts kinetic energy into thermal energy." ;
+  qudt:url "http://wiki.answers.com/Q/What_is_the_symbol_of_friction"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Friction" ;
+  skos:broader quantitykind:Force ;
+.
+quantitykind:Fugacity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fugacity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\tilde{p}_B\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Fugacity\" of a real gas is an effective pressure which replaces the true mechanical pressure in accurate chemical equilibrium calculations. It is equal to the pressure of an ideal gas which has the same chemical potential as the real gas." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fugacity" ;
+.
+quantitykind:FundamentalReciprocalLatticeVector
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Reciprocal_lattice"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Fundamental Reciprocal Lattice Vector\" are fundamental, or primary, translation vectors the reciprocal lattice." ;
+  qudt:symbol "b_1, b_2, b_3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Fundamental Reciprocal Lattice Vector" ;
+  skos:broader quantitykind:AngularReciprocalLatticeVector ;
+.
+quantitykind:GFactorOfNucleus
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Landé_g-factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(g = \\frac{\\mu}{I\\mu_B}\\), where \\(\\mu\\) is the magnitude of magnetic dipole moment, \\(I\\) is the nuclear angular momentum quantum number, and \\(\\mu_B\\) is the Bohr magneton."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"g-Factor of Nucleus\" is associated with the spin and magnetic moments of protons, neutrons, and many nuclei." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "g-Factor of Nucleus" ;
+.
+quantitykind:GROSS-LIFT-OFF-WEIGHT
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The sum of a rocket's inert mass and usable fluids and gases at sea level." ;
+  qudt:url "http://en.wikipedia.org/wiki/Maximum_Takeoff_Weight"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gross Lift-Off Weight"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:Gain
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gain"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:plainTextDescription "A general term used to denote an increase in signal power or signal strength in transmission from one point to another. Gain is usually expressed in decibels and is widely used to denote transducer gain.  An increase or amplification. In radar there are two general usages of the term: (a) antenna gain, or gain factor, is the ratio of the power transmitted along the beam axis to that of an isotropic radiator transmitting the same total power; (b) receiver gain, or video gain, is the amplification given a signal by the receiver." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gain" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:GeneralizedCoordinate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Generalized_coordinates"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q_i\\), where \\(q_i\\) is one of the coordinates that is used to describe the position of the system under consideration, and \\(N\\) is the lowest number of coordinates necessary to fully define the position of the system."^^qudt:LatexString ;
+  qudt:plainTextDescription "Generalized Coordinates refers to the parameters that describe the configuration of the system relative to some reference configuration. These parameters must uniquely define the configuration of the system relative to the reference configuration." ;
+  qudt:symbol "q_i" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Generalized Coordinate" ;
+.
+quantitykind:GeneralizedForce
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Generalized_forces"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\delta A = \\sum Q_i\\delta q_i\\), where \\(A\\) is work and \\(q_i\\) is a generalized coordinate."^^qudt:LatexString ;
+  qudt:plainTextDescription "Generalized Forces find use in Lagrangian mechanics, where they play a role conjugate to generalized coordinates." ;
+  qudt:symbol "Q_i" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Generalized Force" ;
+.
+quantitykind:GeneralizedMomentum
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Momentum"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(p_i = \\frac{\\partial L}{\\partial \\dot{q_i}}\\), where \\(L\\) is the Langrange function and \\(\\dot{q_i}\\) is a generalized velocity."^^qudt:LatexString ;
+  qudt:plainTextDescription "Generalized Momentum, also known as the canonical or conjugate momentum, extends the concepts of both linear momentum and angular momentum. To distinguish it from generalized momentum, the product of mass and velocity is also referred to as mechanical, kinetic or kinematic momentum." ;
+  qudt:symbol "p_i" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Generalized Force" ;
+.
+quantitykind:GeneralizedVelocity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Generalized_coordinates"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\dot{q_i} = \\frac{dq_i}{dt}\\), where \\(q_i\\) is the generalized coordinate and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\dot{q_i}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Generalized Velocities are the time derivatives of the generalized coordinates of the system." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Generalized Velocity" ;
+.
+quantitykind:GibbsEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Thermodynamics"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(G = H - T \\cdot S\\), where \\(H\\) is enthalpy, \\(T\\) is thermodynamic temperature and \\(S\\) is entropy."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Gibbs Energy} is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. \\textit{Internal Energy} is the internal energy of the system, \\textit{Enthalpy} is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name \\textit{Gibbs Free Energy\" is also used." ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gibbs Energy" ;
+  rdfs:seeAlso quantitykind:Energy ;
+  rdfs:seeAlso quantitykind:Enthalpy ;
+  rdfs:seeAlso quantitykind:HelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:InternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:GrandCanonicalPartitionFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Partition_function_(statistical_mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Xi = \\sum_{N_A, N_B, ...} Z(N_A, N_B, ...) \\cdot \\lambda_A^{N_A} \\cdot \\lambda_B^{N_B} \\cdot ...\\), where \\(Z(N_A, N_B, ...)\\) is the canonical partition function for the given number of particles \\(A, B, ...,\\), and \\(\\lambda_A, \\lambda_B, ...\\) are the absolute activities of particles \\(A, B, ...\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Xi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "An \"Grand Canonical Partition Function\" for a grand canonical ensemble, a system that can exchange both heat and particles with the environment, which has a constant temperature and a chemical potential." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Grand Canonical Partition Function" ;
+  skos:broader quantitykind:CanonicalPartitionFunction ;
+.
+quantitykind:GravitationalAttraction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-KiloGM-SEC2 ;
+  qudt:baseUnitDimensions "L^3/M \\cdot T^2" ;
+  qudt:baseUnitDimensions "m^3/kg \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M-1H0T-2D0> ;
+  qudt:informativeReference "http://www.thefreedictionary.com/gravitational+attraction"^^xsd:anyURI ;
+  qudt:plainTextDescription "The force of attraction between all masses in the universe; especially the attraction of the earth's mass for bodies near its surface; the more remote the body the less the gravity; the gravitation between two bodies is proportional to the product of their masses and inversely proportional to the square of the distance between them." ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gravitational Attraction" ;
+.
+quantitykind:GravitationalConstant
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The gravitational constant denoted by letter G, is an empirical physical constant involved in the calculation(s) of gravitational force between two bodies." ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gravitational Constant" ;
+.
+quantitykind:Gravity_API
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:baseSIUnitDimensions "\\(qkdv:A0E0L0I0M0H0T0D1\\)"^^qudt:LatexString ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/API_gravity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription """The American Petroleum Institute gravity, or API gravity, is a measure of how heavy or light a petroleum liquid is compared to water: if its API gravity is greater than 10, it is lighter and floats on water; if less than 10, it is heavier and sinks.
+
+API gravity is thus an inverse measure of a petroleum liquid's density relative to that of water (also known as specific gravity). It is used to compare densities of petroleum liquids. For example, if one petroleum liquid is less dense than another, it has a greater API gravity. Although API gravity is mathematically a dimensionless quantity (see the formula below), it is referred to as being in 'degrees'. API gravity is graduated in degrees on a hydrometer instrument. API gravity values of most petroleum liquids fall between 10 and 70 degrees.""" ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "API Gravity" ;
+.
+quantitykind:GroupSpeedOfSound
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Speed_of_sound"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c_g = \\frac{d\\omega}{dk}\\), where \\(\\omega\\) is the angular frequency and \\(k\\) is angular wavenumber."^^qudt:LatexString ;
+  qudt:plainTextDescription "In a dispersive medium sound speed is a function of sound frequency, through the dispersion relation. The spatial and temporal distribution of a propagating disturbance will continually change. The group speed of sound describes the propagation of the disturbance." ;
+  qudt:symbol "c" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Group Speed of Sound" ;
+  skos:broader quantitykind:SpeedOfSound ;
+.
+quantitykind:GruneisenParameter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Grüneisen_parameter"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\gamma = \\frac{\\alpha_V}{x_T c_V\\rho}\\), where \\(\\alpha_V\\) is the cubic expansion coefficient, \\(x_T\\) is isothermal compressibility, \\(c_V\\) is specific heat capacity at constant volume, and \\(\\rho\\) is mass density."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Gruneisen Parameter\" named after Eduard Grüneisen, describes the effect that changing the volume of a crystal lattice has on its vibrational properties, and, as a consequence, the effect that changing temperature has on the size or dynamics of the lattice." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gruneisen Parameter" ;
+.
+quantitykind:GustatoryThreshold
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_g\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Gustatory Threshold\" are thresholds for classes of tast that can be detected by the human mouth and thresholds of sensitivity to foods, drinks and other substances." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gustatory Threshold" ;
+.
+quantitykind:GyromagneticRatio
+  a qudt:QuantityKind ;
+  dcterms:description "\"Gyromagnetic Ratio}, also sometimes known as the magnetogyric ratio in other disciplines, of a particle or system is the ratio of its magnetic dipole moment to its angular momentum, and it is often denoted by the symbol, \\(\\gamma\\). Its SI units are radian per second per tesla (\\(rad s^{-1} \\cdot T^{1}\\)) or, equivalently, coulomb per kilogram (\\(C \\cdot kg^{-1\"\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-M2-PER-J-SEC ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gyromagnetic_ratio"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L2I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gyromagnetic_ratio"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\gamma J\\), where \\(\\mu\\) is the magnetic dipole moment, and \\(J\\) is the total angular momentum."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Gyromagnetic Ratio" ;
+  skos:broader quantitykind:ElectricChargePerMass ;
+.
+quantitykind:Half-Life
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Half-life"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Half-Life\" is the average duration required for the decay of one half of the atoms or nuclei." ;
+  qudt:symbol "T_{1/2}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Half-life" ;
+.
+quantitykind:HallCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-C ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hall_effect"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "In an isotropic conductor, the relation between electric field strength, \\(E\\), and electric current density, \\(J\\) is \\(E = \\rho J + R_H(B X J)\\), where \\(\\rho\\) is resistivity, and \\(B\\) is magnetic flux density."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Hall Coefficient\" is defined as the ratio of the induced electric field to the product of the current density and the applied magnetic field." ;
+  qudt:symbol "R_H, A_H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Hall Coefficient" ;
+.
+quantitykind:HamiltonFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hamilton–Jacobi_equation"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(H = \\sum p_i\\dot{q_i} - L\\), where \\(p_i\\) is a generalized momentum, \\(\\dot{q_i}\\) is a generalized velocity, and \\(L\\) is the Lagrange function."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Hamilton–Jacobi equation (HJE) is a necessary condition describing extremal geometry in generalizations of problems from the calculus of variations." ;
+  qudt:symbol "H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Hamilton Function" ;
+.
+quantitykind:HeartRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BEAT-PER-MIN ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Heart_rate"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.medterms.com/script/main/art.asp?articlekey=3674"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/oi/authority.20110803100354463"^^xsd:anyURI ;
+  qudt:plainTextDescription "The number of heartbeats per unit of time, usually per minute. The heart rate is based on the number of contractions of the ventricles (the lower chambers of the heart). The heart rate may be too fast (tachycardia) or too slow (bradycardia). The average adult pulse rate at rest is 60–80 per minute, but exercise, injury, illness, and emotion may produce much faster rates." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heart Rate" ;
+.
+quantitykind:HeatCapacity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Heat Capacity\" (usually denoted by a capital \\(C\\), often with subscripts), or thermal capacity, is the measurable physical quantity that characterizes the amount of heat required to change a substance's temperature by a given amount. In the International System of Units (SI), heat capacity is expressed in units of joule(s) (J) per kelvin (K)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT-PER-DEG_F ;
+  qudt:applicableUnit unit:BTU_IT-PER-DEG_R ;
+  qudt:applicableUnit unit:EV-PER-K ;
+  qudt:applicableUnit unit:J-PER-K ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_capacity"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(C = dQ/dT\\), where \\(Q\\) is amount of heat and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:symbol "C_P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heat Capacity" ;
+  skos:broader quantitykind:EnergyPerTemperature ;
+.
+quantitykind:HeatCapacityRatio
+  a qudt:QuantityKind ;
+  dcterms:description "The heat capacity ratio, or ratio of specific heats, is the ratio of the heat capacity at constant pressure (\\(C_P\\)) to heat capacity at constant volume (\\(C_V\\)). For an ideal gas, the heat capacity is constant with temperature (\\(\\theta\\)). Accordingly we can express the enthalpy as \\(H = C_P*\\theta\\) and the internal energy as \\(U = C_V \\cdot \\theta\\). Thus, it can also be said that the heat capacity ratio is the ratio between enthalpy and internal energy."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Heat_capacity_ratio"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_capacity_ratio"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-2D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heat Capacity Ratio" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:HeatFlowRate
+  a qudt:QuantityKind ;
+  dcterms:description "The rate of heat flow between two systems is measured in watts (joules per second). The formula for rate of heat flow is \\(\\bigtriangleup Q / \\bigtriangleup t = -K \\times A \\times \\bigtriangleup T/x\\), where \\(\\bigtriangleup Q / \\bigtriangleup t\\) is the rate of heat flow; \\(-K\\) is the thermal conductivity factor; A is the surface area; \\(\\bigtriangleup T\\) is the change in temperature and \\(x\\) is the thickness of the material. \\(\\bigtriangleup  T/ x\\) is called the temperature gradient and is always negative because of the heat of flow always goes from more thermal energy to less)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT-PER-HR ;
+  qudt:applicableUnit unit:BTU_IT-PER-SEC ;
+  qudt:applicableUnit unit:KiloCAL-PER-MIN ;
+  qudt:applicableUnit unit:KiloCAL-PER-SEC ;
+  qudt:applicableUnit unit:TON_FG ;
+  qudt:applicableUnit unit:W ;
+  qudt:expression "\\(heat-flow-rate\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Rate_of_heat_flow"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heat Flow Rate" ;
+  skos:broader quantitykind:Power ;
+.
+quantitykind:HeatFlowRatePerUnitArea
+  a qudt:QuantityKind ;
+  dcterms:description "\"Heat Flux} is the heat rate per unit area. In SI units, heat flux is measured in \\(W/m^{1\"\\). Heat rate is a scalar quantity, while heat flux is a vectorial quantity. To define the heat flux at a certain point in space, one takes the limiting case where the size of the surface becomes infinitesimally small."^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Heat_flux"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Heat Flow Rate per Unit Area" ;
+  skos:broader quantitykind:PowerPerArea ;
+.
+quantitykind:HelmholtzEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Thermodynamics"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(H = U - T \\cdot S\\), where \\(U\\) is internal energy, \\(T\\) is thermodynamic temperature and \\(S\\) is entropy."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Helmholtz Energy} is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. The potential used depends on the constraints of the system, such as constant temperature or pressure. \\textit{Internal Energy} is the internal energy of the system, \\textit{Enthalpy} is the internal energy of the system plus the energy related to pressure-volume work, and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. The name \\textit{Helmholz Free Energy\" is also used." ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Helmholtz Energy" ;
+  rdfs:seeAlso quantitykind:Energy ;
+  rdfs:seeAlso quantitykind:Enthalpy ;
+  rdfs:seeAlso quantitykind:GibbsEnergy ;
+  rdfs:seeAlso quantitykind:InternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:HorizontalVelocity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Component of a projectile's velocity, which acts parallel to the ground and does not lift the projectile in the air." ;
+  qudt:symbol "V_{X}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Horizontal Velocity" ;
+.
+quantitykind:HyperfineStructureQuantumNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hyperfine_structure"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Hyperfine Structure Quantum Number\" is a quantum number of an atom describing inclination of the nuclear spin with respect to a quantization axis given by the magnetic field produced by the orbital electrons." ;
+  qudt:symbol "F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Hyperfine Structure Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+.
+quantitykind:INERT-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The sum of the vehicle dry mass, residual fluids and gasses, personnel and personnel provisions, and cargo." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inert Mass"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:IgnitionIntervalTime
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ignition interval time" ;
+  skos:broader quantitykind:Time ;
+.
+quantitykind:Illuminance
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Illuminance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E_v = \\frac{d\\Phi}{dA}\\), where \\(d\\Phi\\) is the luminous flux incident on an element of the surface with area \\(dA\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of the intensity of the incident light, wavelength-weighted by the luminosity function to correlate with human brightness perception." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Illuminance" ;
+  skos:broader quantitykind:LuminousFluxPerArea ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Illuminance> ;
+.
+quantitykind:Impedance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electrical_impedance"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electrical_impedance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-43"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\underline{Z} = \\underline{U} / \\underline{I}\\), where \\(\\underline{U}\\) is the voltage phasor and \\(\\underline{I}\\) is the electric current phasor."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\underline{Z}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Impedance\" is the measure of the opposition that a circuit presents to the passage of a current when a voltage is applied. In quantitative terms, it is the complex ratio of the voltage to the current in an alternating current (AC) circuit. Impedance extends the concept of resistance to AC circuits, and possesses both magnitude and phase, unlike resistance, which has only magnitude. When a circuit is driven with direct current (DC), there is no distinction between impedance and resistance; the latter can be thought of as impedance with zero phase angle." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Impedance" ;
+  rdfs:seeAlso quantitykind:ElectricCurrentPhasor ;
+  rdfs:seeAlso quantitykind:VoltagePhasor ;
+.
+quantitykind:Inductance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:H ;
+  qudt:applicableUnit unit:H_Ab ;
+  qudt:applicableUnit unit:H_Stat ;
+  qudt:applicableUnit unit:MicroH ;
+  qudt:applicableUnit unit:MilliH ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/I^2 \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/A^2 \\cdot s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Inductance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-2L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-19"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L =\\frac{\\Psi}{I}\\), where \\(I\\) is an electric current in a thin conducting loop, and \\(\\Psi\\) is the linked flux caused by that electric current."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Inductance\" is an electromagentic quantity that characterizes a circuit's resistance to any change of electric current; a change in the electric current through induces an opposing electromotive force (EMF). Quantitatively, inductance is proportional to the magnetic flux per unit of electric current." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inductance" ;
+  rdfs:seeAlso quantitykind:MutualInductance ;
+.
+quantitykind:InfiniteMultiplicationFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Four_factor_formula"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(k_\\infty\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Infinite Multiplication Factor\" is the multiplication factor for an infinite medium or for an infinite repeating lattice." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Infinite Multiplication Factor" ;
+  skos:broader quantitykind:MultiplicationFactor ;
+  skos:closeMatch quantitykind:EffectiveMultiplicationFactor ;
+.
+quantitykind:InformationEntropy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BAN ;
+  qudt:applicableUnit unit:BIT ;
+  qudt:applicableUnit unit:BYTE ;
+  qudt:applicableUnit unit:ERLANG ;
+  qudt:applicableUnit unit:HART ;
+  qudt:applicableUnit unit:NAT ;
+  qudt:applicableUnit unit:NAT-PER-SEC ;
+  qudt:applicableUnit unit:SHANNON ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:informativeReference "http://simple.wikipedia.org/wiki/Information_entropy"^^xsd:anyURI ;
+  qudt:plainTextDescription "Information Entropy is a concept from information theory. It tells how much information there is in an event. In general, the more uncertain or random the event is, the more information it will contain. The concept of information entropy was created by a mathematician. He was named Claude Elwood Shannon. It has applications in many areas, including lossless data compression, statistical inference, cryptography and recently in other disciplines as biology, physics or machine learning." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Information Entropy" ;
+.
+quantitykind:InformationFlowRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:HART-PER-SEC ;
+  qudt:applicableUnit unit:SHANNON-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Information flow rate" ;
+.
+quantitykind:InitialExpansionRatio
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Initial Expansion Ratio" ;
+  skos:broader quantitykind:ExpansionRatio ;
+.
+quantitykind:InitialVehicleMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M_{o}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Initial Vehicle Mass" ;
+.
+quantitykind:InitialVelocity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The velocity of a moving body at starting; especially, the velocity of a projectile as it leaves the mouth of a firearm from which it is discharged." ;
+  qudt:symbol "V_{i}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Initial Velocity" ;
+.
+quantitykind:InstantaneousPower
+  a qudt:QuantityKind ;
+  dcterms:description """\"Instantaneous Power}, for a two-terminal element or a two-terminal circuit with terminals A and B, is the product of the voltage \\(u_{AB}\\) between the terminals and the electric current i in the element or circuit: \\(p = \\)u_{AB} \\cdot i\\(, where \\)u_{AB\" is the line integral of the electric field strength from A to B, and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs.
+
+
+
+For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element.  For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current."""^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Power"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-30"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-31"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=141-02-14"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=141-03-10"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(p = ui\\), where \\(u\\) is instantaneous voltage and \\(i\\) is instantaneous electric current."^^qudt:LatexString ;
+  qudt:symbol "p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Instantaneous Power" ;
+.
+quantitykind:InternalConversionFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Internal_conversion_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"InternalConversionFactor\" describes the rate of internal conversion. It is the ratio of the number of internal conversion electrons to the number of gamma quanta emitted by the radioactive atom in a given transition." ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "InternalConversionFactor" ;
+.
+quantitykind:InverseAmountOfSubstance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-MOL ;
+  qudt:baseUnitDimensions "/M" ;
+  qudt:baseUnitDimensions "/mol" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L0I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse amount of substance" ;
+.
+quantitykind:InverseEnergy
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "T^2/L^2 \\cdot M" ;
+  qudt:baseUnitDimensions "s^2/kg \\cdot m^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M-1H0T2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Energy" ;
+.
+quantitykind:InverseLength
+  a qudt:QuantityKind ;
+  dcterms:description "Reciprocal length or inverse length is a measurement used in several branches of science and mathematics. As the reciprocal of length, common units used for this measurement include the reciprocal metre or inverse metre (\\(m^{-1}\\)), the reciprocal centimetre or inverse centimetre (\\(cm^{-1}\\)), and, in optics, the dioptre."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KY ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:baseUnitDimensions "/L" ;
+  qudt:baseUnitDimensions "/m" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Reciprocal_length"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Length" ;
+.
+quantitykind:InverseLengthTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M-K ;
+  qudt:baseUnitDimensions "/K \\cdot m" ;
+  qudt:baseUnitDimensions "/\\Theta \\cdot L" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H-1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Length Temperature" ;
+.
+quantitykind:InverseMagneticFlux
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:HZ-PER-V ;
+  qudt:baseUnitDimensions "A \\cdot s^2/kg \\cdot m^2" ;
+  qudt:baseUnitDimensions "I \\cdot T^2/L^2 \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-2I0M-1H0T2D0> ;
+  qudt:plainTextDescription "\"Inverse Magnetic Flux\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Magnetic Flux" ;
+.
+quantitykind:InversePermittivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-FARAD ;
+  qudt:baseUnitDimensions "L^3 \\cdot M/I^2 \\cdot T^4" ;
+  qudt:baseUnitDimensions "kg \\cdot m^3/A^2 \\cdot s^4" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-2L3I0M1H0T-4D0> ;
+  qudt:plainTextDescription "\"Inverse Permittivity\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Permittivity" ;
+.
+quantitykind:InversePressure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-PA ;
+  qudt:exactMatch quantitykind:IsothermalCompressibility ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M-1H0T2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Pressure" ;
+.
+quantitykind:InverseSquareEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-GigaEV2 ;
+  qudt:baseUnitDimensions "T^4/L^4 \\cdot M^2" ;
+  qudt:baseUnitDimensions "s^4/kg^2 \\cdot m^4" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-4I0M-2H0T4D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Square Energy" ;
+.
+quantitykind:InverseSquareMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-PlanckMass2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M-2H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Square Mass" ;
+.
+quantitykind:InverseTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-K ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Temperature" ;
+.
+quantitykind:InverseTime
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "/T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Time" ;
+.
+quantitykind:InverseTimeTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:HZ-PER-K ;
+  qudt:applicableUnit unit:MegaHZ-PER-K ;
+  qudt:baseUnitDimensions "/K \\cdot s" ;
+  qudt:baseUnitDimensions "/\\Theta \\cdot T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H-1T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Time Temperature" ;
+.
+quantitykind:InverseVolume
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Inverse Volume" ;
+.
+quantitykind:IonCurrent
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "An ion current is the influx and/or efflux of ions through an ion channel." ;
+  qudt:symbol "j" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ion Current" ;
+.
+quantitykind:IonTransportNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ion_transport_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(t_B = \\frac{i_B}{i}\\), where \\(i_B\\) is the electric current carried by the ion \\(B\\) and \\(i\\) is the total electric current."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Ion Transport Number\" is a quantity which indicates the different contribution of ions to the electric current in electrolytes due to different electrical mobility." ;
+  qudt:symbol "t_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ion Transport Number" ;
+.
+quantitykind:IonicCharge
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The total charge of an ion. The charge of an electron; the charge of any ion is equal to this electron charge in magnitude, or is an integral multiple of it." ;
+  qudt:symbol "q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ionic Charge" ;
+.
+quantitykind:IonicStrength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ionic_strength"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I = \\frac{1}{2} \\sum z_i^2 b_i\\), where the summation is carried out over all ions with charge number \\(z_i\\) and molality \\(m_i\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Ionic Strength\" of a solution is a measure of the concentration of ions in that solution." ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ionic Strength" ;
+.
+quantitykind:IonizationEnergy
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ionization Energy" ;
+.
+quantitykind:IsentropicCompressibility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-PA ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Compressibility"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varkappa_S = \\frac{1}{V}\\left (\\frac{\\partial V}{\\partial p} \\right )_S\\), where \\(V\\) is volume, \\(p\\) is \\(pressure\\), and \\(S\\) is entropy,"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varkappa_S\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Isentropic compressibility is the extent to which a material reduces its volume when it is subjected to compressive stresses at a constant value of entropy." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Isentropic Compressibility" ;
+.
+quantitykind:IsentropicExponent
+  a qudt:QuantityKind ;
+  dcterms:description "Isentropic exponent is a variant of \"Specific Heat Ratio Capacities}. For an ideal gas \\textit{Isentropic Exponent\"\\(, \\varkappa\\). is equal to \\(\\gamma\\), the ratio of its specific heat capacities \\(c_p\\) and \\(c_v\\) under steady pressure and volume."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Specific_heat_ratio"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Compressibility"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varkappa = -\\frac{V}{p}\\left \\{  \\frac{\\partial p}{\\partial  V}\\right \\}_S\\), where \\(V\\) is volume, \\(p\\) is pressure, and \\(S\\) is entropy."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varkappa\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Isentropic Exponent" ;
+  rdfs:seeAlso quantitykind:IsentropicCompressibility ;
+.
+quantitykind:IsothermalCompressibility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M-1H0T2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Compressibility"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varkappa_T = \\frac{1}{V}\\left (\\frac{\\partial V}{\\partial p} \\right )_T\\), where \\(V\\) is volume, \\(p\\) is \\(pressure\\), and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varkappa_T\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The isothermal compressibility defines the rate of change of system volume with pressure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Isothermal Compressibility Factor" ;
+  rdfs:label "Isothermal compressibility" ;
+.
+quantitykind:Kerma
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:GRAY ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kerma_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "For indirectly ionizing (uncharged) particles, \\(K= \\frac{dE_{tr}}{dm}\\), where \\(dE_{tr}\\) is the mean sum of the initial kinetic energies of all the charged ionizing particles liberated by uncharged ionizing particles in an element of matter, and \\(dm\\) is the mass of that element."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Kerma\" is the sum of the initial kinetic energies of all the charged particles liberated by uncharged ionizing radiation (i.e., indirectly ionizing radiation such as photons and neutrons) in a sample of matter, divided by the mass of the sample." ;
+  qudt:symbol "K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Kerma" ;
+.
+quantitykind:KermaRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:GRAY-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Half-value_layer"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\dot{K} = \\frac{dK}{dt}\\), where \\(K\\) is the increment of kerma during time interval with duration \\(t\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\dot{K}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Kerma Rate\" is the kerma per unit time." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Kerma Rate" ;
+  skos:broader quantitykind:Kerma ;
+.
+quantitykind:KinematicViscosity
+  a qudt:QuantityKind ;
+  dcterms:description "The ratio of the viscosity of a liquid to its density. Viscosity is a measure of the resistance of a fluid which is being deformed by either shear stress or tensile stress. In many situations, we are concerned with the ratio of the inertial force to the viscous force (that is the Reynolds number), the former characterized by the fluid density \\(\\rho\\). This ratio is characterized by the kinematic viscosity (Greek letter \\(\\nu\\)), defined as follows:  \\(\\nu = \\mu / \\rho\\). The SI unit of \\(\\nu\\) is \\(m^{2}/s\\). The SI unit of \\(\\nu\\) is \\(kg/m^{1}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:CentiST ;
+  qudt:applicableUnit unit:FT2-PER-HR ;
+  qudt:applicableUnit unit:FT2-PER-SEC ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:applicableUnit unit:St ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Viscosity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Viscosity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\nu = \\frac{\\eta}{\\rho}\\), where \\(\\eta\\) is dynamic viscosity and \\(\\rho\\) is mass density."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\nu\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Kinematic Viscosity" ;
+  skos:broader quantitykind:AreaPerTime ;
+.
+quantitykind:LagrangeFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lagrangian"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=113-03-76"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L(q_i, \\dot{q_i}) = T(q_i, \\dot{q_i}) - V(q_i)\\), where \\(T\\) is kinetic energy, \\(V\\) is potential energy, \\(q_i\\) is a generalized coordinate, and \\(\\dot{q_i}\\) is a generalized velocity."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Lagrange Function is a function that summarizes the dynamics of the system." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lagrange Function" ;
+.
+quantitykind:Landau-GinzburgNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ginzburg–Landau_theory"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "At zero thermodynamic temperature \\(\\kappa = \\frac{\\lambda_L}{(\\varepsilon\\sqrt{2})}\\), where \\(\\lambda_L\\) is London penetration depth and \\(\\varepsilon\\) is coherence length."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\kappa\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Landau-Ginzburg Number\", also known as the Ginzburg-Landau parameter, describes the relationship between London penetration depth and coherence length." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Landau-Ginzburg Number" ;
+.
+quantitykind:LandeGFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/G-factor_(physics)"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Landé_g-factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(g = \\frac{\\mu}{J\\mu_B}\\), where \\(\\mu\\) is the magnitude of magnetic dipole moment, \\(J\\) is the total angular momentum quantum number, and \\(\\mu_B\\) is the Bohr magneton."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Lande g-Factor\" is a particular example of a g-factor, namely for an electron with both spin and orbital angular momenta. It is named after Alfred Landé, who first described it in 1921." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lande g-Factor" ;
+.
+quantitykind:LarmorAngularFrequency
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Larmor_precession#Larmor_frequency"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\omega_L = \\frac{e}{2m_e}B\\), where \\(e\\) is the elementary charge, \\(m_e\\) is the rest mass of electron, and \\(B\\) is the magnetic flux density."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\omega_L\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Larmor Frequency\" describes angular momentum vector precession about the external field axis with an angular frequency." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Larmor Angular Frequency" ;
+  skos:broader quantitykind:AngularFrequency ;
+.
+quantitykind:LatticeVector
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lattice Vector" ;
+.
+quantitykind:LeakageFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:expression "\\(leakage-factor\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=221-04-12"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sigma = 1 - k^2\\), where \\(k\\) is the coupling factor."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Leakage Factor\" is the ratio of the total magnetic flux to the useful magnetic flux of a magnetic circuit." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Leakage Factor" ;
+.
+quantitykind:Length
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ANGSTROM ;
+  qudt:applicableUnit unit:AU ;
+  qudt:applicableUnit unit:CH ;
+  qudt:applicableUnit unit:CentiM ;
+  qudt:applicableUnit unit:DeciM ;
+  qudt:applicableUnit unit:FATH ;
+  qudt:applicableUnit unit:FM ;
+  qudt:applicableUnit unit:FT ;
+  qudt:applicableUnit unit:FT_US ;
+  qudt:applicableUnit unit:FUR ;
+  qudt:applicableUnit unit:FUR_Long ;
+  qudt:applicableUnit unit:FemtoM ;
+  qudt:applicableUnit unit:IN ;
+  qudt:applicableUnit unit:KiloM ;
+  qudt:applicableUnit unit:LY ;
+  qudt:applicableUnit unit:M ;
+  qudt:applicableUnit unit:MI ;
+  qudt:applicableUnit unit:MI_N ;
+  qudt:applicableUnit unit:MI_US ;
+  qudt:applicableUnit unit:MicroIN ;
+  qudt:applicableUnit unit:MicroM ;
+  qudt:applicableUnit unit:MilLength ;
+  qudt:applicableUnit unit:MilliM ;
+  qudt:applicableUnit unit:PARSEC ;
+  qudt:applicableUnit unit:PCA ;
+  qudt:applicableUnit unit:PT ;
+  qudt:applicableUnit unit:PlanckLength ;
+  qudt:applicableUnit unit:ROD ;
+  qudt:applicableUnit unit:YD ;
+  qudt:baseUnitDimensions "L" ;
+  qudt:baseUnitDimensions "m" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Length"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Length"^^xsd:anyURI ;
+  qudt:plainTextDescription "In geometric measurements, length most commonly refers to the est dimension of an object. In some contexts, the term \"length\" is reserved for a certain dimension of an object along which the length is measured." ;
+  qudt:symbol "l" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length" ;
+.
+quantitykind:LengthByForce
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Force" ;
+.
+quantitykind:LengthEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MegaEV-FemtoM ;
+  qudt:baseUnitDimensions "L^3 \\cdot M/T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^3/s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Energy" ;
+.
+quantitykind:LengthMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-KiloGM ;
+  qudt:baseUnitDimensions "L \\cdot M" ;
+  qudt:baseUnitDimensions "kg \\cdot m" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Mass" ;
+.
+quantitykind:LengthMolarEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-M-PER-MOL ;
+  qudt:baseUnitDimensions "L^3 \\cdot M/M \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^3/mol \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L3I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Molar Energy" ;
+.
+quantitykind:LengthPerUnitElectricCurrent
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "L/I" ;
+  qudt:baseUnitDimensions "m/A" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L1I0M0H0T0D0> ;
+  qudt:plainTextDescription "\"Length per Unit Electric Current\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length per Unit Electric Current" ;
+.
+quantitykind:LengthPercentage
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Percentage" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:LengthTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG_C-CentiM ;
+  qudt:applicableUnit unit:M-K ;
+  qudt:baseUnitDimensions "K \\cdot m" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot L" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Temperature" ;
+.
+quantitykind:LengthTemperatureTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CentiM-SEC-DEG_C ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Length Temperature Time" ;
+.
+quantitykind:Lethargy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.scribd.com/doc/51548050/149/Lethargy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(u = \\ln(\\frac{E_0}{E})\\), where \\(E_0\\) is a reference energy."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Lethargy\" is a dimensionless logarithm of the ratio of the energy of source neutrons to the energy of neutrons after a collision." ;
+  qudt:symbol "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lethargy" ;
+.
+quantitykind:LevelWidth
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/Level+Width"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Gamma = \\frac{\\hbar}{\\tau}\\), where \\(\\hbar\\) is the reduced Planck constant and \\(\\tau\\) is the mean lifetime."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Level Width\" is the uncertainty in the energy of a quantum-mechanical system having discrete energy levels in a state that is not strictly stationary. The system may be an atom, a molecule, or an atomic nucleus." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Level Width" ;
+.
+quantitykind:LiftCoefficient
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The lift coefficient is a dimensionless coefficient that relates the lift generated by a lifting body, the dynamic pressure of the fluid flow around the body, and a reference area associated with the body." ;
+  qudt:symbol "C_{L}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lift Coefficient" ;
+.
+quantitykind:LiftForce
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The lift force, lifting force or simply lift is the sum of all the forces on a body that force it to move perpendicular to the direction of flow." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lift Force" ;
+.
+quantitykind:LinearAbsorptionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:latexDefinition "\\(\\alpha(\\lambda) = \\frac{1}{\\Phi_\\lambda(\\lambda)}\\frac{d\\Phi_\\lambda(\\lambda)}{dl}\\), where \\(\\frac{d\\Phi}{\\Phi}\\) is the relative decrease, caused by absorption, in the spectral radiant flux \\(\\Phi\\) of a collimated beam of electromagnetic radiation corresponding to the wavelength \\(\\lambda\\) during traversal of an infinitesimal layer of a medium and \\(dl\\) is the length traversed."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The Linear Absorption Coefficient is a quantity that characterizes how easily a material or medium can be penetrated by a beam of light, sound, particles, or other energy or matter." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Absorption Coefficient" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Attenuation_coefficient> ;
+.
+quantitykind:LinearAcceleration
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CentiM-PER-SEC2 ;
+  qudt:applicableUnit unit:FT-PER-SEC2 ;
+  qudt:applicableUnit unit:G ;
+  qudt:applicableUnit unit:GAL ;
+  qudt:applicableUnit unit:IN-PER-SEC2 ;
+  qudt:applicableUnit unit:KN-PER-SEC ;
+  qudt:applicableUnit unit:M-PER-SEC2 ;
+  qudt:applicableUnit unit:MicroG ;
+  qudt:applicableUnit unit:MilliG ;
+  qudt:baseUnitDimensions "L/T^2" ;
+  qudt:baseUnitDimensions "m/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Acceleration"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Acceleration" ;
+  skos:broader quantitykind:Acceleration ;
+.
+quantitykind:LinearAttenuationCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Attenuation_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(\\mu = -\\frac{1}{J}\\frac{dJ}{dx}\\), where \\(J\\) is the magnitude of the current rate of a beam of particles parallel to the \\(x-direction\\).
+
+Or:
+
+\\(\\mu(\\lambda) = \\frac{1}{\\Phi_\\lambda(\\lambda)}\\frac{d\\Phi_\\lambda(\\lambda)}{dl}\\), where \\(\\frac{d\\Phi}{\\Phi}\\) is the relative decrease in the spectral radiant flux \\(\\Phi\\) of a collimated beam of electromagnetic radiation corresponding to the wavelength \\(\\lambda\\) during traversal of an infinitesimal layer of a medium and \\(dl\\) is the length traversed."""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Linear Attenuation Coefficient\", also called the attenuation coefficient,  narrow beam attenuation coefficient, or absorption coefficient, is a quantity that characterizes how easily a material or medium can be penetrated by a beam of light, sound, particles, or other energy or matter." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Attenuation Coefficient" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Attenuation_coefficient> ;
+.
+quantitykind:LinearDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M ;
+  qudt:baseUnitDimensions "kg m^{-1}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Linear_density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho_l = \\frac{dm}{dl}\\), where \\(m\\) is mass and \\(l\\) is length."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_l\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The Linear density, linear mass density or linear mass is a measure of mass per unit of length, and it is a characteristic of strings or other one-dimensional objects." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Density" ;
+  skos:broader quantitykind:Density ;
+.
+quantitykind:LinearElectricCurrent
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "A/m" ;
+  qudt:informativeReference "http://www.asknumbers.com/ElectricalConversion.aspx"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Linear Electric Linear Current\" is the electric current per unit line." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Electric Current" ;
+.
+quantitykind:LinearElectricCurrentDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Linear Electric Linear Current Density\" is the electric current per unit length. Electric current, \\(I\\), through a curve \\(C\\) is defined as \\(I = \\int_C J _s \\times e_n\\), where \\(e_n\\) is a unit vector perpendicular to the surface and line vector element, and \\(dr\\) is the differential of position vector \\(r\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-PER-M ;
+  qudt:informativeReference "http://www.asknumbers.com/ElectricalConversion.aspx"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J_s = \\rho_A v\\), where \\(\\rho_A\\) is surface density of electric charge and \\(v\\) is velocity."^^qudt:LatexString ;
+  qudt:symbol "J_s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Electric Current Density" ;
+  rdfs:seeAlso quantitykind:ElectricChargeSurfaceDensity ;
+  rdfs:seeAlso quantitykind:ElectricCurrentDensity ;
+.
+quantitykind:LinearEnergyTransfer
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M ;
+  qudt:applicableUnit unit:KiloEV-PER-MicroM ;
+  qudt:applicableUnit unit:MegaEV-PER-CentiM ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Linear_energy_transfer"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Linear_energy_transfer"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "For ionizing charged particles, \\(L_\\Delta = \\frac{dE_\\Delta}{dl}\\), where \\(dE_\\Delta\\) is the mean energy lost in elctronic collisions locally to matter along a small path through the matter, minus the sum of the kinetic energies of all the electrons released with kinetic energies in excess of \\(\\Delta\\), and \\(dl\\) is the length of that path."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(L_\\Delta\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(L_\\bigtriangleup\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Linear Energy Transfer\"  (LET) is the linear density of energy lost by a charged ionizing particle travelling through matter.Typically, this measure is used to quantify the effects of ionizing radiation on biological specimens or electronic devices." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Energy Transfer" ;
+.
+quantitykind:LinearExpansionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-K ;
+  qudt:expression "\\(lnr-exp-coef\\)"^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_l = \\frac{1}{l} \\; \\frac{dl}{dT}\\), where \\(l\\) is \\(length\\) and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_l\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Expansion Coefficient" ;
+.
+quantitykind:LinearIonization
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ionization#Classical_ionization"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(N_{il} = \\frac{1}{e}\\frac{dQ}{dl}\\), where \\(e\\) is the elementary charge and \\(dQ\\) is the average total charge of all positive ions produced over an infinitesimal element of the path with length \\(dl\\) by an ionizing charged particle."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Linear Ionization\"  is a description of how the ionization of an atom or molecule takes place. For example, an ion with a +2 charge can be created only from an ion with a +1 charge or a +3 charge. That is, the numerical charge of an atom or molecule must change sequentially, always moving from one number to an adjacent, or sequential, number. Using sequential ionization definition." ;
+  qudt:symbol "N_{il}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Ionization" ;
+.
+quantitykind:LinearMomentum
+  a qudt:QuantityKind ;
+  dcterms:description "Linear momentum is the quantity obtained by multiplying the mass of a body by its linear velocity. The momentum of a continuous medium is given by the integral of the velocity over the mass of the medium or by the product of the total mass of the medium and the velocity of the center of gravity of the medium.The SI unit for linear momentum is meter-kilogram per second (\\(m-kg/s\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-M-PER-SEC ;
+  qudt:applicableUnit unit:MegaEV-PER-SpeedOfLight ;
+  qudt:applicableUnit unit:PlanckMomentum ;
+  qudt:baseUnitDimensions "L \\cdot M/T" ;
+  qudt:baseUnitDimensions "kg \\cdot m/s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Momentum"^^xsd:anyURI ;
+  qudt:generalization quantitykind:Momentum ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H0T-1D0> ;
+  qudt:latexDefinition "p = m\\upsilon"^^qudt:LatexString ;
+  qudt:symbol "p" ;
+  qudt:url "http://en.wikipedia.org/wiki/Momentum"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Momentum" ;
+  skos:broader quantitykind:Momentum ;
+.
+quantitykind:LinearStrain
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deformation_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\xi = \\frac{\\Delta l}{l_0}\\), where \\(\\Delta l\\) is the increase in length and \\(l_0\\) is the length in a reference state to be specified."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\xi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "A strain is a normalized measure of deformation representing the displacement between particles in the body relative to a reference length." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Strain" ;
+  skos:broader quantitykind:Strain ;
+.
+quantitykind:LinearThermalExpansion
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-K ;
+  qudt:baseUnitDimensions "L/\\Theta" ;
+  qudt:baseUnitDimensions "m/K" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H-1T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/linear_thermal_expansion"^^xsd:anyURI ;
+  qudt:plainTextDescription "When the temperature of a substance changes, the energy that is stored in the intermolecular bonds between atoms changes. When the stored energy increases, so does the length of the molecular bonds. As a result, solids typically expand in response to heating and contract on cooling; this dimensional response to temperature change is expressed by its coefficient of thermal expansion. Different coefficients of thermal expansion can be defined for a substance depending on whether the expansion is measured by: linear thermal expansion, area thermal expansion, or volumetric thermal expansion." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Thermal Expansion" ;
+.
+quantitykind:LinearVelocity
+  a qudt:QuantityKind ;
+  dcterms:description "Linear Velocity, as the name implies deals with speed in a straight line, the units are often \\(km/hr\\) or \\(m/s\\) or \\(mph\\) (miles per hour). Linear Velocity (v) = change in distance/change in time, where \\(v = \\bigtriangleup d/\\bigtriangleup t\\)"^^qudt:LatexString ;
+  qudt:applicableUnit unit:CentiM-PER-SEC ;
+  qudt:applicableUnit unit:FT-PER-HR ;
+  qudt:applicableUnit unit:FT-PER-MIN ;
+  qudt:applicableUnit unit:FT-PER-SEC ;
+  qudt:applicableUnit unit:IN-PER-SEC ;
+  qudt:applicableUnit unit:KN ;
+  qudt:applicableUnit unit:KiloM-PER-HR ;
+  qudt:applicableUnit unit:KiloM-PER-SEC ;
+  qudt:applicableUnit unit:M-PER-HR ;
+  qudt:applicableUnit unit:M-PER-MIN ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:applicableUnit unit:MI-PER-HR ;
+  qudt:applicableUnit unit:MI-PER-MIN ;
+  qudt:applicableUnit unit:MI_N-PER-HR ;
+  qudt:applicableUnit unit:MI_N-PER-MIN ;
+  qudt:baseUnitDimensions "L/T" ;
+  qudt:baseUnitDimensions "m/s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Velocity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://au.answers.yahoo.com/question/index?qid=20080319082534AAtrClv"^^xsd:anyURI ;
+  qudt:symbol "v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linear Velocity" ;
+  skos:broader quantitykind:Velocity ;
+.
+quantitykind:LinkedFlux
+  a qudt:QuantityKind ;
+  dcterms:description "\"Linked Flux\" is defined as the path integral of the magnetic vector potential. This is the line integral of a magnetic vector potential \\(A\\) along a curve \\(C\\). The line vector element \\(dr\\) is the differential of position vector \\(r\\)."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Magnetic_flux"^^xsd:anyURI ;
+  qudt:expression "\\(linked-flux\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-24"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-1800"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Psi_m = \\int_C A \\cdot dr\\), where \\(A\\) is magnetic vector potential and \\(dr\\) is the vector element of the curve \\(C\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Psi\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Psi_m\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Linked Flux" ;
+.
+quantitykind:LiquidVolume
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CUP ;
+  qudt:applicableUnit unit:GAL_IMP ;
+  qudt:applicableUnit unit:GAL_US ;
+  qudt:applicableUnit unit:L ;
+  qudt:applicableUnit unit:OZ_VOL_US ;
+  qudt:applicableUnit unit:PINT_US ;
+  qudt:applicableUnit unit:QT_US ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.ehow.com/facts_6371078_liquid-volume_.html"^^xsd:anyURI ;
+  qudt:plainTextDescription "Liquid volume is the volume of a given amount of liquid, that is, the amount of space a liquid takes up. There are a number of different units used to measure liquid volume, but most of them fall under either the metric system of measurement or the Imperial system of measurement." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Liquid Volume" ;
+  skos:broader quantitykind:Volume ;
+.
+quantitykind:LogarithmicFrequencyInterval
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(G = \\log_{2}(f2/f1)\\), where \\(f1\\) and \\(f2 \\geq f1\\) are frequencies of two tones."^^qudt:LatexString ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Logarithmic Frequency Interval" ;
+  rdfs:label "Logarithmic frequency interval" ;
+.
+quantitykind:Long-RangeOrderParameter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Long-Range Order Parameter\" is the fraction of atoms in an Ising ferromagnet having magnetic moments in one direction, minus the fraction having magnetic moments in the opposite direction." ;
+  qudt:symbol "R, s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Long-Range Order Parameter" ;
+.
+quantitykind:LorenzCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V2-PER-K2 ;
+  qudt:informativeReference "http://www.matter.org.uk/diffraction/geometry/lattice_vectors.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L = \\frac{\\lambda}{\\sigma T}\\), where \\(\\lambda\\) is thermal conductivity, \\(\\sigma\\) is electric conductivity, and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Lorenz Coefficient\" is part mof the Lorenz curve." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lorenz Coefficient" ;
+.
+quantitykind:LossAngle
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\delta = \\arctan d\\), where \\(d\\) is loss factor."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\delta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Loss Angle\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Loss Angle" ;
+.
+quantitykind:LossFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(d = \\frac{1}{Q}\\), where \\(Q\\) is quality factor."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Loss Factor} is the inverse of \\textit{Quality Factor} and is the ratio of the \\textit{resistance} and modulus of \\textit{reactance\"." ;
+  qudt:symbol "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Loss Factor" ;
+  rdfs:seeAlso quantitykind:QualityFactor ;
+  rdfs:seeAlso quantitykind:Reactance ;
+  rdfs:seeAlso quantitykind:Resistance ;
+.
+quantitykind:LowerCriticalMagneticFluxDensity
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Lower Critical Magnetic Flux Density\" for type II superconductors, is the threshold magnetic flux density for magnetic flux entering the superconductor." ;
+  qudt:symbol "B_{c1}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Lower Critical Magnetic Flux Density" ;
+  skos:closeMatch quantitykind:UpperCriticalMagneticFluxDensity ;
+.
+quantitykind:Luminance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CD-PER-IN2 ;
+  qudt:applicableUnit unit:CD-PER-M2 ;
+  qudt:applicableUnit unit:FT-LA ;
+  qudt:applicableUnit unit:LA ;
+  qudt:applicableUnit unit:STILB ;
+  qudt:baseUnitDimensions "J/L^2" ;
+  qudt:baseUnitDimensions "cd/m^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Luminance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I1M0H0T0D0> ;
+  qudt:latexDefinition "\\(L_v = \\frac{dI_v}{dA}\\), where \\(dI_v\\) is the luminous intensity of an element of the surface with the area \\(dA\\) of the orthogonal projection of this element on a plane perpendicular to the given direction."^^qudt:LatexString ;
+  qudt:plainTextDescription "Luminance is a photometric measure of the luminous intensity per unit area of light travelling in a given direction. It describes the amount of light that passes through or is emitted from a particular area, and falls within a given solid angle." ;
+  qudt:symbol "L_v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminance" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminance> ;
+.
+quantitykind:LuminousEfficacy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LM-PER-W ;
+  qudt:baseUnitDimensions "J \\cdot T^3 \\cdot U/L^2 \\cdot M" ;
+  qudt:baseUnitDimensions "cd \\cdot s^3/kg \\cdot m^2" ;
+  qudt:expression "\\(lm/w\\)"^^qudt:LatexString ;
+  qudt:latexDefinition "\\(K = \\frac{\\Phi_v}{\\Phi}\\), where \\(\\Phi_v\\) is the luminous flux and \\(\\Phi\\) is the corresponding radiant flux."^^qudt:LatexString ;
+  qudt:plainTextDescription "Luminous Efficacy is the ratio of luminous flux (in lumens) to power (usually measured in watts). Depending on context, the power can be either the radiant flux of the source's output, or it can be the total electric power consumed by the source." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Efficacy" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_efficacy> ;
+.
+quantitykind:LuminousEmmitance
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Luminous Emittance\" is the luminous flux per unit area emitted from a surface." ;
+  qudt:symbol "M_v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Emmitance" ;
+  skos:broader quantitykind:LuminousFluxPerArea ;
+.
+quantitykind:LuminousEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LM-SEC ;
+  qudt:latexDefinition "\\(Q_v = \\int_{0}^{\\Delta t}{\\Phi_v}{dt}\\), where \\(\\Phi_v\\) is the luminous flux occurring during the time interval with duration \\(\\Delta t\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Luminous Energy is the perceived energy of light. This is sometimes also called the quantity of light." ;
+  qudt:symbol "Q_v" ;
+  qudt:symbol "Qv" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Energy" ;
+  skos:closeMatch quantitykind:RadiantEnergy ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_energy> ;
+.
+quantitykind:LuminousFlux
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LM ;
+  qudt:baseUnitDimensions "J \\cdot U" ;
+  qudt:baseUnitDimensions "cd" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Luminous_flux"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Luminous_flux"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Phi_v = K_m \\int_{0}^{\\infty}{\\Phi_\\lambda(\\lambda)}{V(\\lambda)d\\lambda}\\), where \\(K_m\\) is the maximum spectral luminous efficacy, \\(\\Phi_\\lambda(\\lambda)\\) is the spectral radiant flux, \\(V(\\lambda)\\) is the spectral luminous efficiency, and \\(\\lambda\\) is the wavelength."^^qudt:LatexString ;
+  qudt:plainTextDescription "Luminous Flux or Luminous Power is the measure of the perceived power of light. It differs from radiant flux, the measure of the total power of light emitted, in that luminous flux is adjusted to reflect the varying sensitivity of the human eye to different wavelengths of light." ;
+  qudt:symbol "F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Flux" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_flux> ;
+.
+quantitykind:LuminousFluxPerArea
+  a qudt:QuantityKind ;
+  dcterms:description "In photometry, illuminance is the total luminous flux incident on a surface, per unit area. It is a measure of how much the incident light illuminates the surface, wavelength-weighted by the luminosity function to correlate with human brightness perception. Similarly, luminous emittance is the luminous flux per unit area emitted from a surface. In SI derived units these are measured in \\(lux (lx)\\) or \\(lumens per square metre\\) (\\(cd \\cdot m^{-2}\\)). In the CGS system, the unit of illuminance is the \\(phot\\), which is equal to \\(10,000 lux\\). The \\(foot-candle\\) is a non-metric unit of illuminance that is used in photography."^^qudt:LatexString ;
+  qudt:applicableUnit unit:FC ;
+  qudt:applicableUnit unit:LUX ;
+  qudt:applicableUnit unit:Phot ;
+  qudt:baseUnitDimensions "J \\cdot U/L^2" ;
+  qudt:baseUnitDimensions "cd/m^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I1M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Illuminance"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Flux per Area" ;
+.
+quantitykind:LuminousIntensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CD ;
+  qudt:applicableUnit unit:CP ;
+  qudt:baseUnitDimensions "J" ;
+  qudt:baseUnitDimensions "cd" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Luminous_intensity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I1M0H0T0D0> ;
+  qudt:plainTextDescription "Luminous Intensity is a measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle. The weighting is determined by the luminosity function, a standardized model of the sensitivity of the human eye to different wavelengths." ;
+  qudt:symbol "J" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Luminous Intensity" ;
+.
+quantitykind:MASS-DELIVERED
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The minimum mass a propulsive system can deliver to a specified target or location. Most mass- delivered requirements have associated Delta-V requirements, effectively specifying the path between the two points." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Delivered"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:MASS-GROWTH-ALLOWANCE
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A factor applied to basic mass at the lowest level of design detail available based on type and maturity of hardware according to an approved MGA depletion schedule." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Growth Allowance"^^rdfs:Literal ;
+  skos:altLabel "MGA" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:MASS-MARGIN
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Requirement minus predicted value. Margin is used as a metric in risk management. Positive margin mitigates the risk of mass increases from requirements maturation and implementation, underestimated predicted system, or subsystem mass." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Margin" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:MASS-PROPERTY-UNCERTAINTY
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Variation in predicted MP due to lack of definition, manufacturing variations, environment effects, or accuracy limitation of measuring devices." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Property Uncertainty" ;
+.
+quantitykind:MOMENT-OF-INERTIA_Y
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
+  qudt:symbol "I_{y}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Moment of Inertia in the Y axis" ;
+  skos:altLabel "MOI" ;
+  skos:broader quantitykind:MomentOfInertia ;
+.
+quantitykind:MOMENT-OF-INERTIA_Z
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
+  qudt:symbol "I_{z}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Moment of Inertia in the Z axis" ;
+  skos:altLabel "MOI" ;
+  skos:broader quantitykind:MomentOfInertia ;
+.
+quantitykind:MachNumber
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mach_number"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31896"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Ma = \\frac{v_o}{c_o}\\), where \\(v_0\\) is speed, and \\(c_o\\) is speed of sound."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mach Number\" is a dimensionless quantity representing the speed of an object moving through air or other fluid divided by the local speed of sound. It is commonly used to represent the speed of an object when it is traveling close to or above the speed of sound. The Mach number is commonly used both with objects traveling at high speed in a fluid, and with high-speed fluid flows inside channels such as nozzles, diffusers or wind tunnels. As it is defined as a ratio of two speeds, it is a dimensionless number." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:symbol "Ma" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mach Number" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Mach_number> ;
+.
+quantitykind:MacroscopicCross-Section
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sum = n_1\\sigma_1 + \\cdots + n_j\\sigma_j +\\), where \\(n_j\\) is the number density and \\(\\sigma_j\\) the cross-section for entities of type \\(j\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sum\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Macroscopic Cross-section\" is the sum of the cross-sections for a reaction or process of a specified type over all atoms or other entities in a given 3D domain, divided by the volume of that domain." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Macroscopic Cross-section" ;
+  skos:broader quantitykind:CrossSection ;
+.
+quantitykind:MacroscopicTotalCross-Section
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nuclear_cross_section"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\sum_{tot}, \\sum_T\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Macroscopic Total Cross-section\" is the total cross-sections for all atoms or other entities in a given 3D domain, divided by the volume of that domain." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Macroscopic Total Cross-section" ;
+  skos:broader quantitykind:CrossSection ;
+.
+quantitykind:MadelungConstant
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Madelung_constant"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "For a uni-univalent ionic crystal of specified structure, the binding energy \\(V_b\\) per pair of ions is \\(V_b = \\alpha\\frac{e^2}{4\\pi \\varepsilon_0 a}\\), where \\(e\\) is the elementary charge, \\(\\varepsilon_0\\) is the electric constant, and \\(a\\) is the lattice constant which should be specified."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Madelung Constant\" is used in determining the electrostatic potential of a single ion in a crystal by approximating the ions by point charges. It is named after Erwin Madelung, a German physicist." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Madelung Constant" ;
+.
+quantitykind:MagneticAreaMoment
+  a qudt:QuantityKind ;
+  qudt:exactMatch quantitykind:MagneticMoment ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-49"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(m = I e_n A\\), where \\(I\\) is electric current in a small closed loop, \\(e_n\\) is a unit vector perpendicular to the loop, and \\(A\\) is the area of the loop. The magnetic moment of a substance within a domain is the vector sum of the magnetic moments of all
+
+entities included in the domain."""^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetic Area Moment}, for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. \\textit{Magnetic Area Moment} is also referred to as \\textit{Mangnetic Moment\"." ;
+  qudt:symbol "m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Area Moment" ;
+.
+quantitykind:MagneticDipoleMoment
+  a qudt:QuantityKind ;
+  dcterms:description "\"Magnetic Dipole Moment\" is the magnetic moment of a system is a measure of the magnitude and the direction of its magnetism. Magnetic moment usually refers to its Magnetic Dipole Moment, and quantifies the contribution of the system's internal magnetism to the external dipolar magnetic field produced by the system (that is, the component of the external magnetic field that is inversely proportional to the cube of the distance to the observer). The Magnetic Dipole Moment is a vector-valued quantity. For a particle or nucleus, vector quantity causing an increment \\(\\Delta W = -\\mu \\cdot B\\) to its energy \\(W\\) in an external magnetic field with magnetic flux density \\(B\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-M2 ;
+  qudt:applicableUnit unit:A-M2-PER-J-SEC ;
+  qudt:applicableUnit unit:EV-PER-T ;
+  qudt:applicableUnit unit:J-PER-T ;
+  qudt:applicableUnit unit:WB-M ;
+  qudt:baseUnitDimensions "A \\cdot m^2" ;
+  qudt:baseUnitDimensions "I \\cdot L^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Magnetic_moment"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L2I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Magnetic_moment"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-55"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(E_m = -m \\cdot B\\), where \\(E_m\\) is the interaction energy of the molecule with magnetic diploe moment \\(m\\) and a magnetic field with magnetic flux density \\(B\\)
+
+or,
+
+\\(J_m = \\mu_0 M\\) where \\(\\mu_0\\) is the magnetic constant and \\(M\\) is Magnetization."""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:symbol "J_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Dipole Moment" ;
+.
+quantitykind:MagneticField
+  a qudt:QuantityKind ;
+  dcterms:description "The Magnetic Field, denoted \\(B\\), is a fundamental field in electrodynamics which characterizes the magnetic force exerted by electric currents.  It is closely related to the auxillary magnetic field H (see quantitykind:AuxillaryMagneticField)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:Gamma ;
+  qudt:applicableUnit unit:T_Ab ;
+  qudt:baseUnitDimensions "M/I \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg/A \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-1D0> ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Field" ;
+.
+quantitykind:MagneticFieldStrength
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Magnetic Field Strength}\\) is a vector quantity obtained at a given point by subtracting the magnetization \\(M\\) from the magnetic flux density \\(B\\) divided by the magnetic constant \\(\\mu_0\\). The magnetic field strength is related to the total current density \\(J_{tot}\\) via: \\(\\text{rot} H = J_{tot}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A-PER-M ;
+  qudt:applicableUnit unit:AT-PER-IN ;
+  qudt:applicableUnit unit:OERSTED ;
+  qudt:applicableUnit unit:T_Ab ;
+  qudt:exactMatch quantitykind:AuxillaryMagneticField ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-1I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-56"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{H} = \\frac{\\mathbf{B} }{\\mu_0} - M\\), where \\(\\mathbf{B} \\) is magnetic flux density, \\(\\mu_0\\) is the magnetic constant and \\(M\\) is magnetization."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mathbf{H} \\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Field Strength" ;
+.
+quantitykind:MagneticFlux
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MX ;
+  qudt:applicableUnit unit:UnitPole ;
+  qudt:applicableUnit unit:V_Ab-SEC ;
+  qudt:applicableUnit unit:WB ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/I \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/A \\cdot s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Magnetic_flux"^^xsd:anyURI ;
+  qudt:expression "\\(magnetic-flux\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-1800"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Phi = \\int_S B \\cdot e_n d A\\), over a surface \\(S\\), where \\(B\\) is magnetic flux density and \\(e_n dA\\) is the vector surface element."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Phi\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\phi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetic Flux\" is the product of the average magnetic field times the perpendicular area that it penetrates." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Flux" ;
+.
+quantitykind:MagneticFluxDensity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Magnetic Flux Density\" is a vector quantity and is the magnetic flux per unit area of a magnetic field at right angles to the magnetic force. It can be defined in terms of the effects the field has, for example by \\(B = F/q v \\sin \\theta\\), where \\(F\\) is the force a moving charge \\(q\\) would experience if it was travelling at a velocity \\(v\\) in a direction making an angle θ with that of the field. The magnetic field strength is also a vector quantity and is related to \\(B\\) by: \\(H = B/\\mu\\), where \\(\\mu\\) is the permeability of the medium."^^qudt:LatexString ;
+  qudt:applicableUnit unit:Gamma ;
+  qudt:applicableUnit unit:Gs ;
+  qudt:applicableUnit unit:T ;
+  qudt:applicableUnit unit:T_Ab ;
+  qudt:baseUnitDimensions "kg/A \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L0I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-1798"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{F}  = qv \\times B\\), where \\(F\\) is force and \\(v\\) is velocity of any test particle with electric charge \\(q\\)."^^qudt:LatexString ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Flux Density" ;
+  rdfs:label "Magnetic flux density" ;
+.
+quantitykind:MagneticFluxPerUnitLength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:T-M ;
+  qudt:baseUnitDimensions "L \\cdot M/I \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m/A \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L1I0M1H0T-2D0> ;
+  qudt:plainTextDescription "\"Magnetic Flux per Unit Length\" is a quantity in the SI and C.G.S. Systems of Quantities." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Flux per Unit Length" ;
+  rdfs:label "Magnetic flux per unit length" ;
+.
+quantitykind:MagneticMoment
+  a qudt:QuantityKind ;
+  qudt:exactMatch quantitykind:MagneticAreaMoment ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-49"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(m = I e_n A\\), where \\(I\\) is electric current in a small closed loop, \\(e_n\\) is a unit vector perpendicular to the loop, and \\(A\\) is the area of the loop. The magnetic moment of a substance within a domain is the vector sum of the magnetic moments of all
+
+entities included in the domain."""^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetic Moment}, for a magnetic dipole, is a vector quantity equal to the product of the current, the loop area, and the unit vector normal to the loop plane, the direction of which corresponds to the loop orientation. \\textit{Magnetic Moment} is also referred to as \\textit{Mangnetic Area Moment\"." ;
+  qudt:symbol "m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Moment" ;
+.
+quantitykind:MagneticPolarization
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Magnetic Polarization}\\) is a vector quantity equal to the product of the magnetization \\(M\\) and the magnetic constant \\(\\mu_0\\)."^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-54"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J_m = \\mu_0 M\\),  where \\(\\mu_0\\) is the magentic constant and \\(M\\) is magnetization."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(J_m\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Polarization" ;
+  rdfs:seeAlso constant:MagneticConstant ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:Magnetization ;
+.
+quantitykind:MagneticQuantumNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Magnetic Quantum Number\" describes the specific orbital (or \"cloud\") within that subshell, and yields the projection of the orbital angular momentum along a specified axis." ;
+  qudt:symbol "m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+  skos:closeMatch quantitykind:OrbitalAngularMomentumQuantumNumber ;
+  skos:closeMatch quantitykind:PrincipalQuantumNumber ;
+  skos:closeMatch quantitykind:SpinQuantumNumber ;
+.
+quantitykind:MagneticReluctivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-T-M ;
+  qudt:baseUnitDimensions "A \\cdot s^2/kg \\cdot m" ;
+  qudt:baseUnitDimensions "I \\cdot T^2/L \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L-1I0M-1H0T2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Permeability_(electromagnetism)"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Length Per Unit Magnetic Flux} is the the resistance of a material to the establishment of a magnetic field in it. It is the reciprocal of \\textit{Magnetic Permeability\", the inverse of the measure of the ability of a material to support the formation of a magnetic field within itself." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Reluctivity" ;
+  rdfs:seeAlso quantitykind:Permeability ;
+.
+quantitykind:MagneticSusceptability
+  a qudt:QuantityKind ;
+  dcterms:description "\"Magnetic Susceptability\" is a scalar or tensor quantity the product of which by the magnetic constant \\(\\mu_0\\) and by the magnetic field strength \\(H\\) is equal to the magnetic polarization \\(J\\). The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:expression "\\(\\kappa = \\frac{M}{H}\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-37"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\kappa = \\frac{M}{H}\\),  where \\(M\\) is magnetization,  and \\(H\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\kappa\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Susceptability" ;
+  rdfs:seeAlso constant:MagneticConstant ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:Magnetization ;
+.
+quantitykind:MagneticTension
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-57"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(U_m = \\int_{r_a(C)}^{r_b} \\mathbf{H} \\cdot dr\\), where \\(\\mathbf{H}\\) is magnetic field strength and \\(r\\) is the position vector along a given curve \\(C\\) from point \\(a\\) to point \\(b\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetic Tension} is a scalar quantity equal to the line integral of the magnetic field strength \\mathbf{H\" along a specified path linking two points a and b." ;
+  qudt:symbol "U_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Tension" ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+.
+quantitykind:MagneticVectorPotential
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-23"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\B = \\textbf{rot} A\\), where \\(B\\) is magnetic flux density."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetic Vector Potential\" is the vector potential of the magnetic flux density. The magnetic vector potential is not unique since any irrotational vector field quantity can be added to a given magnetic vector potential without changing its rotation. Under static conditions the magnetic vector potential is often chosen so that its divergence is zero." ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetic Vector Potential" ;
+  rdfs:seeAlso quantitykind:MagneticFluxDensity ;
+.
+quantitykind:Magnetization
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-M ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-52"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(M = dm/dV\\), where \\(m\\) is magentic moment of a substance in a domain with Volume \\(V\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Magnetization\" is defined as the ratio of magnetic moment per unit volume. It is a vector-valued quantity." ;
+  qudt:symbol "H_i" ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetization" ;
+  skos:broader quantitykind:LinearElectricCurrent ;
+.
+quantitykind:MagnetizationField
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The Magnetization Field is defined as the ratio of magnetic moment per unit volume. It is a vector-valued quantity." ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetization Field" ;
+  skos:broader quantitykind:ElectricCurrentPerUnitLength ;
+.
+quantitykind:MagnetomotiveForce
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Magnetomotive Force}\\)  (\\(mmf\\)) is the ability of an electric circuit to produce magnetic flux. Just as the ability of a battery to produce electric current is called its electromotive force or emf, mmf is taken as the work required to move a unit magnet pole from any point through any path which links the electric circuit back the same point in the presence of the magnetic force produced by the electric current in the circuit. \\(\\textbf{Magnetomotive Force}\\) is the scalar line integral of the magnetic field strength along a closed path."^^qudt:LatexString ;
+  qudt:applicableUnit unit:A ;
+  qudt:applicableUnit unit:AT ;
+  qudt:applicableUnit unit:GI ;
+  qudt:applicableUnit unit:OERSTED-CentiM ;
+  qudt:baseUnitDimensions "A" ;
+  qudt:baseUnitDimensions "I \\cdot U" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Magnetomotive_force"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M0H0T0D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-60"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(F_m = \\oint \\mathbf{H} \\cdot dr\\), where \\(\\mathbf{H}\\) is magnetic field strength and \\(r\\) is position vector along a given curve \\(C\\) from point \\(a\\) to point \\(b\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(F_m \\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Magnetomotive Force" ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+.
+quantitykind:Mass
+  a qudt:QuantityKind ;
+  dcterms:description "In physics, mass, more specifically inertial mass, can be defined as a quantitative measure of an object's resistance to acceleration. The SI unit of mass is the kilogram (\\(kg\\))"^^qudt:LatexString ;
+  qudt:applicableUnit unit:AMU ;
+  qudt:applicableUnit unit:CARAT ;
+  qudt:applicableUnit unit:CWT_LONG ;
+  qudt:applicableUnit unit:CWT_SHORT ;
+  qudt:applicableUnit unit:DWT ;
+  qudt:applicableUnit unit:EarthMass ;
+  qudt:applicableUnit unit:GM ;
+  qudt:applicableUnit unit:GRAIN ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:applicableUnit unit:LB_M ;
+  qudt:applicableUnit unit:LB_T ;
+  qudt:applicableUnit unit:LunarMass ;
+  qudt:applicableUnit unit:OZ_M ;
+  qudt:applicableUnit unit:OZ_TROY ;
+  qudt:applicableUnit unit:PlanckMass ;
+  qudt:applicableUnit unit:SLUG ;
+  qudt:applicableUnit unit:SolarMass ;
+  qudt:applicableUnit unit:TON_Assay ;
+  qudt:applicableUnit unit:TON_LONG ;
+  qudt:applicableUnit unit:TON_M ;
+  qudt:applicableUnit unit:TON_SHORT ;
+  qudt:applicableUnit unit:U ;
+  qudt:baseUnitDimensions "M" ;
+  qudt:baseUnitDimensions "kg" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mass"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass"^^xsd:anyURI ;
+  qudt:symbol "m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass" ;
+.
+quantitykind:MassAbsorptionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-KiloGM ;
+  qudt:latexDefinition "\\(\\a_m = \\frac{a}{\\rho}\\), where \\(a\\) is the linear absorption coefficient and \\(\\rho\\) is the mass density of the medium."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\a_m\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The mass absorption coefficient is the linear absorption coefficient divided by the density of the absorber." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Absorption Coefficient" ;
+  skos:exactMatch <http://medical-dictionary.thefreedictionary.com/mass+absorption+coefficient> ;
+.
+quantitykind:MassAmountOfSubstance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_M-MOL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Amount of Substance" ;
+.
+quantitykind:MassAmountOfSubstanceTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_M-MOL-DEG_F ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Amount of Substance Temperature" ;
+.
+quantitykind:MassAttenuationCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-KiloGM ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_attenuation_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu_m = \\frac{\\mu}{\\rho}\\), where \\(\\mu\\) is the linear attenuation coefficient and \\(\\rho\\) is the mass density of the medium."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu_m\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Attenuation Coefficient\" is a measurement of how strongly a chemical species or substance absorbs or scatters light at a given wavelength, per unit mass." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Attenuation Coefficient" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Mass_attenuation_coefficient> ;
+.
+quantitykind:MassConcentration
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_concentration_(chemistry)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho_B = \\frac{m_B}{V}\\), where \\(m_B\\) is the mass of substance \\(B\\) and \\(V\\) is the volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_B\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Mass Concentration\" of substance B  is defined as the mass of a constituent  divided by the volume of the mixture ." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Concentration" ;
+  skos:broader quantitykind:InverseVolume ;
+.
+quantitykind:MassConcentrationOfWater
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w = m/V\\), where \\(m\\) is mass of water, irrespective of the form of aggregation, and \\(V\\) is volume. Mass concentration of water at saturation is denoted \\(w_{sat}\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Concentration of Water Valour} is one of a number of \\textit{Concentration\" quantities defined by ISO 8000." ;
+  qudt:symbol "w" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Concentration of Water" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassConcentrationOfWaterVapour
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w = m/V\\), where \\(m\\) is mass of water vapour and \\(V\\) is total gas volume. Mass concentration of water vapour at saturation is denoted \\(v_{sat}\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Concentration of Water} is one of a number of \\textit{Concentration\" quantities  defined by ISO 8000." ;
+  qudt:symbol "v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Concentration of Water Vapour" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassDefect
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Binding_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(B = Zm(^{1}\\textrm{H}) + Nm_n - m_a\\), where \\(Z\\) is the proton number of the atom, \\(m(^{1}\\textrm{H})\\) is atomic mass of \\(^{1}\\textrm{H}\\), \\(N\\) is the neutron number, \\(m_n\\) is the rest mass of the neutron, and \\(m_a\\) is the rest mass of the atom."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Mass Defect\", also termed mass deficit, or mass packing fraction, describes mass change (decrease) in bound systems, particularly atomic nuclei." ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Defect" ;
+.
+quantitykind:MassDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M3 ;
+  qudt:baseUnitDimensions "kg m^{-3}" ;
+  qudt:exactMatch quantitykind:Density ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho = \\frac{dm}{dV}\\), where \\(m\\) is mass and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The mass density or density of a material is its mass per unit volume." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Density" ;
+.
+quantitykind:MassEnergyTransferCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-KiloGM ;
+  qudt:informativeReference "http://physics.nist.gov/PhysRefData/XrayMassCoef/chap3.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\frac{\\mu_{tr}}{\\rho} = -\\frac{1}{\\rho}\\frac{1}{R}\\frac{dR_{tr}}{dl}\\), where \\(dR_{tr}\\) is the mean energy that is transferred to kinetic energy of charged particles by interactions of the incident radiation \\(R\\) in traversing a distance \\(dl\\) in the material of density \\(\\rho\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\frac{\\mu_{tr}}{\\rho}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Energy Transfer Coefficient\" is that fraction of the mass attenuation coefficient which contributes to the production of kinetic energy in charged particles." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Energy Transfer Coefficient" ;
+  skos:closeMatch quantitykind:MassAttenuationCoefficient ;
+.
+quantitykind:MassExcess
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_excess"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Delta = m_a - Am_u\\), where \\(m_a\\) is the rest mass of the atom, \\(A\\) is its nucleon number, and \\(m_u\\) is the unified atomic mass constant."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Delta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Mass Excess\" of a nuclide is the difference between its actual mass and its mass number in atomic mass units. It is one of the predominant methods for tabulating nuclear mass." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Excess" ;
+.
+quantitykind:MassFlowRate
+  a qudt:QuantityKind ;
+  dcterms:description "\"Mass Flow Rate} is a measure of Mass flux. The common symbol is \\(\\dot{m\"\\) (pronounced \"m-dot\"), although sometimes \\(\\mu\\) is used. The SI units are \\(kg s-1\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-PER-SEC ;
+  qudt:baseUnitDimensions "kg sec^{-1}" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mass_flow_rate"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_flow_rate"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q_m = \\frac{dm}{dt}\\), where \\(m\\) is mass and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\dot{m}\\)"^^qudt:LatexString ;
+  qudt:symbol "q_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Flow Rate" ;
+  rdfs:seeAlso quantitykind:SpecificImpulse ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:MassFraction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_fraction_(chemistry)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w_B = \\frac{m_B}{m}\\), where \\(m_B\\) is the mass of substance \\(B\\) and \\(m\\) is the total."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Mass Fraction\" is the fraction of one substance with mass to the mass of the total mixture ." ;
+  qudt:symbol "w_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Fraction" ;
+  skos:broader quantitykind:InverseVolume ;
+.
+quantitykind:MassFractionOfDryMatter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w_d= 1 - w_{h2o}\\), where \\(w_{h2o}\\) is mass fraction of water."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Fraction of Dry Matter} is one of a number of \\textit{Concentration\" quantities defined by ISO 8000." ;
+  qudt:symbol "w_d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Fraction of Dry Matter" ;
+  rdfs:seeAlso quantitykind:MassFractionOfWater ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassFractionOfWater
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w_{H_2o} = \\frac{u}{1+u}\\), where \\(u\\) is mass ratio of water to dry water."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Fraction of Water} is one of a number of \\textit{Concentration\" quantities defined by ISO 8000." ;
+  qudt:symbol "w_{H_2o}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Fraction of Water" ;
+  rdfs:seeAlso quantitykind:MassFractionOfDryMatter ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassNumber
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Mass Number\" (A), also called atomic mass number or nucleon number, is the total number of protons and neutrons (together known as nucleons) in an atomic nucleus. Nuclides with the same value of \\(A\\) are called isobars."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(A = Z + N\\), where \\(Z\\) is the atomic number and \\(N\\) is the neutron number."^^qudt:LatexString ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Number" ;
+.
+quantitykind:MassOfElectricalPowerSupply
+  a qudt:QuantityKind ;
+  qudt:symbol "M_{E}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Of Electrical Power Supply" ;
+.
+quantitykind:MassOfSolidBooster
+  a qudt:QuantityKind ;
+  qudt:symbol "M_{SB}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Of Solid Booster" ;
+.
+quantitykind:MassOfTheEarth
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Earth mass is the unit of mass equal to that of the Earth.  Earth mass is often used to describe masses of rocky terrestrial planets." ;
+  qudt:symbol "M_{oplus}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Of The Earth" ;
+.
+quantitykind:MassPerArea
+  a qudt:QuantityKind ;
+  dcterms:description "The area density (also known as areal density, surface density, or superficial density) of a two-dimensional object is calculated as the mass per unit area. The SI derived unit is: kilogram per square metre  (\\(kg \\cdot m^{-2}\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-PER-M2 ;
+  qudt:applicableUnit unit:OZ_M_PER-FT2 ;
+  qudt:applicableUnit unit:OZ_M_PER-YD2 ;
+  qudt:applicableUnit unit:SLUG-PER-FT2 ;
+  qudt:baseUnitDimensions "M/L^2" ;
+  qudt:baseUnitDimensions "kg/m^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Area_density"^^xsd:anyURI ;
+  qudt:latexDefinition "\\rho_A = \\frac {m} {A}"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_A \\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Area" ;
+.
+quantitykind:MassPerAreaTime
+  a qudt:QuantityKind ;
+  dcterms:description "In Physics and Engineering, mass flux is the rate of mass flow per unit area. The common symbols are \\(j\\), \\(J\\), \\(\\phi\\), or \\(\\Phi\\)  (Greek lower or capital Phi), sometimes with subscript \\(m\\) to indicate mass is the flowing quantity.  Its SI units are \\( kg s^{-1} m^{-2}\\)."^^qudt:LatexString ;
+  qudt:baseUnitDimensions "M/L^2 \\cdot T" ;
+  qudt:baseUnitDimensions "kg/m^2 \\cdot s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_flux"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(j_m = \\lim\\limits_{A \\rightarrow 0}\\frac{I_m}{A}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Area Time" ;
+.
+quantitykind:MassPerElectricCharge
+  a qudt:QuantityKind ;
+  dcterms:description "The mass-to-charge ratio ratio (\\(m/Q\\)) is a physical quantity that is widely used in the electrodynamics of charged particles, for example, in electron optics and ion optics. The importance of the mass-to-charge ratio, according to classical electrodynamics, is that two particles with the same mass-to-charge ratio move in the same path in a vacuum when subjected to the same electric and magnetic fields. Its SI units are \\(kg/C\\), but it can also be measured in Thomson (\\(Th\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:T-SEC ;
+  qudt:baseUnitDimensions "M/I \\cdot T" ;
+  qudt:baseUnitDimensions "kg/A \\cdot s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L0I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass-to-charge_ratio"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Electric Charge" ;
+.
+quantitykind:MassPerLength
+  a qudt:QuantityKind ;
+  dcterms:description "Linear density, linear mass density or linear mass is a measure of mass per unit of length, and it is a characteristic of strings or other one-dimensional objects. The SI unit of linear density is the kilogram per metre (\\(kg/m\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:Denier ;
+  qudt:applicableUnit unit:KiloGM-PER-M ;
+  qudt:applicableUnit unit:LB_M-PER-FT ;
+  qudt:applicableUnit unit:LB_M-PER-IN ;
+  qudt:applicableUnit unit:SLUG-PER-FT ;
+  qudt:applicableUnit unit:TEX ;
+  qudt:baseUnitDimensions "M/L" ;
+  qudt:baseUnitDimensions "kg/m" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Linear_density"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Length" ;
+.
+quantitykind:MassPerTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-HR ;
+  qudt:applicableUnit unit:KiloGM-PER-SEC ;
+  qudt:applicableUnit unit:LB_M-PER-HR ;
+  qudt:applicableUnit unit:LB_M-PER-MIN ;
+  qudt:applicableUnit unit:SLUG-PER-SEC ;
+  qudt:applicableUnit unit:TON_SHORT-PER-HR ;
+  qudt:baseUnitDimensions "M/T" ;
+  qudt:baseUnitDimensions "kg/s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass per Time" ;
+.
+quantitykind:MassRatio
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "In aerospace engineering, mass ratio is a measure of the efficiency of a rocket. It describes how much more massive the vehicle is with propellant than without; that is, it is the ratio of the rocket's wet mass (vehicle plus contents plus propellant) to its dry mass (vehicle plus contents)" ;
+  qudt:symbol "R or M_{R}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Ratio" ;
+.
+quantitykind:MassRatioOfWaterToDryMatter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(u = m/m_d\\), where \\(m\\) is mass of water vapour and \\(m_d\\) is mass of dry matter. Mass ratio of water to dry matter at saturation is denoted \\(u_{sat}\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Ratio of Water to Dry Matter} is one of a number of \\textit{Concentration Ratio\" quantities  defined by ISO 8000." ;
+  qudt:symbol "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Concentration of Water To Dry Matter" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassRatioOfWaterVapourToDryGas
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(x = m/m_d\\), where \\(m\\) is mass of water vapour and \\(m_d\\) is mass of dry gas. Mass ratio of water vapour to dry gas  at saturation is denoted \\(x_{sat}\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mass Ratio of Water Vapour to Dry Gas} is one of a number of \\textit{Concentration Ratio\" quantities  defined by ISO 8000." ;
+  qudt:symbol "x" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Ratio of Water Vapour to Dry Gas" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MassTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:GM-PER-DEG_C ;
+  qudt:applicableUnit unit:KiloGM-K ;
+  qudt:applicableUnit unit:LB_M-DEG_F ;
+  qudt:applicableUnit unit:LB_M-DEG_R ;
+  qudt:baseUnitDimensions "K \\cdot kg" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mass Temperature" ;
+.
+quantitykind:MassicActivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BQ-PER-KiloGM ;
+  qudt:informativeReference "http://www.encyclo.co.uk/define/massic%20activity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Massic Activity\" is the activity divided by the total mass of the sample." ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Massic Activity" ;
+.
+quantitykind:MassieuFunction
+  a qudt:QuantityKind ;
+  dcterms:description "The Massieu function, \\(\\Psi\\), is defined as: \\(\\Psi = \\Psi (X_1, \\dots , X_i, Y_{i+1}, \\dots , Y_r  )\\),  where for every system with degree of freedom \\(r\\) one may choose \\(r\\) variables, e.g. , to define a coordinate system, where \\(X\\) and \\(Y\\) are extensive and intensive variables, respectively, and where at least one extensive variable must be within this set in order to define the size of the system. The \\((r + 1)^{th}\\) variable,\\(\\Psi\\) , is then called the Massieu function."^^qudt:LatexString ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Massieu_function"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J = -A/T\\), where \\(A\\) is Helmholtz energy and \\(T\\) is thermodynamic temperature."^^qudt:LatexString ;
+  qudt:symbol "J" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Massieu Function" ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MaxExpectedOperatingThrust
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Maximum Expected Operating Thrust" ;
+  skos:altLabel "MEOT" ;
+  skos:broader quantitykind:MaxOperatingThrust ;
+.
+quantitykind:MaxOperatingThrust
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Max Operating Thrust" ;
+  skos:altLabel "MOT" ;
+  skos:broader quantitykind:Thrust ;
+.
+quantitykind:MaxSeaLevelThrust
+  a qudt:QuantityKind ;
+  rdfs:comment "Max Sea Level thrust (Mlbf) " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Max Sea Level Thrust" ;
+  skos:broader quantitykind:Thrust ;
+.
+quantitykind:MaximumExpectedOperatingPressure
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Maximum Expected Operating Pressure" ;
+  skos:altLabel "MEOP" ;
+.
+quantitykind:MeanLifetime
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Mean Lifetime\" is the average length of time that an element remains in the set of discrete elements in a decaying quantity, \\(N(t)\\)."^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Exponential_decay"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\tau = \\frac{1}{\\lambda}\\), where \\(\\lambda\\) is the decay constant."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mean Lifetime" ;
+.
+quantitykind:MeanMassRange
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T0D0> ;
+  qudt:informativeReference "http://goldbook.iupac.org/M03783.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(R_\\rho = R\\rho\\), where \\(R\\) is the mean linear range and \\(\\rho\\) is the mass density of the sample."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(R_\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mean Mass Range\" is the mean linear range multiplied by the mass density of the material." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mean Mass Range" ;
+.
+quantitykind:MechanicalEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mechanical_energy"^^xsd:anyURI ;
+  qudt:generalization quantitykind:EnergyAndWork ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mechanical_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E = T + V\\), where \\(T\\) is kinetic energy and \\(V\\) is potential energy."^^qudt:LatexString ;
+  qudt:plainTextDescription "Mechanical Energy is the sum of potential energy and kinetic energy. It is the energy associated with the motion and position of an object." ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mechanical Energy" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:MechanicalImpedance
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mechanical Impedance" ;
+.
+quantitykind:MechanicalMobility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM_M ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mechanical Mobility" ;
+.
+quantitykind:MechanicalSurfaceImpedance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:N-SEC-PER-M ;
+  qudt:latexDefinition "\\(Z_m = Z_a A^2\\), where \\(A\\) is the area of the surface considered and \\(Z_a\\) is the acoustic impedance."^^qudt:LatexString ;
+  qudt:plainTextDescription "Mechanical surface impedance at a surface, is the complex quotient of the total force on the surface by the component of the average sound particle velocity at the surface in the direction of the force" ;
+  qudt:symbol "Z" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mechanical Surface Impedance" ;
+  rdfs:label "Mechanical surface impedance" ;
+.
+quantitykind:MicroCanonicalPartitionFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Microcanonical_ensemble"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Partition_function_(statistical_mechanics)#Grand_canonical_partition_function"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Omega = \\sum_r 1\\), where the sum is over all quantum states consistent with given energy. volume, external fields, and content."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Omega\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "A \"Micro Canonical Partition Function\" applies to a micro canonical ensemble, in which the system is allowed to exchange heat with the environment at fixed temperature, volume, and a fixed number of particles." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Micro Canonical Partition Function" ;
+  skos:broader quantitykind:CanonicalPartitionFunction ;
+.
+quantitykind:MicrobialFormation
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:CFU ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Microbial Formation" ;
+.
+quantitykind:Mobility
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-V-SEC ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electron_mobility"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Mobility\" characterizes how quickly a particle can move through a metal or semiconductor, when pulled by an electric field. The average drift speed imparted to a charged particle in a medium by an electric field, divided by the electric field strength." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mobility" ;
+.
+quantitykind:MobilityRatio
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://baervan.nmt.edu/research_groups/reservoir_sweep_improvement/pages/clean_up/mobility.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(b = \\frac{\\mu_n}{\\mu_p}\\), where \\(\\mu_n\\) and \\(\\mu_p\\) are mobilities for electrons and holes, respectively."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"MobilityRatio\" describes permeability of a porous material to a given phase divided by the viscosity of that phase." ;
+  qudt:symbol "b" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mobility Ratio" ;
+.
+quantitykind:ModulusOfAdmittance
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Absolute_value"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Admittance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-51"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Y = \\left | \\underline{Y} \\right |\\), where \\(\\underline{Y}\\) is admittance."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Modulus Of Admittance} is the absolute value of the quantity \\textit{admittance\"." ;
+  qudt:symbol "Y" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Modulus Of Admittance" ;
+  rdfs:seeAlso quantitykind:Admittance ;
+.
+quantitykind:ModulusOfElasticity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Elastic_modulus"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E = \\frac{\\sigma}{\\varepsilon}\\), where \\(\\sigma\\) is the normal stress and \\(\\varepsilon\\) is the linear strain."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Modulus of Elasticity is the mathematical description of an object or substance's tendency to be deformed elastically (that is, non-permanently) when a force is applied to it." ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Modulus of Elasticity" ;
+.
+quantitykind:ModulusOfImpedance
+  a qudt:QuantityKind ;
+  dcterms:description """\"Modulus Of Impedance} is the absolute value of the quantity \\textit{impedance\". Apparent impedance is defined more generally as
+
+the quotient of rms voltage and rms electric current; it is often denoted by \\(Z\\)."""^^qudt:LatexString ;
+  qudt:applicableUnit unit:OHM ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Absolute_value"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electrical_impedance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z = \\left | \\underline{Z} \\right |\\), where \\(\\underline{Z}\\) is impedance."^^qudt:LatexString ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Modulus Of Impedance" ;
+  rdfs:seeAlso quantitykind:Impedance ;
+.
+quantitykind:MolalityOfSolute
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-PER-KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M-1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molality"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(b_B = \\frac{n_B}{m_a}\\), where \\(n_B\\) is the amount of substance and \\(m_A\\) is the mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Molality of Solute\" of a solution is defined as the amount of substance of solute divided by the mass in kg of the solvent." ;
+  qudt:symbol "b_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molality of Solute" ;
+  skos:broader quantitykind:InverseVolume ;
+.
+quantitykind:MolarAbsorptionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-KiloGM ;
+  qudt:latexDefinition "\\(x = aV_m\\), where \\(a\\) is the linear absorption coefficient and \\(V_m\\) is the molar volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Molar Absorption Coefficient\" is a spectrophotometric unit indicating the light a substance absorbs with respect to length, usually centimeters, and concentration, usually moles per liter." ;
+  qudt:symbol "x" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Absorption Coefficient" ;
+  skos:exactMatch <http://medical-dictionary.thefreedictionary.com/molar+absorption+coefficient> ;
+.
+quantitykind:MolarAngularMomentum
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-SEC-PER-MOL ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/M \\cdot T" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/mol \\cdot s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-1D0> ;
+  qudt:url "http://cvika.grimoar.cz/callen/callen_21.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Angular Momentum" ;
+.
+quantitykind:MolarAttenuationCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-MOL ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_attenuation_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu_c = -\\frac{\\mu}{c}\\), where \\(\\mu\\) is the linear attenuation coefficient and \\(c\\) is the amount-of-substance concentration."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu_c\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Molar Attenuation Coefficient\" is a measurement of how strongly a chemical species or substance absorbs or scatters light at a given wavelength, per amount of substance." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Attenuation Coefficient" ;
+  skos:closeMatch quantitykind:MassAttenuationCoefficient ;
+.
+quantitykind:MolarConductivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:S-M2-PER-MOL ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molar_conductivity"^^xsd:anyURI ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/molar+conductivity"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Gamma_m = \\frac{x}{c_B}\\), where \\(x\\) is the electrolytic conductivity and \\(c_B\\) is the amount-of-substance concentration."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Gamma_m\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Molar Conductivity\" is the conductivity of an electrolyte solution divided by the molar concentration of the electrolyte, and so measures the efficiency with which a given electrolyte conducts electricity in solution." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Conductivity" ;
+  skos:broader quantitykind:Conductivity ;
+.
+quantitykind:MolarEnergy
+  a qudt:QuantityKind ;
+  dcterms:description "\"Molar Energy\" is the total energy contained by a thermodynamic system. The unit is \\(J/mol\\), also expressed as \\(joule/mole\\),  or \\(joules per mole\\). This unit is commonly used in the SI unit system. The quantity has the dimension of \\(M \\cdot L^2 \\cdot  T_{-2} \\cdot N^{-1\"\\) where \\(M\\) is mass, \\(L\\) is length, \\(T\\) is time, and \\(N\\) is amount of substance."^^qudt:LatexString ;
+  qudt:applicableUnit unit:J-PER-MOL ;
+  qudt:applicableUnit unit:KiloCAL-PER-MOL ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/N \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/mol \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units-molar_energy-joule_per_mole.cfm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(U_m = \\frac{U}{n}\\), where \\(U\\) is internal energy and \\(n\\) is amount of substance."^^qudt:LatexString ;
+  qudt:symbol "U_M" ;
+  vaem:todo "dimensions are wrong" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Energy" ;
+.
+quantitykind:MolarEntropy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-MOL-K ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Standard_molar_entropy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S_m = \\frac{S}{n}\\), where \\(S\\) is entropy and \\(n\\) is amount of substance."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Standard Molar Entropy\" is the entropy content of one mole of substance, under standard conditions (not standard temperature and pressure STP)." ;
+  qudt:symbol "S_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Entropy" ;
+.
+quantitykind:MolarFlowRate
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "mol sec^{-1}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "https://www.sciencedirect.com/topics/engineering/molar-flow-rate"^^xsd:anyURI ;
+  qudt:plainTextDescription "Molar Flow Rate is a measure of the amount of substance (the number of molecules) that passes through a given area perpendicular to the flow in a given time. Typically this area is constrained, for example a section through a pipe, but it could also apply to an open flow." ;
+  qudt:symbol "q_V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Flow Rate" ;
+  skos:broader quantitykind:Volume ;
+.
+quantitykind:MolarHeatCapacity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-MOL-DEG_F ;
+  qudt:applicableUnit unit:J-PER-MOL-K ;
+  qudt:applicableUnit unit:KiloCAL-PER-MOL-DEG_C ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/\\Theta \\cdot M \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/K \\cdot mol \\cdot s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H-1T-2D0> ;
+  qudt:informativeReference "http://chemistry.about.com/od/chemistryglossary/g/Molar-Heat-Capacity-Definition.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(C_m = \\frac{C}{n}\\), where \\(C\\) is heat capacity and \\(n\\) is amount of substance."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Molar Heat Capacity\" is the amount of heat energy required to raise the temperature of 1 mole of a substance. In SI units, molar heat capacity (symbol: cn) is the amount of heat in joules required to raise 1 mole of a substance 1 Kelvin." ;
+  qudt:symbol "C_m" ;
+  qudt:symbol "cn" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Heat Capacity" ;
+.
+quantitykind:MolarMass
+  a qudt:QuantityKind ;
+  dcterms:description "In chemistry, the molar mass M is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance. It is a physical property of a given substance. The base SI unit for molar mass is \\(kg/mol\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM-PER-MOL ;
+  qudt:baseUnitDimensions "M/M" ;
+  qudt:baseUnitDimensions "kg/mol" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Molar_mass"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molar_mass"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Mass" ;
+.
+quantitykind:MolarOpticalRotatoryPower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:RAD-M2-PER-MOL ;
+  qudt:informativeReference "http://goldbook.iupac.org/O04313.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_n = \\alpha \\frac{A}{n}\\), where \\(\\alpha\\) is the angle of optical rotation, and \\(n\\) is the amount of substance of the optically active component in the path of a linearly polarized light beam of cross sectional area \\(A\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_n\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Molar Optical Rotatory Power\" Angle of optical rotation divided by the optical path length through the medium and by the amount concentration giving the molar optical rotatory power." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Optical Rotatory Power" ;
+.
+quantitykind:MolarVolume
+  a qudt:QuantityKind ;
+  dcterms:description "The molar volume, symbol \\(V_m\\), is the volume occupied by one mole of a substance (chemical element or chemical compound) at a given temperature and pressure. It is equal to the molar mass (\\(M\\)) divided by the mass density (\\(\\rho\\)). It has the SI unit cubic metres per mole (\\(m^{1}/mol\\)). For ideal gases, the molar volume is given by the ideal gas equation: this is a good approximation for many common gases at standard temperature and pressure. For crystalline solids, the molar volume can be measured by X-ray crystallography."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M3-PER-MOL ;
+  qudt:baseUnitDimensions "L^3/M" ;
+  qudt:baseUnitDimensions "m^3/mol" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Molar_volume"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molar_volume"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(V_m = \\frac{V}{n}\\), where \\(V\\) is volume and \\(n\\) is amount of substance."^^qudt:LatexString ;
+  qudt:symbol "V_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molar Volume" ;
+.
+quantitykind:MoleFraction
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mole_fraction"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:plainTextDescription "In chemistry, the mole fraction of a component in a mixture is the relative proportion of molecules belonging to the component to those in the mixture, by number of molecules. It is one way of measuring concentration." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mole Fraction" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:MolecularMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:Da ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Molecular_mass"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molecular_mass#Relative_molecular_mass"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The molecular mass, or molecular weight of a chemical compound is the mass of one molecule of that compound, relative to the unified atomic mass unit, u. Molecular mass should not be confused with molar mass, which is the mass of one mole of a substance." ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molecular Mass" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:MolecularViscosity
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://oceanworld.tamu.edu/resources/ocng_textbook/chapter08/chapter08_01.htm"^^xsd:anyURI ;
+  qudt:plainTextDescription "Molecules in a fluid close to a solid boundary sometime strike the boundary and transfer momentum to it. Molecules further from the boundary collide with molecules that have struck the boundary, further transferring the change in momentum into the interior of the fluid. This transfer of momentum is molecular viscosity. Molecules, however, travel only micrometers between collisions, and the process is very inefficient for transferring momentum even a few centimeters. Molecular viscosity is important only within a few millimeters of a boundary." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Molecular Viscosity" ;
+  skos:broader quantitykind:Viscosity ;
+.
+quantitykind:MomentOfForce
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:N-M ;
+  qudt:baseUnitDimensions "kg \\cdot m^3/s" ;
+  qudt:baseUnitDimensions "n-m" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M1H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Moment_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(M = r x F\\), where \\(r\\) is the position vector and \\(F\\) is the force."^^qudt:LatexString ;
+  qudt:plainTextDescription "Moment of force (often just moment) is the tendency of a force to twist or rotate an object." ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Moment of Force" ;
+.
+quantitykind:MomentOfInertia
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-M2 ;
+  qudt:baseUnitDimensions "L^2 \\cdot M" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Moment_of_inertia"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I_Q = \\int r^2_Q dm\\), where \\(r_Q\\) is the radial distance from a \\(Q-axis\\) and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "The rotational inertia or resistance to change in direction or speed of rotation about a defined axis." ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Moment of Inertia" ;
+  skos:altLabel "MOI" ;
+.
+quantitykind:Momentum
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Momentum"^^xsd:anyURI ;
+  qudt:plainTextDescription "The momentum of a system of particles is given by the sum of the momentums of the individual particles which make up the system or by the product of the total mass of the system and the velocity of the center of gravity of the system. The momentum of a continuous medium is given by the integral of the velocity over the mass of the medium or by the product of the total mass of the medium and the velocity of the center of gravity of the medium." ;
+  qudt:symbol "p" ;
+  qudt:url "http://en.wikipedia.org/wiki/Momentum"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Momentum" ;
+.
+quantitykind:MultiplicationFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Neutron_multiplication_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Multiplication Factor\" is the ratio of the total number of fission or fission-dependent neutrons produced in a time interval to the total number of neutrons lost by absorption and leakage during the same interval." ;
+  qudt:symbol "k" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Multiplication Factor" ;
+.
+quantitykind:MutualInductance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Mutual Inductance} is the non-diagonal term of the inductance matrix. For two loops, the symbol \\(M\\) is used for \\(L_{12\"\\)."^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-36"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L_{mn} = \\frac{\\Psi_m}{I_n}\\), where \\(I_n\\) is an electric current in a thin conducting loop \\(n\\) and \\(\\Psi_m\\) is the linked flux caused by that electric current in another loop \\(m\\)."^^qudt:LatexString ;
+  qudt:symbol "L_{mn}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Mutual Inductance" ;
+  rdfs:seeAlso quantitykind:Inductance ;
+.
+quantitykind:NOMINAL-ASCENT-PROPELLANT-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The amount of propellant mass within a stage that is available for impulse for use in nominal payload performance prediction. This mass excludes loaded propellant that has been set aside for off- nominal performance behavior (FPR and fuel bias)." ;
+  qudt:url "http://elib.dlr.de/68314/1/IAF10-D2.3.1.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nominal Ascent Propellant Mass" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:NapierianAbsorbance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(A_e(\\lambda) = -ln(\\tau(\\lambda))\\), where \\(\\tau\\) is the transmittance at a given wavelength \\(\\lambda\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Napierian Absorbance is the natural (Napierian) logarithm of the reciprocal of the spectral internal transmittance." ;
+  qudt:symbol "A_e, B" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Napierian Absorbance" ;
+  skos:exactMatch <http://eilv.cie.co.at/term/798> ;
+.
+quantitykind:NeelTemperature
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Néel_temperature"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Neel Temperature\" is the critical thermodynamic temperature of an antiferromagnet." ;
+  qudt:symbol "T_C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Neel Temperature" ;
+  skos:closeMatch quantitykind:CurieTemperature ;
+  skos:closeMatch quantitykind:SuperconductionTransitionTemperature ;
+.
+quantitykind:NeutronDiffusionCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/Diffusion+of+Neutrons"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(D_n = -\\frac{J_x}{\\frac{\\partial dn}{\\partial dx}}\\), where \\(J_x\\) is the \\(x-component\\) of the particle current and \\(n\\) is the particle number density."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Diffusion Coefficient\" is " ;
+  qudt:symbol "D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Diffusion Coefficient" ;
+.
+quantitykind:NeutronDiffusionLength
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The neutron diffusion length is equivalent to the relaxation length, that is, to the distance, in which the neutron flux decreases by a factor e" ;
+  qudt:symbol "L_{r}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Neutron Diffusion Length" ;
+.
+quantitykind:NeutronNumber
+  a qudt:QuantityKind ;
+  dcterms:description "\"Neutron Number\", symbol \\(N\\), is the number of neutrons in a nuclide. Nuclides with the same value of \\(N\\) but different values of \\(Z\\) are called isotones. \\(N - Z\\) is called the neutron excess number."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Neutron_number"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "N" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Neutron Number" ;
+.
+quantitykind:NeutronYieldPerAbsorption
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fission_product_yield"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\eta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Neutron Yield per Absorption\" is the average number of fission neutrons, both prompt and delayed, emitted per neutron absorbed in a fissionable nuclide or in a nuclear fuel, as specified." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Neutron Yield per Absorption" ;
+.
+quantitykind:NeutronYieldPerFission
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fission_product_yield"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\nu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Neutron Yield per Fission\" is the average number of fission neutrons, both prompt and delayed, emitted per fission event." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Neutron Yield per Fission" ;
+.
+quantitykind:Non-LeakageProbability
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Six_factor_formula"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Lambda\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Non-Leakage Probability\" is the probability that a neutron will not escape from the reactor during the slowing-down process or while it diffuses as a thermal neutron" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Non-Leakage Probability" ;
+.
+quantitykind:NonActivePower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-A ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-43"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Q^{'} = \\sqrt{{\\left | \\underline{S} \\right |}^2 - P^2}\\), where \\(\\underline{S}\\) is apparent power and \\(P\\) is active power."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Non-active Power\", for a two-terminal element or a two-terminal circuit under periodic conditions, is the quantity equal to the square root of the difference of the squares of the apparent power and the active power." ;
+  qudt:symbol "Q'" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Non-active Power" ;
+  rdfs:seeAlso quantitykind:ActivePower ;
+  rdfs:seeAlso quantitykind:ApparentPower ;
+.
+quantitykind:NormalStress
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_F-PER-IN2 ;
+  qudt:applicableUnit unit:N-PER-M2 ;
+  qudt:applicableUnit unit:PA ;
+  qudt:baseUnitDimensions "n m^{-2}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stress_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sigma = \\frac{dF_n}{dA}\\), where \\(dF_n\\) is the normal component of force and \\(dA\\) is the area of the surface element."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Normal stress is defined as the stress resulting from a force acting normal to a body surface. Normal stress can be caused by several loading methods, the most common being axial tension and compression, bending, and hoop stress." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Normal Stress" ;
+  skos:broader quantitykind:Stress ;
+.
+quantitykind:NozzleThroatCrossSectionalArea
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Cross-sectional area of the nozzle at the throat." ;
+  qudt:symbol "A^*" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nozzle Throat Cross-sectional Area" ;
+.
+quantitykind:NozzleThroatPressure
+  a qudt:QuantityKind ;
+  qudt:symbol "p^*" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nozzle Throat Pressure" ;
+.
+quantitykind:NozzleWallsThrustReaction
+  a qudt:QuantityKind ;
+  qudt:symbol "F_R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nozzle Walls Thrust Reaction" ;
+.
+quantitykind:NuclearQuadrupoleMoment
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nuclear_quadrupole_resonance"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Q = (\\frac{1}{e}) \\int (3z^2 - r^2)\\rho(x, y, z)dV\\), in the quantum state with the nuclear spin in the field direction \\((z)\\), where \\(\\rho(x, y, z)\\) is the nuclear electric charge density, \\(e\\) is the elementary charge, \\(r^2 = x^2 + y^2 + z^2\\), and \\(dV\\) is the volume element \\(dx\\) \\(dy\\) \\(dz\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Nuclear Quadrupole Moment\" is a quantity that characterizes the deviation from spherical symmetry of the electrical charge distribution in an atomic nucleus." ;
+  qudt:symbol "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nuclear Quadrupole Moment" ;
+.
+quantitykind:NuclearSpinQuantumNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I^2 = \\hbar^2 I(I + 1)\\), where \\(\\hbar\\) is the Planck constant."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Spin Quantum Number\"  describes the spin (intrinsic angular momentum) of the electron within that orbital, and gives the projection of the spin angular momentum S along the specified axis" ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spin Quantum Number" ;
+  skos:broader quantitykind:SpinQuantumNumber ;
+.
+quantitykind:NucleonNumber
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "Number of nuceons in an atomic nucleus.A = Z+N. Nuclides with the same value of A are called isobars." ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Nucleon number" ;
+  skos:altLabel "mass-number" ;
+.
+quantitykind:NumberDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Number_density"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Number_density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(n = \\frac{N}{V}\\), where \\(N\\) is the number of particles and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "In physics, astronomy, and chemistry, number density (symbol: n) is a kind of quantity used to describe the degree of concentration of countable objects (atoms, molecules, dust particles, galaxies, etc.) in the three-dimensional physical space." ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Number Density" ;
+  skos:broader quantitykind:InverseVolume ;
+.
+quantitykind:NumberOfParticles
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Particle_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Number of Particles\", also known as the particle number, of a thermodynamic system, conventionally indicated with the letter N, is the number of constituent particles in that system." ;
+  qudt:symbol "N_B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Number of Particles" ;
+.
+quantitykind:OlfactoryThreshold
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_o\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Olfactory Threshold\" are thresholds for the concentrations of various classes of smell that can be detected." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Olfactory Threshold" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Odor_detection_threshold> ;
+.
+quantitykind:OrbitalAngularMomentumPerUnitMass
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Angular momentum of the orbit per unit mass of the vehicle" ;
+  qudt:symbol "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Orbital Angular Momentum per Unit Mass" ;
+.
+quantitykind:OrbitalAngularMomentumQuantumNumber
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Principal Quantum Number\" describes the electron shell, or energy level, of an atom. The value of \\(n\\) ranges from 1 to the shell containing the outermost electron of that atom."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(l^2 = \\hbar^2 l(l + 1), l = 0, 1, ..., n - 1\\), where \\(l_i\\) refers to a specific particle \\(i\\)."^^qudt:LatexString ;
+  qudt:symbol "l" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Orbital Angular Momentum Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+  skos:closeMatch quantitykind:MagneticQuantumNumber ;
+  skos:closeMatch quantitykind:PrincipalQuantumNumber ;
+  skos:closeMatch quantitykind:SpinQuantumNumber ;
+.
+quantitykind:OrbitalRadialDistance
+  a qudt:QuantityKind ;
+  qudt:symbol "r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Orbital Radial Distance" ;
+.
+quantitykind:OrderOfReflection
+  a qudt:QuantityKind ;
+  dcterms:description "\"Order of Reflection\" is \\(n\\) in the Bragg's Law equation."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.answers.com/topic/order-of-reflection"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Order of Reflection" ;
+.
+quantitykind:OsmoticCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Osmotic_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varphi = -(M_A\\sum b_B)^{-1} \\ln a_A\\), where \\(M_A\\) is the molar mass of the solvent \\(A\\), \\(\\sum\\) denotes summation over all the solutes, \\(b_B\\) is the molality of solute \\(B\\), and \\(a_A\\) is the activity of solvent \\(A\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Osmotic Coefficient\" is a quantity which characterises the deviation of a solvent from ideal behavior." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Osmotic Coefficient" ;
+.
+quantitykind:OverRangeDistance
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Additional distance traveled by a rocket because Of excessive initial velocity." ;
+  qudt:symbol "s_i" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Over-range distance" ;
+.
+quantitykind:PREDICTED-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Sum of the basic mass and the MGA. Current prediction of the final mass based on the current requirements and design." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Predicted Mass"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:PRODUCT-OF-INERTIA
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Product of Inertia"^^rdfs:Literal ;
+.
+quantitykind:PRODUCT-OF-INERTIA_X
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A measure of a body's dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body?s principal axis." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Product of Inertia in the X axis" ;
+  skos:broader quantitykind:PRODUCT-OF-INERTIA ;
+.
+quantitykind:PRODUCT-OF-INERTIA_Y
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A measure of a body?s dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Product of Inertia in the Y axis" ;
+  skos:broader quantitykind:PRODUCT-OF-INERTIA ;
+.
+quantitykind:PRODUCT-OF-INERTIA_Z
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A measure of a body?s dynamic (or coupled) imbalance resulting in a precession when rotating about an axis other than the body's principal axis." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Product of Inertia in the Z axis" ;
+  skos:broader quantitykind:PRODUCT-OF-INERTIA ;
+.
+quantitykind:PackingFraction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_packing_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(f = \\frac{\\Delta_r}{A}\\), where \\(\\Delta_r\\) is the relative mass excess and \\(A\\) is the nucleon number."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Packing Fraction\" is the fraction of volume in a crystal structure that is occupied by atoms." ;
+  qudt:symbol "f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Packing Fraction" ;
+.
+quantitykind:ParticleCurrent
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M2-SEC ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\int J \\cdot e_n dA = \\frac{dN}{dt}\\), where \\(e_ndA\\) is the vector surface element, \\(N\\) is the net number of particles passing over a surface, and \\(dt\\) describes the time interval."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Particle Current\" can be used to describe the net number of particles passing through a surface in an infinitesimal time interval." ;
+  qudt:symbol "J, S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Particle Current" ;
+.
+quantitykind:ParticleFluence
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M2 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fluence"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Phi = \\frac{dN}{dA}\\), where \\(dN\\) describes the number of particles incident on a small spherical domain at a given point in space, and \\(dA\\) describes the cross-sectional area of that domain."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Phi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Particle Fluence\" is the total number of particles that intersect a unit area in a specific time interval of interest, and has units of m–2 (number of particles per meter squared)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Particle Fluence" ;
+.
+quantitykind:ParticleFluenceRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M2-SEC ;
+  qudt:informativeReference "http://www.encyclo.co.uk/define/Fluence%20Rate"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\theta = \\frac{d\\Phi}{dt}\\), where \\(d\\Phi\\) is the increment of the particle fluence during an infinitesimal time interval with duration \\(dt\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Particle Fluence Rate\" can be defined as the total number of particles (typically Gamma Ray Photons ) crossing over a sphere of unit cross section which surrounds a Point Source of Ionising Radiation." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Particle Fluence Rate" ;
+.
+quantitykind:ParticleSourceDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M3-SEC ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Particle Source Density\" is the rate of production of particles in a 3D domain divided by the volume of that element." ;
+  qudt:symbol "S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Particle Source Density" ;
+.
+quantitykind:PathLength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Path_length"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"PathLength\" is " ;
+  qudt:symbol "s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Path Length" ;
+.
+quantitykind:PayloadMass
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Payload mass is the mass of the payload carried by the craft. In a multistage spacecraft the payload mass of the last stage is the mass of the payload and the payload masses of the other stages are considered to be the gross masses of the next stages." ;
+  qudt:symbol "M_P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Payload Mass" ;
+.
+quantitykind:PayloadRatio
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The payload ratio is defined as the mass of the payload divided by the empty mass of the structure. Because of the extra cost involved in staging rockets, given the choice, it's often more economic to use few stages with a small payload ratio rather than more stages each with a high payload ratio." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Payload Ratio" ;
+.
+quantitykind:PeltierCoefficient
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermoelectric_effect"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Pi_{ab}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Peltier Coefficient\" represents how much heat current is carried per unit charge through a given material. It is the heat power developed at a junction, divided by the electric current flowing from substance a to substance b." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Peltier Coefficient" ;
+.
+quantitykind:Period
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0> ;
+  qudt:plainTextDescription "Duration of one cycle of a periodic phenomenon." ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Period" ;
+.
+quantitykind:Permeability
+  a qudt:QuantityKind ;
+  dcterms:description "\"Permeability} is the degree of magnetization of a material that responds linearly to an applied magnetic field. In general permeability is a tensor-valued quantity. The definition given applies to an isotropic medium. For an anisotropic medium permeability is a second order tensor. In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself. In other words, it is the degree of magnetization that a material obtains in response to an applied magnetic field. Magnetic permeability is typically represented by the Greek letter \\(\\mu\\). The term was coined in September, 1885 by Oliver Heaviside. The reciprocal of magnetic permeability is \\textit{Magnetic Reluctivity\"."^^qudt:LatexString ;
+  qudt:applicableUnit unit:H-PER-M ;
+  qudt:applicableUnit unit:H_Stat-PER-CentiM ;
+  qudt:applicableUnit unit:PERMEABILITY_REL ;
+  qudt:baseUnitDimensions "L \\cdot M/I^2 \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m/A^2 \\cdot s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Permeability"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-2L1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Permeability_(electromagnetism)"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\frac{B}{H}\\),  where \\(B\\) is magnetic flux density,  and \\(H\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Permeability" ;
+  rdfs:seeAlso constant:MagneticConstant ;
+  rdfs:seeAlso constant:PermeabilityOfVacuum ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:MagneticFluxDensity ;
+.
+quantitykind:Permeance
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Permeance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Lambda = \\frac{1}{R_m}\\), where \\(R_m\\) is reluctance."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Lambda\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Permeance\" is the inverse of reluctance. Permeance is a measure of the quantity of flux for a number of current-turns in magnetic circuit. A magnetic circuit almost acts as though the flux is \"conducted\", therefore permeance is larger for large cross sections of a material and smaller for longer lengths. This concept is analogous to electrical conductance in the electric circuit." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Permeance" ;
+  rdfs:seeAlso quantitykind:Reluctance ;
+.
+quantitykind:Permittivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FARAD-PER-M ;
+  qudt:applicableUnit unit:FARAD_Ab-PER-CentiM ;
+  qudt:applicableUnit unit:PERMITTIVITY_REL ;
+  qudt:baseUnitDimensions "A^2 \\cdot s^4/kg \\cdot m^3" ;
+  qudt:baseUnitDimensions "I^2 \\cdot T^4/L^3 \\cdot M" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Permittivity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L-3I0M-1H0T4D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Permittivity?oldid=494094133"^^xsd:anyURI ;
+  qudt:informativeReference "http://maxwells-equations.com/materials/permittivity.php"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\epsilon = \\frac{D}{E}\\), where \\(D\\) is electric flux density and \\(E\\) is electric field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\epsilon\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Permittivity\" is a physical quantity that describes how an electric field affects, and is affected by a dielectric medium, and is determined by the ability of a material to polarize in response to the field, and thereby reduce the total electric field inside the material.  Permittivity is often a scalar valued quantity, however in the general case it is tensor-valued." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Permittivity" ;
+.
+quantitykind:PermittivityOfFreeSpace
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription """The physical constant called the vacuum permittivity, permittivity of free space or electric constant is an ideal, (baseline) physical constant, which is the value of the absolute dielectric permittivity of classical vacuum. Its value is:
+    """ ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Permittivity Of Free Space" ;
+.
+quantitykind:PhaseCoefficient
+  a qudt:QuantityKind ;
+  dcterms:description "The phase coefficient is the amount of phase shift that occurs as the wave travels one meter. Increasing the loss of the material, via the manipulation of the material's conductivity, will decrease the wavelength (increase \\(\\beta\\)) and increase the attenuation coefficient (increase \\(\\alpha\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Attenuation_coefficient"^^xsd:anyURI ;
+  qudt:latexDefinition "If \\(F(x) = Ae^{-\\alpha x} \\cos{[\\beta (x - x_0)]}\\), then \\(\\alpha\\) is the attenuation coefficient and \\(\\beta\\) is the phase coefficient."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\beta\\)"^^qudt:LatexString ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Phase Coefficient" ;
+  rdfs:label "Phase coefficient" ;
+.
+quantitykind:PhaseDifference
+  a qudt:QuantityKind ;
+  dcterms:description "\"Phase Difference} is the difference, expressed in electrical degrees or time, between two waves having the same frequency and referenced to the same point in time. Two oscillators that have the same frequency and different phases have a phase difference, and the oscillators are said to be out of phase with each other. The amount by which such oscillators are out of step with each other can be expressed in degrees from \\SI{0}{\\degree} to \\SI{360}{\\degree}, or in radians from 0 to \\num{2\\pi\". If the phase difference is 180 degrees (\\(\\pi\\) radians), then the two oscillators are said to be in antiphase."^^qudt:LatexString ;
+  qudt:expression "\\(phase-difference\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Phase_(waves)#Phase_difference"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=103-07-06"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varphi = \\varphi_u - \\varphi_i\\), where \\(\\varphi_u\\) is the initial phase of the voltage and \\(\\varphi_i\\) is the initial phase of the electric current."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Phase Difference" ;
+.
+quantitykind:PhaseSpeedOfSound
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Speed_of_sound"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c = \\frac{\\omega}{k} = \\lambda f\\), where \\(\\omega\\) is the angular frequency, \\(k\\) is angular wavenumber, \\(\\lambda\\) is the wavelength, and \\(f\\) is the frequency."^^qudt:LatexString ;
+  qudt:plainTextDescription "In a dispersive medium sound speed is a function of sound frequency, through the dispersion relation. The spatial and temporal distribution of a propagating disturbance will continually change. Each frequency component propagates at its own Phase Velocity of Sound." ;
+  qudt:symbol "c" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Phase Speed of Sound" ;
+  rdfs:label "Phase speed of sound" ;
+  skos:broader quantitykind:SpeedOfSound ;
+.
+quantitykind:PhotoThresholdOfAwarenessFunction
+  a qudt:QuantityKind ;
+  dcterms:description "\"Photo Threshold of Awareness Function\" is the ability of the human eye to detect a light that results in a \\(1^o\\) radial angle at the eye with a given duration (temporal summation)."^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Photo Threshold of Awareness Function" ;
+.
+quantitykind:PlanckFunction
+  a qudt:QuantityKind ;
+  dcterms:description """The \\(\\textit{Planck function}\\) is used to compute the radiance emitted from objects that radiate like a perfect \"Black Body}. The inverse of the \\(\\textit{Planck Function}\\) is used to find the \\(\\textit{Brightness Temperature}\\) of an object.
+The precise formula for the Planck Function depends on whether the radiance is determined on a \\(\\textit{per unit wavelength}\\) or a \\(\\textit{per unit frequency}\\). In the ISO System of Quantities, \\(\\textit{Planck Function}\\) is defined by the formula: \\(Y = -G/T\\), where \\(G\\) is Gibbs Energy and \\(T\\) is thermodynamic temperature."""^^qudt:LatexString ;
+  qudt:applicableUnit unit:J-PER-K ;
+  qudt:expression "\\(B_{\\nu}(T)\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19680008986_1968008986.pdf"^^xsd:anyURI ;
+  qudt:informativeReference "http://pds-atmospheres.nmsu.edu/education_and_outreach/encyclopedia/planck_function.htm"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.star.nesdis.noaa.gov/smcd/spb/calibration/planck.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition """The Planck function, \\(B_{\\tilde{\\nu}}(T)\\), is given by:
+\\(B_{\\nu}(T) = \\frac{2h c^2\\tilde{\\nu}^3}{e^{hc / k \\tilde{\\nu} T}-1}\\)
+where, \\(\\tilde{\\nu}\\) is wavelength, \\(h\\) is Planck's Constant, \\(k\\) is Boltzman's Constant, \\(c\\) is the speed of light in a vacuum, \\(T\\) is thermodynamic temperature."""^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Planck Function" ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:PlaneAngle
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:ARCMIN ;
+  qudt:applicableUnit unit:ARCSEC ;
+  qudt:applicableUnit unit:DEG ;
+  qudt:applicableUnit unit:GON ;
+  qudt:applicableUnit unit:GRAD ;
+  qudt:applicableUnit unit:MIL ;
+  qudt:applicableUnit unit:MicroRAD ;
+  qudt:applicableUnit unit:MilliARCSEC ;
+  qudt:applicableUnit unit:MilliRAD ;
+  qudt:applicableUnit unit:RAD ;
+  qudt:applicableUnit unit:REV ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Plane_angle"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:informativeReference "http://www.thefreedictionary.com/plane+angle"^^xsd:anyURI ;
+  qudt:plainTextDescription "An angle formed by two straight lines (in the same plane) angle - the space between two lines or planes that intersect; the inclination of one line to another; measured in degrees or radians" ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Plane Angle" ;
+  skos:broader quantitykind:Angle ;
+.
+quantitykind:PoissonRatio
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Poisson%27s_ratio"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\frac{\\Delta \\delta}{\\Delta l}\\), where \\(\\Delta \\delta\\) is the lateral contraction and \\(\\Delta l\\) is the elongation."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The Poisson Ratio is the negative ratio of transverse to axial strain. In fact, when a sample object is stretched (or squeezed), to an extension (or contraction) in the direction of the applied load, it corresponds a contraction (or extension) in a direction perpendicular to the applied load. The ratio between these two quantities is the Poisson's ratio." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Poisson Ratio" ;
+.
+quantitykind:PolarMomentOfInertia
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The polar moment of inertia is a quantity used to predict an object's ability to resist torsion, in objects (or segments of objects) with an invariant circular cross-section and no significant warping or out-of-plane deformation. It is used to calculate the angular displacement of an object subjected to a torque. It is analogous to the area moment of inertia, which characterizes an object's ability to resist bending. " ;
+  qudt:symbol "J_{zz}" ;
+  qudt:url "http://en.wikipedia.org/wiki/Second_moment_of_area"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Polar moment of inertia" ;
+.
+quantitykind:Polarizability
+  a qudt:QuantityKind ;
+  dcterms:description "\"Polarizability\" is the relative tendency of a charge distribution, like the electron cloud of an atom or molecule, to be distorted from its normal shape by an external electric field, which may be caused by the presence of a nearby ion or dipole. The electronic polarizability \\(\\alpha\\) is defined as the ratio of the induced dipole moment of an atom to the electric field that produces this dipole moment. Polarizability is often a scalar valued quantity, however in the general case it is tensor-valued."^^qudt:LatexString ;
+  qudt:applicableUnit unit:C-M2-PER-V ;
+  qudt:applicableUnit unit:C2-M-PER-J ;
+  qudt:baseUnitDimensions "A^2 \\cdot s^4/kg" ;
+  qudt:baseUnitDimensions "I^2 \\cdot T^4/M" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Polarizability"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E2L0I0M-1H0T4D0> ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Polarizability" ;
+.
+quantitykind:PolarizationField
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The Polarization Field is the vector field that expresses the density of permanent or induced electric dipole moments in a dielectric material. The polarization vector P is defined as the ratio of electric dipole moment per unit volume." ;
+  qudt:symbol "P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Polarization Field" ;
+  skos:broader quantitykind:ElectricChargePerArea ;
+.
+quantitykind:PositionVector
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Position_(vector)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(r = \\overrightarrow{OP}\\), where \\(O\\) and \\(P\\) are two points in space."^^qudt:LatexString ;
+  qudt:plainTextDescription "A \"Position Vector\", also known as location vector or radius vector, is a Euclidean vector which represents the position of a point P in space in relation to an arbitrary reference origin O." ;
+  qudt:symbol "r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Position Vector" ;
+.
+quantitykind:Power
+  a qudt:QuantityKind ;
+  dcterms:description "Power is the rate at which work is performed or energy is transmitted, or the amount of energy required or expended for a given unit of time. As a rate of change of work done or the energy of a subsystem, power is: \\(P = W/t\\), where \\(P\\) is power, \\(W\\) is work and {t} is time."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT-PER-HR ;
+  qudt:applicableUnit unit:BTU_IT-PER-SEC ;
+  qudt:applicableUnit unit:ERG-PER-SEC ;
+  qudt:applicableUnit unit:FT-LB_F-PER-HR ;
+  qudt:applicableUnit unit:FT-LB_F-PER-MIN ;
+  qudt:applicableUnit unit:FT-LB_F-PER-SEC ;
+  qudt:applicableUnit unit:HP ;
+  qudt:applicableUnit unit:HP-PER-M ;
+  qudt:applicableUnit unit:HP-PER-V ;
+  qudt:applicableUnit unit:HP_Boiler ;
+  qudt:applicableUnit unit:HP_Water ;
+  qudt:applicableUnit unit:KiloCAL-PER-MIN ;
+  qudt:applicableUnit unit:KiloCAL-PER-SEC ;
+  qudt:applicableUnit unit:KiloW ;
+  qudt:applicableUnit unit:MegaW ;
+  qudt:applicableUnit unit:MilliW ;
+  qudt:applicableUnit unit:PlanckPower ;
+  qudt:applicableUnit unit:TON_FG ;
+  qudt:applicableUnit unit:W ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/s^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Power"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Power"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(P = F \\cdot v\\), where \\(F\\) is force and \\(v\\) is velocity."^^qudt:LatexString ;
+  qudt:symbol "P" ;
+  qudt:symbol "p" ;
+  qudt:url "http://en.wikipedia.org/wiki/Power_%28physics%29"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power" ;
+.
+quantitykind:PowerArea
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "L^4 \\cdot M/T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m^4/s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L4I0M1H0T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power Area" ;
+.
+quantitykind:PowerAreaPerSolidAngle
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-M2-PER-SR ;
+  qudt:applicableUnit unit:W-PER-M2-SR ;
+  qudt:baseUnitDimensions "L^4 \\cdot M/T^3 \\cdot U" ;
+  qudt:baseUnitDimensions "kg \\cdot m^4/s^3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power Area per Solid Angle" ;
+.
+quantitykind:PowerFactor
+  a qudt:QuantityKind ;
+  dcterms:description "\"Power Factor\", under periodic conditions, is the ratio of the absolute value of the active power \\(P\\) to the apparent power \\(S\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:expression "\\(power-factor\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-46"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\lambda = \\left | P \\right | / \\left | S \\right |\\), where \\(P\\) is active power and \\(S\\) is apparent power."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\lambda\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power Factor" ;
+  rdfs:seeAlso quantitykind:ActivePower ;
+  rdfs:seeAlso quantitykind:ApparentPower ;
+.
+quantitykind:PowerPerArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-HR-FT2 ;
+  qudt:applicableUnit unit:BTU_IT-PER-SEC-FT2 ;
+  qudt:applicableUnit unit:ERG-PER-CentiM2-SEC ;
+  qudt:applicableUnit unit:FT-LB_F-PER-FT2-SEC ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM2-MIN ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM2-SEC ;
+  qudt:applicableUnit unit:W-PER-CentiM2 ;
+  qudt:applicableUnit unit:W-PER-FT2 ;
+  qudt:applicableUnit unit:W-PER-IN2 ;
+  qudt:applicableUnit unit:W-PER-M2 ;
+  qudt:baseUnitDimensions "M/T^3" ;
+  qudt:baseUnitDimensions "kg/s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-3D0> ;
+  qudt:url "http://www.physicsforums.com/library.php?do=view_item&itemid=406"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power Per Area" ;
+.
+quantitykind:PowerPerAreaAngle
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power per Area Angle" ;
+.
+quantitykind:PowerPerAreaQuarticTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2-K4 ;
+  qudt:baseUnitDimensions "M/\\Theta^4 \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg/K^4 \\cdot s^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H-4T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power per Area Quartic Temperature" ;
+  rdfs:label "Power per area quartic temperature" ;
+.
+quantitykind:PowerPerElectricCharge
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-PER-SEC ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/I \\cdot T^4" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/A \\cdot s^4" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-4D0> ;
+  qudt:plainTextDescription "\"Power Per Electric Charge\" is the amount of energy generated by a unit of electric charge." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Power Per Electric Charge" ;
+.
+quantitykind:PoyntingVector
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2 ;
+  qudt:expression "\\(poynting-vector\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-66"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{S} = \\mathbf{E}  \\times \\mathbf{H} \\), where \\(\\mathbf{E}\\) is electric field strength and \\mathbf{H}  is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mathbf{S} \\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Poynting Vector} is the vector product of the electric field strength \\mathbf{E} and the magnetic field strength \\mathbf{H\" of the electromagnetic field at a given point. The flux of the Poynting vector through a closed surface is equal to the electromagnetic power passing through this surface. For a periodic electromagnetic field, the time average of the Poynting vector is a vector of which, with certain reservations, the direction may be considered as being the direction of propagation of electromagnetic energy and the magnitude considered as being the average electromagnetic power flux density." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Poynting Vector" ;
+.
+quantitykind:Pressure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BARYE ;
+  qudt:applicableUnit unit:N-PER-M2 ;
+  qudt:applicableUnit unit:PA ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pressure"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pressure"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(p = \\frac{dF}{dA}\\), where \\(dF\\) is the force component perpendicular to the surface element of area \\(dA\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Pressure is an effect which occurs when a force is applied on a surface. Pressure is the amount of force acting on a unit area. Pressure is distinct from stress, as the former is the ratio of the component of force normal to a surface to the surface area. Stress is a tensor that relates the vector force to the vector area." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure" ;
+  skos:broader quantitykind:ForcePerArea ;
+.
+quantitykind:PressureBurningRateConstant
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure Burning Rate Constant" ;
+.
+quantitykind:PressureBurningRateIndex
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\beta\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure Burning Rate Index" ;
+.
+quantitykind:PressureCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA-PER-K ;
+  qudt:expression "\\(pres-coef\\)"^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\beta = \\left (\\frac{\\partial p}{\\partial T} \\right )_V\\), where \\(p\\) is \\(pressure\\),  \\(T\\) is thermodynamic temperature and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\beta\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure Coefficient" ;
+.
+quantitykind:PressurePercentage
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure Percentage" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:PressureRatio
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Pressure Ratio" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:PrincipalQuantumNumber
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Principal Quantum Number\" describes the electron shell, or energy level, of an atom. The value of \\(n\\) ranges from 1 to the shell containing the outermost electron of that atom."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Principal Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+  skos:closeMatch quantitykind:MagneticQuantumNumber ;
+  skos:closeMatch quantitykind:OrbitalAngularMomentumQuantumNumber ;
+  skos:closeMatch quantitykind:SpinQuantumNumber ;
+.
+quantitykind:PropagationCoefficient
+  a qudt:QuantityKind ;
+  dcterms:description "The propagation constant, symbol \\(\\gamma\\), for a given system is defined by the ratio of the amplitude at the source of the wave to the amplitude at some distance x."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Propagation_constant"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\gamma = \\alpha + j\\beta\\), where \\(\\alpha\\) is the attenuation coefficient and \\(\\beta\\) is the phase coefficient."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Propagation Coefficient" ;
+  rdfs:label "Propagation coefficient" ;
+.
+quantitykind:PropellantBurnRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:IN-PER-SEC ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Propellant Burn Rate" ;
+  skos:broader quantitykind:BurnRate ;
+.
+quantitykind:PropellantMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M_f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Propellant Mass" ;
+.
+quantitykind:PropellantMeanBulkTemperature
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Propellant Mean Bulk Temperature" ;
+  skos:altLabel "PMBT" ;
+  skos:broader quantitykind:PropellantTemperature ;
+.
+quantitykind:PropellantTemperature
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Propellant Temperature" ;
+  skos:broader quantitykind:TemperaturePerTime ;
+.
+quantitykind:QualityFactor
+  a qudt:QuantityKind ;
+  dcterms:description "\"Quality Factor\", of a resonant circuit, is a measure of the \"goodness\" or quality of a resonant circuit. A higher value for this figure of merit correspondes to a more narrow bandwith, which is desirable in many applications. More formally, \\(Q\\) is the ratio of power stored to power dissipated in the circuit reactance and resistance, respectively"^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.sourcetronic.com/electrical-measurement-glossary/quality-factor.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.allaboutcircuits.com/vol_2/chpt_6/6.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "If \\(\\underline{Z} = R + jX\\), then \\(Q = \\left | X \\right |/R\\), where \\(\\underline{Z}\\) is impedance, \\(R\\) is resistance, and \\(X\\) is reactance."^^qudt:LatexString ;
+  qudt:symbol "Q" ;
+  vaem:todo "Resolve Quality Facor - electronics and also doses" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Quality Factor" ;
+  rdfs:seeAlso quantitykind:Impedance ;
+  rdfs:seeAlso quantitykind:Resistance ;
+.
+quantitykind:QuantumNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Quantum Number\" describes values of conserved quantities in the dynamics of the quantum system. Perhaps the most peculiar aspect of quantum mechanics is the quantization of observable quantities, since quantum numbers are discrete sets of integers or half-integers." ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Quantum Number" ;
+.
+quantitykind:QuarticElectricDipoleMomentPerCubicEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:C4-M4-PER-J3 ;
+  qudt:baseUnitDimensions "I^4 \\cdot T^{10}/L^2 \\cdot M^3" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E4L-2I0M-3H0T10D0> ;
+  qudt:plainTextDescription "\"Quartic Electric Dipole Moment per Cubic Energy\" is" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Quartic Electric Dipole Moment per Cubic Energy" ;
+.
+quantitykind:RESERVE-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "A quantity of mass held by Program/project management to mitigate the risk of over-predicted performance estimates, under predicted mass estimates, and future operational and mission specific requirements (program mass reserve, manager's mass reserve, launch window reserve, performance reserve, etc.)." ;
+  qudt:symbol "M_{E}" ;
+  qudt:url "http://eaton.math.rpi.edu/CSUMS/Papers/EcoEnergy/koojimanconserve.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reserve Mass" ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:RF-Power
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:B ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:informativeReference "http://ned.ipac.caltech.edu/level5/Glossary/Glossary_R.html"^^xsd:anyURI ;
+  qudt:plainTextDescription "Radio-Frequencypower. Electromagnetic fields alternating at the frequencies of radio waves (up to 1010 Hz), which can be used to accelerate charged particles in accelerators." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "RF-Power" ;
+  skos:broader quantitykind:SignalStrength ;
+.
+quantitykind:RadialDistance
+  a qudt:QuantityKind ;
+  dcterms:description "In classical geometry, the \"Radial Distance\" is a coordinate in polar coordinate systems (r, \\(\\theta\\)). Basically the radial distance is the scalar Euclidean distance between a point and the origin of the system of coordinates."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radial_distance_(geometry)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(d = \\sqrt{r_1^2 + r_2^2 -2r_1r_2\\cos{(\\theta_1 - \\theta_2)}}\\), where \\(P_1\\) and \\(P_2\\) are two points with polar coordinates \\((r_1, \\theta_1)\\) and \\((r_2, \\theta_2)\\), respectively, and \\(d\\) is the distance."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(r_Q, \\rho\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radial Distance" ;
+.
+quantitykind:Radiance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2-SR ;
+  qudt:baseUnitDimensions "M/T^3 \\cdot U" ;
+  qudt:baseUnitDimensions "kg/s^3" ;
+  qudt:latexDefinition "\\(L = \\frac{dI}{dA}\\frac{1}{cos\\alpha}\\), where \\(dI\\) is the radiant intensity emitted from an element of the surface area \\(dA\\), and angle \\(\\alpha\\) is the angle between the normal to the surface and the given direction."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Radiance\" is a radiometric measure that describes the amount of light that passes through or is emitted from a particular area, and falls within a given solid angle in a specified direction." ;
+  qudt:symbol "L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiance" ;
+  skos:broader quantitykind:PowerPerAreaAngle ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Radiance> ;
+.
+quantitykind:RadianceFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(\\beta = \\frac{L_n}{L_d}\\), where \\(L_n\\) is the radiance of a surface element in a given direction and \\(L_d\\) is the radiance of the perfect reflecting or transmitting diffuser identically irradiated and viewed. Reflectance factor is equivalent to radiance factor or luminance factor (when the cone angle is infinitely small, and is equivalent to reflectance when the cone angle is \\(2π sr\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\beta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Radiance Factor is the ratio of the radiance of the surface element in the given direction to that of a perfect reflecting or transmitting diffuser identically irradiated unit." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiance Factor" ;
+  skos:exactMatch <http://www.encyclo.co.uk/define/radiance%20factor> ;
+.
+quantitykind:RadiantEnergyDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31892"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w\\), \\(\\rho = \\frac{dQ}{dV}\\), where \\(dQ\\) is the radiant energy in an elementary three-dimensional domain, and \\(dV\\) is the volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(w, \\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Radiant Energy Density\", or radiant power, is the radiant energy per unit volume." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiant Energy Density" ;
+  skos:broader quantitykind:Power ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Radiant_energy_density> ;
+.
+quantitykind:RadiantFluence
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T-2D0> ;
+  qudt:latexDefinition "\\(H_0 = \\int_{0}^{\\Delta t}{E_0}{dt}\\), where \\(E_0\\) is the spherical radiance acting during time interval with duration \\(\\Delta t\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Radiant fluence rate, or spherical irradiance, is equal to the total radiant flux incident on a small sphere divided by the area of the diametrical cross-section of the sphere." ;
+  qudt:symbol "H_e,0" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiant Fluence" ;
+.
+quantitykind:RadiantFlux
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:latexDefinition "\\(\\Phi = \\frac{dQ}{dt}\\), where \\(dQ\\) is the radiant energy emitted, transferred, or received during a time interval of the duration \\(dt\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\phi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Radiant Flux, or radiant power, is the measure of the total power of electromagnetic radiation (including infrared, ultraviolet, and visible light). The power may be the total emitted from a source, or the total landing on a particular surface." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiant Flux" ;
+  skos:broader quantitykind:Power ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Radiant_flux> ;
+.
+quantitykind:RadiantIntensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-SR ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/T^3 \\cdot U" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/s^3" ;
+  qudt:latexDefinition "\\(I = \\frac{d\\Phi}{d\\Omega}\\), where \\(d\\Phi\\) is the radiant flux leaving the source in an elementary cone containing the given direction with the solid angle \\(d\\Omega\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Radiant Intensity is a measure of the intensity of electromagnetic radiation. It is defined as power per unit solid angle." ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiant Intensity" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Radiant_intensity> ;
+.
+quantitykind:RadiativeHeatTransfer
+  a qudt:QuantityKind ;
+  dcterms:description "\"Radiative Heat Transfer\" is proportional to \\((T_1^4 - T_2^4)\\) and area of the surface, where \\(T_1\\) and \\(T_2\\) are thermodynamic temperatures of two black surfaces, for non totally black surfaces an additional factor less than 1 is needed."^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi_r\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiative Heat Transfer" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Heat_transfer#Radiation> ;
+.
+quantitykind:Radiosity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Radiosity is the total emitted and reflected radiation leaving a surface." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radiosity" ;
+  skos:broader quantitykind:PowerPerArea ;
+.
+quantitykind:Radius
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Radius"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radius"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(r = \\frac{d}{2}\\), where \\(d\\) is the circle diameter."^^qudt:LatexString ;
+  qudt:plainTextDescription "In classical geometry, the \"Radius\" of a circle or sphere is any line segment from its center to its perimeter the radius of a circle or sphere is the length of any such segment." ;
+  qudt:symbol "r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radius" ;
+.
+quantitykind:RadiusOfCurvature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radius_of_curvature_(mathematics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In geometry, the \"Radius of Curvature\", R, of a curve at a point is a measure of the radius of the circular arc which best approximates the curve at that point." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Radius of Curvature" ;
+.
+quantitykind:RatioOfSpecificHeatCapacities
+  a qudt:QuantityKind ;
+  dcterms:description "The specific heat ratio of a gas is the ratio of the specific heat at constant pressure, \\(c_p\\), to the specific heat at constant volume, \\(c_V\\). It is sometimes referred to as the \"adiabatic index} or the \\textit{heat capacity ratio} or the \\textit{isentropic expansion factor} or the \\textit{adiabatic exponent} or the \\textit{isentropic exponent\"."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Specific_heat_ratio"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\gamma = c_p / c_V\\), where \\(c\\) is the specific heat of a gas, \\(c_p\\) is specific heat capacity at constant pressure, \\(c_V\\) is specific heat capacity at constant volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varkappa\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Ratio of Specific Heat Capacities" ;
+  rdfs:seeAlso quantitykind:IsentropicExponent ;
+.
+quantitykind:Reactance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electrical_reactance"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electrical_reactance?oldid=494180019"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-46"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(X = im \\underline{Z}\\), where \\(\\underline{Z}\\) is impedance and \\(im\\) denotes the imaginary part."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Reactance\" is the opposition of a circuit element to a change of electric current or voltage, due to that element's inductance or capacitance. A built-up electric field resists the change of voltage on the element, while a magnetic field resists the change of current. The notion of reactance is similar to electrical resistance, but they differ in several respects. Capacitance and inductance are inherent properties of an element, just like resistance." ;
+  qudt:symbol "X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reactance" ;
+  rdfs:seeAlso quantitykind:Impedance ;
+.
+quantitykind:ReactivePower
+  a qudt:QuantityKind ;
+  dcterms:description "\"Reactive Power}, for a linear two-terminal element or two-terminal circuit, under sinusoidal conditions, is the quantity equal to the product of the apparent power \\(S\\) and the sine of the displacement angle \\(\\psi\\). The absolute value of the reactive power is equal to the non-active power. The ISO (and SI) unit for reactive power is the voltampere. The special name \\textit{var} and symbol \\textit{var\" are given in IEC 60027 1."^^qudt:LatexString ;
+  qudt:applicableUnit unit:V-A_Reactive ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-44"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Q = lm \\underline{S}\\), where \\(\\underline{S}\\) is complex power. Alternatively expressed as: \\(Q = S \\cdot \\sin  \\psi\\), where \\(\\psi\\) is the displacement angle."^^qudt:LatexString ;
+  qudt:symbol "Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reactive Power" ;
+  rdfs:seeAlso quantitykind:ComplexPower ;
+.
+quantitykind:Reactivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nuclear_chain_reaction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho = \\frac{k_{eff} - 1}{k_{eff}}\\), where \\(k_{eff}\\) is the effective multiplication factor."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Reactivity\" characterizes the deflection of reactor from the critical state." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reactivity" ;
+.
+quantitykind:ReactorTimeConstant
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.euronuclear.org/info/encyclopedia/r/reactor-time-constant.htm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Reactor Time Constant\", also called the reactor period, is the time during which the neutron flux density in a reactor changes by the factor e = 2.718 (e: basis of natural logarithms), when the neutron flux density increases or decreases exponentially." ;
+  qudt:symbol "T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reactor Time Constant" ;
+.
+quantitykind:RecombinationCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/recombination+coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(-\\frac{dn^+}{dt} = -\\frac{dn^-}{dt} = an^+n^-\\), where \\(n^+\\) and \\(n^-\\) are the ion number densities of positive and negative ions, respectively, recombined during an infinitesimal time interval with duration \\(dt\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Recombination Coefficient\" is the rate of recombination of positive ions with electrons or negative ions in a gas, per unit volume, divided by the product of the number of positive ions per unit volume and the number of electrons or negative ions per unit volume." ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Recombination Coefficient" ;
+.
+quantitykind:Refectance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(\\rho = \\frac{\\Phi_t}{\\Phi_m}\\), where \\(\\Phi_t\\) is the reflected radiant flux or the reflected luminous flux, and \\(\\Phi_m\\) is the radiant flux or luminous flux of the incident radiation."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Refectance and reflectivity generally refer to the fraction of incident electromagnetic power that is reflected at an interface, while the term \"reflection coefficient\" is used for the fraction of electric field reflected. Reflectance is always a positive real number." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Refectance" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Reflectivity> ;
+.
+quantitykind:Reflectance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dissipation_factor"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(r= \\frac{\\P_r}{\\P_i}\\), where \\(\\P_r\\) is the reflected sound power, and \\(\\P_i\\) is the incident sound power."^^qudt:LatexString ;
+  qudt:plainTextDescription "Reflectance, or reflection factor for sound power, is the ratio of reflected sound power to incident sound power." ;
+  qudt:symbol "r" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reflectance" ;
+.
+quantitykind:ReflectanceFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(R = \\frac{\\Phi_n}{\\Phi_d}\\), where \\(\\Phi_n\\) is the radiant flux or luminous flux reflected in the directions delimited by a given cone and \\(\\Phi_d\\) is the flux reflected in the same directions by an identically radiated diffuser of reflectance equal to 1."^^qudt:LatexString ;
+  qudt:plainTextDescription "Reflectance Factor is the measure of the ability of a surface to reflect light or other electromagnetic radiation, equal to the ratio of the reflected flux to the incident flux." ;
+  qudt:symbol "R" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reflectance Factor" ;
+  skos:exactMatch <http://www.thefreedictionary.com/reflectance+factor> ;
+.
+quantitykind:RefractiveIndex
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Refractive_index"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(n = \\frac{c_0}{c}\\), where \\(c_0\\) is the speed of light in vacuum, and \\(c\\) is the speed of light in the medium."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"refractive index\" or index of refraction n of a substance (optical medium) is a dimensionless number that describes how light, or any other radiation, propagates through that medium." ;
+  qudt:symbol "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Refractive index" ;
+.
+quantitykind:RelativeAtomicMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_atomic_mass"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Relative Atomic Mass \" is a dimensionless physical quantity, the ratio of the average mass of atoms of an element (from a given source) to 1/12 of the mass of an atom of carbon-12 (known as the unified atomic mass unit)" ;
+  qudt:symbol "A_r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Atomic Mass" ;
+.
+quantitykind:RelativeHumidity
+  a qudt:QuantityKind ;
+  dcterms:description "\"Relative Humidity} is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature. The relative humidity of air depends not only on temperature but also on the pressure of the system of interest. \\textit{Relative Humidity} is also referred to as \\text{Relative Partial Pressure\". Relative partial pressure is often referred to as \\(RH\\) and expressed in percent."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:exactMatch quantitykind:RelativePartialPressure ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_humidity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varphi = p / p_{sat}\\), where \\(p\\) is partial pressure of vapour,  \\(p_{sat}\\) is thermodynamic temperature and \\(V\\) is its partial pressure at saturation (at the same temperature). Relative partial pressure is often referred to as \\(RH\\) and expressed in percent. \"Relative Humidity} is also referred to as \\text{Relative Partial Pressure\"."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Humidity" ;
+  rdfs:seeAlso quantitykind:AbsoluteHumidity ;
+  skos:altLabel "RH" ;
+.
+quantitykind:RelativeMassConcentrationOfVapour
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varphi = v / v_{sat}\\), where \\(v\\) is mass concentration of water vapour,  \\(v_{sat}\\) is its mass concentration of water vapour at saturation (at the same temperature). For normal cases, the relative partial pressure may be assumed to be equal to relative mass concentration of vapour."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Relative Mass Concentration of Vapour} is one of a number of \\textit{Relative Concentration\" quantities  defined by ISO 8000." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Mass Concentration of Vapour" ;
+  rdfs:seeAlso quantitykind:RelativePartialPressure ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:RelativeMassDefect
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Binding_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(B_r = \\frac{B}{m_u}\\), where \\(B\\) is the mass defect and \\(m_u\\) is the unified atomic mass constant."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Relative Mass Defect\" is the mass defect between the monoisotopic mass of an element and the mass of its A + 1 or its A + 2 isotopic cluster." ;
+  qudt:symbol "B_r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Mass Defect" ;
+  skos:broader quantitykind:MassDefect ;
+.
+quantitykind:RelativeMassDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:exactMatch quantitykind:Density ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(d = \\frac{\\rho}{\\rho_0}\\), where \\(\\rho\\) is mass density of a substance and \\(\\rho_0\\) is the mass density of a reference substance under conditions that should be specified for both substances."^^qudt:LatexString ;
+  qudt:plainTextDescription "Relative density, or specific gravity, is the ratio of the density (mass of a unit volume) of a substance to the density of a given reference material." ;
+  qudt:symbol "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Mass Density" ;
+.
+quantitykind:RelativeMassExcess
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mass_excess"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\Delta_r = \\frac{\\Delta}{m_u}\\), where \\(\\Delta\\) is the mass excess and \\(m_u\\) is the unified atomic mass constant."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\Delta_r\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Relative Mass Excess\" is the mass excess between the monoisotopic mass of an element and the mass of its A + 1 or its A + 2 isotopic cluster (extrapolated from relative mass defect)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Mass Excess" ;
+.
+quantitykind:RelativeMassRatioOfVapour
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\psi = x / x_{sat}\\), where \\(x\\) is mass ratio of water vapour to dry gas,  \\(x_{sat}\\) is its mass raio of water vapour to dry gas at saturation (at the same temperature)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\psi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Relative Mass Ratio of Vapour} is one of a number of \\textit{Relative Concentration\" quantities  defined by ISO 8000." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Mass Ratio of Vapour" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:RelativeMolecularMass
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Molecular_mass#Relative_molecular_mass"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Relative Molecular Mass \" is equivalent to the numerical value of the molecular mass expressed in unified atomic mass units. The molecular mass (m) is the mass of a molecule." ;
+  qudt:symbol "M_r" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Molecular Mass" ;
+  skos:broader quantitykind:MolecularMass ;
+.
+quantitykind:RelativePartialPressure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:exactMatch quantitykind:RelativeHumidity ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(\\varphi = p / p_{sat}\\), where \\(p\\) is partial pressure of vapour,  \\(p_{sat}\\) is thermodynamic temperature and \\(V\\) is its
+partial pressure at saturation (at the same temperature). Relative partial pressure is often referred to as \\(RH\\) and expressed in percent. \"Relative Partial Pressure} is also referred to as \\text{Relative Humidity\"."""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Partial Pressure" ;
+  skos:altLabel "RH" ;
+.
+quantitykind:RelativePermeability
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Permeability"^^xsd:anyURI ;
+  qudt:expression "\\(rel-permeability\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\frac{B}{H}\\),  where \\(B\\) is magnetic flux density,  and \\(H\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Relative Permeability\" is the ratio of permability to that of a vacuum." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Permeability" ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:MagneticFluxDensity ;
+  rdfs:seeAlso quantitykind:Permeability ;
+  rdfs:seeAlso quantitykind:PermeabilityOfVacuum ;
+.
+quantitykind:RelativePermittivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Permittivity"^^xsd:anyURI ;
+  qudt:expression "\\(rel-permittivity\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\epsilon_r = \\epsilon / \\epsilon_0\\), where \\(\\epsilon\\) is permittivity and \\(\\epsilon_0\\) is the electric constant."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\epsilon_r\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Relative Permittivity\" is the ration of permittivity to the permittivity of a vacuum." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Permittivity" ;
+  rdfs:seeAlso quantitykind:Permittivity ;
+  rdfs:seeAlso quantitykind:PermittivityOfVacuum ;
+.
+quantitykind:RelativePressureCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-K ;
+  qudt:expression "\\(rel-pres-coef\\)"^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_p = \\frac{1}{p}\\left (\\frac{\\partial p}{\\partial T} \\right )_V\\), where \\(p\\) is \\(pressure\\),  \\(T\\) is thermodynamic temperature and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_p\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relative Pressure Coefficient" ;
+.
+quantitykind:RelaxationTIme
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relaxation_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Relaxation TIme\" is a time constant for exponential decay towards equilibrium." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Relaxation TIme" ;
+.
+quantitykind:Reluctance
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Magnetic_reluctance"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(R_m = \\frac{U_m}{\\Phi}\\), where \\(U_m\\) is magnetic tension, and \\(\\Phi\\) is magnetic flux."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Reluctance\" or magnetic resistance, is a concept used in the analysis of magnetic circuits. It is analogous to resistance in an electrical circuit, but rather than dissipating electric energy it stores magnetic energy. In likeness to the way an electric field causes an electric current to follow the path of least resistance, a magnetic field causes magnetic flux to follow the path of least magnetic reluctance. It is a scalar, extensive quantity, akin to electrical resistance." ;
+  qudt:symbol "R_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reluctance" ;
+  rdfs:seeAlso quantitykind:MagneticFlux ;
+  rdfs:seeAlso quantitykind:MagneticTension ;
+.
+quantitykind:ResidualResistivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Residual-resistance_ratio"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\rho_R\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Residual Resistivity\" for metals, is the resistivity extrapolated to zero thermodynamic temperature." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Residual Resistivity" ;
+.
+quantitykind:Resistance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM ;
+  qudt:applicableUnit unit:OHM_Ab ;
+  qudt:applicableUnit unit:OHM_Stat ;
+  qudt:applicableUnit unit:PlanckImpedance ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/I^2 \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/A^2 \\cdot s^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Resistance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-2L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-45"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(R = \\frac{u}{i}\\), where \\(u\\) is instantaneous voltage and \\(i\\) is instantaneous electric current."^^qudt:LatexString ;
+  qudt:plainTextDescription "The electrical resistance of an object is a measure of its opposition to the passage of a steady electric current." ;
+  qudt:symbol "R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Resistance" ;
+  rdfs:seeAlso quantitykind:ElectricCurrent ;
+  rdfs:seeAlso quantitykind:Impedance ;
+  rdfs:seeAlso quantitykind:InstantaneousPower ;
+.
+quantitykind:ResistancePercentage
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E-2L2I0M1H0T-3D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E-2L2I0M1H0T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Resistance Percentage" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:Resistivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:OHM-M ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-12-04"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho = \\frac{1}{\\sigma}\\), if it exists, where \\(\\sigma\\) is conductivity."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Resistivity\" is the inverse of the conductivity when this inverse exists." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Resistivity" ;
+  rdfs:seeAlso quantitykind:Conductivity ;
+.
+quantitykind:ResonanceEscapeProbability
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Four_factor_formula"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Resonance Escape Probability\" is the fraction of fission neutrons that manage to slow down from fission to thermal energies without being absorbed. In an infinite medium, the probability that a neutron slowing down will traverse all or some specified portion of the range of resonance energies without being absorbed." ;
+  qudt:symbol "p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Resonance Escape Probability" ;
+.
+quantitykind:ResonanceEscapeProbabilityForFission
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Fraction of fission neutrons that manage to slow down from fission to thermal energies without being absorbed." ;
+  qudt:symbol "p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Resonance Escape Probability For Fission" ;
+.
+quantitykind:RespiratoryRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BREATH-PER-MIN ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Respiratory_rate"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Respiratory_rate"^^xsd:anyURI ;
+  qudt:plainTextDescription "Respiratory rate (Vf, Rf or RR) is also known by respiration rate, pulmonary ventilation rate, ventilation rate, or breathing frequency is the number of breaths taken within a set amount of time, typically 60 seconds. A normal respiratory rate is termed eupnea, an increased respiratory rate is termed tachypnea and a lower than normal respiratory rate is termed bradypnea." ;
+  qudt:symbol "Vf, Rf or RR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Respiratory Rate" ;
+.
+quantitykind:RestMass
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Rest Mass}, the invariant mass, intrinsic mass, proper mass, or (in the case of bound systems or objects observed in their center of momentum frame) simply mass, is a characteristic of the total energy and momentum of an object or a system of objects that is the same in all frames of reference related by Lorentz transformations. The mass of a particle type X (electron, proton or neutron) when that particle is at rest. For an electron: \\(m_e = 9,109 382 15(45) 10^{-31} kg\\), for a proton: \\(m_p = 1,672 621 637(83) 10^{-27} kg\\), for a neutron: \\(m_n = 1,674 927 211(84) 10^{-27\" kg\\). Rest mass is often denoted \\(m_0\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Invariant_mass"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31895"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m_X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Rest Mass" ;
+  skos:altLabel "Proper Mass" ;
+.
+quantitykind:ReverberationTime
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Reverberation"^^xsd:anyURI ;
+  qudt:plainTextDescription "Reverberation Time is the time required for reflections of a direct sound to decay by 60 dB below the level of the direct sound." ;
+  qudt:symbol "T" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Reverberation Time" ;
+.
+quantitykind:RichardsonConstant
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-M2-K2 ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermionic_emission"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "The thermionic emission current, \\(J\\), for a metal is \\(J = AT^2\\exp{(-\\frac{\\Phi}{kT})}\\), where \\(T\\) is thermodynamic temperature, \\(k\\) is the Boltzmann constant, and \\(\\Phi\\) is a work function."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Richardson Constant\" is a constant used in developing thermionic emission current density for a metal." ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Richardson Constant" ;
+.
+quantitykind:RocketAtmosphericTransverseForce
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Transverse force on rocket due to an atmosphere" ;
+  qudt:symbol "T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Rocket Atmospheric Transverse Force" ;
+.
+quantitykind:ScalarMagneticPotential
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-58"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mathbf{H} = -grad V_m\\), where \\(\\mathbf{H}\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Scalar Magnetic Potential\" is the scalar potential of an irrotational magnetic field strength. The negative of the gradient of the scalar magnetic potential is the irrotational magnetic field strength. The magnetic scalar potential is not unique since any constant scalar field can be added to it without changing its gradient." ;
+  qudt:symbol "V_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Scalar Magnetic Potential" ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+.
+quantitykind:SecondAxialMomentOfArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M4 ;
+  qudt:baseUnitDimensions "m^4" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L4I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Second_moment_of_area"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I_a = \\int r^2_Q dA\\), where \\(r_Q\\) is the radial distance from a \\(Q-axis\\) and \\(A\\) is area."^^qudt:LatexString ;
+  qudt:plainTextDescription "The moment of inertia, also called mass moment of inertia, rotational inertia, polar moment of inertia of mass, or the angular mass is a property of a distribution of mass in space that measures its resistance to rotational acceleration about an axis." ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Second Axial Moment of Area" ;
+.
+quantitykind:SecondMomentOfArea
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The second moment of area is a property of a physical object that can be used to predict its resistance to bending and deflection. The deflection of an object under load depends not only on the load, but also on the geometry of the object's cross-section." ;
+  qudt:symbol "J" ;
+  qudt:url "http://en.wikipedia.org/wiki/Second_moment_of_area"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Second Moment of Area" ;
+.
+quantitykind:SecondPolarMomentOfArea
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M4 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L4I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Second_moment_of_area"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I_p = \\int r^2_Q dA\\), where \\(r_Q\\) is the radial distance from a \\(Q-axis\\) and \\(A\\) is area."^^qudt:LatexString ;
+  qudt:plainTextDescription "The moment of inertia, also called mass moment of inertia, rotational inertia, polar moment of inertia of mass, or the angular mass is a property of a distribution of mass in space that measures its resistance to rotational acceleration about an axis." ;
+  qudt:symbol "I" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Second Polar Moment of Area" ;
+.
+quantitykind:SecondStageMassRatio
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Mass ratio for the second stage of a multistage launcher." ;
+  qudt:symbol "R_2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Second Stage Mass Ratio" ;
+  skos:broader quantitykind:MassRatio ;
+.
+quantitykind:SectionModulus
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Section_modulus"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z = \\frac{I_a}{r_Q_,_m_a_x}\\), where \\(I_a\\) is the second axial moment of area and \\(r_Q_,_m_a_x\\) is the maximum radial distance of any point in the surface considered from the \\(Q-axis\\) with respect to which \\(I_a\\) is defined."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Section Modulus is a geometric property for a given cross-section used in the design of beams or flexural members." ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Section Modulus" ;
+.
+quantitykind:SeebeckCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-PER-K ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermopower"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S_{ab} = \\frac{dE_{ab}}{dT}\\), where \\(E_{ab}\\) is the thermosource voltage between substances a and b, \\(T\\) is the thermodynamic temperature of the hot junction."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Seebeck Coefficient\", or thermopower, or thermoelectric power of a material is a measure of the magnitude of an induced thermoelectric voltage in response to a temperature difference across that material." ;
+  qudt:symbol "S_{ab}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Seebeck Coefficient" ;
+.
+quantitykind:SerumOrPlasmaLevel
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:IU-PER-L ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Serum or Plasma Level" ;
+  skos:broader quantitykind:AmountOfSubstancePerUnitVolume ;
+.
+quantitykind:ShearModulus
+  a qudt:QuantityKind ;
+  dcterms:description "The Shear Modulus or modulus of rigidity, denoted by \\(G\\), or sometimes \\(S\\) or \\(\\mu\\), is defined as the ratio of shear stress to the shear strain."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Shear_modulus"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(G = \\frac{\\tau}{\\gamma}\\), where \\(\\tau\\) is the shear stress and \\(\\gamma\\) is the shear strain."^^qudt:LatexString ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Shear Modulus" ;
+.
+quantitykind:ShearStrain
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deformation_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\gamma = \\frac{\\Delta x}{d}\\), where \\(\\Delta x\\) is the parallel displacement between two surfaces of a layer of thickness \\(d\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Shear Strain is the amount of deformation perpendicular to a given line rather than parallel to it. " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Shear Strain" ;
+  skos:broader quantitykind:Strain ;
+.
+quantitykind:ShearStress
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_F-PER-IN2 ;
+  qudt:applicableUnit unit:N-PER-M2 ;
+  qudt:applicableUnit unit:PA ;
+  qudt:baseUnitDimensions "n m^{-2}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stress_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\tau = \\frac{dF_t}{dA}\\), where \\(dF_t\\) is the tangential component of force and \\(dA\\) is the area of the surface element."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Shear stress occurs when the force  occurs in shear, or perpendicular to the normal." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Normal Stress" ;
+  skos:broader quantitykind:Stress ;
+.
+quantitykind:Short-RangeOrderParameter
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(r, \\sigma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Short-Range Order Parameter\" is the fraction of the nearest-neighbor atom pairs in an Ising ferromagnet having magnetic moments in one direction, minus the fraction having magnetic moments in the opposite direction." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Short-Range Order Parameter" ;
+.
+quantitykind:SignalDetectionThreshold
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DeciB_C ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Signal Detection Threshold" ;
+.
+quantitykind:SignalStrength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:B ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Signal_strength"^^xsd:anyURI ;
+  qudt:plainTextDescription "In telecommunications, particularly in radio, signal strength refers to the magnitude of the electric field at a reference point that is a significant distance from the transmitting antenna. It may also be referred to as received signal level or field strength. Typically, it is expressed in voltage per length or signal power received by a reference antenna. High-powered transmissions, such as those used in broadcasting, are expressed in dB-millivolts per metre (dBmV/m)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Signal Strength" ;
+  skos:broader quantitykind:ElectricField ;
+  skos:broader quantitykind:ElectricFieldStrength ;
+.
+quantitykind:SingleStageLauncherMassRatio
+  a qudt:QuantityKind ;
+  qudt:symbol "R_o" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Single Stage Launcher Mass Ratio" ;
+  skos:broader quantitykind:MassRatio ;
+.
+quantitykind:Slowing-DownDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M3-SEC ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/slowing-down+density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q = -\\frac{dn}{dt}\\), where \\(n\\) is the number density and \\(dt\\) is the duration."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Slowing-Down Density\" is a measure of the rate at which neutrons lose energy in a nuclear reactor through collisions; equal to the number of neutrons that fall below a given energy per unit volume per unit time." ;
+  qudt:symbol "q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Slowing-Down Density" ;
+.
+quantitykind:SolidAngle
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG2 ;
+  qudt:applicableUnit unit:FA ;
+  qudt:applicableUnit unit:SR ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Solid_angle"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:plainTextDescription "The solid angle subtended by a surface S is defined as the surface area of a unit sphere covered by the surface S's projection onto the sphere. A solid angle is related to the surface of a sphere in the same way an ordinary angle is related to the circumference of a circle. Since the total surface area of the unit sphere is 4*pi, the measure of solid angle will always be between 0 and 4*pi." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Solid Angle" ;
+  skos:broader quantitykind:Angle ;
+.
+quantitykind:SoundEnergyDensity
+  a qudt:QuantityKind ;
+  dcterms:description "Sound energy density is the time-averaged sound energy in a given volume divided by that volume. The sound energy density or sound density (symbol \\(E\\) or \\(w\\)) is an adequate measure to describe the sound field at a given point as a sound energy value."^^qudt:LatexString ;
+  qudt:applicableUnit unit:PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_energy_density"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E = \\frac{I}{c}\\), where \\(I\\) is the sound intensity in \\(\\frac{W}{m^2}\\) and \\(c\\) is the sound speed in \\(\\frac{m}{s}\\)."^^qudt:LatexString ;
+  qudt:symbol "E" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Energy Density" ;
+  rdfs:label "Sound energy density" ;
+  skos:broader quantitykind:EnergyDensity ;
+.
+quantitykind:SoundExposure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PA2-SEC ;
+  qudt:informativeReference "http://www.acoustic-glossary.co.uk/definitions-s.htm"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E = \\int_{t1}^{t2}p^2dt\\), where \\(t1\\) and \\(t2\\) are the starting and ending times for the integral and \\(p\\) is the sound pressure."^^qudt:LatexString ;
+  qudt:plainTextDescription "Sound Exposure is the energy of the A-weighted sound calculated over the measurement time(s). For a given period of time, an increase of 10 dB(A) in sound pressure level corresponds to a tenfold increase in E." ;
+  qudt:symbol "E" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Exposure" ;
+  rdfs:label "Sound exposure" ;
+.
+quantitykind:SoundExposureLevel
+  a qudt:QuantityKind ;
+  dcterms:description "Sound Exposure Level abbreviated as \\(SEL\\) and \\(LAE\\), is the total noise energy produced from a single noise event."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:informativeReference "http://www.diracdelta.co.uk/science/source/s/o/sound%20exposure%20level/source.html"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L_E = 10 \\log_{10} \\frac{E}{E_0} dB\\), where \\(E\\) is sound power and the reference value is \\(E_0 = 400 \\mu Pa^2 s\\)."^^qudt:LatexString ;
+  qudt:symbol "L" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Exposure Level" ;
+  rdfs:label "Sound exposure level" ;
+.
+quantitykind:SoundParticleAcceleration
+  a qudt:QuantityKind ;
+  dcterms:description "In a compressible sound transmission medium - mainly air - air particles get an accelerated motion: the particle acceleration or sound acceleration with the symbol a in \\(m/s2\\). In acoustics or physics, acceleration (symbol: \\(a\\)) is defined as the rate of change (or time derivative) of velocity."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M-PER-SEC2 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Particle_acceleration"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(a = \\frac{\\partial v}{\\partial t}\\), where \\(v\\) is sound particle velocity and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:symbol "a" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Particle Acceleration" ;
+  rdfs:label "Sound particle acceleration" ;
+.
+quantitykind:SoundParticleVelocity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Particle_velocity"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(v = \\frac{\\partial\\delta }{\\partial t}\\), where \\(\\delta\\) is sound particle displacement and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:plainTextDescription "Sound Particle velocity is the velocity v of a particle (real or imagined) in a medium as it transmits a wave. In many cases this is a longitudinal wave of pressure as with sound, but it can also be a transverse wave as with the vibration of a taut string. When applied to a sound wave through a medium of a fluid like air, particle velocity would be the physical speed of a parcel of fluid as it moves back and forth in the direction the sound wave is travelling as it passes." ;
+  qudt:symbol "v" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Particle Velocity" ;
+  rdfs:label "Sound particle velocity" ;
+.
+quantitykind:SoundPower
+  a qudt:QuantityKind ;
+  dcterms:description "Sound power or acoustic power \\(P_a\\) is a measure of sonic energy \\(E\\) per time \\(t\\) unit. It is measured in watts and can be computed as sound intensity (\\(I\\)) times area (\\(A\\))."^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_power"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(P_a = IA\\), where \\(I\\) is the sound intensity in \\(\\frac{W}{m^2}\\) and \\(A\\) is the area in \\(m^2\\)."^^qudt:LatexString ;
+  qudt:symbol "P" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Power" ;
+  rdfs:label "Sound power" ;
+  skos:broader quantitykind:Power ;
+.
+quantitykind:SoundPowerLevel
+  a qudt:QuantityKind ;
+  dcterms:description "Sound Power Level abbreviated as \\(SWL\\) expresses sound power more practically as a relation to the threshold of hearing - 10-12 W - in a logarithmic scale."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_power#Sound_power_level"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L_W = 10 \\log_{10} \\frac{P}{P_0} dB\\), where \\(P\\) is sound power and the reference value is \\(P_0 =1pW\\)."^^qudt:LatexString ;
+  qudt:symbol "L" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Power Level" ;
+  rdfs:label "Sound power level" ;
+.
+quantitykind:SoundPressureLevel
+  a qudt:QuantityKind ;
+  dcterms:description "Sound pressure level (\\(SPL\\)) or sound level  is a logarithmic measure of the effective sound pressure of a sound relative to a reference value. It is measured in decibels (dB) above a standard reference level."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_pressure#Sound_pressure_level"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(L_P = 10 \\log_{10} \\frac{p^2}{p_0^2} dB\\), where \\(p\\) is sound pressure and the reference value in airborne acoustics is \\(p_0 = 20 \\mu Pa\\)."^^qudt:LatexString ;
+  qudt:symbol "L" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Pressure Level" ;
+  rdfs:label "Sound pressure level" ;
+.
+quantitykind:SoundReductionIndex
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DeciB ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_reduction_index"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(R = 10 \\log (\\frac{1}{\\tau}) dB\\), where \\(\\tau\\) is the transmission factor."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Sound Reduction Index is used to measure the level of sound insulation provided by a structure such as a wall, window, door, or ventilator." ;
+  qudt:symbol "R" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Reduction Index" ;
+  rdfs:label "Sound reduction index" ;
+.
+quantitykind:SoundVolumeVelocity
+  a qudt:QuantityKind ;
+  dcterms:description "Sound Volume Velocity is the product of particle velocity \\(v\\) and the surface area \\(S\\) through which an acoustic wave of frequency \\(f\\) propagates. Also, the surface integral of the normal component of the sound particle velocity over the cross-section (through which the sound propagates). It is used to calculate acoustic impedance."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M3-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acoustic_impedance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q= vS\\), where \\(v\\) is sound particle velocity and \\(S\\) is the surface area through which an acoustic wave of frequence \\(f\\) propagates."^^qudt:LatexString ;
+  qudt:symbol "q" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Sound Volume Velocity" ;
+  rdfs:label "Sound volume velocity" ;
+.
+quantitykind:SourceVoltage
+  a qudt:QuantityKind ;
+  dcterms:description """\"Source Voltage}, also referred to as \\textit{Source Tension\" is the voltage between the two terminals of a voltage source when there is no
+
+electric current through the source. The name \"electromotive force} with the abbreviation \\textit{EMF\" and the symbol \\(E\\) is deprecated."""^^qudt:LatexString ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:symbol "U_s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Source Voltage" ;
+.
+quantitykind:SourceVoltageBetweenSubstances
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Source Voltage Between Substances\" is the source voltage between substance a and b." ;
+  qudt:symbol "E_{ab}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Source Voltage Between Substances" ;
+.
+quantitykind:SpecificAcousticImpedance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:N-SEC-PER-M3 ;
+  qudt:applicableUnit unit:RAYL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Acoustic Impedance" ;
+.
+quantitykind:SpecificActivity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BQ-PER-KiloGM ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Specific_activity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(a = \\frac{A}{m}\\), where \\(A\\) is the activity of a sample and \\(m\\) is its mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Specific Activity\" is the number of decays per unit time of a radioactive sample. The SI unit of radioactive activity is the becquerel (Bq), in honor of the scientist Henri Becquerel." ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Activity" ;
+  skos:broader quantitykind:Activity ;
+.
+quantitykind:SpecificEnergy
+  a qudt:QuantityKind ;
+  dcterms:description """\\(\\textbf{Specific Energy}\\) is defined as the energy per unit mass. Common metric units are \\(J/kg\\). It is an intensive property. Contrast this with energy, which is an extensive property. There are two main types of specific energy: potential energy and specific kinetic energy. Others are the \\(\\textbf{gray}\\) and \\(\\textbf{sievert}\\), which are measures for the absorption of radiation.
+The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property, which is symbolized by a capital letter. For example, the extensive thermodynamic property enthalpy is symbolized by \\(H\\); specific enthalpy is symbolized by \\(h\\)."""^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT-PER-LB_M ;
+  qudt:applicableUnit unit:BTU_TH-PER-LB_M ;
+  qudt:applicableUnit unit:CAL_IT-PER-G ;
+  qudt:applicableUnit unit:CAL_TH-PER-G ;
+  qudt:applicableUnit unit:ERG-PER-G ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:applicableUnit unit:KiloCAL-PER-GM ;
+  qudt:baseUnitDimensions "L^2/T^2" ;
+  qudt:baseUnitDimensions "m^2/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Specific_energy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Enthalpy"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Specific_energy"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(e = E/m\\), where \\(E\\) is energy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:symbol "e" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Energy" ;
+  rdfs:seeAlso quantitykind:Enthalpy ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  rdfs:seeAlso unit:GRAY ;
+  rdfs:seeAlso unit:SV ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificEnergyImparted
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:GRAY ;
+  qudt:informativeReference "http://www.answers.com/topic/energy-imparted"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "For ionizing radiation, \\(z = \\frac{\\varepsilon}{m}\\), where \\(\\varepsilon\\) is the energy imparted to irradiated matter and \\(m\\) is the mass of that matter."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Specific Energy Imparted\", is the energy imparted to an element of irradiated matter divided by the mass, dm, of that element." ;
+  qudt:symbol "z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Energy Imparted" ;
+  skos:broader quantitykind:SpecificEnergy ;
+.
+quantitykind:SpecificEnthalpy
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textit{Specific Enthalpy}\\) is enthalpy per mass of substance involved. Specific enthalpy is denoted by a lower case h, with dimension of energy per mass (SI unit: joule/kg). In thermodynamics, \\(\\textit{enthalpy}\\) is the sum of the internal energy U and the product of pressure p and volume V of a system: \\(H = U + pV\\).  The internal energy U and the work term pV have dimension of energy, in SI units this is joule; the extensive (linear in size) quantity H has the same dimension."^^rdf:HTML ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Entropy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Enthalpy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(h = H/m\\), where \\(H\\) is enthalpy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:symbol "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Enthalpy" ;
+  rdfs:seeAlso quantitykind:Enthalpy ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificEntropy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Entropy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(s = S/m\\), where \\(S\\) is entropy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Specific Entropy\" is entropy per unit of mass." ;
+  qudt:symbol "s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Entropy" ;
+  rdfs:seeAlso quantitykind:Entropy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificGibbsEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Enthalpy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(g = G/m\\), where \\(G\\) is Gibbs energy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is \"Specific Gibbs Energy}, which is \\textit{Gibbs Energy} per mass of substance involved. \\textit{Specific Gibbs Energy\" is denoted by a lower case g, with dimension of energy per mass (SI unit: joule/kg)." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Gibbs Energy" ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificHeatCapacity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-PER-LB_M-DEG_F ;
+  qudt:applicableUnit unit:BTU_IT-PER-LB_M-DEG_R ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K ;
+  qudt:applicableUnit unit:KiloCAL-PER-GM-DEG_C ;
+  qudt:baseUnitDimensions "L^2/\\Theta \\cdot T^2" ;
+  qudt:baseUnitDimensions "m^2/K \\cdot s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Specific_heat_capacity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0> ;
+  qudt:informativeReference "http://www.taftan.com/thermodynamics/CP.HTM"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Specific Heat Capacity} of a solid or liquid is defined as the heat required to raise unit mass of substance by one degree of temperature. This is \\textit{Heat Capacity} divied by \\textit{Mass\". Note that there are corresponding molar quantities." ;
+  qudt:symbol "c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Capacity" ;
+  rdfs:seeAlso quantitykind:HeatCapacity ;
+  rdfs:seeAlso quantitykind:Mass ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantPressure ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantVolume ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtSaturation ;
+.
+quantitykind:SpecificHeatCapacityAtConstantPressure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K-PA ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0> ;
+  qudt:plainTextDescription "Specific heat at a constant pressure." ;
+  qudt:symbol "c_p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Capacity at Constant Pressure" ;
+  rdfs:label "Specific heat capacity at constant pressure" ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacity ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantVolume ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtSaturation ;
+.
+quantitykind:SpecificHeatCapacityAtConstantVolume
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K-M3 ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0> ;
+  qudt:plainTextDescription "Specific heat per constant volume." ;
+  qudt:symbol "c_v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Capacity at Constant Volume" ;
+  rdfs:label "Specific heat capacity at constant volume" ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacity ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantPressure ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtSaturation ;
+.
+quantitykind:SpecificHeatCapacityAtSaturation
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H-1T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:plainTextDescription "Specific heat per constant volume." ;
+  qudt:symbol "c_{sat}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Capacity at Saturation" ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacity ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantPressure ;
+  rdfs:seeAlso quantitykind:SpecificHeatCapacityAtConstantVolume ;
+.
+quantitykind:SpecificHeatPressure
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K-PA ;
+  qudt:baseUnitDimensions "L^3/\\Theta \\cdot M" ;
+  qudt:baseUnitDimensions "m^3/K \\cdot kg" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M-1H-1T0D0> ;
+  qudt:plainTextDescription "Specific heat at a constant pressure." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Pressure" ;
+.
+quantitykind:SpecificHeatVolume
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM-K-M3 ;
+  qudt:baseUnitDimensions "/K \\cdot m \\cdot s^2" ;
+  qudt:baseUnitDimensions "/\\Theta \\cdot L \\cdot T^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M0H-1T-2D0> ;
+  qudt:plainTextDescription "Specific heat per constant volume." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heat Volume" ;
+.
+quantitykind:SpecificHeatsRatio
+  a qudt:QuantityKind ;
+  dcterms:description "The ratio of specific heats, for the exhaust gases adiabatic gas constant, is the relative amount of compression/expansion energy that goes into temperature \\(T\\) versus pressure \\(P\\) can be characterized by the heat capacity ratio: \\(\\gamma\\frac{C_P}{C_V}\\), where \\(C_P\\) is the specific heat (also called heat capacity) at constant pressure, while \\(C_V\\) is the specific heat at constant volume. "^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Heats Ratio" ;
+.
+quantitykind:SpecificHelmholtzEnergy
+  a qudt:QuantityKind ;
+  dcterms:description "Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is \\(\\textit{Specific Helmholtz Energy}\\), which is \\(\\textit{Helmholz Energy}\\) per mass of substance involved.\\( \\textit{Specific Helmholz Energy}\\) is denoted by a lower case u, with dimension of energy per mass (SI unit: joule/kg)."^^rdf:HTML ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Enthalpy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(a = A/m\\), where \\(A\\) is Helmholtz energy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Helmholtz Energy" ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificInternalEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificImpulse
+  a qudt:QuantityKind ;
+  dcterms:description "The impulse produced by a rocket divided by the mass \\(mp\\) of propellant consumed. Specific impulse \\({I_{sp}}\\) is a widely used measure of performance for chemical, nuclear, and electric rockets. It is usually given in seconds for both U.S. Customary and International System (SI) units.  The impulse produced by a rocket is the thrust force \\(F\\) times its duration \\(t\\) in seconds. \\(I_{sp}\\) is the thrust per unit mass flowrate, but with \\(g_o\\), is the thrust per weight flowrate. The specific impulse is given by the equation: \\(I_{sp} = \\frac{F}{\\dot{m}g_o}\\)."^^qudt:LatexString ;
+  qudt:informativeReference "http://www.grc.nasa.gov/WWW/K-12/airplane/specimp.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Impulse" ;
+  rdfs:seeAlso quantitykind:MassFlowRate ;
+.
+quantitykind:SpecificImpulseByMass
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Impulse by Mass" ;
+  skos:broader quantitykind:LinearVelocity ;
+.
+quantitykind:SpecificImpulseByWeight
+  a qudt:QuantityKind ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Impulse by Weight" ;
+  skos:broader quantitykind:SpecificImpulse ;
+  skos:broader quantitykind:Time ;
+.
+quantitykind:SpecificInternalEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-KiloGM ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.citizendium.org/wiki/Enthalpy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(u = U/m\\), where \\(U\\) is thermodynamic energy and \\(m\\) is mass."^^qudt:LatexString ;
+  qudt:plainTextDescription "Energy has corresponding intensive (size-independent) properties for pure materials. A corresponding intensive property is specific internal energy, which is energy per mass of substance involved. Specific internal energy is denoted by a lower case u, with dimension of energy per mass (SI unit: joule/kg)." ;
+  qudt:symbol "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Internal Energy" ;
+  rdfs:seeAlso quantitykind:InternalEnergy ;
+  rdfs:seeAlso quantitykind:MassieuFunction ;
+  rdfs:seeAlso quantitykind:PlanckFunction ;
+  rdfs:seeAlso quantitykind:SpecificEnergy ;
+  rdfs:seeAlso quantitykind:SpecificEnthalpy ;
+  rdfs:seeAlso quantitykind:SpecificGibbsEnergy ;
+  rdfs:seeAlso quantitykind:SpecificHelmholtzEnergy ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:SpecificOpticalRotatoryPower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:RAD-M2-PER-KiloGM ;
+  qudt:informativeReference "http://goldbook.iupac.org/O04313.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_m = \\alpha \\frac{A}{m}\\), where \\(\\alpha\\) is the angle of optical rotation, and \\(m\\) is the mass of the optically active component in the path of a linearly polarized light beam of cross sectional area \\(A\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_m\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Specific Optical Rotatory Power\" Angle of optical rotation divided by the optical path length through the medium and by the mass concentration of the substance giving the specific optical rotatory power." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Optical Rotatory Power" ;
+.
+quantitykind:SpecificThrust
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Specific_thrust"^^xsd:anyURI ;
+  qudt:id "Q-160-100" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Specific_thrust"^^xsd:anyURI ;
+  qudt:plainTextDescription "Specific impulse (usually abbreviated Isp) is a way to describe the efficiency of rocket and jet engines. It represents the force with respect to the amount of propellant used per unit time.[1] If the \"amount\" of propellant is given in terms of mass (such as kilograms), then specific impulse has units of velocity. If it is given in terms of Earth-weight (such as kiloponds), then specific impulse has units of time. The conversion constant between the two versions of specific impulse is g. The higher the specific impulse, the lower the propellant flow rate required for a given thrust, and in the case of a rocket the less propellant is needed for a given delta-v per the Tsiolkovsky rocket equation." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific thrust" ;
+  rdfs:seeAlso quantitykind:SpecificImpulse ;
+.
+quantitykind:SpecificVolume
+  a qudt:QuantityKind ;
+  dcterms:description "\"Specific Volume\" (\\(\\nu\\)) is the volume occupied by a unit of mass of a material. It is equal to the inverse of density."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M3-PER-KiloGM ;
+  qudt:baseUnitDimensions "L^3/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M-1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Specific_volume"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(sv = \\frac{1}{\\rho}\\), where \\(\\rho\\) is mass density."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Specific Volume" ;
+  rdfs:seeAlso quantitykind:Density ;
+.
+quantitykind:SpectralAngularCross-Section
+  a qudt:QuantityKind ;
+  dcterms:description "\"Spectral Angular Cross-section\" is the cross-section for ejecting or scattering a particle into an elementary cone with energy \\(E\\) in an energy interval, divided by the solid angle \\(d\\Omega\\) of that cone and the range \\(dE\\) of that interval."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M2-PER-J ;
+  qudt:applicableUnit unit:M2-PER-SR-J ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sigma = \\int \\int \\sigma_{\\Omega,E} d\\Omega dE\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma_{\\Omega, E}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spectral Angular Cross-section" ;
+  skos:broader quantitykind:CrossSection ;
+  skos:closeMatch quantitykind:AngularCross-Section ;
+  skos:closeMatch quantitykind:SpectralCross-Section ;
+.
+quantitykind:SpectralCross-Section
+  a qudt:QuantityKind ;
+  dcterms:description "\"Spectral Cross-section\" is the cross-section for a process in which the energy of the ejected or scattered particle is in an interval of energy, divided by the range \\(dE\\) of this interval."^^qudt:LatexString ;
+  qudt:applicableUnit unit:M2-PER-J ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cross_section_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\sigma = \\int \\sigma_E dE\\)"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma_E\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spectral Cross-section" ;
+  skos:broader quantitykind:CrossSection ;
+  skos:closeMatch quantitykind:AngularCross-Section ;
+.
+quantitykind:SpectralLuminousEfficiency
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LM-PER-W ;
+  qudt:latexDefinition "\\(V(\\lambda) = \\frac{\\Phi_\\lambda(\\lambda_m)}{\\Phi_\\lambda(\\lambda)}\\), where \\(\\Phi_\\lambda(\\lambda_m)\\) is the spectral radiant flux at wavelength \\(\\lambda_m\\) and \\(\\Phi_\\lambda(\\lambda)\\) is the spectral radiant flux at wavelength \\(\\lambda\\), such that both radiations produce equal luminous sensations under specified photometric conditions and \\(\\lambda_m\\) is chosen so that the maximum value of this ratio is equal to 1."^^qudt:LatexString ;
+  qudt:plainTextDescription "The Spectral Luminous Efficiency is a measure of how well a light source produces visible light. It is the ratio of luminous flux to power. A common choice is to choose units such that the maximum possible efficacy, 683 lm/W, corresponds to an efficiency of 100%." ;
+  qudt:symbol "V" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spectral Luminous Efficiency" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Luminous_efficacy> ;
+.
+quantitykind:SpectralRadiantEnergyDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M4 ;
+  qudt:expression "\\(M-PER-L2-T2\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T-2D0> ;
+  qudt:plainTextDescription "\"Spectral Radiant Energy Density\" is the spectral concentration of radiant energy density (in terms of wavelength), or the spectral radiant energy density (in terms of wave length)." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spectral Radiant Energy Density" ;
+  skos:broader quantitykind:Power ;
+.
+quantitykind:Speed
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Speed"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:plainTextDescription "Speed is the magnitude of velocity." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Speed" ;
+.
+quantitykind:SpeedOfLight
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textbf{Speed of Light}\\) is the speed of electomagnetic waves in vacuum and has the value \\(2.99792458e8\\, M/Sec\\)\"."^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Speed_of_light"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=113-01-34"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c_0 = 1 / \\sqrt{\\epsilon_0 \\mu_0}\\), where {\\epsilon_0} is the permittivity of vacuum, and \\(\\mu_0\\) is the magnetic constant."^^qudt:LatexString ;
+  qudt:quantityValue quantitykind:SpeedOfLight ;
+  qudt:symbol "C_0" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Speed of Light" ;
+  rdfs:seeAlso constant:MagneticConstant ;
+  rdfs:seeAlso constant:PermittivityOfVacuum ;
+.
+quantitykind:SpeedOfSound
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M-PER-SEC ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Speed_of_sound"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Speed_of_sound"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(c = \\sqrt{\\frac{K}{\\rho}}\\), where \\(K\\) is the coefficient of stiffness, the bulk modulus (or the modulus of bulk elasticity for gases), and \\(\\rho\\) is the density. Also, \\(c^2 = \\frac{\\partial p}{\\partial \\rho}\\), where \\(p\\) is the pressure and \\(\\rho\\) is the density."^^qudt:LatexString ;
+  qudt:plainTextDescription "The speed of sound is the distance travelled during a unit of time by a sound wave propagating through an elastic medium." ;
+  qudt:symbol "c" ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Speed of Sound" ;
+  rdfs:label "Speed of sound" ;
+.
+quantitykind:SphericalIlluminance
+  a qudt:QuantityKind ;
+  dcterms:description "Spherical illuminance is equal to quotient of the total luminous flux \\(\\Phi_v\\) incident on a small sphere by the cross section area of that sphere."^^qudt:LatexString ;
+  qudt:latexDefinition "\\(E_v,0 = \\int_{4\\pi sr}{L_v}{d\\Omega}\\), where \\(d\\Omega\\) is the solid angle of each elementary beam passing through the given point and \\(L_v\\) is its luminance at that point in the direction of the beam."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Illuminance" ;
+  skos:broader quantitykind:Illuminance ;
+  skos:exactMatch <http://eilv.cie.co.at/term/1245> ;
+.
+quantitykind:SpinQuantumNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(s^2 = \\hbar^2 s(s + 1)\\), where \\(s\\) is the spin quantum number and \\(\\hbar\\) is the Planck constant."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Spin Quantum Number\"  describes the spin (intrinsic angular momentum) of the electron within that orbital, and gives the projection of the spin angular momentum S along the specified axis" ;
+  qudt:symbol "s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Spin Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+  skos:closeMatch quantitykind:MagneticQuantumNumber ;
+  skos:closeMatch quantitykind:OrbitalAngularMomentumQuantumNumber ;
+  skos:closeMatch quantitykind:PrincipalQuantumNumber ;
+.
+quantitykind:SquareEnergy
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "L^4 \\cdot M^2/T^4" ;
+  qudt:baseUnitDimensions "kg^2 \\cdot m^4/s^4" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L4I0M2H0T-4D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Square Energy" ;
+.
+quantitykind:StagePropellantMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stage Propellant Mass" ;
+.
+quantitykind:StageStructuralMass
+  a qudt:QuantityKind ;
+  qudt:symbol "M_S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stage Structure Mass" ;
+.
+quantitykind:StandardAbsoluteActivity
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Standard Absolute Activity\" is proportional to the absoulte activity of the pure substance \\(B\\) at the same temperature and pressure multiplied by the standard pressure."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Activity_coefficient"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\lambda_B^\\Theta = \\lambda_B^*(p^\\Theta)\\), where \\(\\lambda_B^\\Theta\\) the absolute activity of the pure substance \\(B\\) at the same temperature and pressure, and \\(p^\\Theta\\) is standard pressure."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\lambda_B^\\Theta\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Standard Absolute Activity" ;
+.
+quantitykind:StandardChemicalPotential
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-MOL ;
+  qudt:expression "\\(j-mol^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A-1E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Chemical_potential"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu_B^\\Theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Standard Chemical Potential\" is the value of the chemical potential at standard conditions" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Standard Chemical Potential" ;
+  skos:broader quantitykind:ChemicalPotential ;
+.
+quantitykind:StandardGravitationalParameter
+  a qudt:QuantityKind ;
+  dcterms:description "In celestial mechanics the standard gravitational parameter of a celestial body is the product of the gravitational constant G and the mass M of the body. Expressed as \\(\\mu = G \\cdot M\\). The SI units of the standard gravitational parameter are \\(m^{3}s^{-2}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:KiloM3-PER-SEC2 ;
+  qudt:applicableUnit unit:M3-PER-SEC2 ;
+  qudt:baseUnitDimensions "L^3/T^2" ;
+  qudt:baseUnitDimensions "m^3/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Standard_gravitational_parameter"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Standard_gravitational_parameter"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Standard Gravitational Parameter" ;
+.
+quantitykind:StaticFriction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Friction"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Friction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\mu = \\frac{F_max}{N}\\), where \\(F_max\\) is the maximum tangential component of the contact force and \\(N\\) is the normal component of the contact force between two bodies at relative rest."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Static friction is friction between two or more solid objects that are not moving relative to each other. For example, static friction can prevent an object from sliding down a sloped surface. " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Static Friction" ;
+  skos:broader quantitykind:Friction ;
+.
+quantitykind:StatisticalWeight
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Statistical_weight"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:plainTextDescription "A \"Statistical Weight\" is the relative probability (possibly unnormalized) of a particular feature of a state." ;
+  qudt:symbol "g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Statistical Weight" ;
+.
+quantitykind:StochasticProcess
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Stochastic_process"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stochastic_process"^^xsd:anyURI ;
+  qudt:plainTextDescription "In probability theory, a stochastic process, or sometimes random process  is a collection of random variables; this is often used to represent the evolution of some random value, or system, over time. This is the probabilistic counterpart to a deterministic process (or deterministic system)." ;
+  qudt:symbol "X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stochastic Process" ;
+  skos:broader quantitykind:Frequency ;
+.
+quantitykind:StoichiometricNumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stoichiometry"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\nu_B\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Chemical reactions, as macroscopic unit operations, consist of simply a very large number of elementary reactions, where a single molecule reacts with another molecule. As the reacting molecules (or moieties) consist of a definite set of atoms in an integer ratio, the ratio between reactants in a complete reaction is also in integer ratio. A reaction may consume more than one molecule, and the \"Stoichiometric Number\" counts this number, defined as positive for products (added) and negative for reactants (removed)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stoichiometric Number" ;
+.
+quantitykind:Strain
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Strain"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\epsilon\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In any branch of science dealing with materials and their behaviour, strain is the geometrical expression of deformation caused by the action of stress on a physical body. Strain is calculated by first assuming a change between two body states: the beginning state and the final state. Then the difference in placement of two points in this body in those two states expresses the numerical value of strain. Strain therefore expresses itself as a change in size and/or shape. [Wikipedia]" ;
+  qudt:url "http://www.freestudy.co.uk/mech%20prin%20h2/stress.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Strain" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:StrainEnergyDensity
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Defined as the 'work done' for a given strain, that is the area under the stress-strain curve after a specified eation. Source(s): \\href{http://www.prepol.com/product-range/product-subpages/terminology}{www.prepol.com}" ;
+  qudt:symbol "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Strain Energy Density" ;
+  skos:broader quantitykind:EnergyDensity ;
+.
+quantitykind:Stress
+  a qudt:QuantityKind ;
+  dcterms:description "Stress is a measure of the average amount of force exerted per unit area of a surface within a deformable body on which internal forces act. In other words, it is a measure of the intensity or internal distribution of the total internal forces acting within a deformable body across imaginary surfaces. These internal forces are produced between the particles in the body as a reaction to external forces applied on the body. Stress is defined as \\({\\rm{Stress}} = \\frac{F}{A}\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BARAD ;
+  qudt:latexDefinition "{\\rm{Stress}} = \\frac{F}{A}"^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  qudt:url "http://www.freestudy.co.uk/mech%20prin%20h2/stress.pdf"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Stress" ;
+  skos:broader quantitykind:ForcePerArea ;
+.
+quantitykind:StructuralEfficiency
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\gamma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Structural efficiency is a function of the weight of structure to the afforded vehicle's strength." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Structural Efficiency" ;
+.
+quantitykind:StructureFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Structure_factor"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(F(h, k, l) = \\sum_{n=1}^N f_n\\exp{[2\\pi i(hx_n + ky_n +lz_n)]}\\), where \\(f_n\\) is the atomic scattering factor for atom \\(n\\), and \\(x_n\\), \\(y_n\\), and \\(z_n\\) are fractional coordinates in the unit cell; for \\(h\\), \\(k\\), and \\(l\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Structure Factor\" is a mathematical description of how a material scatters incident radiation." ;
+  qudt:symbol "F(h, k, l)" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Structure Factor" ;
+.
+quantitykind:SuperconductionTransitionTemperature
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Superconductivity"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Superconduction Transition Temperature\" is the critical thermodynamic temperature of a superconductor." ;
+  qudt:symbol "T_c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Superconduction Transition Temperature" ;
+  skos:closeMatch quantitykind:CurieTemperature ;
+  skos:closeMatch quantitykind:NeelTemperature ;
+.
+quantitykind:SurfaceActivityDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BQ-PER-M2 ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(a_s = \\frac{A}{S}\\), where \\(S\\) is the total area of the surface of a sample and \\(A\\) is its activity."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Surface Activity Density\" is undefined." ;
+  qudt:symbol "a_s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Surface Activity Density" ;
+.
+quantitykind:SurfaceCoefficientOfHeatTransfer
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-M2-K ;
+  qudt:expression "\\(surface-heat-xfer-coeff\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H-1T-3D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q = h (T_s - T_r)\\), where \\(T_s\\) is areic heat flow rate is the thermodynamic temperature of the surface, and is a reference thermodynamic temperature characteristic of the adjacent surroundings."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Surface Coefficient of Heat Transfer" ;
+.
+quantitykind:SurfaceDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:KiloGM-PER-M2 ;
+  qudt:baseUnitDimensions "kg m^{-2}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M1H0T0D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Area_density"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\rho_A = \\frac{dm}{dA}\\), where \\(m\\) is mass and \\(A\\) is area."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\rho_A\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "The area density (also known as areal density, surface density, or superficial density) of a two-dimensional object is calculated as the mass per unit area." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Surface Density" ;
+  skos:broader quantitykind:Density ;
+.
+quantitykind:Susceptance
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Susceptance"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Susceptance?oldid=430151986"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-12-54"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(B = \\lim{\\underline{Y}}\\), where \\(\\underline{Y}\\) is admittance."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Susceptance\" is the imaginary part of admittance. The inverse of admittance is impedance and the real part of admittance is conductance. " ;
+  qudt:symbol "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Susceptance" ;
+  rdfs:seeAlso quantitykind:Conductance ;
+  rdfs:seeAlso quantitykind:Impedance ;
+.
+quantitykind:TARGET-BOGIE-MASS
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "An informal mass limit established by a Project Office (at the Element Integrated Product Team (IPT) level or below) to control mass." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Target Bogie Mass"^^rdfs:Literal ;
+  skos:broader quantitykind:Mass ;
+.
+quantitykind:Temperature
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Temperature"^^xsd:anyURI ;
+  qudt:plainTextDescription "Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold. Objects of low temperature are cold, while various degrees of higher temperatures are referred to as warm or hot. Heat spontaneously flows from bodies of a higher temperature to bodies of lower temperature, at a rate that increases with the temperature difference and the thermal conductivity." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temperature" ;
+  rdfs:seeAlso <http://en.wikipedia.org/wiki/Temperature#Temperature_scales> ;
+.
+quantitykind:TemperatureAmountOfSubstance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:MOL-DEG_C ;
+  qudt:applicableUnit unit:MOL-K ;
+  qudt:baseUnitDimensions "K \\cdot mol" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A1E0L0I0M0H1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temperature Amount of Substance" ;
+.
+quantitykind:TemperaturePerMagneticFluxDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:K-PER-T ;
+  qudt:baseUnitDimensions "A \\cdot K \\cdot s^2/kg" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot I \\cdot T^2/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E1L0I0M-1H1T2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temperature per Magnetic Flux Density" ;
+.
+quantitykind:TemperaturePerTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG_C-PER-HR ;
+  qudt:applicableUnit unit:DEG_C-PER-MIN ;
+  qudt:applicableUnit unit:DEG_C-PER-SEC ;
+  qudt:applicableUnit unit:DEG_F-PER-HR ;
+  qudt:applicableUnit unit:DEG_F-PER-MIN ;
+  qudt:applicableUnit unit:DEG_F-PER-SEC ;
+  qudt:applicableUnit unit:DEG_R-PER-HR ;
+  qudt:applicableUnit unit:DEG_R-PER-MIN ;
+  qudt:applicableUnit unit:DEG_R-PER-SEC ;
+  qudt:applicableUnit unit:K-PER-HR ;
+  qudt:applicableUnit unit:K-PER-MIN ;
+  qudt:applicableUnit unit:K-PER-SEC ;
+  qudt:baseUnitDimensions "K/s" ;
+  qudt:baseUnitDimensions "\\Theta/T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temperature per Time" ;
+.
+quantitykind:TemperatureRatio
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temperature Ratio" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:TemporalSummationFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-SEC-SR ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Temporal Summation Function\" is the ability of the human eye to produce a composite signal from the signals coming into an eye during a short time interval." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Temporal Summation Function" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Summation_(neurophysiology)#Temporal_summation> ;
+.
+quantitykind:Tension
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tension"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Tension" ;
+  skos:broader quantitykind:ForceMagnitude ;
+.
+quantitykind:ThermalConductance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:W-PER-K ;
+  qudt:exactMatch quantitykind:CoefficientOfHeatTransfer ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H-1T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_insulation"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(G = 1/R\\), where \\(R\\) is \"Thermal Resistance\""^^qudt:LatexString ;
+  qudt:plainTextDescription "This quantity is also called \"Heat Transfer Coefficient\"." ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Conductance" ;
+  rdfs:seeAlso quantitykind:CoefficientOfHeatTransfer ;
+.
+quantitykind:ThermalConductivity
+  a qudt:QuantityKind ;
+  dcterms:description "In physics, thermal conductivity, \\(k\\) (also denoted as \\(\\lambda\\)), is the property of a material's ability to conduct heat. It appears primarily in Fourier's Law for heat conduction and is the areic heat flow rate divided by temperature gradient."^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT-FT-PER-FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:BTU_IT-IN-PER-FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:BTU_IT-IN-PER-FT2-SEC-DEG_F ;
+  qudt:applicableUnit unit:BTU_TH-FT-PER-FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:BTU_TH-IN-PER-FT2-HR-DEG_F ;
+  qudt:applicableUnit unit:BTU_TH-IN-PER-FT2-SEC-DEG_F ;
+  qudt:applicableUnit unit:KiloCAL-PER-CentiM-SEC-DEG_C ;
+  qudt:applicableUnit unit:W-PER-M-K ;
+  qudt:baseUnitDimensions "L \\cdot M/\\Theta \\cdot T^3" ;
+  qudt:baseUnitDimensions "kg \\cdot m/K \\cdot s^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:expression "\\(thermal-k\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M1H-1T-3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\lambda = \\frac{\\varphi}{T}\\), where \\(\\varphi\\) is areic heat flow rate and \\(T\\) is temperature gradient."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\lambda\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Conductivity" ;
+.
+quantitykind:ThermalDiffusionFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.thermopedia.com/content/1189/"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\alpha_T = \\frac{k_T}{(x_A x_B)}\\), where \\(k_T\\) is the thermal diffusion ratio, and \\(x_A\\) and \\(x_B\\) are the local amount-of-substance fractions of the two substances \\(A\\) and \\(B\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha_T\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Thermal diffusion is a phenomenon in which a temperature gradient in a mixture of fluids gives rise to a flow of one constituent relative to the mixture as a whole. in the context of the equation that describes thermal diffusion, the \"Thermal Diffusion Factor\" is ." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Diffusion Factor" ;
+.
+quantitykind:ThermalDiffusionRatio
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://www.thermopedia.com/content/1189/"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "In a steady state of a binary mixture in which thermal diffusion occurs, \\(grad x_B  = -(\\frac{k_T}{T}) grad T\\), where \\(x_B\\) is the amount-of-substance fraction of the heavier substance \\(B\\), and \\(T\\) is the local thermodynamic temperature."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Thermal Diffusion Ratio\" is proportional to the product of the component concentrations." ;
+  qudt:symbol "k_T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Diffusion Ratio" ;
+.
+quantitykind:ThermalDiffusionRatioCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  qudt:informativeReference "http://www.thermopedia.com/content/1189/"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(D_T  = kT \\cdot D\\), where \\(k_T\\) is the thermal diffusion ratio, and \\(D\\) is the diffusion coefficient."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Thermal Diffusion Coefficient\" is ." ;
+  qudt:symbol "D_T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Diffusion Coefficient" ;
+.
+quantitykind:ThermalDiffusivity
+  a qudt:QuantityKind ;
+  dcterms:description "In heat transfer analysis, thermal diffusivity (usually denoted \\(\\alpha\\) but \\(a\\), \\(\\kappa\\),\\(k\\), and \\(D\\) are also used) is the thermal conductivity divided by density and specific heat capacity at constant pressure. The formula is: \\(\\alpha = {k \\over {\\rho c_p}}\\), where k is thermal conductivity (\\(W/(\\mu \\cdot K)\\)), \\(\\rho\\) is density (\\(kg/m^{3}\\)), and \\(c_p\\) is specific heat capacity (\\(\\frac{J}{(kg \\cdot K)}\\)) .The denominator \\(\\rho c_p\\), can be considered the volumetric heat capacity (\\(\\frac{J}{(m^{3} \\cdot K)}\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:FT2-PER-HR ;
+  qudt:applicableUnit unit:M2-PER-SEC ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_diffusivity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_diffusivity"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(a = \\frac{\\lambda}{\\rho   c_\\rho}\\), where \\(\\lambda\\) is thermal conductivity, \\(\\rho\\) is mass density and \\(c_\\rho\\) is specific heat capacity at constant pressure."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\alpha\\)"^^qudt:LatexString ;
+  qudt:symbol "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Diffusivity" ;
+  rdfs:seeAlso <http://no-valid-base-found.com/> ;
+  skos:broader quantitykind:AreaPerTime ;
+.
+quantitykind:ThermalEfficiency
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_efficiency"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:plainTextDescription "Thermal efficiency is a dimensionless performance measure of a thermal device such as an internal combustion engine, a boiler, or a furnace. The input to the device is heat, or the heat-content of a fuel that is consumed. The desired output is mechanical work, or heat, or possibly both." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Efficiency" ;
+  skos:broader quantitykind:DimensionlessRatio ;
+.
+quantitykind:ThermalEnergy
+  a qudt:QuantityKind ;
+  dcterms:description "\"Thermal Energy} is the portion of the thermodynamic or internal energy of a system that is responsible for the temperature of the system. From a macroscopic thermodynamic description, the thermal energy of a system is given by its constant volume specific heat capacity C(T), a temperature coefficient also called thermal capacity, at any given absolute temperature (T): \\(U_{thermal\" = C(T) \\cdot T\\). "^^qudt:LatexString ;
+  qudt:applicableUnit unit:BTU_IT ;
+  qudt:applicableUnit unit:BTU_TH ;
+  qudt:applicableUnit unit:CAL_IT ;
+  qudt:applicableUnit unit:CAL_TH ;
+  qudt:applicableUnit unit:KiloCAL ;
+  qudt:applicableUnit unit:THM_EEC ;
+  qudt:applicableUnit unit:THM_US ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_energy"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_energy"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Energy" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:ThermalEnergyLength
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:BTU_IT-FT ;
+  qudt:applicableUnit unit:BTU_IT-IN ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M1H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Energy Length" ;
+.
+quantitykind:ThermalInsulance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Thermal Insulation} is the reduction of heat transfer (the transfer of thermal energy between objects of differing temperature) between objects in thermal contact or in range of radiative influence. In building technology, this quantity is often called \\textit{Thermal Resistance\", with the symbol \\(R\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:CLO ;
+  qudt:applicableUnit unit:FT2-HR-DEG_F-PER-BTU_IT ;
+  qudt:applicableUnit unit:M2-K-PER-W ;
+  qudt:baseUnitDimensions "K \\cdot s^3/kg" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot T^3/M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M-1H1T3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_insulation"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(M = 1/K\\), where \\(K\\) is \"Coefficient of Heat Transfer\""^^qudt:LatexString ;
+  qudt:symbol "M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Insulance" ;
+  rdfs:seeAlso quantitykind:CoefficientOfHeatTransfer ;
+.
+quantitykind:ThermalResistance
+  a qudt:QuantityKind ;
+  dcterms:description "\"Thermal Resistance} is a heat property and a measure of a temperature difference by which an object or material resists a heat flow (heat per time unit or thermal resistance). Thermal resistance is the reciprocal thermal conductance. the thermodynamic temperature difference divided by heat flow rate. Thermal resistance \\(R\\) has the units \\(\\frac{m^2 \\cdot K}{W\"\\). "^^qudt:LatexString ;
+  qudt:applicableUnit unit:DEG_F-HR-PER-BTU_IT ;
+  qudt:applicableUnit unit:K-PER-W ;
+  qudt:baseUnitDimensions "K \\cdot s^3/kg \\cdot m^2" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot T^3/L^2 \\cdot M" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thermal_resistance"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-2I0M-1H1T3D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_resistance"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:symbol "R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Resistance" ;
+  rdfs:seeAlso quantitykind:HeatFlowRate ;
+  rdfs:seeAlso quantitykind:ThermalInsulance ;
+  rdfs:seeAlso quantitykind:ThermodynamicTemperature ;
+.
+quantitykind:ThermalResistivity
+  a qudt:QuantityKind ;
+  dcterms:description "The reciprocal of thermal conductivity is thermal resistivity, measured in \\(kelvin-metres\\) per watt (\\(K \\cdot m/W\\))."^^qudt:LatexString ;
+  qudt:applicableUnit unit:DEG_F-HR ;
+  qudt:applicableUnit unit:FT2-PER-BTU_IT-IN ;
+  qudt:applicableUnit unit:M-K-PER-W ;
+  qudt:baseUnitDimensions "K \\cdot s^3/kg \\cdot m" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot T^3/L \\cdot M" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M-1H1T3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Resistivity" ;
+.
+quantitykind:ThermalUtilizationFactor
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Four_factor_formula"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The \"Thermal Utilization Factor\" in an infinite medium, is the ratio of the number of thermal absorbed in a fissionable nuclide or in a nuclear fuel, as specified, to the total number of thermal neutrons absorbed." ;
+  qudt:symbol "f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Utilization Factor" ;
+.
+quantitykind:ThermalUtilizationFactorForFission
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "Probability that a neutron that gets absorbed does so in the fuel material." ;
+  qudt:symbol "f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermal Utilization Factor For Fission" ;
+.
+quantitykind:ThermodynamicCriticalMagneticFluxDensity
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(G_n - G_s = \\frac{1}{2}\\frac{B_c^2 \\cdot V}{\\mu_0}\\), where \\(G_n\\) and \\(G_s\\) are the Gibbs energies at zero magnetic flux density in a normal conductor and superconductor, respectively, \\(\\mu_0\\) is the magnetic constant, and \\(V\\) is volume."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Thermodynamic Critical Magnetic Flux Density\" is the " ;
+  qudt:symbol "B_c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermodynamic Critical Magnetic Flux Density" ;
+.
+quantitykind:ThermodynamicEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:exactMatch quantitykind:InternalEnergy ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  qudt:latexDefinition "For a closed thermodynamic system, \\(\\Delta U = Q + W\\), where \\(Q\\) is amount of heat transferred to the system and \\(W\\) is work done on the system provided that no chemical reactions occur."^^qudt:LatexString ;
+  qudt:symbol "U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermodynamic Energy" ;
+  skos:broader quantitykind:EnergyAndWork ;
+.
+quantitykind:ThermodynamicEntropy
+  a qudt:QuantityKind ;
+  dcterms:description "Thermodynamic Entropy is a measure of the unavailability of a system’s energy to do work. It is a measure of the randomness of molecules in a system and is central to the second law of thermodynamics and the fundamental thermodynamic relation, which deal with physical processes and whether they occur spontaneously. The dimensions of entropy are energy divided by temperature, which is the same as the dimensions of Boltzmann's constant (\\(kB\\)) and heat capacity. The SI unit of entropy is \\(joule per kelvin\\). [Wikipedia]"^^qudt:LatexString ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermodynamic Entropy" ;
+  skos:broader quantitykind:EnergyPerTemperature ;
+.
+quantitykind:ThermodynamicTemperature
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DEG_F ;
+  qudt:applicableUnit unit:DEG_R ;
+  qudt:applicableUnit unit:K ;
+  qudt:applicableUnit unit:MilliDEG_C ;
+  qudt:applicableUnit unit:PlanckTemperature ;
+  qudt:baseUnitDimensions "K" ;
+  qudt:baseUnitDimensions "\\Theta" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Temperature"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+  qudt:latexSymbol "\\(\\Theta\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription """Temperature is a physical property of matter that quantitatively expresses the common notions of hot and cold.
+In thermodynamics, in a system of which the entropy is considered as an independent externally controlled variable, absolute, or thermodynamic, temperature is defined as the derivative of the internal energy with respect to the entropy. This is a base quantity in the International System of Quantities, ISQ, on which the International System of Units, SI, is based.""" ;
+  qudt:symbol "T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thermodynamic Temperature" ;
+.
+quantitykind:Thickness
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thickness"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.merriam-webster.com/dictionary/thickness"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Thickness\" is the the smallest of three dimensions: length, width, thickness." ;
+  qudt:symbol "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thickness" ;
+.
+quantitykind:ThomsonCoefficient
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:V-PER-K ;
+  qudt:informativeReference "http://www.daviddarling.info/encyclopedia/T/Thomson_effect.html"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\mu\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Thomson Coefficient\" represents Thomson heat power developed, divided by the electric current and the temperature difference." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thomson Coefficient" ;
+.
+quantitykind:Thrust
+  a qudt:QuantityKind ;
+  dcterms:description """Thrust is a reaction force described quantitatively by Newton's Second and Third Laws. When a system expels or accelerates mass in one direction the accelerated mass will cause a proportional but opposite force on that system.
+The pushing or pulling force developed by an aircraft engine or a rocket engine.
+The force exerted in any direction by a fluid jet or by a powered screw, as, the thrust of an antitorque rotor.
+(symbol F). Specifically, in rocketry, \\( F\\,= m\\cdot v\\) where m is propellant mass flow and v is exhaust velocity relative to the vehicle. Also called momentum thrust."""^^qudt:LatexString ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thrust"^^xsd:anyURI ;
+  qudt:plainTextDescription "Thrust is a reaction force described quantitatively by Newton's Second and Third Laws. When a system expels or accelerates mass in one direction the accelerated mass will cause a proportional but opposite force on that system." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thrust" ;
+  skos:broader quantitykind:Force ;
+.
+quantitykind:ThrustCoefficient
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription "The thrust force of a jet-propulsion engine per unit of frontal area per unit of incompressible dynamic pressure " ;
+  qudt:symbol "C_{F}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thrust Coefficient" ;
+.
+quantitykind:ThrustToMassRatio
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:LB_F-PER-LB_M ;
+  qudt:applicableUnit unit:N-PER-KiloGM ;
+  qudt:baseUnitDimensions "L/T^2" ;
+  qudt:baseUnitDimensions "m/s^2" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thrust To Mass Ratio" ;
+.
+quantitykind:ThrustToWeightRatio
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\psi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Thrust-to-weight ratio is a ratio of thrust to weight of a rocket, jet engine, propeller engine, or a vehicle propelled by such an engine. It is a dimensionless quantity and is an indicator of the performance of the engine or vehicle." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thrust To Weight Ratio" ;
+.
+quantitykind:ThrusterPowerToThrustEfficiency
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\eta\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Thruster Power To Thrust Efficiency" ;
+.
+quantitykind:Time
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:DAY ;
+  qudt:applicableUnit unit:DAY_Sidereal ;
+  qudt:applicableUnit unit:HR ;
+  qudt:applicableUnit unit:HR_Sidereal ;
+  qudt:applicableUnit unit:KiloSEC ;
+  qudt:applicableUnit unit:MIN ;
+  qudt:applicableUnit unit:MIN_Sidereal ;
+  qudt:applicableUnit unit:MO ;
+  qudt:applicableUnit unit:MO_MeanGREGORIAN ;
+  qudt:applicableUnit unit:MO_MeanJulian ;
+  qudt:applicableUnit unit:MO_Synodic ;
+  qudt:applicableUnit unit:MicroSEC ;
+  qudt:applicableUnit unit:MilliSEC ;
+  qudt:applicableUnit unit:NanoSEC ;
+  qudt:applicableUnit unit:PlanckTime ;
+  qudt:applicableUnit unit:SEC ;
+  qudt:applicableUnit unit:SH ;
+  qudt:applicableUnit unit:WK ;
+  qudt:applicableUnit unit:YR ;
+  qudt:applicableUnit unit:YR_Common ;
+  qudt:applicableUnit unit:YR_Sidereal ;
+  qudt:applicableUnit unit:YR_TROPICAL ;
+  qudt:baseUnitDimensions "T" ;
+  qudt:baseUnitDimensions "s" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Time"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0> ;
+  qudt:plainTextDescription "Time is a basic component of the measuring system used to sequence events, to compare the durations of events and the intervals between them, and to quantify the motions of objects." ;
+  qudt:symbol "t" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Time" ;
+.
+quantitykind:TimePercentage
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Time Percentage" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:TimeSquared
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:SEC2 ;
+  qudt:baseUnitDimensions "T^2" ;
+  qudt:baseUnitDimensions "s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Time_Squared"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T2D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Time Squared" ;
+.
+quantitykind:TimeTemperature
+  a qudt:QuantityKind ;
+  qudt:baseUnitDimensions "K \\cdot s" ;
+  qudt:baseUnitDimensions "\\Theta \\cdot T" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T1D0> ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31890"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Time Temperature" ;
+.
+quantitykind:Torque
+  a qudt:QuantityKind ;
+  dcterms:description """In physics, a torque (\\(\\tau\\)) is a vector that measures the tendency of a force to rotate an object about some axis. The magnitude of a torque is defined as force times its lever arm. Just as a force is a push or a pull, a torque can be thought of as a twist. The SI unit for torque is newton meters (\\(N m\\)). In U.S. customary units, it is measured in foot pounds (ft lbf) (also known as \"pounds feet\").
+Mathematically, the torque on a particle (which has the position r in some reference frame) can be defined as the cross product: \\(τ = r x F\\)
+where,
+r is the particle's position vector relative to the fulcrum
+F is the force acting on the particles,
+or, more generally, torque can be defined as the rate of change of angular momentum: \\(τ = dL/dt\\)
+where,
+L is the angular momentum vector
+t stands for time."""^^qudt:LatexString ;
+  qudt:applicableUnit unit:DYN-CentiM ;
+  qudt:applicableUnit unit:KiloGM_F-PER-M ;
+  qudt:applicableUnit unit:LB_F-FT ;
+  qudt:applicableUnit unit:LB_F-IN ;
+  qudt:applicableUnit unit:N-M ;
+  qudt:applicableUnit unit:OZ_F-IN ;
+  qudt:baseUnitDimensions "L^2 \\cdot M/T^2" ;
+  qudt:baseUnitDimensions "kg \\cdot m^2/s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Torque"^^xsd:anyURI ;
+  qudt:exactMatch quantitykind:MomentOfForce ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Torque"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\tau = M \\cdot e_Q\\), where \\(M\\) is the momentof force and \\(e_Q\\) is a unit vector directed along a \\(Q-axis\\) with respect to which the torque is considered."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\tau\\)"^^qudt:LatexString ;
+  qudt:url "http://en.wikipedia.org/wiki/Torque"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Torque" ;
+.
+quantitykind:TotalAngularMomentumQuantumNumber
+  a qudt:QuantityKind ;
+  dcterms:description "The \"Total Angular Quantum Number\" describes the magnitude of total angular momentum \\(J\\), where \\(j\\) refers to a specific particle and \\(J\\) is used for the whole system."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quantum_number"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:symbol "j" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Angular Momentum Quantum Number" ;
+  skos:broader quantitykind:QuantumNumber ;
+  skos:closeMatch quantitykind:MagneticQuantumNumber ;
+  skos:closeMatch quantitykind:PrincipalQuantumNumber ;
+  skos:closeMatch quantitykind:SpinQuantumNumber ;
+.
+quantitykind:TotalAtomicStoppingPower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-M2 ;
+  qudt:informativeReference "http://www.answers.com/topic/atomic-stopping-power"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S_a = \\frac{S}{n}\\), where \\(S\\) is the total linear stopping power and \\(n\\) is the number density of the atoms in the substance."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Total Atomic Stopping Power\" for an ionizing particle passing through an element, is the particle's energy loss per atom within a unit area normal to the particle's path; equal to the linear energy transfer (energy loss per unit path length) divided by the number of atoms per unit volume." ;
+  qudt:symbol "S_a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Atomic Stopping Power" ;
+.
+quantitykind:TotalCurrent
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(I_{tot}= I + I_D\\), where \\(I\\) is electric current and \\(I_D\\) is displacement current."^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Total Current\" is the sum of the electric current that is flowing through a surface and the displacement current." ;
+  qudt:symbol "I_t" ;
+  qudt:symbol "I_{tot}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Current" ;
+  rdfs:seeAlso quantitykind:DisplacementCurrent ;
+  rdfs:seeAlso quantitykind:ElectricCurrent ;
+.
+quantitykind:TotalCurrentDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:A-PER-M2 ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(J_{tot}= J + J_D\\), where \\(J\\) is electric current density and \\(J_D\\) is displacement current density."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(J_{tot}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Total Current Density\" is the sum of the electric current density and the displacement current density." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Current Density" ;
+  rdfs:seeAlso quantitykind:DisplacementCurrentDensity ;
+  rdfs:seeAlso quantitykind:ElectricCurrentDensity ;
+.
+quantitykind:TotalIonization
+  a qudt:QuantityKind ;
+  dcterms:description "\"Total Ionization\" by a particle, total mean charge, divided by the elementary charge, \\(e\\), of all positive ions produced by an ionizing charged particle along its entire path and along the paths of any secondary charged particles."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ionization#Classical_ionization"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(N = \\int N_i dl\\)."^^qudt:LatexString ;
+  qudt:symbol "N_i" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Ionization" ;
+.
+quantitykind:TotalLinearStoppingPower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stopping_power_(particle_radiation)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S = -\\frac{dE}{dx}\\), where \\(-dE\\) is the energy decrement in the \\(x-direction\\) along an elementary path with the length \\(dx\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "The \"Total Linear Stopping Power\" is defined as the average energy loss of the particle per unit path length." ;
+  qudt:symbol "S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Linear Stopping Power" ;
+.
+quantitykind:TotalMassStoppingPower
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-M2-PER-KiloGM ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stopping_power_(particle_radiation)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(S_m = \\frac{S}{\\rho}\\), where \\(S\\) is the total linear stopping power and \\(\\rho\\) is the mass density of the sample."^^qudt:LatexString ;
+  qudt:plainTextDescription "If a substance is compared in gaseous and solid form, then the linear stopping powers of the two states are very different just because of the different density. One therefore often divides S(E) by the density of the material to obtain the \"Mass Stopping Power\". The mass stopping power then depends only very little on the density of the material." ;
+  qudt:symbol "S_m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Total Mass Stopping Power" ;
+.
+quantitykind:TouchThresholds
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_t\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Touch Thresholds\" are thresholds for touch, vibration and other stimuli to the skin." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Touch Thresholds" ;
+.
+quantitykind:Transmittance
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(\\tau = \\frac{\\Phi_t}{\\Phi_m}\\), where \\(\\Phi_t\\) is the transmitted radiant flux or the transmitted luminous flux, and \\(\\Phi_m\\) is the radiant flux or luminous flux of the incident radiation."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\tau, T\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "Transmittance is the fraction of incident light (electromagnetic radiation) at a specified wavelength that passes through a sample." ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  vaem:todo "belongs to SOQ-ISO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Transmittance" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Transmittance> ;
+.
+quantitykind:TransmittanceDensity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:latexDefinition "\\(A_1_0(\\lambda) = -lg(\\tau(\\lambda))\\), where \\(\\tau\\) is the transmittance at a given wavelength \\(\\lambda\\)."^^qudt:LatexString ;
+  qudt:plainTextDescription "Transmittance is the fraction of incident light (electromagnetic radiation) at a specified wavelength that passes through a sample." ;
+  qudt:symbol "A_10, D" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Transmittance Density" ;
+.
+quantitykind:TrueExhaustVelocity
+  a qudt:QuantityKind ;
+  qudt:symbol "u_{e}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "True Exhaust Velocity" ;
+.
+quantitykind:Turbidity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:NTU ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Turbidity"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Turbidity"^^xsd:anyURI ;
+  qudt:plainTextDescription "Turbidity is the cloudiness or haziness of a fluid, or of air, caused by individual particles (suspended solids) that are generally invisible to the naked eye, similar to smoke in air. Turbidity in open water is often caused by phytoplankton and the measurement of turbidity is a key test of water quality. The higher the turbidity, the higher the risk of the drinkers developing gastrointestinal diseases, especially for immune-compromised people, because contaminants like virus or bacteria can become attached to the suspended solid. The suspended solids interfere with water disinfection with chlorine because the particles act as shields for the virus and bacteria. Similarly suspended solids can protect bacteria from UV sterilisation of water. Fluids can contain suspended solid matter consisting of particles of many different sizes. While some suspended material will be large enough and heavy enough to settle rapidly to the bottom container if a liquid sample is left to stand (the settleable solids), very small particles will settle only very slowly or not at all if the sample is regularly agitated or the particles are colloidal. These small solid particles cause the liquid to appear turbid." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Turbidity" ;
+.
+quantitykind:Turns
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:plainTextDescription "\"Turns\" is the number of turns in a winding." ;
+  qudt:symbol "N" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Turns" ;
+.
+quantitykind:UniversalGasConstant
+  a qudt:QuantityKind ;
+  qudt:plainTextDescription """The gas constant (also known as the molar, universal, or ideal gas constant) is a physical constant which is featured in many fundamental equations in the physical sciences, such as the ideal gas law and the Nernst equation.
+Physically, the gas constant is the constant of proportionality that happens to relate the energy scale in physics to the temperature scale, when a mole of particles at the stated temperature is being considered.""" ;
+  qudt:symbol "R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Universal Gas Constant" ;
+.
+quantitykind:UpperCriticalMagneticFluxDensity
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Upper Critical Magnetic Flux Density\" for type II superconductors, is the threshold magnetic flux density for disappearance of bulk superconductivity." ;
+  qudt:symbol "B_{c2}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Upper Critical Magnetic Flux Density" ;
+  skos:closeMatch quantitykind:LowerCriticalMagneticFluxDensity ;
+.
+quantitykind:VacuumThrust
+  a qudt:QuantityKind ;
+  qudt:expression "\\(VT\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Vacuum Thrust" ;
+  skos:broader quantitykind:Thrust ;
+.
+quantitykind:VehicleVelocity
+  a qudt:QuantityKind ;
+  qudt:symbol "V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Vehicle Velocity" ;
+  skos:broader quantitykind:Velocity ;
+.
+quantitykind:Velocity
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Velocity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Velocity"^^xsd:anyURI ;
+  qudt:plainTextDescription "In kinematics, velocity is the speed of an object and a specification of its direction of motion. Speed describes only how fast an object is moving, whereas velocity gives both how fast and in what direction the object is moving." ;
+  qudt:symbol "v" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Velocity" ;
+.
+quantitykind:VideoFrameRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FRAME-PER-SEC ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Frame_rate"^^xsd:anyURI ;
+  qudt:plainTextDescription "Frame rate (also known as frame frequency) is the frequency (rate) at which an imaging device produces unique consecutive images called frames. The term applies equally well to computer graphics, video cameras, film cameras, and motion capture systems. Frame rate is most often expressed in frames per second (FPS) and is also expressed in progressive scan monitors as hertz (Hz)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Video Frame Rate" ;
+  skos:broader quantitykind:InformationFlowRate ;
+.
+quantitykind:Viscosity
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Viscosity"^^xsd:anyURI ;
+  qudt:plainTextDescription "Viscosity is a measure of the resistance of a fluid which is being deformed by either shear stress or extensional stress. In general terms it is the resistance of a liquid to flow, or its \"thickness\". Viscosity describes a fluid's internal resistance to flow and may be thought of as a measure of fluid friction. [Wikipedia]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Viscosity" ;
+.
+quantitykind:VisibleRadiantEnergy
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radiant_energy"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31892"^^xsd:anyURI ;
+  qudt:latexDefinition "Q"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Visible Radiant Energy\", also known as luminous energy, is the energy of electromagnetic waves. It is energy of the particles that are emitted, transferred, or received as radiation." ;
+  qudt:symbol "Q" ;
+  qudt:systemDerivedQuantityKind qudt:SOQ_SI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Visible Radiant Energy" ;
+  skos:broader quantitykind:EnergyAndWork ;
+  skos:closeMatch quantitykind:LuminousEnergy ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Radiant_energy> ;
+.
+quantitykind:VisionThreshods
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_v\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Vision Threshods\" is the thresholds of sensitivity of the eye." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Vision Threshods" ;
+  skos:exactMatch <http://en.wikipedia.org/wiki/Absolute_threshold#Vision> ;
+.
+quantitykind:Voltage
+  a qudt:QuantityKind ;
+  dcterms:description """\\(\\textit{Voltage}\\), also referred to as \\(\\textit{Electric Tension}\\), is the difference between electrical potentials of two points. For an electric field within a medium, \\(U_{ab} = - \\int_{r_a}^{r_b} E . {dr}\\), where \\(E\\) is electric field strength.
+For an irrotational electric field, the voltage is independent of the path between the two points \\(a\\) and \\(b\\)."""^^qudt:LatexString ;
+  qudt:exactMatch quantitykind:EnergyPerElectricCharge ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-3D0> ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(U_{ab} = V_a - V_b\\), where \\(V_a\\) and \\(V_b\\) are electric potentials at points \\(a\\) and \\(b\\), respectively."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\(U_{ab}\\)\\)"^^qudt:LatexString ;
+  qudt:symbol "U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Voltage" ;
+  skos:broader quantitykind:EnergyPerElectricCharge ;
+.
+quantitykind:VoltagePercentage
+  a qudt:QuantityKind ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+  qudt:latexSymbol "\\(\\Uppsi\\)"^^qudt:LatexString ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-3D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E-1L2I0M1H0T-3D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Voltage Percentage" ;
+  skos:broader quantitykind:Dimensionless ;
+.
+quantitykind:VoltagePhasor
+  a qudt:QuantityKind ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=131-11-26"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "When \\(u = \\hat{U} \\cos{(\\omega t + \\alpha)}\\), where \\(u\\) is the voltage, \\(\\omega\\) is angular frequency, \\(t\\) is time, and \\(\\alpha\\) is initial phase, then \\(\\underline{U} = Ue^{ja}\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\underline{U}\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Voltage Phasor\" is a representation of voltage as a sinusoidal integral quantity using a complex quantity whose argument is equal to the initial phase and whose modulus is equal to the root-mean-square value. A phasor is a constant complex number, usually expressed in exponential form, representing the complex amplitude (magnitude and phase) of a sinusoidal function of time. Phasors are used by electrical engineers to simplify computations involving sinusoids, where they can often reduce a differential equation problem to an algebraic one." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Voltage Phasor" ;
+.
+quantitykind:Volume
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:AC-FT ;
+  qudt:applicableUnit unit:BBL ;
+  qudt:applicableUnit unit:CentiM3 ;
+  qudt:applicableUnit unit:FBM ;
+  qudt:applicableUnit unit:FT3 ;
+  qudt:applicableUnit unit:IN3 ;
+  qudt:applicableUnit unit:M3 ;
+  qudt:applicableUnit unit:MI3 ;
+  qudt:applicableUnit unit:MilliM3 ;
+  qudt:applicableUnit unit:PINT ;
+  qudt:applicableUnit unit:PlanckVolume ;
+  qudt:applicableUnit unit:QT ;
+  qudt:applicableUnit unit:RT ;
+  qudt:applicableUnit unit:ST ;
+  qudt:applicableUnit unit:TBSP ;
+  qudt:applicableUnit unit:TSP ;
+  qudt:applicableUnit unit:YD3 ;
+  qudt:baseUnitDimensions "L^3" ;
+  qudt:baseUnitDimensions "m^3" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Volume"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:plainTextDescription "The volume of a solid object is the three-dimensional concept of how much space it occupies, often quantified numerically. One-dimensional figures (such as lines) and two-dimensional shapes (such as squares) are assigned zero volume in the three-dimensional space." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume" ;
+.
+quantitykind:VolumeFlowRate
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-SEC ;
+  qudt:baseUnitDimensions "m sec^{-1}" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Volumetric_flow_rate"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(q_V = \\frac{dV}{dt}\\), where \\(V\\) is volume and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:plainTextDescription "Volumetric Flow Rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time." ;
+  qudt:symbol "q_V" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume Flow Rate" ;
+  skos:broader quantitykind:Volume ;
+.
+quantitykind:VolumeFraction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:baseSIUnitDimensions "\\(qkdv:A0E0L0I0M0H0T0D1\\)"^^qudt:LatexString ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Volume_fraction"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31894"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\varphi_B = \\frac{x_B V_{m,B}^*}{\\sum x_i V_{m,i}^*}\\), where \\(V_{m,i}^*\\) is the molar volume of the pure substances \\(i\\) at the same temperature and pressure, \\(x_i\\) denotes the amount-of-substance fraction of substance \\(i\\), and \\(\\sum\\) denotes summation over all substances \\(i\\)."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\varphi_B\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Volume Fraction\" is the volume of a constituent divided by the volume of all constituents of the mixture prior to mixing. Volume fraction is also called volume concentration in ideal solutions where the volumes of the constituents are additive (the volume of the solution is equal to the sum of the volumes of its ingredients)." ;
+  qudt:qkdvDenominator <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  qudt:qkdvNumerator <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T0D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume Fraction" ;
+.
+quantitykind:VolumePerUnitTime
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:FT3-PER-MIN ;
+  qudt:applicableUnit unit:FT3-PER-SEC ;
+  qudt:applicableUnit unit:GAL_US-PER-DAY ;
+  qudt:applicableUnit unit:GAL_US-PER-MIN ;
+  qudt:applicableUnit unit:IN3-PER-MIN ;
+  qudt:applicableUnit unit:M3-PER-HR ;
+  qudt:applicableUnit unit:M3-PER-SEC ;
+  qudt:applicableUnit unit:YD3-PER-MIN ;
+  qudt:baseUnitDimensions "L^3/T" ;
+  qudt:baseUnitDimensions "m^3/s" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume per Unit Time" ;
+.
+quantitykind:VolumeStrain
+  a qudt:QuantityKind ;
+  dcterms:description "Volume, or volumetric, Strain, or dilatation (the relative variation of the volume) is the trace of the tensor \\(\\vartheta\\)."^^qudt:LatexString ;
+  qudt:applicableUnit unit:UNITLESS ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deformation_(mechanics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\vartheta = \\frac{\\Delta V}{V_0}\\), where \\(\\Delta V\\) is the increase in volume and \\(V_0\\) is the volume in a reference state to be specified."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\vartheta\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume Strain" ;
+  skos:broader quantitykind:Strain ;
+.
+quantitykind:VolumeThermalExpansion
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:M3-PER-K ;
+  qudt:baseUnitDimensions "L^3/\\Theta" ;
+  qudt:baseUnitDimensions "m^3/K" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H-1T0D0> ;
+  qudt:plainTextDescription """When the temperature of a substance changes, the energy that is stored in the intermolecular bonds between atoms changes. When the stored energy increases, so does the length of the molecular bonds. As a result, solids typically expand in response to heating and contract on cooling; this dimensional response to temperature change is expressed by its coefficient of thermal expansion.
+
+Different coefficients of thermal expansion can be defined for a substance depending on whether the expansion is measured by:
+
+    * linear thermal expansion
+    * area thermal expansion
+    * volumetric thermal expansion
+
+These characteristics are closely related. The volumetric thermal expansion coefficient can be defined for both liquids and solids. The linear thermal expansion can only be defined for solids, and is common in engineering applications.
+
+Some substances expand when cooled, such as freezing water, so they have negative thermal expansion coefficients. [Wikipedia]""" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volume Thermal Expansion" ;
+.
+quantitykind:VolumetricHeatCapacity
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J-PER-M3-K ;
+  qudt:baseUnitDimensions "M/\\Theta \\cdot L \\cdot T^2" ;
+  qudt:baseUnitDimensions "kg/K \\cdot m \\cdot s^2" ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Volumetric_heat_capacity"^^xsd:anyURI ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H-1T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Volumetric_heat_capacity"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Volumetric Heat Capacity (VHC)}, also termed \\textit{volume-specific heat capacity}, describes the ability of a given volume of a substance to store internal energy while undergoing a given temperature change, but without undergoing a phase transition. It is different from specific heat capacity in that the VHC is a \\textit{per unit volume} measure of the relationship between thermal energy and temperature of a material, while the specific heat is a \\textit{per unit mass\" measure (or occasionally per molar quantity of the material)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volumetric Heat Capacity" ;
+.
+quantitykind:VolumicElectromagneticEnergy
+  a qudt:QuantityKind ;
+  dcterms:description "\\(\\textit{Volumic Electromagnetic Energy}\\), also known as the \\(\\textit{Electromagnetic Energy Density}\\), is the energy associated with an electromagnetic field, per unit volume of the field."^^rdf:HTML ;
+  qudt:applicableUnit unit:J-PER-M3 ;
+  qudt:exactMatch quantitykind:ElectromagneticEnergyDensity ;
+  qudt:expression "\\(volumic-electromagnetic-energy\\)"^^qudt:LatexString ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L-1I0M1H0T-2D0> ;
+  qudt:informativeReference "http://www.electropedia.org/iev/iev.nsf/display?openform&ievref=121-11-64"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=31891"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(w = (1/2) ( \\mathbf{E} \\cdot \\mathbf{D} + \\mathbf{B} \\cdot \\mathbf{H})\\), where \\(\\mathbf{E}\\) is electric field strength, \\(\\mathbf{D}\\) is electric flux density, \\(\\mathbf{M}\\) is magnetic flux density, and \\(\\mathbf{H}\\) is magnetic field strength."^^qudt:LatexString ;
+  qudt:latexSymbol "\\(w\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Volumic Electromagnetic Energy" ;
+  rdfs:seeAlso quantitykind:ElectricFieldStrength ;
+  rdfs:seeAlso quantitykind:ElectricFluxDensity ;
+  rdfs:seeAlso quantitykind:MagneticFieldStrength ;
+  rdfs:seeAlso quantitykind:MagneticFluxDensity ;
+.
+quantitykind:Vorticity
+  a qudt:QuantityKind ;
+  qudt:latexSymbol "\\(\\omega\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "In the simplest sense, vorticity is the tendency for elements of a fluid to \"spin.\" More formally, vorticity can be related to the amount of \"circulation\" or \"rotation\" (or more strictly, the local angular rate of rotation) in a fluid. The average vorticity in a small region of fluid flow is equal to the circulation C around the boundary of the small region, divided by the area A of the small region. Mathematically, vorticity is a vector field and is defined as the curl of the velocity field." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Vorticity" ;
+  skos:broader quantitykind:AngularVelocity ;
+.
+quantitykind:WarmReceptorThreshold
+  a qudt:QuantityKind ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Tbar_w\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Warm Receptor Threshold\" is the threshold of warm-sensitive free nerve-ending." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Warm Receptor Threshold" ;
+.
+quantitykind:Wavenumber
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:PER-M ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Wavenumber"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(\\sigma = \\frac{\\nu}{c}\\), where \\(\\sigma\\) is the wave number, \\(\\nu\\) is the frequency, and \\(c\\) is the speed of light in the medium.
+
+Or:
+
+\\(k = \\frac{2\\pi}{\\lambda}= \\frac{2\\pi\\upsilon}{\\upsilon_p}=\\frac{\\omega}{\\upsilon_p}\\), where \\(\\upsilon\\) is the frequency of the wave, \\(\\lambda\\) is the wavelength, \\(\\omega = 2\\pi \\upsilon\\) is the angular frequency of the wave, and \\(\\upsilon_p\\) is the phase velocity of the wave."""^^qudt:LatexString ;
+  qudt:latexSymbol "\\(\\sigma\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Wavenumber\" is the spatial frequency of a wave - the number of waves that exist over a specified distance. More formally, it is the reciprocal of the wavelength. It is also the magnitude of the wave vector. Light passing through different media keeps its frequency, but not its wavelength or wavenumber. The unit for wavenumber commonly used in spectroscopy is centimetre to power minus one, PER-CM, rather than metre to power minus one, PER-M." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Wave Number" ;
+  rdfs:label "Wavenumber" ;
+.
+quantitykind:WebTime
+  a qudt:QuantityKind ;
+  rdfs:comment "Web Time" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Web Time" ;
+.
+quantitykind:WebTimeAverageThrust
+  a qudt:QuantityKind ;
+  rdfs:comment "Web Time Avg Thrust (Mlbf)" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Web Time Average Thrust" ;
+  skos:broader quantitykind:Thrust ;
+.
+quantitykind:Weight
+  a qudt:QuantityKind ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Weight"^^xsd:anyURI ;
+  qudt:plainTextDescription "The force with which a body is attracted toward an astronomical body.  Or, the product of the mass of a body and the acceleration acting on a body.  In a dynamic situation, the weight can be a multiple of that under resting conditions. Weight also varies on other planets in accordance with their gravity." ;
+  qudt:symbol "bold letter W" ;
+  qudt:url "http://en.wikipedia.org/wiki/Weight"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Weight" ;
+.
+quantitykind:Work
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:applicableUnit unit:N-M ;
+  qudt:baseUnitDimensions "n m" ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Work_(physics)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(A = \\int Pdt\\), where \\(P\\) is power and \\(t\\) is time."^^qudt:LatexString ;
+  qudt:plainTextDescription "A force is said to do Work when it acts on a body so that there is a displacement of the point of application, however small, in the direction of the force. " ;
+  qudt:symbol "A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Work" ;
+.
+quantitykind:WorkFunction
+  a qudt:QuantityKind ;
+  qudt:applicableUnit unit:J ;
+  qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Work_function"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\Phi\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "\"Work Function\" is the energy difference between an electron at rest at infinity and an electron at a certain energy level. The minimum energy (usually measured in electronvolts) needed to remove an electron from a solid to a point immediately outside the solid surface (or energy needed to move an electron from the Fermi level into vacuum)." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "Work Function" ;
+.
+unit:A
+  qudt:plainTextDescription "The 'ampere' is the SI unit of electric current and is one of the seven SI base units." ;
+.
+<http://voag.linkedmodel.org/schema/voag#QUDT-QUANTITY-KINDS-VocabCatalogEntry_v1.2>
+  a vaem:CatalogEntry ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "QUDT Quantity Kinds Vocabulary Catalog Entry v1.2" ;
+.
+vaem:GMD_QUDT-QUANTITY-KINDS-ALL
+  a vaem:GraphMetaData ;
+  dcterms:contributor "Jack Hodges" ;
+  dcterms:contributor "Steve Ray" ;
+  dcterms:created "2019-08-01T16:25:54.850+00:00"^^xsd:dateTime ;
+  dcterms:creator "Ralph Hodgson" ;
+  dcterms:creator "Steve Ray" ;
+  dcterms:description "Provides the set of all quantity kinds."^^rdf:HTML ;
+  dcterms:modified "2020-03-20T12:30:51.335-07:00"^^xsd:dateTime ;
+  dcterms:rights "The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available at https://creativecommons.org/licenses/by/4.0/. Attribution should be made to QUDT.org" ;
+  dcterms:subject "QUANTITY-KINDS-ALL" ;
+  vaem:applicableDiscipline "All disciplines" ;
+  vaem:applicableDomain "Science, Medicine and Engineering" ;
+  vaem:dateCreated "2019-08-01T21:26:38"^^xsd:dateTime ;
+  vaem:graphTitle "QUDT Quantity Kinds Version 2.1.2" ;
+  vaem:hasGraphRole vaem:VocabularyGraph ;
+  vaem:intent "TBD" ;
+  vaem:isMetadataFor <http://qudt.org/2.1/vocab/quantitykind> ;
+  vaem:latestPublishedVersion "http://www.qudt.org/doc/2020/03/DOC_VOCAB-QUANTITY-KINDS-ALL-v2.1.html" ;
+  vaem:logo "http://www.linkedmodel.org/lib/lm/images/logos/qudt_logo-300x110.png" ;
+  vaem:namespace "http://qudt.org/vocab/quantitykind/" ;
+  vaem:namespacePrefix "quantitykind" ;
+  vaem:owner "qudt.org" ;
+  vaem:previousPublishedVersion "http://www.qudt.org/doc/2020/02/DOC_VOCAB-QUANTITY-KINDS-ALL-v2.1.html"^^xsd:anyURI ;
+  vaem:revision "2.1.2" ;
+  vaem:specificity 1 ;
+  vaem:turtleFileURL "http://qudt.org/2.1/vocab/quantitykind" ;
+  vaem:usesNonImportedResource dc:contributor ;
+  vaem:usesNonImportedResource dc:creator ;
+  vaem:usesNonImportedResource dc:description ;
+  vaem:usesNonImportedResource dc:rights ;
+  vaem:usesNonImportedResource dc:subject ;
+  vaem:usesNonImportedResource dc:title ;
+  vaem:usesNonImportedResource dcterms:contributor ;
+  vaem:usesNonImportedResource dcterms:created ;
+  vaem:usesNonImportedResource dcterms:creator ;
+  vaem:usesNonImportedResource dcterms:description ;
+  vaem:usesNonImportedResource dcterms:modified ;
+  vaem:usesNonImportedResource dcterms:rights ;
+  vaem:usesNonImportedResource dcterms:subject ;
+  vaem:usesNonImportedResource dcterms:title ;
+  vaem:usesNonImportedResource voag:QUDT-Attribution ;
+  vaem:usesNonImportedResource <http://voag.linkedmodel.org/schema/voag#QUDT-QUANTITY-KINDS-VocabCatalogEntry_v1.2> ;
+  vaem:usesNonImportedResource <http://voag.linkedmodel.org/voag/QUDT-Attribution> ;
+  vaem:usesNonImportedResource skos:closeMatch ;
+  vaem:usesNonImportedResource skos:exactMatch ;
+  vaem:withAttributionTo voag:QUDT-Attribution ;
+  vaem:withAttributionTo <http://voag.linkedmodel.org/voag/QUDT-Attribution> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
+  rdfs:label "QUDT Quantity Kinds Vocabulary Version 2.1.2" ;
+.

--- a/support/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
+++ b/support/VOCAB_QUDT-UNITS-ALL-v2.1.ttl
@@ -1,0 +1,20462 @@
+# baseURI: http://qudt.org/2.1/vocab/unit
+# imports: http://qudt.org/2.1/schema/qudt
+# imports: http://qudt.org/2.1/vocab/quantitykind
+# imports: http://qudt.org/2.1/vocab/sou/all
+
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix qkdv: <http://qudt.org/vocab/dimensionvector/> .
+@prefix quantitykind: <http://qudt.org/vocab/quantitykind/> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix vaem: <http://www.linkedmodel.org/schema/vaem#> .
+@prefix voag: <http://voag.linkedmodel.org/schema/voag#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://qudt.org/2.1/vocab/unit>
+  a owl:Ontology ;
+  vaem:hasGraphMetadata vaem:GMD_QUDT-UNITS-ALL ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QUDT Units of Measure for All Units Release 2.1" ;
+  owl:imports <http://qudt.org/2.1/schema/qudt> ;
+  owl:imports <http://qudt.org/2.1/vocab/quantitykind> ;
+  owl:imports <http://qudt.org/2.1/vocab/sou/all> ;
+  owl:versionIRI <http://qudt.org/2.1/vocab/unit> ;
+.
+qudt:hasPrefixUnit
+  rdfs:comment "Specifies which prefix unit is used." ;
+.
+quantitykind:IonizationEnergy
+  qudt:hasDimensionVector qkdv:A-1E0L2I0M1H0T-2D0 ;
+.
+unit:A
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """The  \\(\\textit{ampere}\\), often shortened to \\(\\textit{amp}\\), is the SI unit of electric current and is one of the seven SI base units.
+\\(\\text{A}\\ \\equiv\\ \\text{amp (or ampere)}\\ \\equiv\\ \\frac{\\text{C}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{coulomb}}{\\text{second}}\\ \\equiv\\ \\frac{\\text{J}}{\\text{Wb}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{weber}}\\)
+Note that SI supports only the use of symbols and deprecates the use of any abbreviations for units."""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ampere"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA101" ;
+  qudt:iec61360Code "0112/2///62720#UAD717" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere?oldid=494026699"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ampere> ;
+  qudt:symbol "A" ;
+  qudt:ucumCaseInsensitiveCode "A" ;
+  qudt:ucumCode "A" ;
+  qudt:uneceCommonCode "AMP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere" ;
+  skos:altLabel "amp" ;
+.
+unit:A-HR
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Ampere hour</em> is a practical unit of electric charge equal to the charge flowing in one hour through a conductor passing one ampere. An ampere-hour or amp-hour (symbol \\(Ah,\\,AHr,\\, A \\cdot h, A h\\)) is a unit of electric charge, with sub-units milliampere-hour (\\(mAh\\)) and milliampere second (\\(mAs\\)). One ampere-hour is equal to 3600 coulombs (ampere-seconds), the electric charge transferred by a steady current of one ampere for one hour. The ampere-hour is frequently used in measurements of electrochemical systems such as electroplating and electrical batteries. The commonly seen milliampere-hour (\\(mAh\\) or \\(mA \\cdot h\\)) is one-thousandth of an ampere-hour (\\(3.6 \\,coulombs\\))</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3600.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA102" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ampere-hour"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780199233991.001.0001/acref-9780199233991-e-86"^^xsd:anyURI ;
+  qudt:symbol "AHr" ;
+  qudt:uneceCommonCode "AMH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Hour" ;
+.
+unit:A-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of electromagnetic moment."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A-M^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:iec61360Code "0112/2///62720#UAA106" ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+meter+squared"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A5" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Meter Squared" ;
+.
+unit:A-M2-PER-J-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of gyromagnetic ratio."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A-m^2/J-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:informativeReference "http://encyclopedia2.thefreedictionary.com/ampere+square+meter+per+joule+second"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Meter Squared Per Joule Second" ;
+.
+unit:A-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearElectricCurrent ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAB073" ;
+  qudt:plainTextDescription "SI base unit ampere divided by the 0,01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "A2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "A PER CentiM" ;
+  skos:prefLabel "ampere per centimetre" ;
+.
+unit:A-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB052" ;
+  qudt:plainTextDescription "SI base unit ampere divided by the 0,000 1-fold  of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "A4" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "A PER CentiM2" ;
+  skos:prefLabel "ampere per centimetre squared" ;
+.
+unit:A-PER-DEG_C
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A measure used to express how a current is subject to temperature. Originally used in Wien's Law to describe phenomena related to filaments. One use today is to express how a current generator derates with temperature."^^rdf:HTML ;
+  qudt:conversionMultiplier "57.2957795"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A/degC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitTemperature ;
+  qudt:informativeReference "http://books.google.com/books?id=zkErAAAAYAAJ&pg=PA60&lpg=PA60&dq=ampere+per+degree"^^xsd:anyURI ;
+  qudt:informativeReference "http://web.mit.edu/course/21/21.guide/use-tab.htm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Degree Celsius" ;
+.
+unit:A-PER-J
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "The inverse measure of \\(joule-per-ampere\\) or \\(weber\\). The measure for the reciprical of magnetic flux."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A/J\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerUnitEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Joule" ;
+.
+unit:A-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>AmperePerMeter</p> is the SI unit of magnetic field strength. One ampere per meter is equal to \\(\\pi/250\\) oersteds (\\(12.566\\, 371\\,millioersteds\\)) in CGS units. The ampere per meter is also the SI unit of \"magnetization\" in the sense of magnetic dipole moment per unit volume; in this context \\(1 A/m = 0.001\\,emu\\,per\\,cubic\\,centimeter\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AuxillaryMagneticField ;
+  qudt:iec61360Code "0112/2///62720#UAA104" ;
+  qudt:uneceCommonCode "AE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Meter" ;
+.
+unit:A-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textbf{Ampere Per Square Meter}\\) is a unit in the category of electric current density. This unit is commonly used in the SI unit system."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(A/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA105" ;
+  qudt:informativeReference "https://cdd.iec.ch/cdd/iec61360/iec61360.nsf/Units/0112-2---62720%23UAA105"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Square Meter" ;
+.
+unit:A-PER-M2-K2
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(a/m^2-k^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:RichardsonConstant ;
+  qudt:iec61360Code "0112/2///62720#UAB353" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A6" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Meter Squared Kelvin Squared" ;
+.
+unit:A-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearElectricCurrent ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAB072" ;
+  qudt:plainTextDescription "SI base unit ampere divided by the 0,001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "A3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "A PER MilliM" ;
+  skos:prefLabel "ampere per millimetre" ;
+.
+unit:A-PER-MilliM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB051" ;
+  qudt:plainTextDescription "SI base unit ampere divided by the 0,000 001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "A7" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "A PER MilliM2" ;
+  skos:prefLabel "ampere per millimetre squared" ;
+.
+unit:A-PER-RAD
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Ampere per Radian</em> is a derived unit for measuring the amount of current per unit measure of angle, expressed in ampere per radian.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(a-per-rad\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentPerAngle ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere per Radian" ;
+.
+unit:A-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA107" ;
+  qudt:plainTextDescription "product out of the SI base unit ampere and the SI base unit second" ;
+  qudt:uneceCommonCode "A8" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "A SEC" ;
+  skos:prefLabel "ampere second" ;
+.
+unit:AC
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "The acre is a unit of area in a number of different systems, including the imperial and U.S. customary systems. Its international symbol is ac. The most commonly used acres today are the international acre and, in the United States, the survey acre. The most common use of the acre is to measure tracts of land. One international acre is equal to 4046.8564224 square metres. "^^rdf:HTML ;
+  qudt:conversionMultiplier "4046.8564224"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Acre"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA320" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acre?oldid=495387342"^^xsd:anyURI ;
+  qudt:symbol "acre" ;
+  qudt:ucumCaseInsensitiveCode "[ACR_BR]" ;
+  qudt:ucumCaseSensitiveCode "[acr_br]" ;
+  qudt:ucumCode "[ACR_BR]" ;
+  qudt:ucumCode "[acr_br]" ;
+  qudt:uneceCommonCode "ACR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Acre" ;
+  skos:altLabel "acre" ;
+.
+unit:AC-FT
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">An acre-foot is a unit of volume commonly used in the United States in reference to large-scale water resources, such as reservoirs, aqueducts, canals, sewer flow capacity, and river flows. It is defined by the volume of one acre of surface area to a depth of one foot. Since the acre is defined as a chain by a furlong (\\(66 ft \\times 660 ft\\)) the acre-foot is exactly \\(43,560 cubic feet\\). For irrigation water, the volume of \\(1 ft \\times 1 \\; ac = 43,560 \\; ft^{3} (1,233.482 \\; m^{3}, 325,851 \\; US gal)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1233.4818375475202e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Acre-foot"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-35"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/acreFoot> ;
+  qudt:symbol "ac-ft" ;
+  qudt:ucumCaseInsensitiveCode "[ACR_BR].[FT_I]" ;
+  qudt:ucumCaseSensitiveCode "[acr_br].[ft_i]" ;
+  qudt:ucumCode "[ACR_BR].[FT_I]" ;
+  qudt:ucumCode "[acr_br].[ft_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Acre Foot" ;
+.
+unit:AFN
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Afghanistan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Afghani"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Afghani?oldid=485904590"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Afghani" ;
+.
+unit:AMD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Armenia"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Armenian_dram"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Armenian_dram?oldid=492709723"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Armenian Dram" ;
+.
+unit:AMU
+  a qudt:Unit ;
+  dcterms:description "The <i>Unified Atomic Mass Unit</i> (symbol: \\(\\mu\\)) or <i>dalton</i> (symbol: Da) is a unit that is used for indicating mass on an atomic or molecular scale. It is defined as one twelfth of the rest mass of an unbound atom of carbon-12 in its nuclear and electronic ground state, and has a value of \\(1.660538782(83) \\times 10^{-27} kg\\).  One \\(Da\\) is approximately equal to the mass of one proton or one neutron. The CIPM have categorised it as a <i>\"non-SI unit whose values in SI units must be obtained experimentally\"</i>."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.66053878283e-27 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:Da ;
+  qudt:exactMatch unit:U ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass_unit"^^xsd:anyURI ;
+  qudt:symbol "\\(\\mu\\)" ;
+  qudt:ucumCaseInsensitiveCode "AMU" ;
+  qudt:ucumCaseSensitiveCode "u" ;
+  qudt:ucumCode "AMU" ;
+  qudt:ucumCode "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Atomic mass unit" ;
+.
+unit:ANGSTROM
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The \\(Angstr\\ddot{o}m\\) is an internationally recognized unit of length equal to \\(0.1 \\,nanometre\\) or \\(1 \\times 10^{-10}\\,metres\\).  Although accepted for use, it is not formally defined within the International System of Units(SI). The angstrom is often used in the natural sciences to express the sizes of atoms, lengths of chemical bonds and the wavelengths of electromagnetic radiation, and in technology for the dimensions of parts of integrated circuits. It is also commonly used in structural biology.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/%C3%85ngstr%C3%B6m"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA023" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ångström?oldid=436192495"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(\\AA\\)"^^qudt:LatexString ;
+  qudt:symbol "A" ;
+  qudt:ucumCaseInsensitiveCode "AO" ;
+  qudt:ucumCaseSensitiveCode "Ao" ;
+  qudt:ucumCode "AO" ;
+  qudt:ucumCode "Ao" ;
+  qudt:uneceCommonCode "A11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Angstrom" ;
+.
+unit:ARCMIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21,600), or \\(\\pi /10,800 radians\\). In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21,600 of a rotation. "^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.000290888209"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:ARCMIN ;
+  qudt:exactMatch unit:MIN_Angle ;
+  qudt:exactMatch unit:RAD ;
+  qudt:hasQuantityKind quantitykind:AngularMeasurement ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA097" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc"^^xsd:anyURI ;
+  qudt:siUnitsExpression "1" ;
+  qudt:symbol "arcMin" ;
+  qudt:ucumCaseSensitiveCode "'" ;
+  qudt:ucumCode "'" ;
+  qudt:uneceCommonCode "D61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ArcMinute" ;
+.
+unit:ARCSEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Arc Second\" is a unit of angular measure, also called the \\(\\textit{second of arc}\\), equal to \\(1/60 \\; arcminute\\). One arcsecond is a very small angle: there are 1,296,000 in a circle. The SI recommends \\(\\textit{double prime}\\) (\\(''\\)) as the symbol for the arcsecond. The symbol has become common in astronomy, where very small angles are stated in milliarcseconds (\\(mas\\))."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.84813681E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:ARCSEC ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA096" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc#Symbols.2C_abbreviations_and_subdivisions"^^xsd:anyURI ;
+  qudt:symbol "\"" ;
+  qudt:ucumCaseSensitiveCode "''" ;
+  qudt:ucumCode "''" ;
+  qudt:uneceCommonCode "D62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ArcSecond" ;
+.
+unit:ARE
+  a qudt:Unit ;
+  dcterms:description "An 'are' is a unit of area equal to 0.02471 acre and 100 centare."^^rdf:HTML ;
+  qudt:conversionMultiplier "100"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB048" ;
+  qudt:informativeReference "http://www.anidatech.com/units.html"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/are> ;
+  qudt:symbol "a" ;
+  qudt:ucumCaseInsensitiveCode "AR" ;
+  qudt:ucumCaseSensitiveCode "ar" ;
+  qudt:ucumCode "AR" ;
+  qudt:ucumCode "ar" ;
+  qudt:uneceCommonCode "ARE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "are" ;
+.
+unit:ARS
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Argentina"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Argentine_peso"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Argentine_peso?oldid=491431588"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Argentine Peso" ;
+.
+unit:AT
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The <em>ampere-turn</em> was the MKS unit of magnetomotive force (MMF), represented by a direct current of one ampere flowing in a single-turn loop in a vacuum. \"Turns\" refers to the winding number of an electrical conductor comprising an inductor. The ampere-turn was replaced by the SI unit, ampere.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  qudt:symbol "At" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Turn" ;
+.
+unit:AT-PER-IN
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The 'ampere-turn-per-inch' is a measure of magnetic field intensity and is eual to 12.5664 Oersted."^^rdf:HTML ;
+  qudt:conversionMultiplier "39.3700787"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(At/in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AuxillaryMagneticField ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Turn per Inch" ;
+.
+unit:AT-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of magnetic field strength. One ampere per meter is equal to \\(\\pi/250\\) oersteds (12.566 371 millioersteds) in CGS units. The ampere per meter is also the SI unit of \"magnetization\" in the sense of magnetic dipole moment per unit volume; in this context \\(1 A/m = 0.001 emu per cubic centimeter\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(At/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AuxillaryMagneticField ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere Turn per Meter" ;
+.
+unit:ATM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The standard atmosphere (symbol: atm) is an international reference pressure defined as \\(101.325 \\,kPa\\) and formerly used as unit of pressure. For practical purposes it has been replaced by the bar which is \\(100 kPa\\). The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "101325"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA322" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atmosphere_(unit)"^^xsd:anyURI ;
+  qudt:symbol "atm" ;
+  qudt:ucumCaseInsensitiveCode "ATM" ;
+  qudt:ucumCaseSensitiveCode "atm" ;
+  qudt:ucumCode "ATM" ;
+  qudt:ucumCode "atm" ;
+  qudt:uneceCommonCode "ATM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Standard Atmosphere" ;
+.
+unit:ATM_T
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">A technical atmosphere (symbol: at) is a non-SI unit of pressure equal to one kilogram-force per square centimeter. The symbol 'at' clashes with that of the katal (symbol: 'kat'), the SI unit of catalytic activity; a kilotechnical atmosphere would have the symbol 'kat', indistinguishable from the symbol for the katal. It also clashes with that of the non-SI unit, the attotonne, but that unit would be more likely be rendered as the equivalent SI unit.</p>
+<p class=\"lm-para\">Assay ton (abbreviation 'AT') is not a unit of measurement, but a standard quantity used in assaying ores of precious metals; it is \\(29 1D6 \\,grams\\) (short assay ton) or \\(32 2D3 \\,grams\\) (long assay ton), the amount which bears the same ratio to a milligram as a short or long ton bears to a troy ounce. In other words, the number of milligrams of a particular metal found in a sample of this size gives the number of troy ounces contained in a short or long ton of ore.</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "98066.5"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA321" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Technical_atmosphere"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(1 at = 98.0665 kPa \\approx 0.96784 standard atmospheres\\)"^^qudt:LatexString ;
+  qudt:symbol "at" ;
+  qudt:ucumCaseInsensitiveCode "ATT" ;
+  qudt:ucumCaseSensitiveCode "att" ;
+  qudt:ucumCode "ATT" ;
+  qudt:ucumCode "att" ;
+  qudt:uneceCommonCode "ATT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Technical Atmosphere" ;
+.
+unit:AU
+  a qudt:Unit ;
+  dcterms:description "An astronomical unit (abbreviated as AU, au, a.u., or ua) is a unit of length equal to \\(149,597,870,700 metres\\) (\\(92,955,807.273 mi\\)) or approximately the mean Earth Sun distance."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.495978706916E11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Astronomical_unit"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB066" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Astronomical_unit"^^xsd:anyURI ;
+  qudt:plainTextDescription "An astronomical unit (abbreviated as AU, au, a.u., or ua) is a unit of length equal to 149,597,870,700 metres (92,955,807.273 mi) or approximately the mean Earth Sun distance. The symbol ua is recommended by the International Bureau of Weights and Measures, and the international standard ISO 80000, while au is recommended by the International Astronomical Union, and is more common in Anglosphere countries. In general, the International System of Units only uses capital letters for the symbols of units which are named after individual scientists, while au or a.u. can also mean atomic unit or even arbitrary unit. However, the use of AU to refer to the astronomical unit is widespread. The astronomical constant whose value is one astronomical unit is referred to as unit distance and is given the symbol A. [Wikipedia]" ;
+  qudt:symbol "AU" ;
+  qudt:symbol "au" ;
+  qudt:ucumCaseInsensitiveCode "ASU" ;
+  qudt:ucumCaseInsensitiveCode "AU" ;
+  qudt:ucumCode "ASU" ;
+  qudt:ucumCode "AU" ;
+  qudt:uneceCommonCode "A12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "astronomical-unit" ;
+.
+unit:AUD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Australia, Australian Antarctic Territory, Christmas Island, Cocos (Keeling) Islands, Heard and McDonald Islands, Kiribati, Nauru, Norfolk Island, Tuvalu"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Australian_dollar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Australian_dollar?oldid=495046408"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/AustralianDollar> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Australian Dollar" ;
+.
+unit:AWG
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Aruba"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Aruban_florin"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Aruban_florin?oldid=492925638"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Aruban Guilder" ;
+.
+unit:AZN
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Azerbaijan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Azerbaijani_manat"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Azerbaijani_manat?oldid=495479090"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Azerbaijanian Manat" ;
+.
+unit:A_Ab
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "10"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abampere"^^xsd:anyURI ;
+  qudt:exactMatch unit:BIOT ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abampere?oldid=489318583"^^xsd:anyURI ;
+  qudt:informativeReference "http://wordinfo.info/results/abampere"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-13?rskey=i2kRRz"^^xsd:anyURI ;
+  qudt:isScalingOf unit:A ;
+  qudt:latexDefinition "\\(1\\,abA = 10\\,A\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abampere> ;
+  qudt:plainTextDescription "The Abampere (aA), also called the biot after Jean-Baptiste Biot, is the basic electromagnetic unit of electric current in the emu-cgs system of units (electromagnetic cgs). One abampere is equal to ten amperes in the SI system of units. An abampere is the constant current that produces, when maintained in two parallel conductors of negligible circular section and of infinite length placed 1 centimetre apart, a force of 2 dynes per centimetre between the two conductors." ;
+  qudt:symbol "abA" ;
+  qudt:ucumCaseInsensitiveCode "BI" ;
+  qudt:ucumCaseSensitiveCode "Bi" ;
+  qudt:ucumCode "BI" ;
+  qudt:ucumCode "Bi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abampere" ;
+  skos:altLabel "biot" ;
+.
+unit:A_Ab-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Abampere centimeter squared\" is the unit of magnetic moment in the electromagnetic centimeter-gram-second system."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(aAcm2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:informativeReference "http://wordinfo.info/unit/4266"^^xsd:anyURI ;
+  vaem:todo "Determine type for magnetic moment" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ampere centimeter" ;
+.
+unit:A_Ab-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Abampere Per Square Centimeter (aA/cm2) is a unit in the category of Electric current density. It is also known as abamperes per square centimeter, abampere/square centimeter, abampere/square centimetre, abamperes per square centimetre, abampere per square centimetre. This unit is commonly used in the cgs unit system. Abampere Per Square Centimeter (\\(aA/cm^2\\)) has a dimension of \\(L^{-2}I\\) where L is length, and I is electric current. It can be converted to the corresponding standard SI unit \\(A/m^{2}\\) by multiplying its value by a factor of 100000."^^qudt:LatexString ;
+  qudt:conversionMultiplier "100000"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:expression "\\(aba-per-cm2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:informativeReference "http://wordinfo.info/results/abampere"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_current_density--abampere_per_square_centimeter.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abampere per Square Centimeter" ;
+.
+unit:A_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Statampere\" (statA) is a unit in the category of Electric current. It is also known as statamperes. This unit is commonly used in the cgs unit system. Statampere (statA) has a dimension of I where I is electric current. It can be converted to the corresponding standard SI unit A by multiplying its value by a factor of 3.355641E-010."^^rdf:HTML ;
+  qudt:conversionMultiplier 3.335641E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_current--statampere.cfm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statampere> ;
+  qudt:symbol "statA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statampere" ;
+.
+unit:A_Stat-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The Statampere per Square Centimeter is a unit of electric current density in the c.g.s. system of units."^^rdf:HTML ;
+  qudt:conversionMultiplier 3.335641E-6 ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:expression "\\(statA / cm^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statampere per Square Centimeter" ;
+.
+unit:Atto
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"atto\" is a decimal prefix for expressing a value with a scaling of \\(10^{-18}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Atto"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atto?oldid=412748080"^^xsd:anyURI ;
+  qudt:symbol "a" ;
+  qudt:ucumCaseInsensitiveCode "A" ;
+  qudt:ucumCaseSensitiveCode "a" ;
+  qudt:ucumCode "A" ;
+  qudt:ucumCode "a" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Atto" ;
+.
+unit:AttoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "An AttoColomb is \\(10^{-18} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Atto ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "aC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "AttoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:AttoFARAD
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-18 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA319" ;
+  qudt:plainTextDescription "0,000 000 000 000 000 001-fold of the SI derived unit farad" ;
+  qudt:uneceCommonCode "H48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "AttoFARAD" ;
+  skos:prefLabel "attofarad" ;
+.
+unit:AttoJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-18 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:iec61360Code "0112/2///62720#UAB125" ;
+  qudt:plainTextDescription "0,000 000 000 000 000 001-fold of the derived SI unit joule" ;
+  qudt:uneceCommonCode "A13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "AttoJ" ;
+  skos:prefLabel "attojoule" ;
+.
+unit:AttoJ-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-18 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Action ;
+  qudt:iec61360Code "0112/2///62720#UAB151" ;
+  qudt:plainTextDescription "unit of the Planck's constant as product of the SI derived unit joule and the SI base unit second" ;
+  qudt:uneceCommonCode "B18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "AttoJ SEC" ;
+  skos:prefLabel "joule second" ;
+.
+unit:B
+  a qudt:DimensionlessUnit ;
+  a qudt:LogarithmicUnit ;
+  a qudt:Unit ;
+  dcterms:description "A logarithmic unit of sound pressure equal to 10 decibels (dB),  It is defined as: \\(1 B = (1/2) \\log_{10}(Np)\\)"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:RF-Power ;
+  qudt:hasQuantityKind quantitykind:SignalStrength ;
+  qudt:iec61360Code "0112/2///62720#UAB351" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sound_unit"^^xsd:anyURI ;
+  qudt:symbol "B" ;
+  qudt:ucumCaseInsensitiveCode "B" ;
+  qudt:ucumCode "B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bel" ;
+.
+unit:BAN
+  a qudt:Unit ;
+  dcterms:description "A ban is a logarithmic unit which measures information or entropy, based on base 10 logarithms and powers of 10, rather than the powers of 2 and base 2 logarithms which define the bit. One ban is approximately \\(3.32 (log_2 10) bits\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "2.30258509"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ban"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ban?oldid=472969907"^^xsd:anyURI ;
+  qudt:symbol "ban" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ban" ;
+.
+unit:BAR
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to \\(100,000\\,Pa\\). It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000\\,Pa = 1 \\,bar \\approx 750.0616827\\, Torr\\). </p>
+<p class=\"lm-para\">Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI.</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA323" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar?oldid=493875987"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bar> ;
+  qudt:symbol "bar" ;
+  qudt:ucumCaseInsensitiveCode "BAR" ;
+  qudt:ucumCaseSensitiveCode "bar" ;
+  qudt:ucumCode "BAR" ;
+  qudt:ucumCode "bar" ;
+  qudt:uneceCommonCode "BAR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bar" ;
+.
+unit:BAR-L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA326" ;
+  qudt:plainTextDescription "product of the unit bar and the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BAR L PER SEC" ;
+  skos:prefLabel "bar litre per second" ;
+.
+unit:BAR-M3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA814" ;
+  qudt:plainTextDescription "product out of the 0,001-fold of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BAR M3 PER SEC" ;
+  skos:prefLabel "bar metre cubed per second" ;
+.
+unit:BAR-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA325" ;
+  qudt:plainTextDescription "pressure relation consisting of the unit bar divided by the unit bar" ;
+  qudt:uneceCommonCode "J56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BAR PER BAR" ;
+  skos:prefLabel "bar per bar" ;
+.
+unit:BAR-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA324" ;
+  qudt:plainTextDescription "unit with the name bar divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BAR PER K" ;
+  skos:prefLabel "bar per kelvin" ;
+.
+unit:BARAD
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">A barad is a dyne per square centimetre (\\(dyn \\cdot cm^{-2}\\)), and is equal to \\(0.1 Pa \\) (\\(1 \\, micro \\, bar\\), \\(0.000014504 \\, p.s.i.\\)). Note that this is precisely the microbar, the confusable bar being related in size to the normal atmospheric pressure, at \\(100\\,dyn \\cdot cm^{-2}\\). Accordingly barad was not abbreviated, so occurs prefixed as in \\(cbarad = centibarad\\). Despite being the coherent unit for pressure in c.g.s., barad was probably much less common than the non-coherent bar. Barad is sometimes called \\(barye\\), a name also used for \\(bar\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:BARYE ;
+  qudt:hasQuantityKind quantitykind:Stress ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Barad" ;
+.
+unit:BARN
+  a qudt:Unit ;
+  dcterms:description "A barn (symbol b) is a unit of area. Originally used in nuclear physics for expressing the cross sectional area of nuclei and nuclear reactions, today it is used in all fields of high energy physics to express the cross sections of any scattering process, and is best understood as a measure of the probability of interaction between small particles. A barn is defined as \\(10^{28} m^2 (100 fm^2)\\) and is approximately the cross sectional area of a uranium nucleus. The barn is also the unit of area used in nuclear quadrupole resonance and nuclear magnetic resonance to quantify the interaction of a nucleus with an electric field gradient. While the barn is not an SI unit, it is accepted for use with the SI due to its continued use in particle physics."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-28 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Barn"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB297" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Barn?oldid=492907677"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Barn_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/barn> ;
+  qudt:symbol "b" ;
+  qudt:ucumCaseInsensitiveCode "BRN" ;
+  qudt:ucumCaseSensitiveCode "b" ;
+  qudt:ucumCode "BRN" ;
+  qudt:ucumCode "b" ;
+  qudt:uneceCommonCode "A14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Barn" ;
+.
+unit:BARYE
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The barye, or sometimes barad, barrie, bary, baryd, baryed, or barie, is the centimetre-gram-second (CGS) unit of pressure. It is equal to 1 dyne per square centimetre.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "0.1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Barye"^^xsd:anyURI ;
+  qudt:exactMatch unit:BARAD ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Barye?oldid=478631158"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:latexDefinition "\\(g/(cm\\cdot s{2}\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/barye> ;
+  qudt:symbol "\\rho" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Barye" ;
+  skos:altLabel "barad" ;
+  skos:altLabel "barie" ;
+  skos:altLabel "bary" ;
+  skos:altLabel "baryd" ;
+  skos:altLabel "baryed" ;
+.
+unit:BBD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Barbados"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Barbadian_dollar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Barbadian_dollar?oldid=494388633"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Barbados Dollar" ;
+.
+unit:BBL
+  a qudt:Unit ;
+  dcterms:description "A barrel is one of several units of volume, with dry barrels, fluid barrels (UK beer barrel, U.S. beer barrel), oil barrel, etc. The volume of some barrel units is double others, with various volumes in the range of about 100-200 litres (22-44 imp gal; 26-53 US gal)."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Barrel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA334" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Barrel?oldid=494614619"^^xsd:anyURI ;
+  qudt:symbol "bbl" ;
+  qudt:ucumCaseInsensitiveCode "[BBL_US]" ;
+  qudt:ucumCaseSensitiveCode "[bbl_us]" ;
+  qudt:ucumCode "[BBL_US]" ;
+  qudt:ucumCode "[bbl_us]" ;
+  qudt:uneceCommonCode "BLL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Barrel" ;
+.
+unit:BBL_UK_PET
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.591132e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CartesianVolume ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA329" ;
+  qudt:plainTextDescription "unit of the volume for crude oil according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_UK_PET" ;
+  skos:prefLabel "barrel (UK petroleum)" ;
+.
+unit:BBL_UK_PET-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.841587e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA331" ;
+  qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit day" ;
+  qudt:uneceCommonCode "J59" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_UK_PET PER DAY" ;
+  skos:prefLabel "barrel (UK petroleum) per day" ;
+.
+unit:BBL_UK_PET-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.41981e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA332" ;
+  qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit hour" ;
+  qudt:uneceCommonCode "J60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_UK_PET PER HR" ;
+  skos:prefLabel "barrel (UK petroleum) per hour" ;
+.
+unit:BBL_UK_PET-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.651886e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA330" ;
+  qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the unit minute" ;
+  qudt:uneceCommonCode "J58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_UK_PET PER MIN" ;
+  skos:prefLabel "barrel (UK petroleum) per minute" ;
+.
+unit:BBL_UK_PET-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.591132e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA333" ;
+  qudt:plainTextDescription "unit of the volume barrel (UK petroleum) for crude oil according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_UK_PET PER SEC" ;
+  skos:prefLabel "barrel (UK petroleum) per second" ;
+.
+unit:BBL_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.589873e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CartesianVolume ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA334" ;
+  qudt:plainTextDescription "unit of the volume for crude oil according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "BLL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US" ;
+  skos:prefLabel "barrel (US)" ;
+.
+unit:BBL_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.84e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA335" ;
+  qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit day" ;
+  qudt:uneceCommonCode "B1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US PER DAY" ;
+  skos:prefLabel "barrel (US) per day" ;
+.
+unit:BBL_US-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.6498e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA337" ;
+  qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit minute" ;
+  qudt:uneceCommonCode "J63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US PER MIN" ;
+  skos:prefLabel "barrel (US) per minute" ;
+.
+unit:BBL_US_DRY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.156281989625e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CartesianVolume ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:iec61360Code "0112/2///62720#UAB117" ;
+  qudt:plainTextDescription "non SI-conform unit of the volume in the USA which applies to a resolution from 1912: 1 dry barrel (US) equals approximately to 115,63 litre" ;
+  qudt:uneceCommonCode "BLD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US_DRY" ;
+  skos:prefLabel "dry barrel (US)" ;
+.
+unit:BBL_US_PET-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.4163e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA336" ;
+  qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the unit hour" ;
+  qudt:uneceCommonCode "J62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US_PET PER HR" ;
+  skos:prefLabel "barrel (US petroleum) per hour" ;
+.
+unit:BBL_US_PET-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.589873e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA338" ;
+  qudt:plainTextDescription "unit of the volume barrel (US petroleum) for crude oil according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BBL_US_PET PER SEC" ;
+  skos:prefLabel "barrel (US petroleum) per second" ;
+.
+unit:BDT
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bangladesh"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bangladeshi_taka"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bangladeshi_taka?oldid=492673895"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bangladeshi Taka" ;
+.
+unit:BEAT-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Heart Beat per Minute\" is a unit for  'Heart Rate' expressed as \\(BPM\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:HeartRate ;
+  qudt:symbol "beats-per-min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Heart Beats per Minute" ;
+.
+unit:BFT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0.0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:iec61360Code "0112/2///62720#UAA110" ;
+  qudt:plainTextDescription "unit for classification of winds according to their speed, developed by Sir Francis Beaufort as measure for the over-all behaviour of a ship's sail at different wind speeds" ;
+  qudt:uneceCommonCode "M19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Beaufort" ;
+  skos:prefLabel "Beaufort" ;
+.
+unit:BHD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bahrain"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bahraini_dinar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bahraini_dinar?oldid=493086643"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bahraini Dinar" ;
+.
+unit:BIOT
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  dcterms:description "\"Biot\" is another name for the abampere (aA), which is the basic electromagnetic unit of electric current in the emu-cgs (centimeter-gram-second) system of units. It is called after a French physicist, astronomer, and mathematician Jean-Baptiste Biot. One abampere is equal to ten amperes in the SI system of units. One abampere is the current, which produces a force of 2 dyne/cm between two infinitively long parallel wires that are 1 cm apart."^^rdf:HTML ;
+  qudt:conversionMultiplier 3.335641E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Biot"^^xsd:anyURI ;
+  qudt:exactMatch unit:A_Ab ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAB210" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Biot?oldid=443318821"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/current/10-4/"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/biot> ;
+  qudt:symbol "Bi" ;
+  qudt:ucumCaseInsensitiveCode "BI" ;
+  qudt:ucumCaseSensitiveCode "Bi" ;
+  qudt:ucumCode "BI" ;
+  qudt:ucumCode "Bi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Biot" ;
+.
+unit:BIT
+  a qudt:Unit ;
+  dcterms:description "In information theory, a bit is the amount of information that, on average, can be stored in a discrete bit. It is thus the amount of information carried by a choice between two equally likely outcomes. One bit corresponds to about 0.693 nats (ln(2)), or 0.301 hartleys (log10(2))."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.693147181"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bit"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:iec61360Code "0112/2///62720#UAA339" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bit?oldid=495288173"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bit> ;
+  qudt:symbol "b" ;
+  qudt:uneceCommonCode "J63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bit" ;
+.
+unit:BIT-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A bit per second (B/s) is a unit of data transfer rate equal to 1 bits per second."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobyte_per_second"^^xsd:anyURI ;
+  qudt:symbol "bps" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bit per Second" ;
+.
+unit:BQ
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI derived unit of activity, usually meaning radioactivity. \"Radioactivity\" is caused when atoms disintegrate, ejecting energetic particles. One becquerel is the radiation caused by one disintegration per second; this is equivalent to about 27.0270 picocuries (pCi). The unit is named for a French physicist, Antoine-Henri Becquerel (1852-1908), the discoverer of radioactivity. Note: both the becquerel and the hertz are basically defined as one event per second, yet they measure different things. The hertz is used to measure the rates of events that happen periodically in a fixed and definite cycle. The becquerel is used to measure the rates of events that happen sporadically and unpredictably, not in a definite cycle."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Becquerel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA111" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Becquerel?oldid=493710036"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/becquerel> ;
+  qudt:symbol "Bq" ;
+  qudt:ucumCaseInsensitiveCode "BQ" ;
+  qudt:ucumCaseSensitiveCode "Bq" ;
+  qudt:ucumCode "BQ" ;
+  qudt:ucumCode "Bq" ;
+  qudt:uneceCommonCode "BQL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Becquerel" ;
+.
+unit:BQ-PER-KiloGM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The only unit in the category of Specific radioactivity. It is also known as becquerels per kilogram, becquerel/kilogram. This unit is commonly used in the SI unit system. Becquerel Per Kilogram (Bq/kg) has a dimension of \\(M{-1}T{-1}\\) where \\(M\\) is mass, and \\(T\\) is time. It essentially the same as the corresponding standard SI unit \\(/kg/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Bq/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificActivity ;
+  qudt:iec61360Code "0112/2///62720#UAA112" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_radioactivity--becquerel_per_kilogram.cfm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "\"Bequerel per Kilogram\" is used to describe radioactivity, which is often expressed in becquerels per unit of volume or weight, to express how much radioactive material is contained in a sample." ;
+  qudt:uneceCommonCode "A18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Becquerel per Kilogram" ;
+.
+unit:BQ-PER-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Bq/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SurfaceActivityDensity ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Becquerel per Square Meter" ;
+.
+unit:BQ-PER-M3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Becquerel Per Cubic Meter (\\(Bq/m3\\)) is a unit in the category of Radioactivity concentration. It is also known as becquerels per cubic meter, becquerel per cubic metre, becquerels per cubic metre, becquerel/cubic inch. This unit is commonly used in the SI unit system. Becquerel Per Cubic Meter (Bq/m3) has a dimension of \\(L{-3}T{-1}\\) where \\(L\\) is length, and \\(T\\) is time. It essentially the same as the corresponding standard SI unit \\(/s\\cdot m{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Bq/m^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ActivityConcentration ;
+  qudt:iec61360Code "0112/2///62720#UAB126" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--radioactivity_concentration--becquerel_per_cubic_meter.cfm"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:plainTextDescription "The SI derived unit of unit in the category of Radioactivity concentration." ;
+  qudt:uneceCommonCode "A19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Becquerel per Cubic Meter" ;
+.
+unit:BREATH-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of respiratory rate."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(breaths/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:RespiratoryRate ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Breath per Minute" ;
+.
+unit:BSD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bahamas"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bahamian_dollar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bahamian_dollar?oldid=492776024"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bahamian Dollar" ;
+.
+unit:BTU_IT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{British Thermal Unit}\\) (BTU or Btu) is a traditional unit of energy equal to about \\(1.0550558526 \\textit{ kilojoule}\\). It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from \\(39 \\,^{\\circ}{\\rm F}\\)  to \\(40 \\,^{\\circ}{\\rm F}\\) . The unit is most often used in the power, steam generation, heating and air conditioning industries. In scientific contexts the BTU has largely been replaced by the SI unit of energy, the \\(joule\\), though it may be used as a measure of agricultural energy production (BTU/kg). It is still used unofficially in metric English-speaking countries (such as Canada), and remains the standard unit of classification for air conditioning units manufactured and sold in many non-English-speaking metric countries."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1055.05585262"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/British_thermal_unit"^^xsd:anyURI ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_ics/catalogue_detail_ics.htm?csnumber=31890"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.knowledgedoor.com/2/units_and_constants_handbook/british-thermal-unit_group.html"^^xsd:anyURI ;
+  qudt:symbol "Btu_{it}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "British Thermal Unit (International Definition)" ;
+.
+unit:BTU_IT-FT
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  dcterms:description "<p><em>BTU Foot</em> is an Imperial unit for <em>Thermal Energy Length</em> expressed as \\(Btu-ft\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "321.581024"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu-ft\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU Foot" ;
+.
+unit:BTU_IT-FT-PER-FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(BTU_{IT}\\), Foot per Square Foot Hour Degree Fahrenheit</em> is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu_{it} \\cdot ft/(hr \\cdot ft^2  \\cdot degF)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.730734666"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(IT) ft/(hr ft^2 degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA115" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  qudt:plainTextDescription "British thermal unit (international table) foot per hour foot squared degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
+  qudt:uneceCommonCode "J40" ;
+  vaem:comment "owl:sameAs: unit:BTU_IT-FT-PER-HR-FT2-DEG_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (IT) Foot per Square Foot Hour Degree Fahrenheit" ;
+.
+unit:BTU_IT-FT-PER-HR-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.730735e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA115" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT FT PER HR FT2 DEG_F" ;
+  skos:prefLabel "British thermal unit (international table) foot per hour foot squared degree Fahrenheit" ;
+.
+unit:BTU_IT-IN
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU Inch</em> is an Imperial unit for 'Thermal Energy Length' expressed as \\(Btu-in\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "26.7984187"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu-in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergyLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU Inch" ;
+.
+unit:BTU_IT-IN-PER-FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(BTU_{th}\\) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu_{it}-in/(hr-ft^{2}-degF)\\). An International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. \\(1 Btu_{it} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\) shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.144227889"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(it)-in-per-hr-ft2-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA117" ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  qudt:latexSymbol "\\($$Btu_{it} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)$$\\)"^^qudt:LatexString ;
+  qudt:plainTextDescription "BTU (th) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity', an International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units." ;
+  qudt:uneceCommonCode "J41" ;
+  vaem:comment "owl:sameAs: unit:BTU_IT-IN-PER-HR-FT2-DEG_F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (IT) Inch per Square Foot Hour Degree Fahrenheit" ;
+  skos:prefLabel "British thermal unit (international table) inch per hour foot squared degree Fahrenheit" ;
+.
+unit:BTU_IT-IN-PER-FT2-SEC-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(BTU_{IT} Inch per Square Foot Second Degree Fahrenheit\\) is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu_{it}-in/(ft^{2}-s-degF)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "519.220399911"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(it)-in-per-s-ft2-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA118" ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  qudt:plainTextDescription "British thermal unit (international table) inch per second foot squared degree Fahrenheit is the unit of the thermal conductivity according to the Imperial system of units." ;
+  qudt:uneceCommonCode "J42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (IT) Inch per Square Foot Second Degree Fahrenheit" ;
+.
+unit:BTU_IT-IN-PER-HR-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.442279e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA117" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT IN PER HR FT2 DEG_F" ;
+  owl:sameAs unit:BTU_IT-IN-PER-FT2-HR-DEG_F ;
+  skos:prefLabel "British thermal unit (international table) inch per hour foot squaredÂ degree Fahrenheit" ;
+.
+unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.192204e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA118" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT IN PER SEC FT2 DEG_F" ;
+  owl:sameAs unit:BTU_IT-IN-PER-FT2-SEC-DEG_F ;
+  skos:prefLabel "British thermal unit (international table) inch per second foot squaredÂ degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>British Thermal Unit (IT) Per Fahrenheit Degree (\\(Btu (IT)/^\\circ F\\)) is a measure of heat capacity. It can be converted to the corresponding standard SI unit J/K by multiplying its value by a factor of 1899.10534.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1899.100535"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/degF\\)"^^qudt:LatexString ;
+  qudt:expression "\\(btu-per-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (IT) per Degree Fahrenheit" ;
+  rdfs:label "BTU per Degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-DEG_R
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU per Degree Rankine</em> is an Imperial unit for 'Heat Capacity' expressed as \\(Btu/degR\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1899.100535"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(btu-per-degR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Degree Rankine" ;
+.
+unit:BTU_IT-PER-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">\\(\\textit{BTU per Square Foot}\\) is an Imperial unit for  'Energy Per Area' expressed as \\(Btu/ft^2\\)</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier "11356.5267"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Square Foot" ;
+.
+unit:BTU_IT-PER-FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU per Square Foot Hour Degree Fahrenheit</em> is an Imperial unit for 'Coefficient Of Heat Transfer' expressed as \\(Btu/(hr-ft^{2}-degF)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(hr-ft^{2}-degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Square Foot Hour Degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-FT2-SEC-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU per Square Foot Second Degree Fahrenheit</em> is an Imperial unit for 'Coefficient Of Heat Transfer' expressed as \\(Btu/(ft^{2}-s-degF)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(ft^{2}-s-degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Square Foot Second Degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-FT3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">\\(\\textit{British Thermal Unit (IT) Per Cubic Foot}\\) (\\(Btu (IT)/ft^3\\)) is a unit in the category of Energy density. It is also known as Btu per cubic foot, Btu/cubic foot. This unit is commonly used in the UK, US unit systems. It has a dimension of \\(ML^{-1}T^{-2}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. It can be converted to the corresponding standard SI unit \\(J/m^3\\) by multiplying its value by a factor of 37258.94579.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.725894579E04 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(IT)-per-ft3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyDensity ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "British Thermal Unit (IT) Per Cubic Foot" ;
+.
+unit:BTU_IT-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The British thermal unit (BTU or Btu) is a traditional unit of energy equal to about 1 055.05585 joules. It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from \\(39 \\,^{\\circ}{\\rm F}\\) (\\(3.9 \\,^{\\circ}{\\rm C}\\)) to \\(40 \\,^{\\circ}{\\rm F}\\) (\\(4.4 \\,^{\\circ}{\\rm C}\\)). The unit is most often used in the power, steam generation, heating and air conditioning industries. In scientific contexts the BTU has largely been replaced by the SI unit of energy, the joule, though it may be used as a measure of agricultural energy production (BTU/kg).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.29307107"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Hour" ;
+.
+unit:BTU_IT-PER-HR-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">\\(\\textit{BTU per Hour Square Foot}\\) is an Imperial unit for  'Power Per Area' expressed as \\(Btu/(hr-ft^2)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "3.15459075"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(hr-ft^{2})\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Hour Square Foot" ;
+.
+unit:BTU_IT-PER-HR-FT2-DEG_R
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0.555556e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:iec61360Code "0112/2///62720#UAB099" ;
+  qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:uneceCommonCode "A23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER HR FT2 DEG_R" ;
+  skos:prefLabel "British thermal unit (international table) per hour foot squared degree Rankine" ;
+.
+unit:BTU_IT-PER-LB_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.37185970623768328e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB150" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit avoirdupois pound according to the avoirdupois system of units" ;
+  qudt:uneceCommonCode "AZ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER LB_F" ;
+  skos:prefLabel "British thermal unit (international table) per pound" ;
+.
+unit:BTU_IT-PER-LB_F-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA119" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the product of the units avoirdupois pound according to the avoirdupois system of units and degree Fahrenheit" ;
+  qudt:uneceCommonCode "J43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER LB_F DEG_F" ;
+  skos:prefLabel "British thermal unit (international table) per pound degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-LB_F-DEG_R
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.269e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAB141" ;
+  qudt:plainTextDescription "unit of the heat capacity as British thermal unit according to the international table related to degree Rankine according to the Imperial system of units divided by the unit avoirdupois pound according to the avoirdupois system of units" ;
+  qudt:uneceCommonCode "A21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER LB_F DEG_R" ;
+  skos:prefLabel "British thermal unit (international table) per pound degree Rankine" ;
+.
+unit:BTU_IT-PER-LB_M
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The amount of energy generated by a pound of substance is measured in British thermal units (IT) per pound of mass. 1 \\(Btu_{IT}/lb\\) is equivalent to \\(2.326 \\times 10^3\\) joule per kilogram (J/kg)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.326E+03 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/lb\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU-IT-PER-lb" ;
+.
+unit:BTU_IT-PER-LB_M-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>British Thermal Unit (therm.) Per Pound Per Fahrenheit Degree (Btu (therm.)/lb- degF) is a unit in the category of Specific heat. This unit is commonly used in the UK unit system. British Thermal Unit (therm.) Per Pound Per Fahrenheit Degree (Btu (therm.)/lb-degF) has a dimension of \\(L2T^{-2}Q^{-1}\\) where \\(L\\) is length, \\(T\\) is time, and \\(Q\\) is temperature. It can be converted to the corresponding standard SI unit \\(J/kg-K\\) by multiplying its value by a factor of 4183.99895.</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(lb-degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Pound Degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-LB_M-DEG_R
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU per Pound Degree Rankine</em> is a unit for 'Specific Heat Capacity' expressed as \\(Btu/(lb-degR)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(lb-degR)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Pound Degree Rankine" ;
+.
+unit:BTU_IT-PER-LB_M-MOL
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><b>BTU per Pound Mole</b> is an Imperial unit for <em>'Energy And Work Per Mass Amount Of Substance'</em> expressed as \\(Btu/(lb-mol)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(lb-mol)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWorkPerMassAmountOfSubstance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Pound Mole" ;
+.
+unit:BTU_IT-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.758e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA120" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
+  qudt:uneceCommonCode "J44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER MIN" ;
+  skos:prefLabel "British thermal unit (international table) per minute" ;
+.
+unit:BTU_IT-PER-MOL-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><b>BTU per Pound Mole Degree Fahrenheit</b> is an Imperial unit for <em>'Molar Heat Capacity'</em> expressed as \\(Btu/(lb-mol-degF)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(lb-mol-degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Pound Mole Degree Fahrenheit" ;
+.
+unit:BTU_IT-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>BTU per Second</em> is an Imperial unit for 'Heat Flow Rate' expressed as \\(Btu/s\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1055.05585262"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:informativeReference "http://www.simetric.co.uk/sibtu.htm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Second" ;
+.
+unit:BTU_IT-PER-SEC-FT-DEG_R
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.7866e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAB107" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "A22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER SEC FT DEG_R" ;
+  skos:prefLabel "British thermal unit (international table) per second foot degree Rankine" ;
+.
+unit:BTU_IT-PER-SEC-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">\\(\\textit{BTU per Second Square Foot}\\) is an Imperial unit for  'Power Per Area' expressed as \\(Btu/(s\\cdot ft^2)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "11356.5267"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu/(s-ft^{2})\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU per Second Square Foot" ;
+.
+unit:BTU_IT-PER-SEC-FT2-DEG_R
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.489e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:iec61360Code "0112/2///62720#UAB098" ;
+  qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:uneceCommonCode "A20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_IT PER SEC FT2 DEG_R" ;
+  skos:prefLabel "British thermal unit (international table) per second foot squaredÂ degree Rankine" ;
+.
+unit:BTU_MEAN
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1055.05585262"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA113" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_MEAN" ;
+  skos:prefLabel "British thermal unit (mean)" ;
+.
+unit:BTU_TH
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>British Thermal Unit (thermochemical definition} (\\(BTU_{th}\\)) is a traditional unit of energy equal to about \\(1.0543502645 kilojoule\\). It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from \\(39 \\,^{\\circ}{\\rm F}\\) (\\(39 \\,^{\\circ}{\\rm C}\\)) to \\(40 \\,^{\\circ}{\\rm F}\\) (\\(4.4 \\,^{\\circ}{\\rm C\"\\)). The unit is most often used in the power, steam generation, heating and air conditioning industries. In scientific contexts the BTU has largely been replaced by the SI unit of energy, the \\(joule\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0543502645e+03 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/British_thermal_unit"^^xsd:anyURI ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.iso.org/iso/home/store/catalogue_ics/catalogue_detail_ics.htm?csnumber=31890"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.knowledgedoor.com/2/units_and_constants_handbook/british-thermal-unit_group.html"^^xsd:anyURI ;
+  qudt:symbol "Btu_{th}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "British Thermal Unit (Thermochemical Definition)" ;
+.
+unit:BTU_TH-FT-PER-FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>\\(BTU_{TH}\\) Foot per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu_{th} \\cdot ft/(hr \\cdot ft^2 \\cdot degF)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.729577206"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(IT) ft/(hr ft^2 degF)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (TH) Foot per Square Foot Hour Degree Fahrenheit" ;
+.
+unit:BTU_TH-FT-PER-HR-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.73e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA123" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J46" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH FT PER HR FT2 DEG_F" ;
+  skos:prefLabel "British thermal unit (thermochemical) foot per hour foot squaredÂ degree Fahrenheit" ;
+.
+unit:BTU_TH-IN-PER-FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>\\(BTU_{th}\\) Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu-in/(hr-ft^{2}-degF)\\). A thermochemical British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. \\(1 Btu_{th} \\cdot in/(hr \\cdot ft^{2</em>  \\cdot degF)\\) shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.144131434"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(th)-in-per-hr-ft2-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(Btu_{th} \\cdot in/(hr \\cdot ft^{2}  \\cdot degF)\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (TH) Inch per Square Foot Hour Degree Fahrenheit" ;
+.
+unit:BTU_TH-IN-PER-FT2-SEC-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>\\(BTU_{TH}\\) Inch per Square Foot Second Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as \\(Btu_{th} \\cdot in/(ft^{2} \\cdot s \\cdot degF)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "519.220399911"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(it)-in-per-s-ft2-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/thermal-conductivity/c/"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU (TH) Inch per Square Foot Second Degree Fahrenheit" ;
+.
+unit:BTU_TH-IN-PER-HR-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.441314e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA125" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH IN PER HR FT2 DEG_F" ;
+  skos:prefLabel "British thermal unit (thermochemical) inch per hour squareÂ foot degree Fahrenheit" ;
+.
+unit:BTU_TH-IN-PER-SEC-FT2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.188732e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA126" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH IN PER SEC FT2 DEG_F" ;
+  skos:prefLabel "British thermal unit (thermochemical) inch per secondÂ foot squaredÂ degree Fahrenheit" ;
+.
+unit:BTU_TH-PER-FT3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">British Thermal Unit (TH) Per Cubic Foot (\\(Btu (TH)/ft^3\\)) is a unit in the category of Energy density. It is also known as Btu per cubic foot, Btu/cubic foot. This unit is commonly used in the UK, US unit systems. It has a dimension of \\(ML^{-1}T^{-2}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. It can be converted to the corresponding standard SI unit \\(J/m^3\\) by multiplying its value by a factor of 37234.03.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.723403E04 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Btu(th)-per-ft3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyDensity ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_density--british_thermal_unit_it_per_cubic_foot.cfm"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.translatorscafe.com/cafe/EN/units-converter/fuel-efficiency--volume/c/"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "British Thermal Unit (TH) Per Cubic Foot" ;
+.
+unit:BTU_TH-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.929e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA124" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit hour" ;
+  qudt:uneceCommonCode "J47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH PER HR" ;
+  skos:prefLabel "British thermal unit (thermochemical) per hour" ;
+.
+unit:BTU_TH-PER-LB-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.26654e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA127" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units divided by the units pound and degree Fahrenheit" ;
+  qudt:uneceCommonCode "J50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH PER LB DEG_F" ;
+  skos:prefLabel "British thermal unit (thermochemical) per pound degree Fahrenheit" ;
+.
+unit:BTU_TH-PER-LB_M
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>British Thermal Unit (therm.) Per Pound Mass (Btu (TH)/lbm) is a unit in the category of Thermal heat capacity. It is also known as Btu per pound, Btu/pound, Btu/lb. This unit is commonly used in the UK unit system. British Thermal Unit (therm.) Per Pound Mass (Btu (therm.)/lbm) has a dimension of L2T-2 where L is length, and T is time. It can be converted to the corresponding standard SI unit J/kg by multiplying its value by a factor of 2324.443861.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 2.324443861E+03 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(btu_th-per-lb\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "British Thermal Unit (TH) Per Pound" ;
+.
+unit:BTU_TH-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.7573e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA128" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the unit minute" ;
+  qudt:uneceCommonCode "J51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH PER MIN" ;
+  skos:prefLabel "British thermal unit (thermochemical) per minute" ;
+.
+unit:BTU_TH-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.05435e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA129" ;
+  qudt:plainTextDescription "unit of the heat energy according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BTU_TH PER SEC" ;
+  skos:prefLabel "British thermal unit (thermochemical) per second" ;
+.
+unit:BU_UK
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A bushel is an imperial unit of dry volume, equivalent in each of these systems to 4 pecks or 8 gallons. It is used for volumes of dry commodities (not liquids), most often in agriculture. It is abbreviated as bsh. or bu. In modern usage, the dry volume is usually only nominal, with bushels referring to standard weights instead."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.03636872"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bushel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA344" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bushel?oldid=476704875"^^xsd:anyURI ;
+  qudt:symbol "bui" ;
+  qudt:ucumCaseInsensitiveCode "[BU_BR]" ;
+  qudt:ucumCaseSensitiveCode "[bu_br]" ;
+  qudt:ucumCode "[BU_BR]" ;
+  qudt:ucumCode "[bu_br]" ;
+  qudt:uneceCommonCode "BUI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "bushel (UK)" ;
+.
+unit:BU_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.209343e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA345" ;
+  qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "J64" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_UK PER DAY" ;
+  skos:prefLabel "bushel (UK) per day" ;
+.
+unit:BU_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.010242e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA346" ;
+  qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "J65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_UK PER HR" ;
+  skos:prefLabel "bushel (UK) per hour" ;
+.
+unit:BU_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.061453e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA347" ;
+  qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "J66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_UK PER MIN" ;
+  skos:prefLabel "bushel (UK) per minute" ;
+.
+unit:BU_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.636872e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA348" ;
+  qudt:plainTextDescription "unit of the volume bushel (UK) (for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J67" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_UK PER SEC" ;
+  skos:prefLabel "bushel (UK) per second" ;
+.
+unit:BU_US
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A bushel is an imperial and U.S. customary unit of dry volume, equivalent in each of these systems to 4 pecks or 8 gallons. It is used for volumes of dry commodities (not liquids), most often in agriculture. It is abbreviated as bsh. or bu. In modern usage, the dry volume is usually only nominal, with bushels referring to standard weights instead."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.03523907"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bushel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA353" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bushel?oldid=476704875"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/bushel-US> ;
+  qudt:symbol "bua" ;
+  qudt:ucumCaseInsensitiveCode "[BU_US]" ;
+  qudt:ucumCaseSensitiveCode "[bu_us]" ;
+  qudt:ucumCode "[BU_US]" ;
+  qudt:ucumCode "[bu_us]" ;
+  qudt:uneceCommonCode "BUA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "bushel (US)" ;
+.
+unit:BU_US_DRY-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.0786e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA349" ;
+  qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "J68" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_US_DRY PER DAY" ;
+  skos:prefLabel "bushel (US dry) per day" ;
+.
+unit:BU_US_DRY-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.789e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA350" ;
+  qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "J69" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_US_DRY PER HR" ;
+  skos:prefLabel "bushel (US dry) per hour" ;
+.
+unit:BU_US_DRY-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.8732e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA351" ;
+  qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "J70" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_US_DRY PER MIN" ;
+  skos:prefLabel "bushel (US dry) per minute" ;
+.
+unit:BU_US_DRY-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.523907e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA352" ;
+  qudt:plainTextDescription "unit of the volume bushel (US dry) for dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "BU_US_DRY PER SEC" ;
+  skos:prefLabel "bushel (US dry) per second" ;
+.
+unit:BYR
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Belarus"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Belarusian_ruble"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Belarusian_ruble?oldid=494143246"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Belarussian Ruble" ;
+.
+unit:BYTE
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The byte is a unit of digital information in computing and telecommunications that most commonly consists of eight bits."^^rdf:HTML ;
+  qudt:conversionMultiplier "5.54517744"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Byte"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAA354" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Byte?oldid=493588918"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/byte> ;
+  qudt:symbol "B" ;
+  qudt:uneceCommonCode "AD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Byte" ;
+.
+unit:BelizeDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Belize"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Belize_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(BZD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Belize_dollar?oldid=462662376"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Belize Dollar" ;
+.
+unit:BermudaDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bermuda"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bermudian_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(BMD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bermudian_dollar?oldid=492670344"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bermuda Dollar" ;
+.
+unit:BolivianMvdol
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bolivia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(BOV\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bolivian Mvdol (Funds code)" ;
+.
+unit:Boliviano
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bolivia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bolivian_boliviano"^^xsd:anyURI ;
+  qudt:expression "\\(BOB\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bolivian_boliviano?oldid=494873944"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Boliviano" ;
+.
+unit:BrazilianReal
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Brazil"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Brazilian_real"^^xsd:anyURI ;
+  qudt:expression "\\(BRL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Brazilian_real?oldid=495278259"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/BrazilianReal> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Brazilian Real" ;
+.
+unit:BruneiDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Brunei"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Brunei_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(BND\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Brunei_dollar?oldid=495134546"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Brunei Dollar" ;
+.
+unit:BulgarianLev
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bulgaria"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bulgarian_lev"^^xsd:anyURI ;
+  qudt:expression "\\(BGN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bulgarian_lev?oldid=494947467"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Bulgarian Lev" ;
+.
+unit:BurundianFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Burundi"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Burundian_franc"^^xsd:anyURI ;
+  qudt:expression "\\(BIF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Burundian_franc?oldid=489383699"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Burundian Franc" ;
+.
+unit:C
+  a qudt:CGS-Unit ;
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of electric charge. One coulomb is the amount of charge accumulated in one second by a current of one ampere. Electricity is actually a flow of charged particles, such as electrons, protons, or ions. The charge on one of these particles is a whole-number multiple of the charge e on a single electron, and one coulomb represents a charge of approximately 6.241 506 x 1018 e. The coulomb is named for a French physicist, Charles-Augustin de Coulomb (1736-1806), who was the first to measure accurately the forces exerted between electric charges."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Coulomb"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA130" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Coulomb?oldid=491815163"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/coulomb> ;
+  qudt:symbol "C" ;
+  qudt:ucumCaseInsensitiveCode "C" ;
+  qudt:ucumCode "C" ;
+  qudt:uneceCommonCode "COU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb" ;
+.
+unit:C-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Coulomb Meter (C-m) is a unit in the category of Electric dipole moment. It is also known as atomic unit, u.a., au, ua. This unit is commonly used in the SI unit system. Coulomb Meter (C-m) has a dimension of LTI where L is length, T is time, and I is electric current. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricDipoleMoment ;
+  qudt:iec61360Code "0112/2///62720#UAA133" ;
+  qudt:symbol "C m" ;
+  qudt:uneceCommonCode "A26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb Meter" ;
+.
+unit:C-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Coulomb Square Meter (C-m2) is a unit in the category of Electric quadrupole moment. This unit is commonly used in the SI unit system. Coulomb Square Meter (C-m2) has a dimension of L2TI where L is length, T is time, and I is electric current. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C m^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricQuadrupoleMoment ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb Square Meter" ;
+.
+unit:C-M2-PER-V
+  a qudt:Unit ;
+  dcterms:description "Coulomb Square Meter (C-m2-per-volt) is a unit in the category of Electric polarizability."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C m^{2} v^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Polarizability ;
+  qudt:iec61360Code "0112/2///62720#UAB486" ;
+  qudt:uneceCommonCode "A27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb Square Meter Per Volt" ;
+.
+unit:C-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB101" ;
+  qudt:plainTextDescription "derived SI unit coulomb divided by the 0,000 1-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "A33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "C PER CentiM2" ;
+  skos:prefLabel "coulomb per centimetre squared" ;
+.
+unit:C-PER-CentiM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB120" ;
+  qudt:plainTextDescription "derived SI unit coulomb divided by the 0,000 001-fold of the power of the SI base unit metre by exponent 3" ;
+  qudt:uneceCommonCode "A28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "C PER CentiM3" ;
+  skos:prefLabel "coulomb per centimetre cubed" ;
+.
+unit:C-PER-KiloGM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Coulomb Per Kilogram (C/kg)</em> is the unit in the category of Exposure. It is also known as coulombs per kilogram, coulomb/kilogram. This unit is commonly used in the SI unit system. Coulomb Per Kilogram (C/kg) has a dimension of \\(M^{-1}TI\\) where \\(M\\) is mass, \\(T\\) is time, and \\(I\\) is electric current. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  qudt:iec61360Code "0112/2///62720#UAA131" ;
+  qudt:uneceCommonCode "CKG" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb per Kilogram" ;
+.
+unit:C-PER-KiloGM-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of exposure rate"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C/kg-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ExposureRate ;
+  qudt:iec61360Code "0112/2///62720#UAA132" ;
+  qudt:informativeReference "http://en.wikibooks.org/wiki/Basic_Physics_of_Nuclear_Medicine/Units_of_Radiation_Measurement"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb Per Kilogram Second" ;
+.
+unit:C-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Coulomb per Meter\" is a unit for  'Electric Charge Line Density' expressed as \\(C/m\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeLineDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB337" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb per Meter" ;
+.
+unit:C-PER-M2
+  a qudt:CGS-Unit ;
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Coulomb Per Square Meter (\\(C/m^2\\)) is a unit in the category of Electric charge surface density. It is also known as coulombs per square meter, coulomb per square metre, coulombs per square metre, coulomb/square meter, coulomb/square metre. This unit is commonly used in the SI unit system. Coulomb Per Square Meter (C/m2) has a dimension of \\(L^{-2}TI\\) where L is length, T is time, and I is electric current. This unit is the standard SI unit in this category. "^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C/m^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA134" ;
+  qudt:uneceCommonCode "A34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb per Square Meter" ;
+.
+unit:C-PER-M3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Coulomb Per Cubic Meter (\\(C/m^{3}\\)) is a unit in the category of Electric charge density. It is also known as coulomb per cubic metre, coulombs per cubic meter, coulombs per cubic metre, coulomb/cubic meter, coulomb/cubic metre. This unit is commonly used in the SI unit system. Coulomb Per Cubic Meter has a dimension of \\(L^{-3}TI\\) where \\(L\\) is length, \\(T\\) is time, and \\(I\\) is electric current. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C/m^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA135" ;
+  qudt:uneceCommonCode "A29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb per Cubic Meter" ;
+.
+unit:C-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><strong>Coulomb Per Mol</strong> (\\(C/mol\\)) is a unit in the category of Molar electric charge. It is also known as \\(coulombs/mol\\). Coulomb Per Mol has a dimension of \\(TN{-1}I\\) where \\(T\\) is time, \\(N\\) is amount of substance, and \\(I\\) is electric current. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(c-per-mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerAmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAB142" ;
+  qudt:uneceCommonCode "A32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Coulomb per Mole" ;
+.
+unit:C-PER-MilliM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB100" ;
+  qudt:plainTextDescription "derived SI unit coulomb divided by the 0,000 001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "A35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "C PER MilliM2" ;
+  skos:prefLabel "coulomb per millimetre squared" ;
+.
+unit:C-PER-MilliM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB119" ;
+  qudt:plainTextDescription "derived SI unit coulomb divided by the 0,000 000 001-fold of the power of the SI base unit metre by exponent 3" ;
+  qudt:uneceCommonCode "A30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "C PER MilliM3" ;
+  skos:prefLabel "coulomb per millimetre cubed" ;
+.
+unit:C2-M-PER-J
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Square Coulomb Meter per Joule\" is a unit for  'Polarizability' expressed as \\(C^{2} m^{2} J^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C^{2} m^{2} J^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Polarizability ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Coulomb Meter per Joule" ;
+.
+unit:C3-M-PER-J2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Cubic Coulomb Meter per Square Joule\" is a unit for  'Cubic Electric Dipole Moment Per Square Energy' expressed as \\(C^{3} m^{3} J^{-2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(C^{3} m^{3} J^{-2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:CubicElectricDipoleMomentPerSquareEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Coulomb Meter per Square Joule" ;
+.
+unit:C4-M4-PER-J3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Quartic Coulomb Meter per Cubic Energy\" is a unit for  'Quartic Electric Dipole Moment Per Cubic Energy' expressed as \\(C^{4} m^{4} J^{-3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "1"^^xsd:double ;
+  qudt:expression "\\(C^4m^4/J^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:QuarticElectricDipoleMomentPerCubicEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quartic Coulomb Meter per Cubic Energy" ;
+.
+unit:CAD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Canada"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Canadian_dollar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Canadian_dollar?oldid=494738466"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/CanadianDollar> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Canadian Dollar" ;
+.
+unit:CAL_15_DEG_C
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1855e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB139" ;
+  qudt:plainTextDescription "unit for the quantity of heat which is required to warm up 1 g  of water, which is free of air, at a constant pressure of 101.325 kPa (the pressure of the standard atmosphere on sea level) from 14.5 degrees Celsius to 15.5 degrees Celsius" ;
+  qudt:uneceCommonCode "A1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL (15 degrees C)" ;
+  skos:prefLabel "calorie (15 degrees C)" ;
+.
+unit:CAL_IT
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p> International Table calorie. </p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "4.1868"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "International Table calorie" ;
+.
+unit:CAL_IT-PER-G
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Calories produced per gram of substance.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 4.1868E+03 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cal_it-per-g\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "calorieIT per gram (calIT/g)" ;
+.
+unit:CAL_IT-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB176" ;
+  qudt:plainTextDescription "unit calorie according to the international steam table divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "D75" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_IT PER GM" ;
+  skos:prefLabel "calorie (international table) per gram" ;
+.
+unit:CAL_IT-PER-GM-DEG_C
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA362" ;
+  qudt:plainTextDescription "unit calorieIT divided by the products of the units gram and degree Celsius" ;
+  qudt:uneceCommonCode "J76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_IT PER GM DEG_C" ;
+  skos:prefLabel "calorie (international table) per gram degree Celsius" ;
+.
+unit:CAL_IT-PER-GM-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA363" ;
+  qudt:plainTextDescription "unit calorieIT divided by the product of the SI base unit gram and Kelvin" ;
+  qudt:uneceCommonCode "D76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_IT PER GM K" ;
+  skos:prefLabel "calorie (international table) per gram kelvin" ;
+.
+unit:CAL_IT-PER-SEC-CentiM-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAB108" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "D71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_IT PER SEC CentiM K" ;
+  skos:prefLabel "calorie (international table) per second centimetre kelvin" ;
+.
+unit:CAL_IT-PER-SEC-CentiM2-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:iec61360Code "0112/2///62720#UAB096" ;
+  qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:uneceCommonCode "D72" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_IT PER SEC CentiM2Â K" ;
+  skos:prefLabel "calorie (international table) per second centimetre squaredÂ kelvin" ;
+.
+unit:CAL_MEAN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.19e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA360" ;
+  qudt:plainTextDescription "unit used particularly for calorific values of foods" ;
+  qudt:uneceCommonCode "J75" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_MEAN" ;
+  skos:prefLabel "calorie (mean)" ;
+.
+unit:CAL_TH
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The energy needed to increase the temperature of a given mass of water by \\(1 ^\\circ C\\( at atmospheric pressure depends on the starting temperature and is difficult to measure precisely. Accordingly, there have been several definitions of the calorie. The two perhaps most popular definitions used in older literature are the \\(15 ^\\circ C\\) calorie and the thermochemical calorie.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "4.184"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Calorie"^^xsd:anyURI ;
+  qudt:latexDefinition """\\(1 \\; cal_{th} = 4.184 J\\)
+
+\\(\\approx 0.003964 BTU\\)
+
+\\(\\approx 1.163 \\times 10^{-6} kWh\\)
+
+\\(\\approx 2.611 \\times 10^{19} eV\\)"""^^qudt:LatexString ;
+  qudt:symbol "cal_{th}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Thermochemical Calorie" ;
+.
+unit:CAL_TH-PER-CentiM-SEC-DEG_C
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA365" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER CentiM SEC DEG_C" ;
+  skos:prefLabel "calorie (thermochemical) per centimetre second degree Celsius" ;
+.
+unit:CAL_TH-PER-G
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Thermochemical Calorie. Calories produced per gram of substance.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 4.184E+03 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cal\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--thermal_heat_capacity--british_thermal_unit_therm_per_pound_mass.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "calorieTH per gram (calTH/g)" ;
+.
+unit:CAL_TH-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB153" ;
+  qudt:plainTextDescription "unit thermochemical calorie divided by the 0,001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "B36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER GM" ;
+  skos:prefLabel "calorie (thermochemical) per gram" ;
+.
+unit:CAL_TH-PER-GM-DEG_C
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA366" ;
+  qudt:plainTextDescription "unit calorieth divided by the product of the unit gram and degree Celsius" ;
+  qudt:uneceCommonCode "J79" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER GM DEG_C" ;
+  skos:prefLabel "calorie (thermochemical) per gram degree Celsius" ;
+.
+unit:CAL_TH-PER-GM-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA367" ;
+  qudt:plainTextDescription "unit calorieth divided by the product of the SI derived unit gram and the SI base unit Kelvin" ;
+  qudt:uneceCommonCode "D37" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER GM K" ;
+  skos:prefLabel "calorie (thermochemical) per gram kelvin" ;
+.
+unit:CAL_TH-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.973e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA368" ;
+  qudt:plainTextDescription "unit calorie divided by the unit minute" ;
+  qudt:uneceCommonCode "J81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER MIN" ;
+  skos:prefLabel "calorie (thermochemical) per minute" ;
+.
+unit:CAL_TH-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "4.184"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA369" ;
+  qudt:plainTextDescription "unit calorie divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J82" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER SEC" ;
+  skos:prefLabel "calorie (thermochemical) per second" ;
+.
+unit:CAL_TH-PER-SEC-CentiM-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAB109" ;
+  qudt:plainTextDescription "unit of the thermal conductivity according to the Imperial system of units" ;
+  qudt:uneceCommonCode "D38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER SEC CentiM K" ;
+  skos:prefLabel "calorie (thermochemical) per second centimetre kelvin" ;
+.
+unit:CAL_TH-PER-SEC-CentiM2-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:iec61360Code "0112/2///62720#UAB097" ;
+  qudt:plainTextDescription "unit of the heat transfer coefficient according to the Imperial system of units" ;
+  qudt:uneceCommonCode "D39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CAL_TH PER SEC CentiM2 K" ;
+  skos:prefLabel "calorie (thermochemical) per second centimetre squaredÂ kelvin" ;
+.
+unit:CARAT
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">The carat is a unit of mass equal to 200 mg and is used for measuring gemstones and pearls. The current definition, sometimes known as the metric carat, was adopted in 1907 at the Fourth General Conference on Weights and Measures, and soon afterward in many countries around the world.</p>
+<p class=\"lm-para\">The carat is divisible into one hundred points of two milligrams each. Other subdivisions, and slightly different mass values, have been used in the past in different locations. In terms of diamonds, a paragon is a flawless stone of at least 100 carats (20 g). The ANSI X.12 EDI standard abbreviation for the carat is \\(CD\\).</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0002"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Carat"^^xsd:anyURI ;
+  qudt:expression "\\(Nm/ct\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Carat?oldid=477129057"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "[CAR_M]" ;
+  qudt:ucumCaseSensitiveCode "[car_m]" ;
+  qudt:ucumCode "[CAR_M]" ;
+  qudt:ucumCode "[car_m]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Carat" ;
+  skos:altLabel "metric carat" ;
+.
+unit:CARAT_M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.0e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB166" ;
+  qudt:plainTextDescription "unit metric carat for the mass of precious stones" ;
+  qudt:uneceCommonCode "CTM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CARAT_M" ;
+  skos:prefLabel "metric carat" ;
+.
+unit:CD
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Candela}\\) is a unit for  'Luminous Intensity' expressed as \\(cd\\).  The candela is the SI base unit of luminous intensity; that is, power emitted by a light source in a particular direction, weighted by the luminosity function (a standardized model of the sensitivity of the human eye to different wavelengths, also known as the luminous efficiency function). A common candle emits light with a luminous intensity of roughly one candela."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Candela"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousIntensity ;
+  qudt:iec61360Code "0112/2///62720#UAA370" ;
+  qudt:iec61360Code "0112/2///62720#UAD719" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Candela?oldid=484253082"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/candela> ;
+  qudt:symbol "cd" ;
+  qudt:ucumCaseInsensitiveCode "CD" ;
+  qudt:ucumCaseSensitiveCode "cd" ;
+  qudt:ucumCode "CD" ;
+  qudt:ucumCode "cd" ;
+  qudt:uneceCommonCode "CDL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Candela" ;
+.
+unit:CD-PER-IN2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Candela per Square Inch\" is a unit for  'Luminance' expressed as \\(cd/in^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1550.0031000062002e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cd/in^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
+  qudt:iec61360Code "0112/2///62720#UAB257" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Candela per Square Inch" ;
+.
+unit:CD-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The candela per square metre (\\(cd/m^2\\)) is the derived SI unit of luminance. The unit is based on the candela, the SI unit of luminous intensity, and the square metre, the SI unit of area. Nit (nt) is a deprecated non-SI name also used for this unit (\\(1 nit = 1 cd/m^2\\)). As a measure of light emitted per unit area, this unit is frequently used to specify the brightness of a display device. Most consumer desktop liquid crystal displays have luminances of 200 to 300 \\(cd/m^2\\); the sRGB spec for monitors targets 80 cd/m2. HDTVs range from 450 to about 1000 cd/m2. Typically, calibrated monitors should have a brightness of \\(120 cd/m^2\\). \\(Nit\\) is believed to come from the Latin word nitere, to shine."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cd/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
+  qudt:iec61360Code "0112/2///62720#UAA371" ;
+  qudt:uneceCommonCode "A24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "candela per square meter" ;
+.
+unit:CFU
+  a qudt:Unit ;
+  dcterms:description "\"Colony Forming Unit\" is a unit for  'Microbial Formation' expressed as \\(CFU\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Colony-forming_unit"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MicrobialFormation ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Colony-forming_unit?oldid=473146689"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/colonyFormingUnit> ;
+  qudt:symbol "CFU" ;
+  qudt:ucumCaseInsensitiveCode "[CFU]" ;
+  qudt:ucumCode "[CFU]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Colony Forming Unit" ;
+.
+unit:CH
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A chain is a unit of length. It measures 66 feet, or 22 yards, or 100 links, or 4 rods. There are 10 chains in a furlong, and 80 chains in one statute mile. An acre is the area of 10 square chains (that is, an area of one chain by one furlong). The chain has been used for several centuries in Britain and in some other countries influenced by British practice."^^rdf:HTML ;
+  qudt:conversionMultiplier "20.1168"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Chain"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB203" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Chain?oldid=494116185"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/chain> ;
+  qudt:symbol "ch" ;
+  qudt:ucumCaseInsensitiveCode "[CH_BR]" ;
+  qudt:ucumCaseSensitiveCode "[ch_br]" ;
+  qudt:ucumCode "[CH_BR]" ;
+  qudt:ucumCode "[ch_br]" ;
+  qudt:uneceCommonCode "X1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "chain" ;
+  skos:altLabel "Gunter's chain" ;
+.
+unit:CLO
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>A C.G.S System unit for <em>Thermal Insulance</em> expressed as \"clo\".</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "0.155"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:iec61360Code "0112/2///62720#UAA374" ;
+  qudt:symbol "clo" ;
+  qudt:uneceCommonCode "J83" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Clo" ;
+.
+unit:CM_H2O
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Centimeter of Water</em> is a C.G.S System unit for  'Force Per Area' expressed as \\(cmH2O\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "98.0630016"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Centimetre_of_water"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Centimetre_of_water?oldid=487656894"^^xsd:anyURI ;
+  qudt:symbol "cmH2O" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centimeter of Water" ;
+.
+unit:CORD
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "The cord is a unit of measure of dry volume used in Canada and the United States to measure firewood and pulpwood. A cord is the amount of wood that, when 'ranked and well stowed' (arranged so pieces are aligned, parallel, touching and compact), occupies a volume of 128 cubic feet (3.62 m). This corresponds to a well stacked woodpile 4 feet (122 cm) wide, 4 feet (122 cm) high, and 8 feet (244 cm) long; or any other arrangement of linear measurements that yields the same volume. The name cord probably comes from the use of a cord or string to measure it. "^^rdf:HTML ;
+  qudt:conversionMultiplier "3.62"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cord"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cord?oldid=490232340"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/cord> ;
+  qudt:symbol "C" ;
+  qudt:ucumCaseInsensitiveCode "[CRD_US]" ;
+  qudt:ucumCaseSensitiveCode "[crd_us]" ;
+  qudt:ucumCode "[CRD_US]" ;
+  qudt:ucumCode "[crd_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cord" ;
+.
+unit:CP
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Candlepower\" (abbreviated as cp) is a now-obsolete unit which was used to express levels of light intensity in terms of the light emitted by a candle of specific size and constituents. In modern usage Candlepower equates directly to the unit known as the candela."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Candlepower"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousIntensity ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Candlepower?oldid=491140098"^^xsd:anyURI ;
+  qudt:symbol "cd" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Candlepower" ;
+.
+unit:CUP
+  a qudt:Unit ;
+  dcterms:description "\"US Liquid Cup\" is a unit for  'Liquid Volume' expressed as \\(cup\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.3658825E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "cup" ;
+  qudt:ucumCaseInsensitiveCode "[CUP_US]" ;
+  qudt:ucumCaseSensitiveCode "[cup_us]" ;
+  qudt:ucumCode "[CUP_US]" ;
+  qudt:ucumCode "[cup_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Liquid Cup" ;
+.
+unit:CUP_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.365882e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA404" ;
+  qudt:plainTextDescription "unit of the volume according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "G21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CUP_US" ;
+  skos:prefLabel "cup (US)" ;
+.
+unit:CWT_LONG
+  a qudt:Unit ;
+  dcterms:description "\"Hundred Weight - Long\" is a unit for  'Mass' expressed as \\(cwt\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cwt long\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:ucumCaseInsensitiveCode "[LCWT_AV]" ;
+  qudt:ucumCaseSensitiveCode "[lcwt_av]" ;
+  qudt:ucumCode "[LCWT_AV]" ;
+  qudt:ucumCode "[lcwt_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hundred Weight - Long" ;
+  rdfs:label "Long Hundred Weight" ;
+  skos:altLabel "British hundredweight" ;
+.
+unit:CWT_SHORT
+  a qudt:Unit ;
+  dcterms:description "\"Hundred Weight - Short\" is a unit for  'Mass' expressed as \\(cwt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "45.359237"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cwt\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:ucumCaseInsensitiveCode "[SCWT_AV]" ;
+  qudt:ucumCaseSensitiveCode "[scwt_av]" ;
+  qudt:ucumCode "[SCWT_AV]" ;
+  qudt:ucumCode "[scwt_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hundred Weight - Short" ;
+  skos:altLabel "U.S. hundredweight" ;
+.
+unit:C_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"abcoulomb\" (abC or aC) or electromagnetic unit of charge (emu of charge) is the basic physical unit of electric charge in the cgs-emu system of units. One abcoulomb is equal to ten coulombs (\\(1\\,abC\\,=\\,10\\,C\\))."^^qudt:LatexString ;
+  qudt:conversionMultiplier "10.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abcoulomb"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abcoulomb?oldid=477198635"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-9?rskey=KHjyOu"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abcoulomb> ;
+  qudt:symbol "abC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abcoulomb" ;
+.
+unit:C_Ab-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """Abcoulomb Per Square Centimeter is a unit in the category of Electric charge surface density. It is also known as abcoulombs per square centimeter, abcoulomb per square centimetre, abcoulombs per square centimetre, abcoulomb/square centimeter,abcoulomb/square centimetre. This unit is commonly used in the cgs unit system.
+Abcoulomb Per Square Centimeter (abcoulomb/cm2) has a dimension of \\(L_2TI\\).  where L is length, T is time, and I is electric current. It can be converted to the corresponding standard SI unit \\(C/m^2\\) by multiplying its value by a factor of 100,000."""^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(abc-per-cm2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_charge_surface_density--abcoulomb_per_square_centimeter.cfm"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(abcoulomb/cm^2\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abcoulomb per Square Centimeter" ;
+.
+unit:C_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """The statcoulomb (\\(statC\\)) or franklin (\\(Fr\\)) or electrostatic unit of charge (\\(esu\\)) is the physical unit for electrical charge used in the centimetre-gram-second system of units (cgs) and Gaussian units. It is a derived unit given by \\(1 statC = 1 g cm s = 1 erg cm\\). The SI system of units uses the coulomb (C) instead. The conversion between C and statC is different in different contexts.
+The number 2997924580 is 10 times the value of the speed of light expressed in meters/second, and the conversions are exact except where indicated. The coulomb is an extremely large charge rarely encountered in electrostatics, while the statcoulomb is closer to everyday charges."""^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.33564E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Statcoulomb"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Statcoulomb?oldid=492664360"^^xsd:anyURI ;
+  qudt:latexDefinition "$$1 C \\leftrightarrow 2997924580 statC \\approx 3.00 \\times 10 statC,\\\\1 \\hspace{0.3pc} statC \\leftrightarrow \\hspace{0.3pc} \\approx 3.34 \\times 10 C$$"^^qudt:LatexString ;
+  qudt:latexDefinition "$$1 C \\leftrightarrow 4 \\pi \\times 2997924580 statC \\approx 3.77 \\times 10 statC,\\\\1 \\hspace{0.3pc} statC \\leftrightarrow \\hspace{0.2pc} \\approx 2.6 \\times 10 C$$"^^qudt:LatexString ;
+  qudt:latexDefinition "$$1 C/m \\leftrightarrow 4 \\pi \\times 2997924580 \\times 10 statC/cm \\approx 3.77 \\times 10 statC/cm,\\\\1 \\hspace{0.3pc} statC/cm \\leftrightarrow \\hspace{0.3pc} \\approx 2.65 \\times 10 C/m$$"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statcoulomb> ;
+  qudt:symbol "statC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statcoulomb" ;
+.
+unit:C_Stat-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Statcoulomb per Square Centimeter</em> is a unit of measure for electric flux density and electric polarization. One Statcoulomb per Square Centimeter is \\(2.15\\times 10^9 \\, coulomb\\,per\\,square\\,inch\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.33564E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(statc-per-cm2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statcoulomb per Square Centimeter" ;
+.
+unit:C_Stat-PER-MOL
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Statcoulomb per Mole\" is a unit of measure for the electical charge associated with one mole of a substance. The mole is a unit of measurement used in chemistry to express amounts of a chemical substance, defined as an amount of a substance that contains as many elementary entities (e.g., atoms, molecules, ions, electrons) as there are atoms in 12 grams of pure carbon-12 (12C), the isotope of carbon with atomic weight 12."^^rdf:HTML ;
+  qudt:conversionMultiplier 3.33564E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(statC/mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerAmountOfSubstance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statcoulomb per Mole" ;
+.
+unit:CapeVerdeEscudo
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cape Verde"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cape_Verdean_escudo"^^xsd:anyURI ;
+  qudt:expression "\\(CVE\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cape_Verdean_escudo?oldid=491416749"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cape Verde Escudo" ;
+.
+unit:CaymanIslandsDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cayman Islands"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cayman_Islands_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(KYD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cayman_Islands_dollar?oldid=494206112"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cayman Islands Dollar" ;
+.
+unit:Cedi
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Ghana"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ghanaian_cedi"^^xsd:anyURI ;
+  qudt:expression "\\(GHS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ghanaian_cedi?oldid=415914569"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cedi" ;
+.
+unit:Centi
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'centi' is a decimal prefix for expressing a value with a scaling of \\(10^{-2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Centi-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Centi-?oldid=480291808"^^xsd:anyURI ;
+  qudt:symbol "c" ;
+  qudt:ucumCaseInsensitiveCode "C" ;
+  qudt:ucumCaseSensitiveCode "c" ;
+  qudt:ucumCode "C" ;
+  qudt:ucumCode "c" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centi" ;
+.
+unit:CentiBAR
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to 100,000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000\\,Pa = 1 bar \\approx 750.0616827 Torr\\).</p>
+<p class=\"lm-para\">Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI.</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Centi ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BAR ;
+  qudt:symbol "cbar" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centibar" ;
+.
+unit:CentiC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A CentiCoulomb is \\(10^{-2} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Centi ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "dC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:CentiGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB077" ;
+  qudt:plainTextDescription "0,000 01-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "CGM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiGM" ;
+  skos:prefLabel "centigram" ;
+.
+unit:CentiL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA373" ;
+  qudt:plainTextDescription "0,01-fold of the unit litre" ;
+  qudt:uneceCommonCode "CLT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiL" ;
+  skos:prefLabel "centilitre" ;
+.
+unit:CentiM
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  dcterms:description "A centimetre is a unit of length in the metric system, equal to one hundredth of a metre, which is the SI base unit of length. Centi is the SI prefix for a factor of 10.  The centimetre is the base unit of length in the now deprecated centimetre-gram-second (CGS) system of units."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Centimetre"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Centi ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA375" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Centimetre?oldid=494931891"^^xsd:anyURI ;
+  qudt:isScalingOf unit:M ;
+  qudt:symbol "cm" ;
+  qudt:ucumCaseInsensitiveCode "CM" ;
+  qudt:ucumCaseSensitiveCode "cm" ;
+  qudt:ucumCode "CM" ;
+  qudt:ucumCode "cm" ;
+  qudt:uneceCommonCode "CMT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centimeter" ;
+.
+unit:CentiM-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAA378" ;
+  qudt:plainTextDescription "0,01-fold of the SI base unit metre divided by the unit hour" ;
+  qudt:uneceCommonCode "H49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM PER HR" ;
+  skos:prefLabel "centimetre per hour" ;
+.
+unit:CentiM-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA376" ;
+  qudt:plainTextDescription "0,01-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM PER K" ;
+  skos:prefLabel "centimetre per kelvin" ;
+.
+unit:CentiM-PER-SEC
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Centimeter per Second\" is a C.G.S System unit for  'Linear Velocity' expressed as \\(cm/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA379" ;
+  qudt:latexDefinition "\\(cm/s\\)"^^qudt:LatexString ;
+  qudt:ucumCaseInsensitiveCode "CM.S-1" ;
+  qudt:ucumCaseInsensitiveCode "CM/S" ;
+  qudt:ucumCaseSensitiveCode "cm.s-1" ;
+  qudt:ucumCaseSensitiveCode "cm/s" ;
+  qudt:ucumCode "CM.S-1" ;
+  qudt:ucumCode "CM/S" ;
+  qudt:ucumCode "cm.s-1" ;
+  qudt:ucumCode "cm/s" ;
+  qudt:uneceCommonCode "2M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "centimeter per second" ;
+.
+unit:CentiM-PER-SEC2
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Centimeter per Second Squared}\\) is a C.G.S System unit for  \\(\\textit{Linear Acceleration}\\) expressed as \\(cm/s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm/s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAB398" ;
+  qudt:ucumCaseInsensitiveCode "CM.S-2" ;
+  qudt:ucumCaseInsensitiveCode "CM/S2" ;
+  qudt:ucumCaseSensitiveCode "cm.s-2" ;
+  qudt:ucumCaseSensitiveCode "cm/s2" ;
+  qudt:ucumCode "CM.S-2" ;
+  qudt:ucumCode "CM/S2" ;
+  qudt:ucumCode "cm.s-2" ;
+  qudt:ucumCode "cm/s2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centimeter per Second Squared" ;
+.
+unit:CentiM-SEC-DEG_C
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Centimeter Second Degree Celsius</em> is a C.G.S System unit for 'Length Temperature Time' expressed as \\(cm-s-degC\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm-s-degC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LengthTemperatureTime ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centimeter Second Degree Celsius" ;
+.
+unit:CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of area equal to that of a square, of sides 1cm"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(sqcm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA384" ;
+  qudt:ucumCaseInsensitiveCode "CM2" ;
+  qudt:ucumCaseSensitiveCode "cm2" ;
+  qudt:ucumCode "CM2" ;
+  qudt:ucumCode "cm2" ;
+  qudt:uneceCommonCode "CMK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Centimeter" ;
+.
+unit:CentiM2-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Square centimeter minute\" is a unit for  'Area Time' expressed as \\(cm^{2} . m\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0060e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm^{2}m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:ucumCaseInsensitiveCode "CM2.MIN" ;
+  qudt:ucumCaseSensitiveCode "cm2.min" ;
+  qudt:ucumCode "CM2.MIN" ;
+  qudt:ucumCode "cm2.min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Centimeter Minute" ;
+.
+unit:CentiM2-SEC
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Square Centimeter Second\" is a C.G.S System unit for  'Area Time' expressed as \\(cm^2 . s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm^2 . s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:ucumCaseInsensitiveCode "CM2.S" ;
+  qudt:ucumCaseSensitiveCode "cm2.s" ;
+  qudt:ucumCode "CM2.S" ;
+  qudt:ucumCode "cm2.s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Centimeter Second" ;
+.
+unit:CentiM3
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The CGS unit of volume, equal to 10-6 cubic meter, 1 milliliter, or about 0.061 023 7 cubic inch"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cubic-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA385" ;
+  qudt:ucumCaseInsensitiveCode "CM3" ;
+  qudt:ucumCaseSensitiveCode "cm3" ;
+  qudt:ucumCode "CM3" ;
+  qudt:ucumCode "cm3" ;
+  qudt:uneceCommonCode "CMQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "cubic centimeter" ;
+.
+unit:CentiM3-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-11 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA388" ;
+  qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit day" ;
+  qudt:uneceCommonCode "G47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER DAY" ;
+  skos:prefLabel "centimetre cubed per day" ;
+.
+unit:CentiM3-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-10 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA391" ;
+  qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
+  qudt:uneceCommonCode "G48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER HR" ;
+  skos:prefLabel "centimetre cubed per hour" ;
+.
+unit:CentiM3-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA386" ;
+  qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "G27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER K" ;
+  skos:prefLabel "centimetre cubed per kelvin" ;
+.
+unit:CentiM3-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA394" ;
+  qudt:plainTextDescription "volume ratio consisting of the 0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "J87" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER M3" ;
+  skos:prefLabel "centimetre cubed per metre cubed" ;
+.
+unit:CentiM3-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA395" ;
+  qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
+  qudt:uneceCommonCode "G49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER MIN" ;
+  skos:prefLabel "centimetre cubed per minute" ;
+.
+unit:CentiM3-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA398" ;
+  qudt:plainTextDescription "0.000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
+  qudt:uneceCommonCode "A36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER MOL" ;
+  skos:prefLabel "centimetre cubed per mole" ;
+.
+unit:CentiM3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA399" ;
+  qudt:plainTextDescription "0,000 001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "2J" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM3 PER SEC" ;
+  skos:prefLabel "centimetre cubed per second" ;
+.
+unit:CentiM_HG
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.333224e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA403" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure, that corresponds with the static pressure generated by a mercury column with the height of 1 centimetre" ;
+  qudt:uneceCommonCode "J89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM_HG" ;
+  skos:prefLabel "centimetre of mercury" ;
+.
+unit:CentiM_Water
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA402" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure, that corresponds with the static pressure generated by a water column with the height of 1 centimetre" ;
+  qudt:uneceCommonCode "H78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiM_Water" ;
+  skos:prefLabel "conventional centimetre of water" ;
+.
+unit:CentiN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA355" ;
+  qudt:plainTextDescription "0,01-fold of the product of the SI derived unit newton and SI base unit metre" ;
+  qudt:uneceCommonCode "J72" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiN M" ;
+  skos:prefLabel "centinewton metre" ;
+.
+unit:CentiP
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Centipoise</em> is a C.G.S System unit for  'Dynamic Viscosity' expressed as \\(cP\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA356" ;
+  qudt:symbol "cP" ;
+  qudt:uneceCommonCode "C7" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centipoise" ;
+.
+unit:CentiPOISE
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA356" ;
+  qudt:plainTextDescription "0,01-fold of the CGS unit of the dynamic viscosity poise" ;
+  qudt:uneceCommonCode "C7" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiPOISE" ;
+  skos:prefLabel "centipoise" ;
+.
+unit:CentiPOISE-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA358" ;
+  qudt:plainTextDescription "0,01-fold of the CGS unit of the dynamic viscosity poise divided by the unit of the pressure bar" ;
+  qudt:uneceCommonCode "J74" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CentiPOISE PER BAR" ;
+  skos:prefLabel "centipoise per bar" ;
+.
+unit:CentiST
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Centistokes</em> is a C.G.S System unit for  'Kinematic Viscosity' expressed as \\(cSt\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:KinematicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA359" ;
+  qudt:symbol "cSt" ;
+  qudt:uneceCommonCode "4C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Centistokes" ;
+.
+unit:ChileanPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Chile"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Chilean_peso"^^xsd:anyURI ;
+  qudt:expression "\\(CLP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Chilean_peso?oldid=495455481"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Chilean Peso" ;
+.
+unit:Ci
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The curie (symbol Ci) is a non-SI unit of radioactivity, named after Marie and Pierre Curie. It is defined as \\(1Ci = 3.7 \\times 10 decays per second\\). Its continued use is discouraged. One Curie is roughly the activity of 1 gram of the radium isotope Ra, a substance studied by the Curies. The SI derived unit of radioactivity is the becquerel (Bq), which equates to one decay per second. Therefore: \\(1Ci = 3.7 \\times 10 Bq= 37 GBq\\) and \\(1Bq \\equiv 2.703 \\times 10Ci \\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.7E10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA138" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curie?oldid=495080313"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/curie> ;
+  qudt:symbol "Ci" ;
+  qudt:ucumCaseInsensitiveCode "CI" ;
+  qudt:ucumCaseSensitiveCode "Ci" ;
+  qudt:ucumCode "CI" ;
+  qudt:ucumCode "Ci" ;
+  qudt:uneceCommonCode "CUR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Curie" ;
+.
+unit:ColombianPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Colombia"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Colombian_peso"^^xsd:anyURI ;
+  qudt:expression "\\(COP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Colombian_peso?oldid=490834575"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Colombian Peso" ;
+.
+unit:ComoroFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Comoros"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Comorian_franc"^^xsd:anyURI ;
+  qudt:expression "\\(KMF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Comorian_franc?oldid=489502162"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Comoro Franc" ;
+.
+unit:ConvertibleMark
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bosnia and Herzegovina"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(BAM\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Convertible Marks" ;
+.
+unit:CordobaOro
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Nicaragua"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nicaraguan_c%C3%B3rdoba"^^xsd:anyURI ;
+  qudt:expression "\\(NIO\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nicaraguan_córdoba?oldid=486140595"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cordoba Oro" ;
+.
+unit:CostaRicanColon
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Costa Rica"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Costa_Rican_col%C3%B3n"^^xsd:anyURI ;
+  qudt:expression "\\(CRC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Costa_Rican_colón?oldid=491007608"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Costa Rican Colon" ;
+.
+unit:CroatianKuna
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Croatia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Croatian_kuna"^^xsd:anyURI ;
+  qudt:expression "\\(HRK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Croatian_kuna?oldid=490959527"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Croatian Kuna" ;
+.
+unit:CubanPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cuba"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cuban_peso"^^xsd:anyURI ;
+  qudt:expression "\\(CUP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cuban_peso?oldid=486492974"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cuban Peso" ;
+.
+unit:CyprusPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cyprus"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cypriot_pound"^^xsd:anyURI ;
+  qudt:expression "\\(CYP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cypriot_pound?oldid=492644935"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cyprus Pound" ;
+.
+unit:CzechKoruna
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Czech Republic"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Czech_koruna"^^xsd:anyURI ;
+  qudt:expression "\\(CZK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Czech_koruna?oldid=493991393"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Czech Koruna" ;
+.
+unit:DAY
+  a qudt:Unit ;
+  dcterms:description "Mean solar day"^^rdf:HTML ;
+  qudt:conversionMultiplier "86400"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Day"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA407" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Day?oldid=494970012"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/day> ;
+  qudt:symbol "d" ;
+  qudt:ucumCaseSensitiveCode "d" ;
+  qudt:ucumCode "d" ;
+  qudt:uneceCommonCode "DAY" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Day" ;
+.
+unit:DAY_Sidereal
+  a qudt:Unit ;
+  dcterms:description "The length of time which passes between a given fixed star in the sky crossing a given projected meridian (line of longitude). The sidereal day is \\(23 h 56 m 4.1 s\\), slightly shorter than the solar day because the Earth 's orbital motion about the Sun  means the Earth  has to rotate slightly more than one turn with respect to the \"fixed\" stars in order to reach the same Earth-Sun orientation. Another way of thinking about the difference is that it amounts to \\(1/365.2425^{th}\\) of a day per day, since even if the Earth  did not spin on its axis at all, the Sun  would appear to make one rotation around the Earth  as the Earth  completed a single orbit (which takes one year)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA412" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
+  qudt:informativeReference "http://scienceworld.wolfram.com/astronomy/SiderealDay.html"^^xsd:anyURI ;
+  qudt:symbol "d" ;
+  qudt:ucumCaseInsensitiveCode "D" ;
+  qudt:ucumCaseSensitiveCode "d" ;
+  qudt:ucumCode "D" ;
+  qudt:ucumCode "d" ;
+  qudt:uneceCommonCode "DMT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sidereal Day" ;
+.
+unit:DECADE
+  a qudt:DimensionlessUnit ;
+  a qudt:LogarithmicUnit ;
+  a qudt:Unit ;
+  dcterms:description "One decade is a factor of 10 difference between two numbers (an order of magnitude difference) measured on a logarithmic scale. It is especially useful when referring to frequencies and when describing frequency response of electronic systems, such as audio amplifiers and filters. The factor-of-ten in a decade can be in either direction: so one decade up from 100 Hz is 1000 Hz, and one decade down is 10 Hz. The factor-of-ten is what is important, not the unit used, so \\(3.14 rad/s\\) is one decade down from \\(31.4 rad/s\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Decade_(log_scale)"^^xsd:anyURI ;
+  qudt:symbol "oct" ;
+  qudt:ucumCaseInsensitiveCode "D" ;
+  qudt:ucumCaseSensitiveCode "d" ;
+  qudt:ucumCode "D" ;
+  qudt:ucumCode "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dec" ;
+.
+unit:DEG
+  a qudt:Unit ;
+  dcterms:description "A degree (in full, a degree of arc, arc degree, or arcdegree), usually denoted by \\(^\\circ\\) (the degree symbol), is a measurement of plane angle, representing 1/360 of a full rotation; one degree is equivalent to  \\(2\\pi /360 rad\\), \\(0.017453 rad\\). It is not an SI unit, as the SI unit for angles is radian, but is an accepted SI unit."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0174532925"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA024" ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-331"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degree> ;
+  qudt:symbol "\\,^{\\circ}" ;
+  qudt:ucumCaseInsensitiveCode "DEG" ;
+  qudt:ucumCaseSensitiveCode "deg" ;
+  qudt:ucumCode "DEG" ;
+  qudt:ucumCode "deg" ;
+  qudt:uneceCommonCode "DD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree" ;
+.
+unit:DEG-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Degree per Hour\" is an Imperial unit for  'Angular Velocity' expressed as \\(deg/h\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.84813681E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(deg/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:ucumCaseInsensitiveCode "DEG/HR" ;
+  qudt:ucumCaseSensitiveCode "deg/h" ;
+  qudt:ucumCode "DEG/HR" ;
+  qudt:ucumCode "deg/h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree per Hour" ;
+.
+unit:DEG-PER-MIN
+  a qudt:Unit ;
+  dcterms:description "A unit of measure for the rate of change of plane angle, \\(d\\omega / dt\\),  in durations of one minute.The vector \\(\\omega\\) is directed along the axis of rotation in the direction for which the rotation is clockwise."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.000290888209"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(deg-per-min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:ucumCaseInsensitiveCode "DEG/MIN" ;
+  qudt:ucumCaseSensitiveCode "deg/min" ;
+  qudt:ucumCode "DEG/MIN" ;
+  qudt:ucumCode "deg/min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree per Minute" ;
+.
+unit:DEG-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Degree per Second\" is an Imperial unit for  'Angular Velocity' expressed as \\(deg/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0174532925"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(deg/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA026" ;
+  qudt:ucumCaseInsensitiveCode "DEG/S" ;
+  qudt:ucumCaseSensitiveCode "deg/s" ;
+  qudt:ucumCode "DEG/S" ;
+  qudt:ucumCode "deg/s" ;
+  qudt:uneceCommonCode "E96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree per Second" ;
+.
+unit:DEG-PER-SEC2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Degree per Second Squared}\\) is an Imperial unit for \\(\\textit{Angular Acceleration}\\) expressed as \\(deg/s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0174532925"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(deg/s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAB407" ;
+  qudt:ucumCaseInsensitiveCode "DEG/S2" ;
+  qudt:ucumCaseSensitiveCode "deg/s2" ;
+  qudt:ucumCode "DEG/S2" ;
+  qudt:ucumCode "deg/s2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree per Second Squared" ;
+.
+unit:DEG2
+  a qudt:Unit ;
+  dcterms:description "A square degree is a non-SI unit measure of solid angle. It is denoted in various ways, including deg, sq. deg. and \\(\\circ^2\\). Just as degrees are used to measure parts of a circle, square degrees are used to measure parts of a sphere. Analogous to one degree being equal to \\(\\pi /180 radians\\), a square degree is equal to (\\(\\pi /180)\\) or about 1/3283 steradian. The number of square degrees in a whole sphere is or approximately 41 253 deg. This is the total area of the 88 constellations in the list of constellations by area. For example, observed from the surface of the Earth, the Moon has a diameter of approximately \\(0.5^\\circ\\), so it covers a solid angle of approximately 0.196 deg, which is \\(4.8 \\times 10\\) of the total sky sphere."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.00030461742"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(deg^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SolidAngle ;
+  qudt:ucumCaseInsensitiveCode "DEG2" ;
+  qudt:ucumCaseSensitiveCode "deg2" ;
+  qudt:ucumCode "DEG2" ;
+  qudt:ucumCode "deg2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square degree" ;
+.
+unit:DEGREE_API
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Gravity_API ;
+  qudt:iec61360Code "0112/2///62720#UAA027" ;
+  qudt:plainTextDescription "unit for the determination of the density of petroleum at 60 degrees F (15.56 degrees C)" ;
+  qudt:uneceCommonCode "J13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_API" ;
+  skos:prefLabel "degree API" ;
+.
+unit:DEGREE_BALLING
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA031" ;
+  qudt:plainTextDescription "unit for the mixing ratio of a soluble dry substance in water at 17.5 degrees C similar to the percent designation for solutions, in which a solution of 1 g saccharose in 100 g saccharose/ water solution corresponds to 1 degree Balling and respectively a one percent solution" ;
+  qudt:uneceCommonCode "J17" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGrEE_BALLING" ;
+  skos:prefLabel "degree Balling" ;
+.
+unit:DEGREE_BAUME
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA028" ;
+  qudt:plainTextDescription """graduation of the areometer scale for determination of densitiy of fluids.
+
+The Baumé scale is a pair of hydrometer scales developed by French pharmacist Antoine Baumé in 1768 to measure density of various liquids. The unit of the Baumé scale has been notated variously as degrees Baumé, B°, Bé° and simply Baumé (the accent is not always present). One scale measures the density of liquids heavier than water and the other, liquids lighter than water. The Baumé of distilled water is 0. The API gravity scale is based on errors in early implementations of the Baumé scale.""" ;
+  qudt:uneceCommonCode "J14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_BAUME" ;
+  skos:prefLabel "degree Baume (origin scale)" ;
+.
+unit:DEGREE_BAUME_US_HEAVY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA029" ;
+  qudt:plainTextDescription "graduation of the areometer scale for determination of density of fluids according to the Anglo-American system of units, which are heavier than water" ;
+  qudt:uneceCommonCode "J15" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_BAUME US Heavy" ;
+  skos:prefLabel "degree Baume (US heavy)" ;
+.
+unit:DEGREE_BAUME_US_LIGHT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA030" ;
+  qudt:plainTextDescription "graduation of the areometer scale for determination of density of fluids according to the Anglo-American system of units, which are lighter than water" ;
+  qudt:uneceCommonCode "J16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_BAUME US LIGHT" ;
+  skos:prefLabel "degree Baume (US light)" ;
+.
+unit:DEGREE_BRIX
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA032" ;
+  qudt:plainTextDescription "unit named according to Adolf Brix for the mixing ratio of a soluble dry substance in water with 15.5 °C similar to the percent designation for solutions, in which a solution of 1 g saccharose in 100 g saccharose/water solution corresponds to 1 °Brix and respectively an one percent solution" ;
+  qudt:uneceCommonCode "J18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_BRIX" ;
+  skos:prefLabel "degree Brix" ;
+.
+unit:DEGREE_OECHSLE
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA048" ;
+  qudt:plainTextDescription "unit of the density of the must, as measure for the proportion of the soluble material in the grape must" ;
+  qudt:uneceCommonCode "J27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_OECHSLE" ;
+  skos:prefLabel "degree Oechsle" ;
+.
+unit:DEGREE_PLATO
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA049" ;
+  qudt:plainTextDescription "unit for the mixing ratio of the original gravity in the beer brew at 17,5 Â°C before the fermentation" ;
+  qudt:uneceCommonCode "PLA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_PLATO" ;
+  skos:prefLabel "degree Plato" ;
+.
+unit:DEGREE_TWADDELL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA054" ;
+  qudt:plainTextDescription "unit of the density of fluids, which are heavier than water" ;
+  qudt:uneceCommonCode "J31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEGREE_TWADDELL" ;
+  skos:prefLabel "degree Twaddell" ;
+.
+unit:DEG_C
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Celsius}\\), also known as centigrade, is a scale and unit of measurement for temperature. It can refer to a specific temperature on the Celsius scale as well as a unit to indicate a temperature interval, a difference between two temperatures or an uncertainty. This definition fixes the magnitude of both the degree Celsius and the kelvin as precisely 1 part in 273.16 (approximately 0.00366) of the difference between absolute zero and the triple point of water. Thus, it sets the magnitude of one degree Celsius and that of one kelvin as exactly the same. Additionally, it establishes the difference between the two scales' null points as being precisely \\(273.15\\,^{\\circ}{\\rm C}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "273.15"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Celsius"^^xsd:anyURI ;
+  qudt:expression "\\(degC\\)"^^qudt:LatexString ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec04.html#4.2.1.1\">SP811 section 4.2.1.1</a></p>"^^rdf:HTML ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec06.html#6.2.8\">SP811 section 6.2.8</a></p>"^^rdf:HTML ;
+  qudt:hasQuantityKind quantitykind:CelciusTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAA033" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Celsius?oldid=494152178"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\,^{\\circ}{\\rm C}\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeCelsius> ;
+  qudt:uneceCommonCode "CEL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Celsius" ;
+  skos:altLabel "degree-centigrade" ;
+.
+unit:DEG_C-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Celsius Centimeter</em> is a C.G.S System unit for 'Length Temperature' expressed as \\(cm-degC\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(cm-degC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LengthTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Celsius Centimeter" ;
+.
+unit:DEG_C-PER-HR
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Celsius per Hour</em> is a unit for 'Temperature Per Time' expressed as \\(degC / hr\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degC / hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA036" ;
+  qudt:uneceCommonCode "H12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Celsius per Hour" ;
+.
+unit:DEG_C-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TemperatureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA034" ;
+  qudt:plainTextDescription "unit with the name Degree Celsius divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "E98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEG_C PER K" ;
+  skos:prefLabel "degree Celsius per kelvin" ;
+.
+unit:DEG_C-PER-MIN
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Celsius per Minute</em> is a unit for 'Temperature Per Time' expressed as \\(degC / m\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degC / m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA037" ;
+  qudt:uneceCommonCode "H13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Celsius per Minute" ;
+.
+unit:DEG_C-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Celsius per Second</em> is a unit for 'Temperature Per Time' expressed as \\(degC / s\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degC / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA038" ;
+  qudt:uneceCommonCode "H14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Celsius per Second" ;
+.
+unit:DEG_F
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<em>Degree Fahrenheit</em> is an Imperial unit for 'Thermodynamic Temperature' expressed as \\(\\,^{\\circ}{\\rm F}\\)"^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.5555555555555555556E0 ;
+  qudt:conversionOffset 255.37037037037037037E0 ;
+  qudt:expression "\\(degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAA039" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeFahrenheit> ;
+  qudt:uneceCommonCode "FAH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit" ;
+.
+unit:DEG_F-HR
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Fahrenheit Hour</em> is an Imperial unit for 'Thermal Resistivity' expressed as \\(degF-hr\\).</p></p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF-hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit Hour" ;
+.
+unit:DEG_F-HR-FT2-PER-BTU_IT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.89563e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:iec61360Code "0112/2///62720#UAA043" ;
+  qudt:plainTextDescription "unit of the thermal resistor according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEG_F HR FT2 PER BTU_IT" ;
+  skos:prefLabel "degree Fahrenheit hour foot squared per British thermal unit (international table)" ;
+.
+unit:DEG_F-HR-FT2-PER-BTU_TH
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.8969e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:iec61360Code "0112/2///62720#UAA040" ;
+  qudt:plainTextDescription "unit of the thermal resistor according to the according to the Imperial system of units" ;
+  qudt:uneceCommonCode "J19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEG_F HR FT2 PER BTU_TH" ;
+  skos:prefLabel "degree Fahrenheit hour foot squared per British thermal unit (thermochemical)" ;
+.
+unit:DEG_F-HR-PER-BTU_IT
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Fahrenheit Hour per BTU</em> is an Imperial unit for 'Thermal Resistance' expressed as \\(degF-hr/Btu\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF-hr/Btu\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalResistance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit Hour per BTU" ;
+.
+unit:DEG_F-PER-HR
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Fahrenheit per Hour</em> is a unit for 'Temperature Per Time' expressed as \\(degF / h\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF / h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA044" ;
+  qudt:uneceCommonCode "J23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit per Hour" ;
+.
+unit:DEG_F-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.555556e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TemperatureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA041" ;
+  qudt:plainTextDescription "traditional unit degree Fahrenheit for temperature according to the Anglo-American system of units divided by the SI base unit Kelvin" ;
+  qudt:uneceCommonCode "J20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DEG_F PER K" ;
+  skos:prefLabel "degree Fahrenheit per kelvin" ;
+.
+unit:DEG_F-PER-MIN
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Fahrenheit per Minute</em> is a unit for 'Temperature Per Time' expressed as \\(degF / m\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF / m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA045" ;
+  qudt:uneceCommonCode "J24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit per Minute" ;
+.
+unit:DEG_F-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "<p><em>Degree Fahrenheit per Second</em> is a unit for 'Temperature Per Time' expressed as \\(degF / s\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA046" ;
+  qudt:uneceCommonCode "J25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit per Second" ;
+.
+unit:DEG_F-PER-SEC2
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Degree Fahrenheit per Second Squared}\\) is a C.G.S System unit for expressinh the acceleration of a temperature expressed as \\(degF / s^2\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degF / s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:plainTextDescription "'Degree Fahrenheit per Second Squared' is a unit for expressing the acceleration of a temperature expressed as 'degF /s2'." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Fahrenheit per Second Squared" ;
+.
+unit:DEG_R
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Rankine is a thermodynamic (absolute) temperature scale. The symbol for degrees Rankine is \\(^\\circ R\\) or \\(^\\circ Ra\\) if necessary to distinguish it from the Rømer and Réaumur scales). Zero on both the Kelvin and Rankine scales is absolute zero, but the Rankine degree is defined as equal to one degree Fahrenheit, rather than the one degree Celsius used by the Kelvin scale. A temperature of \\(-459.67 ^\\circ F\\) is exactly equal to \\(0 ^\\circ R\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.5555555555555555556E0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAA050" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Rankine_scale"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/degreeRankine> ;
+  qudt:symbol "°R" ;
+  qudt:symbol "°Ra" ;
+  qudt:uneceCommonCode "A48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Rankine" ;
+.
+unit:DEG_R-PER-HR
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>A rate of change of temperature measured in degree Rankine in periods of one hour.</p>"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degR / h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA051" ;
+  qudt:isScalingOf unit:DEG_R-PER-MIN ;
+  qudt:uneceCommonCode "J28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Rankine per Hour" ;
+.
+unit:DEG_R-PER-MIN
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>A rate of change of temperature measured in degree Rankine in periods of one minute</p>"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degR / m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA052" ;
+  qudt:isScalingOf unit:DEG_R-PER-SEC ;
+  qudt:uneceCommonCode "J29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Rankine per Minute" ;
+.
+unit:DEG_R-PER-SEC
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>A rate of change of temperature measured in degree Rankine in periods of one second.</p>"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(degR / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA053" ;
+  qudt:uneceCommonCode "J30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Degree Rankine per Second" ;
+.
+unit:DIOPTER
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A dioptre, or diopter, is a unit of measurement for the optical power of a lens or curved mirror, which is equal to the reciprocal of the focal length measured in metres (that is, \\(1/metre\\)). For example, a \\(3 \\; dioptre\\) lens brings parallel rays of light to focus at \\(1/3\\,metre\\). The same unit is also sometimes used for other reciprocals of distance, particularly radii of curvature and the vergence of optical beams. Though the diopter is based on the SI-metric system it has not been included in the standard so that there is no international name or abbreviation for this unit of measurement within the international system of units this unit for optical power would need to be specified explicitly as the inverse metre."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dioptre"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Curvature ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dioptre?oldid=492506920"^^xsd:anyURI ;
+  qudt:symbol "D" ;
+  qudt:ucumCaseInsensitiveCode "[DIOP]" ;
+  qudt:ucumCaseSensitiveCode "[diop]" ;
+  qudt:ucumCode "[DIOP]" ;
+  qudt:ucumCode "[diop]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Diopter" ;
+.
+unit:DPI
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.937008e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseLength ;
+  qudt:iec61360Code "0112/2///62720#UAA421" ;
+  qudt:plainTextDescription "point density as amount of the picture base element divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:uneceCommonCode "E39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DOTS PER IN" ;
+  skos:prefLabel "dots per inch" ;
+.
+unit:DRAM_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.7718451953125e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB181" ;
+  qudt:plainTextDescription "non SI-conforming unit of mass comes from the Anglo-American Troy or Apothecaries' Weight System of units which is  mainly used in England, in the Netherlands and in the USA as a commercial weight" ;
+  qudt:uneceCommonCode "DRI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DRAM_UK" ;
+  skos:prefLabel "dram (UK)" ;
+.
+unit:DRAM_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.8879346e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB180" ;
+  qudt:plainTextDescription "non SI-conform unit of the mass according to the avoirdupois system of units: 1 dram (av. ) = 1/16 ounce (av. ) = 1/256 pound (av.)" ;
+  qudt:uneceCommonCode "DRA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DRAM_US" ;
+  skos:prefLabel "dram (US)" ;
+.
+unit:DWT
+  a qudt:Unit ;
+  dcterms:description "\"Penny Weight\" is a unit for  'Mass' expressed as \\(dwt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.00155517384"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pennyweight"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pennyweight?oldid=486693644"^^xsd:anyURI ;
+  qudt:symbol "dwt" ;
+  qudt:ucumCode "[PWT_TR]" ;
+  qudt:ucumCode "[pwt_tr]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Penny Weight" ;
+  skos:altLabel "dryquartus" ;
+.
+unit:DYN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "In physics, the dyne is a unit of force specified in the centimetre-gram-second (CGS) system of units. One dyne is equal to In physics, the dyne is a unit of force specified in the centimetre-gram-second (CGS) system of units. One dyne is equal to \\SI{10}{\\micro\\newton}. Equivalently, the dyne is defined as 'the force required to accelerate a mass of one gram at a rate of one centimetre per second squared'. The dyne per centimetre is the unit traditionally used to measure surface tension. For example, the surface tension of distilled water is \\(72 dyn/cm\\) at 25 deg C (77 deg F). Equivalently, the dyne is defined as 'the force required to accelerate a mass of one gram at a rate of one centimetre per second squared'. The dyne per centimetre is the unit traditionally used to measure surface tension. For example, the surface tension of distilled water is 72 dyn/cm at 25 deg C (77 deg F)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dyne"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA422" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dyne?oldid=494703827"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:latexDefinition "\\(g\\cdot cm/s^{2}\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/dyne> ;
+  qudt:symbol "dyn" ;
+  qudt:ucumCaseInsensitiveCode "DYN" ;
+  qudt:ucumCaseSensitiveCode "dyn" ;
+  qudt:ucumCode "DYN" ;
+  qudt:ucumCode "dyn" ;
+  qudt:uneceCommonCode "DU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dyne" ;
+.
+unit:DYN-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Dyne Centimeter\" is a C.G.S System unit for  'Torque' expressed as \\(dyn-cm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(dyn-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA423" ;
+  qudt:uneceCommonCode "J94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dyne Centimeter " ;
+.
+unit:DYN-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB106" ;
+  qudt:plainTextDescription "CGS unit of the surface tension" ;
+  qudt:uneceCommonCode "DX" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DYN PER CentiM" ;
+  skos:prefLabel "dyne per centimetre" ;
+.
+unit:DYN-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Dyne per Square Centimeter\" is a C.G.S System unit for  'Force Per Area' expressed as \\(dyn/cm^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-1 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(dyn/cm^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA424" ;
+  qudt:uneceCommonCode "D9" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dyne per Square Centimeter" ;
+.
+unit:DYN-SEC-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAB144" ;
+  qudt:plainTextDescription "CGS unit of the mechanical impedance" ;
+  qudt:uneceCommonCode "A51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DYN SEC PER CentiM" ;
+  skos:prefLabel "dyne second per centimetre" ;
+.
+unit:DYN-SEC-PER-CentiM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:iec61360Code "0112/2///62720#UAB102" ;
+  qudt:plainTextDescription "CGS unit of the acoustic image impedance of the medium" ;
+  qudt:uneceCommonCode "A50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DYN SEC PER CentiM3" ;
+  skos:prefLabel "dyne second per cubic centimetre" ;
+.
+unit:DZD
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Algeria"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Algerian_dinar"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Algerian_dinar?oldid=492845503"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Algerian Dinar" ;
+.
+unit:Da
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The unified atomic mass unit (symbol: \\(\\mu\\)) or dalton (symbol: Da) is a unit that is used for indicating mass on an atomic or molecular scale. It is defined as one twelfth of the rest mass of an unbound atom of carbon-12 in its nuclear and electronic ground state, and has a value of \\(1.660538782(83) \\times 10^{-27} kg\\). One \\(Da\\) is approximately equal to the mass of one proton or one neutron. The CIPM have categorised it as a \"non-SI unit whose values in SI units must be obtained experimentally\"."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.66053878283e-27 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dalton"^^xsd:anyURI ;
+  qudt:exactMatch unit:AMU ;
+  qudt:exactMatch unit:U ;
+  qudt:hasQuantityKind quantitykind:MolecularMass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass_unit"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dalton?oldid=495038954"^^xsd:anyURI ;
+  qudt:symbol "Da" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dalton" ;
+  skos:altLabel "atomic-mass-unit" ;
+.
+unit:Dalasi
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Gambia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gambian_dalasi"^^xsd:anyURI ;
+  qudt:expression "\\(GMD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gambian_dalasi?oldid=489522429"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dalasi" ;
+.
+unit:DanishKrone
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Denmark, Faroe Islands, Greenland"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Danish_krone"^^xsd:anyURI ;
+  qudt:expression "\\(DKK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Danish_krone?oldid=491168880"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Danish Krone" ;
+.
+unit:Debye
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Debye\" is a C.G.S System unit for  'Electric Dipole Moment' expressed as \\(D\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.33564E-30 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Debye"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricDipoleMoment ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Debye?oldid=492149112"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/debye> ;
+  qudt:symbol "D" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Debye" ;
+.
+unit:Deca
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0E1 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Deca"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "da" ;
+  qudt:ucumCaseInsensitiveCode "DA" ;
+  qudt:ucumCaseSensitiveCode "da" ;
+  qudt:ucumCode "DA" ;
+  qudt:ucumCode "da" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Deca" ;
+.
+unit:DecaARE
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB049" ;
+  qudt:plainTextDescription "unit of the area which is mainly common in the agriculture and forestry: 1 da = 10 a = 1 000 mÂ²" ;
+  qudt:uneceCommonCode "DAA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaARE" ;
+  skos:prefLabel "decare" ;
+.
+unit:DecaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A DecaCoulomb is \\(10 C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "10.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Deca ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "daC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:DecaGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB075" ;
+  qudt:plainTextDescription "0,01-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "DJ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaGM" ;
+  skos:prefLabel "decagram" ;
+.
+unit:DecaL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB115" ;
+  qudt:plainTextDescription "10-fold of the unit litre" ;
+  qudt:uneceCommonCode "A44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaL" ;
+  skos:prefLabel "decalitre" ;
+.
+unit:DecaM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB064" ;
+  qudt:plainTextDescription "10-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "A45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaM" ;
+  skos:prefLabel "decametre" ;
+.
+unit:DecaM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB179" ;
+  qudt:plainTextDescription "1 000-fold of the power of the SI base unit metre by exponent 3" ;
+  qudt:uneceCommonCode "DMA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaM3" ;
+  skos:prefLabel "decametre cubed" ;
+.
+unit:DecaPA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAB375" ;
+  qudt:plainTextDescription "10-fold of the derived SI unit pascal" ;
+  qudt:uneceCommonCode "H75" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DecaPA" ;
+  skos:prefLabel "decapascal" ;
+.
+unit:Deci
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"deci\" is a decimal prefix for expressing a value with a scaling of \\(10^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-1 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Deci-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deci-?oldid=469980160"^^xsd:anyURI ;
+  qudt:symbol "d" ;
+  qudt:ucumCaseInsensitiveCode "D" ;
+  qudt:ucumCaseSensitiveCode "d" ;
+  qudt:ucumCode "D" ;
+  qudt:ucumCode "d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Deci" ;
+.
+unit:DeciB
+  a qudt:DimensionlessUnit ;
+  a qudt:LogarithmicUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">A customary logarithmic measure most commonly used (in various ways) for measuring sound.Sound is measured on a logarithmic scale. Informally, if one sound is \\(1\\,bel\\) (10 decibels) \"louder\" than another, this means the louder sound is 10 times louder than the fainter one. A difference of 20 decibels corresponds to an increase of 10 x 10 or 100 times in intensity.</p>
+
+<p class=\"lm-para\">The beginning of the scale, 0 decibels, can be set in different ways, depending on exactly the aspect of sound being measured. For sound intensity (the power of the sound waves per unit of area) \\(0\\,decibel\\) is equal to \\(1\\,picoWatts\\,per\\,Metre\\,Squared\\). This corresponds approximately to the faintest sound that can be detected by a person who has good hearing. For sound pressure (the pressure exerted by the sound waves) 0 decibels equals \\(20\\,micropascals\\,RMS\\), and for sound power \\(0\\,decibels\\) sometimes equals \\(1\\,picoWatt\\). In all cases, one decibel equals \\(\\approx\\,0.115129\\,neper\\).</p>"""^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Decibel"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:RF-Power ;
+  qudt:hasQuantityKind quantitykind:SignalStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA409" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Decibel?oldid=495380648"^^xsd:anyURI ;
+  qudt:symbol "dB" ;
+  qudt:uneceCommonCode "2N" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Decibel" ;
+.
+unit:DeciBAR
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to 100,000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000 Pa = 1 bar \\approx 750.0616827 Torr\\). Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Deci ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BAR ;
+  qudt:symbol "dbar" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Decibar" ;
+.
+unit:DeciB_C
+  a qudt:Unit ;
+  dcterms:description "\"Decibel Carrier Unit\" is a unit for  'Signal Detection Threshold' expressed as \\(dBc\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:SignalDetectionThreshold ;
+  qudt:symbol "dBc" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Decibel Carrier Unit" ;
+.
+unit:DeciB_M
+  a qudt:DimensionlessUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Decibel Referred to 1mw\" is a  'Dimensionless Ratio' expressed as \\(dBm\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:symbol "dBm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Decibel Referred to 1mw" ;
+.
+unit:DeciC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A DeciCoulomb is \\(10^{-1} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Deci ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "dC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:DeciGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB076" ;
+  qudt:plainTextDescription "0,000 1-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "DG" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciGM" ;
+  skos:prefLabel "decigram" ;
+.
+unit:DeciL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB113" ;
+  qudt:plainTextDescription "0,1-fold of the unit litre" ;
+  qudt:uneceCommonCode "DLT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciL" ;
+  skos:prefLabel "decilitre" ;
+.
+unit:DeciL-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
+  qudt:iec61360Code "0112/2///62720#UAB094" ;
+  qudt:plainTextDescription "0,1-fold of the unit of the volume litre divided by the 0,001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciL PER GM" ;
+  skos:prefLabel "decilitre per gram" ;
+.
+unit:DeciM
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A decimeter is a tenth of a meter."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Deci ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA412" ;
+  qudt:isScalingOf unit:M ;
+  qudt:ucumCaseInsensitiveCode "DM" ;
+  qudt:ucumCaseSensitiveCode "dm" ;
+  qudt:ucumCode "DM" ;
+  qudt:ucumCode "dm" ;
+  qudt:uneceCommonCode "DMT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Decimeter" ;
+.
+unit:DeciM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA413" ;
+  qudt:plainTextDescription "0.1-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "DMK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM2" ;
+  skos:prefLabel "decimetre squared" ;
+.
+unit:DeciM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA414" ;
+  qudt:plainTextDescription "0.1-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "DMQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3" ;
+  skos:prefLabel "decimetre cubed" ;
+.
+unit:DeciM3-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407407e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA415" ;
+  qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time day" ;
+  qudt:uneceCommonCode "J90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER DAY" ;
+  skos:prefLabel "decimetre cubed per day" ;
+.
+unit:DeciM3-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA416" ;
+  qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit hour" ;
+  qudt:uneceCommonCode "E92" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER HR" ;
+  skos:prefLabel "decimetre cubed per hour" ;
+.
+unit:DeciM3-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA417" ;
+  qudt:plainTextDescription "volume ratio consisting of the 0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "J91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER M3" ;
+  skos:prefLabel "decimetre cubed per metre cubed" ;
+.
+unit:DeciM3-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA418" ;
+  qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time minute" ;
+  qudt:uneceCommonCode "J92" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER MIN" ;
+  skos:prefLabel "decimetre cubed per minute" ;
+.
+unit:DeciM3-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA419" ;
+  qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the SI base unit mol" ;
+  qudt:uneceCommonCode "A37" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER MOL" ;
+  skos:prefLabel "decimetre cubed per mole" ;
+.
+unit:DeciM3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA420" ;
+  qudt:plainTextDescription "0,001-fold of the power of the SI base unit metre with the exponent 3 divided by the unit for time second" ;
+  qudt:uneceCommonCode "J93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciM3 PER SEC" ;
+  skos:prefLabel "decimetre cubed per second" ;
+.
+unit:DeciN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAB084" ;
+  qudt:plainTextDescription "0,1-fold of the product of the derived SI unit joule and the SI base unit metre" ;
+  qudt:uneceCommonCode "DN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciN M" ;
+  skos:prefLabel "decinewton metre" ;
+.
+unit:DeciTON_M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB078" ;
+  qudt:plainTextDescription "100-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "DTN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "DeciTON_M" ;
+  skos:prefLabel "decitonne" ;
+.
+unit:Deka
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "<strong>deka</strong> is a decimal prefix for expressing a value with a scaling of \\(10^{1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "10.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Deca"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Deca?oldid=480093935"^^xsd:anyURI ;
+  qudt:symbol "da" ;
+  qudt:ucumCaseInsensitiveCode "DA" ;
+  qudt:ucumCaseSensitiveCode "da" ;
+  qudt:ucumCode "DA" ;
+  qudt:ucumCode "da" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Deka" ;
+.
+unit:Denar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Former Yugoslav Republic of Macedonia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Macedonian_denar"^^xsd:anyURI ;
+  qudt:expression "\\(MKD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Macedonian_denar?oldid=489550202"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Denar" ;
+.
+unit:Denier
+  a qudt:Unit ;
+  dcterms:description "Denier or den is a unit of measure for the linear mass density of fibers. It is defined as the mass in grams per 9,000 meters. In the International System of Units the tex is used instead (see below). The denier is based on a natural standard: a single strand of silk is approximately one denier. A 9,000-meter strand of silk weighs about one gram. The term denier is from the French denier, a coin of small value (worth 1/12 of a sou). Applied to yarn, a denier was held to be equal in weight to 1/24 of an ounce. The term microdenier is used to describe filaments that weigh less than one gram per 9,000 meter length."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.1E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Denier"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB244" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Denier?oldid=463382291"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Units_of_textile_measurement#Denier"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "[DEN]" ;
+  qudt:ucumCaseSensitiveCode "[den]" ;
+  qudt:ucumCode "[DEN]" ;
+  qudt:ucumCode "[den]" ;
+  qudt:uneceCommonCode "A49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Denier" ;
+.
+unit:DjiboutiFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Djibouti"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Djiboutian_franc"^^xsd:anyURI ;
+  qudt:expression "\\(DJF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Djiboutian_franc?oldid=486807423"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Djibouti Franc" ;
+.
+unit:Dobra
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "The currency of São Tomé and Príncipe"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dobra"^^xsd:anyURI ;
+  qudt:expression "\\(STD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dobra?oldid=475725328"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dobra" ;
+.
+unit:DominicanPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Dominican Republic"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Dominican_peso"^^xsd:anyURI ;
+  qudt:expression "\\(DOP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Dominican_peso?oldid=493950199"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dominican Peso" ;
+.
+unit:E
+  a qudt:Unit ;
+  dcterms:description "\"Elementary Charge\", usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176565(35) \\times 10 coulombs\\). In the cgs system, \\(e\\) is \\(4.80320425(10) \\times 10 statcoulombs\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "16.02176565"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:symbol "e" ;
+  qudt:ucumCaseInsensitiveCode "[E]" ;
+  qudt:ucumCaseSensitiveCode "[e]" ;
+  qudt:ucumCode "[E]" ;
+  qudt:ucumCode "[e]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Elementary Charge" ;
+.
+unit:ERG
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "An erg is the unit of energy and mechanical work in the centimetre-gram-second (CGS) system of units, symbol 'erg'. Its name is derived from the Greek ergon, meaning 'work'. An erg is the amount of work done by a force of one dyne exerted for a distance of one centimeter. In the CGS base units, it is equal to one gram centimeter-squared per second-squared (\\(g \\cdot cm/s\\)). It is thus equal to 10 joules or 100 nanojoules in SI units. \\(1 erg = 10 J = 100 nJ\\),  \\(1 erg = 624.15 GeV = 6.2415 \\times 10 eV\\), \\(1 erg = 1 dyne cm = 1 g \\cdot cm/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Erg"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA429" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Erg?oldid=490293432"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:latexDefinition "\\(g\\cdot cm^{2}/s^{2}\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/erg> ;
+  qudt:symbol "erg" ;
+  qudt:ucumCaseInsensitiveCode "ERG" ;
+  qudt:ucumCaseSensitiveCode "erg" ;
+  qudt:ucumCode "ERG" ;
+  qudt:ucumCode "erg" ;
+  qudt:uneceCommonCode "A57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg" ;
+.
+unit:ERG-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
+  qudt:iec61360Code "0112/2///62720#UAB145" ;
+  qudt:plainTextDescription "CGS unit of the length-related energy" ;
+  qudt:uneceCommonCode "A58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ERG PER CentiM" ;
+  skos:prefLabel "erg per centimetre" ;
+.
+unit:ERG-PER-CentiM2-SEC
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Erg per Square Centimeter Second\" is a C.G.S System unit for  'Power Per Area' expressed as \\(erg/(cm^{2}-s)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(erg/(cm^{2}-s)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB055" ;
+  qudt:uneceCommonCode "A65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg per Square Centimeter Second" ;
+.
+unit:ERG-PER-CentiM3
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(erg-per-cm3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB146" ;
+  qudt:uneceCommonCode "A60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg per Cubic Centimeter" ;
+.
+unit:ERG-PER-G
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:expression "\\(erg-per-g\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB061" ;
+  qudt:uneceCommonCode "A61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg per Gram" ;
+.
+unit:ERG-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB061" ;
+  qudt:plainTextDescription "CGS unit of the mass-related energy" ;
+  qudt:uneceCommonCode "A61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ERG PER GM" ;
+  skos:prefLabel "erg per gram" ;
+.
+unit:ERG-PER-GM-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:iec61360Code "0112/2///62720#UAB147" ;
+  qudt:plainTextDescription "CGS unit of the mass-related power" ;
+  qudt:uneceCommonCode "A62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ERG PER GM SEC" ;
+  skos:prefLabel "erg per gram second" ;
+.
+unit:ERG-PER-SEC
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Erg per Second\" is a C.G.S System unit for  'Power' expressed as \\(erg/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(erg/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA430" ;
+  qudt:latexDefinition "\\(g\\cdot cm^{2}/s^{3}\\)"^^qudt:LatexString ;
+  qudt:uneceCommonCode "A63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg per Second" ;
+.
+unit:ERG-SEC
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:symbol "erg s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erg Second" ;
+.
+unit:ERLANG
+  a qudt:Unit ;
+  dcterms:description "The \"Erlang\" is a dimensionless unit that is used in telephony as a measure of offered load or carried load on service-providing elements such as telephone circuits or telephone switching equipment."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Erlang_(unit)"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:iec61360Code "0112/2///62720#UAB340" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Erlang_(unit)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:symbol "E" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Erlang" ;
+.
+unit:EV
+  a qudt:Unit ;
+  dcterms:description "An electron volt (eV) is the energy that an electron gains when it travels through a potential of one volt. You can imagine that the electron starts at the negative plate of a parallel plate capacitor and accelerates to the positive plate, which is at one volt higher potential. Numerically \\(1 eV\\) equals \\(1.6x10^{-19} joules\\), where \\(1 joule\\) is \\(6.2x10^{18} eV\\). For example, it would take \\(6.2x10^{20} eV/sec\\) to light a 100 watt light bulb."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-19 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Electron_volt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Electron_volt?oldid=344021738"^^xsd:anyURI ;
+  qudt:informativeReference "http://physics.nist.gov/cuu/Constants/bibliography.html"^^xsd:anyURI ;
+  qudt:quantityValue qudt:ValueForElectronVolt ;
+  qudt:symbol "eV" ;
+  qudt:ucumCaseInsensitiveCode "EV" ;
+  qudt:ucumCaseSensitiveCode "eV" ;
+  qudt:ucumCode "EV" ;
+  qudt:ucumCode "eV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Electron Volt" ;
+.
+unit:EV-PER-K
+  a qudt:Unit ;
+  dcterms:description "<p><em>Electron Volt per Kelvin</em> is a unit for 'Heat Capacity' expressed as \\(ev/K\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-19 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ev/K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Electron Volt per Kelvin" ;
+.
+unit:EV-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.602176e-19 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
+  qudt:iec61360Code "0112/2///62720#UAA426" ;
+  qudt:plainTextDescription "unit electronvolt divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "A54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "EV PER M" ;
+  skos:prefLabel "electronvolt per metre" ;
+.
+unit:EV-PER-T
+  a qudt:Unit ;
+  dcterms:description "\"Electron Volt per Tesla\" is a unit for  'Magnetic Dipole Moment' expressed as \\(eV T^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-19 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(eV T^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Electron Volt per Tesla" ;
+.
+unit:EV-SEC
+  a qudt:Unit ;
+  dcterms:description "\"Electron Volt Second\" is a unit for  'Angular Momentum' expressed as \\(eV s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-19 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:symbol "eV s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Electron Volt Second" ;
+.
+unit:E_h
+  a qudt:Unit ;
+  dcterms:description """<p>The \\(\\textit{Hartree}\\) (symbol: \\(E_h\\) or \\(Ha\\)), also known as the \\(\\text{Hartree\\,Energy}\\), is the atomic unit of energy. The hartree energy is equal to the absolute value of the electric potential energy of the hydrogen atom in its ground state. The energy of the electron in an H-atom in its ground state is \\(-E_H\\), where \\(E_H= 2 R_\\infty \\cdot hc_0\\). The 2006 CODATA recommended value was \\(E_H = 4.35974394(22) \\times 10^{-18} J = 27.21138386(68) eV\\).</p>
+<dt class=\"size-14\">Definition:</dt>
+<dd>\\(E_H= \\frac{e^2}{4\\pi \\epsilon_0 a_0 }\\)<br/>
+where, \\(e\\) is the elementary charge, \\(\\epsilon_0\\) is the electric constant, and \\(a_0\\) is the Bohr radius.'</dd>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.35974394E-18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hartree"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hartree?oldid=489318053"^^xsd:anyURI ;
+  qudt:symbol "E_h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hartree" ;
+.
+unit:EarthMass
+  a qudt:Unit ;
+  dcterms:description "Earth mass (\\(M_{\\oplus}\\)) is the unit of mass equal to that of the Earth. In SI Units, \\(1 M_{\\oplus} = 5.9722 \\times 1024 kg\\). Earth mass is often used to describe masses of rocky terrestrial planets. The four terrestrial planets of the Solar System, Mercury, Venus, Earth, and Mars, have masses of 0.055, 0.815, 1.000, and 0.107 Earth masses respectively."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Earth_mass"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Earth_mass?oldid=495457885"^^xsd:anyURI ;
+  qudt:latexDefinition """One Earth mass can be converted to related units:
+
+81.3 Lunar mass (ML)
+0.00315 Jupiter mass (MJ) (Jupiter has 317.83 Earth masses)[1]
+0.0105 Saturn mass (Saturn has 95.16 Earth masses)[3]
+0.0583 Neptune mass (Neptune has 17.147 Earth masses)[4]
+0.000 003 003 Solar mass (\\(M_{\\odot}\\)) (The Sun has 332946 Earth masses)"""^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Earth mass" ;
+.
+unit:EastCaribbeanDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Anguilla, Antigua and Barbuda, Dominica, Grenada, Montserrat, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/East_Caribbean_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(XCD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/East_Caribbean_dollar?oldid=493020176"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "East Caribbean Dollar" ;
+.
+unit:EgyptianPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Egypt"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Egyptian_pound"^^xsd:anyURI ;
+  qudt:expression "\\(EGP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Egyptian_pound?oldid=494670285"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Egyptian Pound" ;
+.
+unit:ElementaryCharge
+  a qudt:Unit ;
+  dcterms:description "<p><em>Elementary Charge</em>, usually denoted as \\(e\\), is the electric charge carried by a single proton, or equivalently, the negation (opposite) of the electric charge carried by a single electron. This elementary charge is a fundamental physical constant. To avoid confusion over its sign, e is sometimes called the elementary positive charge. This charge has a measured value of approximately \\(1.602176565(35) \\times 10\\,coulombs\\). In the cgs system, \\(e\\) is \\(4.80320425(10) \\times 10\\, statcoulombs\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "16.02176565"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:symbol "e" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Elementary Charge" ;
+.
+unit:EthiopianBirr
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Ethiopia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ethiopian_birr"^^xsd:anyURI ;
+  qudt:expression "\\(ETB\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ethiopian_birr?oldid=493373507"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ethiopian Birr" ;
+.
+unit:Euro
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "European Union Euro"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Euro"^^xsd:anyURI ;
+  qudt:expression "\\(EUR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Euro?oldid=495293446"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/euro> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Euro" ;
+.
+unit:EuropeanCompositeUnit
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bonds market unit"^^rdf:HTML ;
+  qudt:expression "\\(XBA\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "European Composite Unit (EURCO) (Bonds market unit)" ;
+.
+unit:EuropeanMonetaryUnit
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bonds market unit"^^rdf:HTML ;
+  qudt:expression "\\(XBB\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "European Monetary Unit (E.M.U.-6) (Bonds market unit)" ;
+.
+unit:EuropeanUnitOfAccount17
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bonds market unit"^^rdf:HTML ;
+  qudt:expression "\\(XBD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "European Unit of Account 17 (E.U.A.-17) (Bonds market unit)" ;
+.
+unit:EuropeanUnitOfAccount9
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bonds market unit"^^rdf:HTML ;
+  qudt:expression "\\(XBC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "European Unit of Account 9 (E.U.A.-9) (Bonds market unit)" ;
+.
+unit:Exa
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'exa' is a decimal prefix for expressing a value with a scaling of \\(10^{18}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Exa-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Exa-?oldid=494400216"^^xsd:anyURI ;
+  qudt:symbol "E" ;
+  qudt:ucumCaseInsensitiveCode "EX" ;
+  qudt:ucumCaseSensitiveCode "E" ;
+  qudt:ucumCode "E" ;
+  qudt:ucumCode "EX" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Exa" ;
+.
+unit:ExaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "An ExaCoulomb is \\(10^{18} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Exa ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "EC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ExaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:ExaJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+18 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAB122" ;
+  qudt:plainTextDescription "1 000 000 000 000 000 000-fold of the derived SI unit joule" ;
+  qudt:uneceCommonCode "A68" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ExaJ" ;
+  skos:prefLabel "exajoule" ;
+.
+unit:Exbi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{6}\\), or \\(2^{60}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "152921504606846976.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Ei" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Exbi" ;
+.
+unit:F
+  a qudt:Unit ;
+  dcterms:description "\"Faraday\" is a unit for  'Electric Charge' expressed as \\(F\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "96485.3399"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/faraday> ;
+  qudt:symbol "F" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Faraday" ;
+.
+unit:FA
+  a qudt:Unit ;
+  dcterms:description "\"Fractional area\" is a unit for  'Solid Angle' expressed as \\(fa\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "12.5663706"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:SolidAngle ;
+  qudt:symbol "fa" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Fractional area" ;
+.
+unit:FARAD
+  a qudt:CGS-Unit ;
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of electric capacitance. Very early in the study of electricity scientists discovered that a pair of conductors separated by an insulator can store a much larger charge than an isolated conductor can store. The better the insulator, the larger the charge that the conductors can hold. This property of a circuit is called capacitance, and it is measured in farads. One farad is defined as the ability to store one coulomb of charge per volt of potential difference between the two conductors. This is a natural definition, but the unit it defines is very large. In practical circuits, capacitance is often measured in microfarads, nanofarads, or sometimes even in picofarads (10-12 farad, or trillionths of a farad). The unit is named for the British physicist Michael Faraday (1791-1867), who was known for his work in electricity and electrochemistry."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Farad"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA144" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Farad?oldid=493070876"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/farad> ;
+  qudt:siUnitsExpression "C/V" ;
+  qudt:symbol "F" ;
+  qudt:ucumCaseInsensitiveCode "F" ;
+  qudt:ucumCode "F" ;
+  qudt:uneceCommonCode "FAR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Farad" ;
+.
+unit:FARAD-PER-KiloM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA145" ;
+  qudt:plainTextDescription "SI derived unit farad divided by the 1 000-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FARAD PER KiloM" ;
+  skos:prefLabel "farad per kilometre" ;
+.
+unit:FARAD-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Farad Per Meter (\\(F/m\\)) is a unit in the category of Electric permittivity. It is also known as farad/meter. This unit is commonly used in the SI unit system. Farad Per Meter has a dimension of M-1L-3T4I2 where M is mass, L is length, T is time, and I is electric current. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(F/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA146" ;
+  qudt:uneceCommonCode "A69" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Farad per Meter" ;
+.
+unit:FARAD_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "An abfarad is an obsolete electromagnetic (CGS) unit of capacitance equal to \\(10^{9}\\) farads (1,000,000,000 F or 1 GF). The absolute farad of the e.m.u. system, for a steady current identically \\(abC/abV\\), and identically reciprocal abdaraf. 1 abF = 1 GF."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abfarad"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abfarad?oldid=407124018"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-13"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abfarad> ;
+  qudt:symbol "abF" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abfarad" ;
+.
+unit:FARAD_Ab-PER-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The absolute dielectric constant of free space is defined as the ratio of displacement to the electric field intensity. The unit of measure is the abfarad per centimeter, a derived CGS unit."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(abf-per-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abfarad per Centimeter" ;
+.
+unit:FARAD_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Statfarad (statF) is a unit in the category of Electric capacitance. It is also known as statfarads. This unit is commonly used in the cgs unit system. Statfarad (statF) has a dimension of \\(M^{-1}L^{-2}T^4I^2\\) where M is mass, L is length, T is time, and I is electric current. It can be converted to the corresponding standard SI unit F by multiplying its value by a factor of 1.11265E-012."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.113E-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_capacitance--statfarad.cfm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statfarad> ;
+  qudt:symbol "statF" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statfarad" ;
+.
+unit:FATH
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A fathom = 1.8288 meters, is a unit of length in the imperial and the U.S. customary systems, used especially for measuring the depth of water. There are two yards in an imperial or U.S. fathom. Originally based on the distance between the man's outstretched arms, the size of a fathom has varied slightly depending on whether it was defined as a thousandth of an (Admiralty) nautical mile or as a multiple of the imperial yard.  Abbreviations: f, fath, fm, fth, fthm."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.8288"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Fathom"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fathom?oldid=493265429"^^xsd:anyURI ;
+  qudt:symbol "fath" ;
+  qudt:ucumCaseInsensitiveCode "[FTH_I]" ;
+  qudt:ucumCaseSensitiveCode "[fth_i]" ;
+  qudt:ucumCode "[FTH_I]" ;
+  qudt:ucumCode "[fth_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Fathom" ;
+.
+unit:FBM
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The board-foot is a specialized unit of measure for the volume of lumber in the United States and Canada. It is the volume of a one-foot length of a board one foot wide and one inch thick. Board-foot can be abbreviated FBM (for 'foot, board measure'), BDFT, or BF. Thousand board-feet can be abbreviated as MFBM, MBFT or MBF. "^^rdf:HTML ;
+  qudt:conversionMultiplier "0.002360"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:symbol "Bf" ;
+  qudt:ucumCaseInsensitiveCode "[BF_I]" ;
+  qudt:ucumCaseSensitiveCode "[bf_i]" ;
+  qudt:ucumCode "[BF_I]" ;
+  qudt:ucumCode "[bf_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Board Foot" ;
+.
+unit:FC
+  a qudt:Unit ;
+  dcterms:description "\"Foot Candle\" is a unit for  'Luminous Flux Per Area' expressed as \\(fc\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Foot-candle"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousFluxPerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Foot-candle?oldid=475579268"^^xsd:anyURI ;
+  qudt:symbol "fc" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Candle" ;
+.
+unit:FM
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The \\(\\textit{fermi}\\), or \\(\\textit{femtometer}\\) (other spelling \\(femtometre\\), symbol \\(fm\\)) is an SI unit of length equal to \\(10^{-15} metre\\). This distance is often encountered in nuclear physics as a characteristic of this scale. The symbol for the fermi is also \\(fm\\)."^^qudt:LatexString ;
+  qudt:conversionCoefficient "0.0"^^xsd:double ;
+  qudt:conversionMultiplier 1.0E-15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:FemtoM ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fermi_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/fermi> ;
+  qudt:symbol "fm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "fermi" ;
+.
+unit:FR
+  a qudt:Unit ;
+  dcterms:description "\"Franklin\" is a unit for  'Electric Charge' expressed as \\(Fr\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Franklin"^^xsd:anyURI ;
+  qudt:exactMatch unit:C_Stat ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAB212" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Franklin?oldid=495090654"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/franklin> ;
+  qudt:symbol "Fr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Franklin" ;
+.
+unit:FRAME-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Frame per Second\" is a unit for  'Video Frame Rate' expressed as \\(fps\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:VideoFrameRate ;
+  qudt:symbol "fps" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Frame per Second" ;
+.
+unit:FT
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A foot is a unit of length defined as being 0.3048 m exactly and used in the imperial system of units and United States customary units. It is subdivided into 12 inches. The foot is still officially used in Canada and still commonly used in the United Kingdom, although the latter has partially metricated its units of measurement. "^^rdf:HTML ;
+  qudt:conversionMultiplier "0.3048"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Foot_%28length%29"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA440" ;
+  qudt:symbol "ft" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]" ;
+  qudt:ucumCode "[FT_I]" ;
+  qudt:ucumCode "[ft_i]" ;
+  qudt:uneceCommonCode "FOT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot" ;
+.
+unit:FT-LA
+  a qudt:Unit ;
+  dcterms:description "\"Foot Lambert\" is a C.G.S System unit for  'Luminance' expressed as \\(ft-L\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "3.4262591"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-L\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Lambert" ;
+.
+unit:FT-LB_F
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force\" is an Imperial unit for  'Energy And Work' expressed as \\(ft-lbf\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.35581807"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Foot-pound_force"^^xsd:anyURI ;
+  qudt:expression "\\(ft-lbf\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Foot-pound_force?oldid=453269257"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force" ;
+.
+unit:FT-LB_F-PER-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound per Square Foot\" is an Imperial unit for  'Energy Per Area' expressed as \\(ft-lbf/ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "14.5939042"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound per Square Foot" ;
+.
+unit:FT-LB_F-PER-FT2-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force per Square Foot Second\" is an Imperial unit for  'Power Per Area' expressed as \\(ft \\cdot lbf/(ft^2 \\cdot s)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "14.5939042"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/ft^2s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:latexSymbol "\\(ft \\cdot lbf/(ft^2 \\cdot s)\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force per Square Foot Second" ;
+.
+unit:FT-LB_F-PER-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force per Hour\" is an Imperial unit for  'Power' expressed as \\(ft-lbf/hr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.76616129E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force per Hour" ;
+.
+unit:FT-LB_F-PER-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force per Square Meter\" is a unit for  'Energy Per Area' expressed as \\(ft-lbf/m^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/m^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force per Square Meter" ;
+.
+unit:FT-LB_F-PER-MIN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force per Minute\" is an Imperial unit for  'Power' expressed as \\(ft-lbf/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0225969678"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force per Minute" ;
+.
+unit:FT-LB_F-PER-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force per Second\" is an Imperial unit for  'Power' expressed as \\(ft-lbf/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.35581807"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft-lbf/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force per Second" ;
+.
+unit:FT-LB_F-SEC
+  a qudt:Unit ;
+  dcterms:description "\"Foot Pound Force Second\" is a unit for  'Angular Momentum' expressed as \\(lbf / s\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:ucumCaseInsensitiveCode "[FT_I].[LBF_AV].S" ;
+  qudt:ucumCaseSensitiveCode "[ft_i].[lbf_av].s" ;
+  qudt:ucumCode "[FT_I].[LBF_AV].S" ;
+  qudt:ucumCode "[ft_i].[lbf_av].s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Pound Force Second" ;
+.
+unit:FT-PDL
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot Poundal\" is an Imperial unit for  'Energy And Work' expressed as \\(ft-pdl\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.042140124"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAB220" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/footPoundal> ;
+  qudt:symbol "ft-pdl" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot Poundal" ;
+.
+unit:FT-PER-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.4864e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA441" ;
+  qudt:plainTextDescription "unit foot as a linear measure according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:uneceCommonCode "K13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT PER DEG_F" ;
+  skos:prefLabel "foot per degree Fahrenheit" ;
+.
+unit:FT-PER-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot per Hour\" is an Imperial unit for  'Linear Velocity' expressed as \\(ft/hr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 8.466666666666667E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA442" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I].HR-1" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]/HR" ;
+  qudt:ucumCaseSensitiveCode "[ft_i].h-1" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]/h" ;
+  qudt:ucumCode "[FT_I].HR-1" ;
+  qudt:ucumCode "[FT_I]/HR" ;
+  qudt:ucumCode "[ft_i].h-1" ;
+  qudt:ucumCode "[ft_i]/h" ;
+  qudt:uneceCommonCode "K14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot per Hour" ;
+.
+unit:FT-PER-MIN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Foot per Minute\" is an Imperial unit for  'Linear Velocity' expressed as \\(ft/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.00508e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA448" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]/MIN" ;
+  qudt:ucumCaseSensitiveCode "[ft_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]/min" ;
+  qudt:ucumCode "[FT_I].MIN-1" ;
+  qudt:ucumCode "[FT_I]/MIN" ;
+  qudt:ucumCode "[ft_i].min-1" ;
+  qudt:ucumCode "[ft_i]/min" ;
+  qudt:uneceCommonCode "FR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot per Minute" ;
+.
+unit:FT-PER-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{foot per second}\\) (plural \\(\\textit{feet per second}\\)) is a unit of both speed (scalar) and velocity (vector quantity, which includes direction). It expresses the distance in feet (\\(ft\\)) traveled or displaced, divided by the time in seconds (\\(s\\), or \\(sec\\)). The corresponding unit in the International System of Units (SI) is the \\(\\textit{metre per second}\\). Abbreviations include \\(ft/s\\), \\(ft/sec\\) and \\(fps\\), and the rarely used scientific notation \\(ft\\,s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.3048e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Foot_per_second"^^xsd:anyURI ;
+  qudt:expression "\\(ft/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA449" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Foot_per_second?oldid=491316573"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "[FT_I].S-1" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]/S" ;
+  qudt:ucumCaseSensitiveCode "[ft_i].s-1" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]/s" ;
+  qudt:ucumCode "[FT_I].S-1" ;
+  qudt:ucumCode "[FT_I]/S" ;
+  qudt:ucumCode "[ft_i].s-1" ;
+  qudt:ucumCode "[ft_i]/s" ;
+  qudt:uneceCommonCode "FS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot per Second" ;
+.
+unit:FT-PER-SEC2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Foot per Second Squared}\\) is an Imperial unit for \\(\\textit{Linear Acceleration}\\) expressed as \\(ft/s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.3048e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft/s^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAA452" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I].S-2" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]/S2" ;
+  qudt:ucumCaseSensitiveCode "[ft_i].s-2" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]/s2" ;
+  qudt:ucumCode "[FT_I].S-2" ;
+  qudt:ucumCode "[FT_I]/S2" ;
+  qudt:ucumCode "[ft_i].s-2" ;
+  qudt:ucumCode "[ft_i]/s2" ;
+  qudt:uneceCommonCode "A73" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot per Second Squared" ;
+.
+unit:FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The square foot (plural square feet; abbreviated \\(ft^2\\) or \\(sq \\, ft\\)) is an imperial unit and U.S. customary unit of area, used mainly in the United States, Canada, United Kingdom, Hong Kong, Bangladesh, India, Pakistan and Afghanistan. It is defined as the area of a square with sides of 1 foot in length."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.09290304"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA454" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]2" ;
+  qudt:ucumCaseInsensitiveCode "[SFT_I]" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]2" ;
+  qudt:ucumCaseSensitiveCode "[sft_i]" ;
+  qudt:ucumCode "[FT_I]2" ;
+  qudt:ucumCode "[SFT_I]" ;
+  qudt:ucumCode "[ft_i]2" ;
+  qudt:ucumCode "[sft_i]" ;
+  qudt:uneceCommonCode "FTK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot" ;
+.
+unit:FT2-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Foot Degree Fahrenheit</em> is an Imperial unit for 'Area Temperature' expressed as \\(ft^{2}-degF\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot Degree Fahrenheit" ;
+.
+unit:FT2-HR-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Foot Hour Degree Fahrenheit</em> is an Imperial unit for 'Area Time Temperature' expressed as \\(ft^{2}-hr-degF\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}-hr-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot Hour Degree Fahrenheit" ;
+.
+unit:FT2-HR-DEG_F-PER-BTU_IT
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Foot Hour Degree Fahrenheit per BTU</em> is an Imperial unit for 'Thermal Insulance' expressed as \\((degF-hr-ft^{2})/Btu\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(sqft-hr-degF/btu\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot Hour Degree Fahrenheit per BTU" ;
+.
+unit:FT2-PER-BTU_IT-IN
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00346673589"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft2-per-btu-in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot per BTU Inch" ;
+.
+unit:FT2-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Foot per Hour</em> is an Imperial unit for \\(\\textit{Kinematic Viscosity}\\) and  \\(\\textit{Thermal Diffusivity}\\) expressed as \\(ft^{2}/hr\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.58064E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:KinematicViscosity ;
+  qudt:hasQuantityKind quantitykind:ThermalDiffusivity ;
+  qudt:iec61360Code "0112/2///62720#UAB247" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot per Hour" ;
+.
+unit:FT2-PER-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Square Foot per Second\" is an Imperial unit for  'Kinematic Viscosity' expressed as \\(ft^{2}/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.09290304e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:KinematicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA455" ;
+  qudt:uneceCommonCode "S3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot per Second" ;
+.
+unit:FT2-SEC-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Foot Second Degree Fahrenheit</em> is an Imperial unit for 'Area Time Temperature' expressed as \\(ft^{2}\\cdot s\\cdot degF\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{2}-s-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTimeTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Foot Second Degree Fahrenheit" ;
+.
+unit:FT3
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The cubic foot is an Imperial and US customary unit of volume, used in the United States and the United Kingdom. It is defined as the volume of a cube with sides of one foot (0.3048 m) in length. To calculate cubic feet multiply length X width X height. "^^rdf:HTML ;
+  qudt:conversionMultiplier 0.028316846592e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA456" ;
+  qudt:ucumCaseInsensitiveCode "[CFT_I]" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]3" ;
+  qudt:ucumCaseSensitiveCode "[cft_i]" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]3" ;
+  qudt:ucumCode "[CFT_I]" ;
+  qudt:ucumCode "[FT_I]3" ;
+  qudt:ucumCode "[cft_i]" ;
+  qudt:ucumCode "[ft_i]3" ;
+  qudt:uneceCommonCode "FTQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Foot" ;
+.
+unit:FT3-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.277413e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA458" ;
+  qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
+  qudt:uneceCommonCode "K22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT3 PER DAY" ;
+  skos:prefLabel "cubic foot per day" ;
+.
+unit:FT3-PER-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.097033e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA457" ;
+  qudt:plainTextDescription "power of the unit foot as a linear measure according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
+  qudt:uneceCommonCode "K21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT3 PER DEG_F" ;
+  skos:prefLabel "cubic foot per degree Fahrenheit" ;
+.
+unit:FT3-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.865792e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA459" ;
+  qudt:plainTextDescription "power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
+  qudt:uneceCommonCode "2K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT3 PER HR" ;
+  skos:prefLabel "cubic foot per hour" ;
+.
+unit:FT3-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Cubic Foot per Minute\" is an Imperial unit for  'Volume Per Unit Time' expressed as \\(ft^3/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.719474432000001E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{3}/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAA461" ;
+  qudt:ucumCaseInsensitiveCode "[CFT_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[CFT_I]/MIN" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]3.MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]3/MIN" ;
+  qudt:ucumCaseSensitiveCode "[cft_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[cft_i]/min" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]3.min-1" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]3/min" ;
+  qudt:ucumCode "[CFT_I].MIN-1" ;
+  qudt:ucumCode "[CFT_I]/MIN" ;
+  qudt:ucumCode "[FT_I]3.MIN-1" ;
+  qudt:ucumCode "[FT_I]3/MIN" ;
+  qudt:ucumCode "[cft_i].min-1" ;
+  qudt:ucumCode "[cft_i]/min" ;
+  qudt:ucumCode "[ft_i]3.min-1" ;
+  qudt:ucumCode "[ft_i]3/min" ;
+  qudt:uneceCommonCode "2L" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Foot per Minute" ;
+.
+unit:FT3-PER-MIN-FT2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.08e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:iec61360Code "0112/2///62720#UAB086" ;
+  qudt:plainTextDescription "unit of the volume flow rate according to the Anglio-American and imperial system of units cubic foot per minute related to the transfer area according to the Anglian American and Imperial system of units square foot" ;
+  qudt:uneceCommonCode "36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT3 PER MIN FT2" ;
+  skos:prefLabel "cubic foot per minute square foot" ;
+.
+unit:FT3-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Cubic Foot per Second\" is an Imperial unit for \\( \\textit{Volume Per Unit Time}\\) expressed as \\(ft^3/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.028316846592000004e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ft^{3}/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAA462" ;
+  qudt:ucumCaseInsensitiveCode "[CFT_I].S-1" ;
+  qudt:ucumCaseInsensitiveCode "[CFT_I]/S" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]3.S-1" ;
+  qudt:ucumCaseInsensitiveCode "[FT_I]3/S" ;
+  qudt:ucumCaseSensitiveCode "[cft_i].s-1" ;
+  qudt:ucumCaseSensitiveCode "[cft_i]/s" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]3.s-1" ;
+  qudt:ucumCaseSensitiveCode "[ft_i]3/s" ;
+  qudt:ucumCode "[CFT_I].S-1" ;
+  qudt:ucumCode "[CFT_I]/S" ;
+  qudt:ucumCode "[FT_I]3.S-1" ;
+  qudt:ucumCode "[FT_I]3/S" ;
+  qudt:ucumCode "[cft_i].s-1" ;
+  qudt:ucumCode "[cft_i]/s" ;
+  qudt:ucumCode "[ft_i]3.s-1" ;
+  qudt:ucumCode "[ft_i]3/s" ;
+  qudt:uneceCommonCode "E17" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Foot per Second" ;
+.
+unit:FT_HG
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.063666e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA464" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure, at which 1 ftHg corresponds to the static pressure, which is excited by a mercury column with a height of 1 foot" ;
+  qudt:uneceCommonCode "K25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FT_HG" ;
+  skos:prefLabel "foot of mercury" ;
+.
+unit:FT_US
+  a qudt:US-SurveyUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{US Survey Foot}\\) is a C.G.S System unit for 'Length' expressed as \\(ftUS\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.3048006"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:symbol "ft_us" ;
+  qudt:ucumCaseInsensitiveCode "[FT_US]" ;
+  qudt:ucumCaseSensitiveCode "[ft_us]" ;
+  qudt:ucumCode "[FT_US]" ;
+  qudt:ucumCode "[ft_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Survey Foot" ;
+.
+unit:FT_Water
+  a qudt:Unit ;
+  dcterms:description "\"Foot of Water\" is a unit for  'Force Per Area' expressed as \\(ftH2O\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA463" ;
+  qudt:symbol "ftH2O" ;
+  qudt:uneceCommonCode "K24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Foot of Water" ;
+.
+unit:FUR
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:US-SurveyUnit ;
+  a qudt:Unit ;
+  dcterms:description "A furlong is a measure of distance in imperial units and U.S. customary units equal to one-eighth of a mile, equivalent to 220 yards, 660 feet, 40 rods, or 10 chains. The exact value of the furlong varies slightly among English-speaking countries. Five furlongs are approximately 1 kilometre (1.0058 km is a closer approximation). Since the original definition of the metre was one-quarter of one ten-millionth of the circumference of the Earth (along the great circle coincident with the meridian of longitude passing through Paris), the circumference of the Earth is about 40,000 km or about 200,000 furlongs. "^^rdf:HTML ;
+  qudt:conversionMultiplier "201.1680"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Furlong"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB204" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Furlong?oldid=492237369"^^xsd:anyURI ;
+  qudt:symbol "fur" ;
+  qudt:ucumCaseInsensitiveCode "[FUR_US]" ;
+  qudt:ucumCaseSensitiveCode "[fur_us]" ;
+  qudt:ucumCode "[FUR_US]" ;
+  qudt:ucumCode "[fur_us]" ;
+  rdfs:comment "Check if this is US-Survey or International Customary definition (multiplier)" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Furlong" ;
+.
+unit:FUR_Long
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(longfur\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Long Furlong" ;
+.
+unit:FalklandIslandsPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Falkland Islands"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Falkland_Islands_pound"^^xsd:anyURI ;
+  qudt:expression "\\(FKP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Falkland_Islands_pound?oldid=489513616"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Falkland Islands Pound" ;
+.
+unit:Femto
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'femto' is a decimal prefix for expressing a value with a scaling of \\(10^{-15}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Femto-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Femto-?oldid=467211359"^^xsd:anyURI ;
+  qudt:symbol "f" ;
+  qudt:ucumCaseInsensitiveCode "F" ;
+  qudt:ucumCaseSensitiveCode "f" ;
+  qudt:ucumCode "F" ;
+  qudt:ucumCode "f" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Femto" ;
+.
+unit:FemtoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A FemtoCoulomb is \\(10^{-15} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Femto ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "fC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FemtoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:FemtoJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-15 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAB124" ;
+  qudt:plainTextDescription "0,000 000 000 000 001-fold of the derived SI unit joule" ;
+  qudt:uneceCommonCode "A70" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "FemtoJ" ;
+  skos:prefLabel "femtojoule" ;
+.
+unit:FemtoM
+  a qudt:Unit ;
+  dcterms:description "The \\(\\textit{femtometre}\\) is an SI unit of length equal to \\(10^{-15} meter\\). This distance can also be called \\(\\textit{fermi}\\) and was so named in honour of Enrico Fermi. It is often encountered in nuclear physics as a characteristic of this scale. The symbol for the fermi is also \\(fm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:FM ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB063" ;
+  qudt:symbol "fm" ;
+  qudt:ucumCaseInsensitiveCode "FM" ;
+  qudt:ucumCaseSensitiveCode "fm" ;
+  qudt:ucumCode "FM" ;
+  qudt:ucumCode "fm" ;
+  qudt:uneceCommonCode "A71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Femtometer" ;
+.
+unit:FijiDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Fiji"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Fijian_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(FJD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Fijian_dollar?oldid=494373740"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Fiji Dollar" ;
+.
+unit:Flight
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:symbol "flight" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Flight" ;
+.
+unit:Forint
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Hungary"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hungarian_forint"^^xsd:anyURI ;
+  qudt:expression "\\(HUF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hungarian_forint?oldid=492818607"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Forint" ;
+.
+unit:FrancCongolais
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Democratic Republic of Congo"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Congolese_franc"^^xsd:anyURI ;
+  qudt:expression "\\(CDF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Congolese_franc?oldid=490314640"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Franc Congolais" ;
+.
+unit:G
+  a qudt:Unit ;
+  dcterms:description "\"Gravity\" is a unit for  'Linear Acceleration' expressed as \\(G\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "9.80665"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:symbol "G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gravity" ;
+.
+unit:GAL
+  a qudt:Unit ;
+  dcterms:description "The \\(\\textit{Gal}\\), sometimes called \\(galileo\\), is the unit of acceleration of free fall used extensively in the science of gravimetry. The gal is defined as \\(1 \\textit{centimeter per second squared}\\) (\\(1 cm/s^2\\)). The \\(milliGal\\) (\\(mGal\\)) and \\(microGal\\) refer respectively to one thousandth and one millionth of a Gal."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gal"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gal?oldid=482010741"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gal> ;
+  qudt:plainTextDescription "CGS unit of acceleration called gal with the definition: 1 Gal = 1 cm/s" ;
+  qudt:symbol "a" ;
+  qudt:ucumCaseInsensitiveCode "GL" ;
+  qudt:ucumCaseSensitiveCode "Gal" ;
+  qudt:ucumCode "GL" ;
+  qudt:ucumCode "Gal" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gal" ;
+  skos:prefLabel "Galileo" ;
+.
+unit:GAL_IMP
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Imperial Gallon\" is an Imperial unit for  'Liquid Volume' expressed as \\(galIMP\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.54609E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "gal" ;
+  qudt:ucumCaseInsensitiveCode "[GAL_BR]" ;
+  qudt:ucumCaseSensitiveCode "[gal_br]" ;
+  qudt:ucumCode "[GAL_BR]" ;
+  qudt:ucumCode "[gal_br]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Gallon" ;
+.
+unit:GAL_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.54609e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA500" ;
+  qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:uneceCommonCode "GLI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_UK" ;
+  skos:prefLabel "gallon (UK)" ;
+.
+unit:GAL_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.261678e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA501" ;
+  qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit day" ;
+  qudt:uneceCommonCode "K26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_UK PER DAY" ;
+  skos:prefLabel "gallon (UK) per day" ;
+.
+unit:GAL_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.262803e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA502" ;
+  qudt:plainTextDescription "unit gallon (UK dry or Liq.) according to the Imperial system of units divided by the SI unit hour" ;
+  qudt:uneceCommonCode "K27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_UK PER HR" ;
+  skos:prefLabel "gallon (UK) per hour" ;
+.
+unit:GAL_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.576817e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA503" ;
+  qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI unit minute" ;
+  qudt:uneceCommonCode "G3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_UK PER MIN" ;
+  skos:prefLabel "gallon UK) per minute" ;
+.
+unit:GAL_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.54609e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA504" ;
+  qudt:plainTextDescription "unit gallon (UK dry or liq.) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_UK PER SEC" ;
+  skos:prefLabel "gallon (UK) per second" ;
+.
+unit:GAL_US
+  a qudt:Unit ;
+  dcterms:description "\"US Gallon\" is a unit for  'Liquid Volume' expressed as \\(galUS\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.003785412"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "gal" ;
+  qudt:ucumCaseInsensitiveCode "[GAL_US]" ;
+  qudt:ucumCaseSensitiveCode "[gal_us]" ;
+  qudt:ucumCode "[GAL_US]" ;
+  qudt:ucumCode "[gal_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Gallon" ;
+  skos:altLabel "Queen Anne's wine gallon" ;
+.
+unit:GAL_US-PER-DAY
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"US Gallon per Day\" is a unit for  'Volume Per Unit Time' expressed as \\(gal/d\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.38126389E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(gal/d\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:ucumCaseInsensitiveCode "[GAL_US].D-1" ;
+  qudt:ucumCaseInsensitiveCode "[GAL_US]/D" ;
+  qudt:ucumCaseSensitiveCode "[gal_us].d-1" ;
+  qudt:ucumCaseSensitiveCode "[gal_us]/d" ;
+  qudt:ucumCode "[GAL_US].D-1" ;
+  qudt:ucumCode "[GAL_US]/D" ;
+  qudt:ucumCode "[gal_us].d-1" ;
+  qudt:ucumCode "[gal_us]/d" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Gallon per Day" ;
+.
+unit:GAL_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.051503e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA507" ;
+  qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI unit hour" ;
+  qudt:uneceCommonCode "G50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_US PER HR" ;
+  skos:prefLabel "gallon (US) per hour" ;
+.
+unit:GAL_US-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"US Gallon per Minute\" is a C.G.S System unit for  'Volume Per Unit Time' expressed as \\(gal/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 6.30902E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(gal/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:ucumCaseInsensitiveCode "[GAL_US].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[GAL_US]/MIN" ;
+  qudt:ucumCaseSensitiveCode "[gal_us].min-1" ;
+  qudt:ucumCaseSensitiveCode "[gal_us]/min" ;
+  qudt:ucumCode "[GAL_US].MIN-1" ;
+  qudt:ucumCode "[GAL_US]/MIN" ;
+  qudt:ucumCode "[gal_us].min-1" ;
+  qudt:ucumCode "[gal_us]/min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Gallon per Minute" ;
+.
+unit:GAL_US-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.785412e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA509" ;
+  qudt:plainTextDescription "unit gallon (US, liq.) according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAL_US PER SEC" ;
+  skos:prefLabel "gallon (US liquid) per second" ;
+.
+unit:GAL_US_DRY
+  a qudt:Unit ;
+  dcterms:description "\"Dry Gallon US\" is a unit for  'Dry Volume' expressed as \\(dry_gal\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.40488377E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:symbol "dry_gal" ;
+  qudt:ucumCaseInsensitiveCode "[GAL_WI]" ;
+  qudt:ucumCaseSensitiveCode "[gal_wi]" ;
+  qudt:ucumCode "[GAL_WI]" ;
+  qudt:ucumCode "[gal_wi]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Dry Gallon US" ;
+  skos:altLabel "Winchester gallon" ;
+  skos:altLabel "corn gallon" ;
+.
+unit:GAUGE_FR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.333333e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB377" ;
+  qudt:plainTextDescription "unit for the diameter of thin tubes in the medical technology (e.g. catheter) and telecommunications engineering (e.g. fiberglasses) with correspondence to: 1 Fg = 0,333 333 333 10 â» 3 m" ;
+  qudt:uneceCommonCode "H79" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAUGE_FR" ;
+  skos:prefLabel "French gauge" ;
+.
+unit:GAUSS
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB135" ;
+  qudt:plainTextDescription "CGS unit of the magnetic flux density B" ;
+  qudt:uneceCommonCode "76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GAUSS" ;
+  skos:prefLabel "gauss" ;
+.
+unit:GI
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The fundamental unit of magnetomotive force (\\(mmf\\)) in electromagnetic units is called a Gilbert. It is the \\(mmf\\) which will produce a magnetic field strength of one Gauss (Maxwell per Square Centimeter) in a path one centimeter long."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.795774715"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gilbert"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  qudt:iec61360Code "0112/2///62720#UAB211" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gilbert?oldid=492755037"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gilbert> ;
+  qudt:symbol "Gi" ;
+  qudt:ucumCaseInsensitiveCode "GB" ;
+  qudt:ucumCaseSensitiveCode "Gb" ;
+  qudt:ucumCode "GB" ;
+  qudt:ucumCode "Gb" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gilbert" ;
+.
+unit:GI_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.420653e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA511" ;
+  qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units (1/32 Imperial Gallon)" ;
+  qudt:uneceCommonCode "GII" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_UK" ;
+  skos:prefLabel "gill (UK)" ;
+.
+unit:GI_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.644274e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA512" ;
+  qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "K32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_UK PER DAY" ;
+  skos:prefLabel "gill (UK) per day" ;
+.
+unit:GI_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.946258e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA513" ;
+  qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_UK PER HR" ;
+  skos:prefLabel "gill (UK) per hour" ;
+.
+unit:GI_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.367755e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA514" ;
+  qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "K34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_UK PER MIN" ;
+  skos:prefLabel "gill (UK) per minute" ;
+.
+unit:GI_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.420653e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA515" ;
+  qudt:plainTextDescription "unit of the volume gill (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_UK PER SEC" ;
+  skos:prefLabel "gill (UK) per second" ;
+.
+unit:GI_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.18294125e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA516" ;
+  qudt:plainTextDescription "unit of the volume according the Anglo-American system of units (1/32 US Gallon)" ;
+  qudt:uneceCommonCode "GIA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_US" ;
+  skos:prefLabel "gill (US)" ;
+.
+unit:GI_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.369145e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA517" ;
+  qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "K36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_US PER DAY" ;
+  skos:prefLabel "gill (US) per day" ;
+.
+unit:GI_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.285947e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA518" ;
+  qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K37" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_US PER HR" ;
+  skos:prefLabel "gill (US) per hour" ;
+.
+unit:GI_US-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.971568e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA519" ;
+  qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "K38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_US PER MIN" ;
+  skos:prefLabel "gill (US) per minute" ;
+.
+unit:GI_US-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.182941e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA520" ;
+  qudt:plainTextDescription "unit of the volume gill (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GI_US PER SEC" ;
+  skos:prefLabel "gill (US) per second" ;
+.
+unit:GM
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of mass in the metric system. The name comes from the Greek gramma, a small weight identified in later Roman and Byzantine times with the Latin scripulum or scruple (the English scruple is equal to about 1.3 grams). The gram was originally defined to be the mass of one cubic centimeter of pure water, but to provide precise standards it was necessary to construct physical objects of specified mass. One gram is now defined to be 1/1000 of the mass of the standard kilogram, a platinum-iridium bar carefully guarded by the International Bureau of Weights and Measures in Paris for more than a century. (The kilogram, rather than the gram, is considered the base unit of mass in the SI.) The gram is a small mass, equal to about 15.432 grains or 0.035 273 966 ounce. "^^rdf:HTML ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gram"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA465" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gram?oldid=493995797"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gram> ;
+  qudt:symbol "g" ;
+  qudt:ucumCaseInsensitiveCode "G" ;
+  qudt:ucumCaseSensitiveCode "g" ;
+  qudt:ucumCode "G" ;
+  qudt:ucumCode "g" ;
+  qudt:uneceCommonCode "GRM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gram" ;
+.
+unit:GM-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:iec61360Code "0112/2///62720#UAB381" ;
+  qudt:plainTextDescription "unit of the imbalance as product of the 0,001-fold of the SI base unit kilogram and the 0,001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM MilliM" ;
+  skos:prefLabel "gram millimetre" ;
+.
+unit:GM-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB103" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0,0001-fold of the power of the SI base unit metre and exponent 2" ;
+  qudt:uneceCommonCode "25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER CentiM2" ;
+  skos:prefLabel "gram per centimetre squared" ;
+.
+unit:GM-PER-CentiM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA469" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0,000 001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER CentiM3" ;
+  skos:prefLabel "gram per centimetre cubed" ;
+.
+unit:GM-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA472" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit day" ;
+  qudt:uneceCommonCode "F26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER DAY" ;
+  skos:prefLabel "gram per day" ;
+.
+unit:GM-PER-DEG_C
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Gram Degree Celsius</em> is a C.G.S System unit for 'Mass Temperature' expressed as \\(g \\cdot degC\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(g-degC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gram Degree Celsius" ;
+.
+unit:GM-PER-DeciM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA475" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0,001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "F23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER DeciM3" ;
+  skos:prefLabel "gram per decimetre cubed" ;
+.
+unit:GM-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA478" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit hour" ;
+  qudt:uneceCommonCode "F27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER HR" ;
+  skos:prefLabel "gram per hour" ;
+.
+unit:GM-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA481" ;
+  qudt:plainTextDescription "0,001 fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "GK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER KiloGM" ;
+  skos:prefLabel "gram per kilogram" ;
+.
+unit:GM-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA482" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:uneceCommonCode "GL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER L" ;
+  skos:prefLabel "gram per litre" ;
+.
+unit:GM-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA485" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "GF" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER M" ;
+  skos:prefLabel "gram per metre" ;
+.
+unit:GM-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA486" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "GM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER M2" ;
+  skos:prefLabel "gram per metre squared" ;
+.
+unit:GM-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA487" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "A93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER M3" ;
+  skos:prefLabel "gram per metre cubed" ;
+.
+unit:GM-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA490" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the unit minute" ;
+  qudt:uneceCommonCode "F28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER MIN" ;
+  skos:prefLabel "gram per minute" ;
+.
+unit:GM-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarMass ;
+  qudt:iec61360Code "0112/2///62720#UAA496" ;
+  qudt:plainTextDescription "0,01-fold of the SI base unit kilogram divided by the SI base unit mol" ;
+  qudt:uneceCommonCode "A94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER MOL" ;
+  skos:prefLabel "gram per mole" ;
+.
+unit:GM-PER-MilliL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA493" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0,001-fold of the unit litre" ;
+  qudt:uneceCommonCode "GJ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER MilliL" ;
+  skos:prefLabel "gram per millilitre" ;
+.
+unit:GM-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB376" ;
+  qudt:plainTextDescription "0,001-fold of the SI base unit kilogram divided by the 0,001-fold the SI base unit meter" ;
+  qudt:uneceCommonCode "H76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER MilliM" ;
+  skos:prefLabel "gram per millimetre" ;
+.
+unit:GM-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA497" ;
+  qudt:plainTextDescription "0,001fold of the SI base unit kilogram divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM PER SEC" ;
+  skos:prefLabel "gram per second" ;
+.
+unit:GM_F-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA510" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:uneceCommonCode "K31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GM_F PER CentiM2" ;
+  skos:prefLabel "gram?force per square centimetre" ;
+.
+unit:GON
+  a qudt:Unit ;
+  dcterms:description "\"Gon\" is a C.G.S System unit for  'Plane Angle' expressed as \\(gon\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.015707963267949"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gon"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA522" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gon?oldid=424098171"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gon> ;
+  qudt:symbol "gon" ;
+  qudt:ucumCaseInsensitiveCode "GON" ;
+  qudt:ucumCaseSensitiveCode "gon" ;
+  qudt:ucumCode "GON" ;
+  qudt:ucumCode "gon" ;
+  qudt:uneceCommonCode "A91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gon" ;
+.
+unit:GR
+  a qudt:DimensionlessUnit ;
+  a qudt:Unit ;
+  dcterms:description "the tangent of an angle of inclination multiplied by 100"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Grade"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Grade?oldid=485504533"^^xsd:anyURI ;
+  qudt:symbol "gr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Grade" ;
+.
+unit:GRAD
+  a qudt:Unit ;
+  dcterms:description "\"Grad\" is a unit for  'Plane Angle' expressed as \\(grad\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.0157079633"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Grad"^^xsd:anyURI ;
+  qudt:exactMatch unit:GON ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA522" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Grad?oldid=490906645"^^xsd:anyURI ;
+  qudt:symbol "grad" ;
+  qudt:uneceCommonCode "A91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Grad" ;
+.
+unit:GRAIN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A grain is a unit of measurement of mass that is nominally based upon the mass of a single seed of a cereal.  The grain is the only unit of mass measure common to the three traditional English mass and weight systems; the obsolete Tower grain was, by definition, exactly  /64 of a troy grain. Since 1958, the grain or troy grain measure has been defined in terms of units of mass in the International System of Units as precisely 64.79891 milligrams. Thus, \\(1 gram \\approx 15.4323584 grains\\).  There are precisely 7,000 grains per avoirdupois pound in the imperial and U.S. customary units, and 5,760 grains in the Troy pound."^^qudt:LatexString ;
+  qudt:conversionMultiplier 6.479891E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cereal"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA523" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cereal?oldid=495222949"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/grain> ;
+  qudt:symbol "gr" ;
+  qudt:ucumCaseInsensitiveCode "[GR]" ;
+  qudt:ucumCaseSensitiveCode "[gr]" ;
+  qudt:ucumCode "[GR]" ;
+  qudt:ucumCode "[gr]" ;
+  qudt:uneceCommonCode "GRN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Grain" ;
+.
+unit:GRAIN-PER-GAL
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Grain per Gallon\" is an Imperial unit for  'Density' expressed as \\(gr/gal\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.017118061"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(gr/gal\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Grain per Gallon" ;
+.
+unit:GRAIN-PER-GAL_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.711806e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA524" ;
+  qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "K41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GRAIN PER GAL_US" ;
+  skos:prefLabel "grain per gallon (US)" ;
+.
+unit:GRAY
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of radiation dose. Radiation carries energy, and when it is absorbed by matter the matter receives this energy. The dose is the amount of energy deposited per unit of mass. One gray is defined to be the dose of one joule of energy absorbed per kilogram of matter, or 100 rad. The unit is named for the British physician L. Harold Gray (1905-1965), an authority on the use of radiation in the treatment of cancer."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Grey"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDose ;
+  qudt:iec61360Code "0112/2///62720#UAA163" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Grey?oldid=494774160"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gray> ;
+  qudt:siUnitsExpression "J/kg" ;
+  qudt:symbol "Gy" ;
+  qudt:ucumCaseInsensitiveCode "GY" ;
+  qudt:ucumCaseSensitiveCode "Gy" ;
+  qudt:ucumCode "GY" ;
+  qudt:ucumCode "Gy" ;
+  qudt:uneceCommonCode "A95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gray" ;
+.
+unit:GRAY-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Gray per Second\" is a unit for  'Absorbed Dose Rate' expressed as \\(Gy/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Gy/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDoseRate ;
+  qudt:iec61360Code "0112/2///62720#UAA164" ;
+  qudt:uneceCommonCode "A96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gray per Second" ;
+.
+unit:Gamma
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Gamma\" is a C.G.S System unit for  'Magnetic Field'."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gamma"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB213" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gamma?oldid=494680973"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/gamma> ;
+  qudt:symbol "gamma" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gamma" ;
+.
+unit:Gibi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{3}\\), or \\(2^{30}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1073741824"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Gi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gibi" ;
+.
+unit:GibraltarPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Gibraltar"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gibraltar_pound"^^xsd:anyURI ;
+  qudt:expression "\\(GIP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gibraltar_pound?oldid=494842600"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gibraltar pound" ;
+.
+unit:Giga
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'giga' is a decimal prefix for expressing a value with a scaling of \\(10^{9}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Giga-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Giga-?oldid=473222816"^^xsd:anyURI ;
+  qudt:symbol "G" ;
+  qudt:ucumCaseInsensitiveCode "GA" ;
+  qudt:ucumCaseSensitiveCode "G" ;
+  qudt:ucumCode "G" ;
+  qudt:ucumCode "GA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Giga" ;
+.
+unit:GigaBQ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB047" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the derived SI unit becquerel" ;
+  qudt:uneceCommonCode "GBQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaBQ" ;
+  skos:prefLabel "gigabecquerel" ;
+.
+unit:GigaBYTE
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The gigabyte is a multiple of the unit byte for digital information storage. The prefix giga means 10 in the International System of Units (SI), therefore 1 gigabyte is \\(1,000,000,000 \\; bytes\\). The unit symbol for the gigabyte is \\(GB\\) or \\(Gbyte\\), but not \\(Gb\\) (lower case b) which is typically used for the gigabit. Historically, the term has also been used in some fields of computer science and information technology to denote the \\(gibibyte\\), or \\(1073741824 \\; bytes\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1073741824"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gigabyte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Giga ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAB185" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gigabyte?oldid=493019145"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "GB" ;
+  qudt:uneceCommonCode "E34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaByte" ;
+  skos:altLabel "gbyte" ;
+.
+unit:GigaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e09 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Giga ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "GC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:GigaC-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:iec61360Code "0112/2///62720#UAA149" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "A84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaC PER M3" ;
+  skos:prefLabel "gigacoulomb per metre cubed" ;
+.
+unit:GigaEV
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Giga Electron Volt\" is a unit for  'Energy And Work' expressed as \\(GeV\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:symbol "GeV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Giga Electron Volt" ;
+.
+unit:GigaHZ
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The hertz (symbol Hz) is the SI unit of frequency defined as the number of cycles per second of a periodic phenomenon. A GigaHertz is \\(10^{9} hz\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hertz"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:iec61360Code "0112/2///62720#UAA150" ;
+  qudt:symbol "GHz" ;
+  qudt:ucumCaseInsensitiveCode "GAHZ" ;
+  qudt:ucumCaseSensitiveCode "GHz" ;
+  qudt:ucumCode "GAHZ" ;
+  qudt:ucumCode "GHz" ;
+  qudt:uneceCommonCode "A86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gigahertz" ;
+.
+unit:GigaHZ-M
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA151" ;
+  qudt:plainTextDescription "product of the 1 000 000 000-fold of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:uneceCommonCode "M18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaHZ M" ;
+  skos:prefLabel "gigahertz metre" ;
+.
+unit:GigaJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA152" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit joule" ;
+  qudt:uneceCommonCode "GV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaJ" ;
+  skos:prefLabel "gigajoule" ;
+.
+unit:GigaOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA147" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "A87" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaOHM" ;
+  skos:prefLabel "gigaohm" ;
+.
+unit:GigaPA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA153" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit pascal" ;
+  qudt:uneceCommonCode "A89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaPA" ;
+  skos:prefLabel "gigapascal" ;
+.
+unit:GigaW
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA154" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the SI derived unit watt" ;
+  qudt:uneceCommonCode "A90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaW" ;
+  skos:prefLabel "gigawatt" ;
+.
+unit:GigaW-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA155" ;
+  qudt:plainTextDescription "1 000 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:uneceCommonCode "GWH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "GigaW HR" ;
+  skos:prefLabel "gigawatt hour" ;
+.
+unit:Gold-OunceTroy
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  qudt:expression "\\(XAU\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gold (one Troy ounce)" ;
+.
+unit:GoldFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bank for International Settlements"^^rdf:HTML ;
+  qudt:expression "\\(XFO\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gold franc (special settlement currency)" ;
+.
+unit:Gs
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The gauss, abbreviated as \\(G\\), is the cgs unit of measurement of a magnetic field \\(B\\), which is also known as the \"magnetic flux density\" or the \"magnetic induction\".  One gauss is defined as one maxwell per square centimeter; it equals \\(10^{-4} tesla\\) (or \\(100 micro T\\)). The Gauss is identical to maxwells per square centimetre; technically defined in a three-dimensional system, it corresponds in the SI, with its extra base unit the ampere. The gauss is quite small by earthly standards, 1 Gs being only about four times Earth's flux density, but it is subdivided, with \\(1 gauss = 105 gamma\\). This unit of magnetic induction is also known as the \\(\\textit{abtesla}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Gauss_%28unit%29"^^xsd:anyURI ;
+  qudt:exactMatch unit:T_Ab ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Gauss_(unit)"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.diracdelta.co.uk/science/source/g/a/gauss/source.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-526?rskey=HAbfz2"^^xsd:anyURI ;
+  qudt:symbol "Gs" ;
+  qudt:ucumCaseInsensitiveCode "G" ;
+  qudt:ucumCaseInsensitiveCode "GS" ;
+  qudt:ucumCode "G" ;
+  qudt:ucumCode "GS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Gs" ;
+.
+unit:Guarani
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Paraguay"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Guaran%C3%AD"^^xsd:anyURI ;
+  qudt:expression "\\(PYG\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Guaraní?oldid=412592698"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Guarani" ;
+.
+unit:GuineaFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Guinea"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Guinean_franc"^^xsd:anyURI ;
+  qudt:expression "\\(GNF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Guinean_franc?oldid=489527042"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Guinea Franc" ;
+.
+unit:GuyanaDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Guyana"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Guyanese_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(GYD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Guyanese_dollar?oldid=495070062"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Guyana Dollar" ;
+.
+unit:H
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p>The SI unit of electric inductance. A changing magnetic field induces an electric current in a loop of wire (or in a coil of many loops) located in the field. Although the induced voltage depends only on the rate at which the magnetic flux changes, measured in webers per second, the amount of the current depends also on the physical properties of the coil. A coil with an inductance of one henry requires a flux of one weber for each ampere of induced current.</p>
+<p>If, on the other hand, it is the current which changes, then the induced field will generate a potential difference within the coil: if the inductance is one henry a current change of one ampere per second generates a potential difference of one volt. The henry is a large unit; inductances in practical circuits are measured in millihenrys (mH) or microhenrys (u03bc H). The unit is named for the American physicist Joseph Henry (1797-1878), one of several scientists who discovered independently how magnetic fields can be used to generate alternating currents.</p>
+<p>\\(\\text{H} \\; \\equiv \\; \\text{henry}\\; \\equiv\\; \\frac{\\text{Wb}}{\\text{A}}\\; \\equiv\\; \\frac{\\text{weber}}{\\text{amp}}\\; \\equiv\\ \\frac{\\text{V}\\cdot\\text{s}}{\\text{A}}\\; \\equiv\\; \\frac{\\text{volt} \\cdot \\text{second}}{\\text{amp}}\\; \\equiv\\ \\Omega\\cdot\\text{s}\\; \\equiv\\; \\text{ohm.second}\\)</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Henry"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:iec61360Code "0112/2///62720#UAA165" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Henry?oldid=491435978"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/henry> ;
+  qudt:siUnitsExpression "Wb/A" ;
+  qudt:symbol "H" ;
+  qudt:ucumCaseInsensitiveCode "H" ;
+  qudt:ucumCode "H" ;
+  qudt:uneceCommonCode "81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Henry" ;
+.
+unit:H-PER-KiloOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA167" ;
+  qudt:plainTextDescription "SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "H03" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "H PER KiloOHM" ;
+  skos:prefLabel "henry per kiloohm" ;
+.
+unit:H-PER-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The henry per meter (symbolized \\(H/m\\)) is the unit of magnetic permeability in the International System of Units ( SI ). Reduced to base units in SI, \\(1\\,H/m\\) is the equivalent of one kilogram meter per second squared per ampere squared.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(H/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Permeability ;
+  qudt:iec61360Code "0112/2///62720#UAA168" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Henry?oldid=491435978"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Henry per Meter"@us ;
+  rdfs:label "Henry per Metre"@en ;
+.
+unit:H-PER-OHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA166" ;
+  qudt:plainTextDescription "SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:uneceCommonCode "H04" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "H PER OHM" ;
+  skos:prefLabel "henry per ohm" ;
+.
+unit:HA
+  a qudt:Unit ;
+  dcterms:description "The customary metric unit of land area, equal to 100 ares. One hectare is a square hectometer, that is, the area of a square 100 meters on each side: exactly 10 000 square meters or approximately 107 639.1 square feet, 11 959.9 square yards, or 2.471 054 acres."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hectare"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA532" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hectare?oldid=494256954"^^xsd:anyURI ;
+  qudt:symbol "ha" ;
+  qudt:ucumCaseInsensitiveCode "HAR" ;
+  qudt:ucumCaseSensitiveCode "har" ;
+  qudt:ucumCode "HAR" ;
+  qudt:ucumCode "har" ;
+  qudt:uneceCommonCode "HAR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hectare" ;
+.
+unit:HART
+  a qudt:Unit ;
+  dcterms:description "The \"Hartley\" is a unit of information."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:iec61360Code "0112/2///62720#UAB344" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hartley> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hartley" ;
+.
+unit:HART-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "The \"Hartley per Second\" is a unit of information rate."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Hart/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InformationFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB347" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hartley per Second" ;
+.
+unit:HP
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "550 foot-pound force per second"^^rdf:HTML ;
+  qudt:conversionMultiplier "745.6999"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Horsepower"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Horsepower?oldid=495510329"^^xsd:anyURI ;
+  qudt:symbol "HP" ;
+  qudt:ucumCaseInsensitiveCode "[HP]" ;
+  qudt:ucumCode "[HP]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Horsepower" ;
+.
+unit:HP-PER-M
+  a qudt:Unit ;
+  dcterms:description "\"Horsepower Metric\" is a unit for  'Power' expressed as \\(hp/m\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(hp/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Horsepower Metric" ;
+.
+unit:HP-PER-V
+  a qudt:Unit ;
+  dcterms:description "\"Horsepower Electric\" is a unit for  'Power' expressed as \\(hp/V\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(hp/V\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Horsepower Electric" ;
+.
+unit:HP_Boiler
+  a qudt:Unit ;
+  dcterms:description "\"Boiler Horsepower\" is a unit for  'Power' expressed as \\(hp_boiler\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "9809.5"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(boiler_hp\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Boiler Horsepower" ;
+.
+unit:HP_Brake
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.8095e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA536" ;
+  qudt:plainTextDescription "unit of the power according to the Imperial system of units" ;
+  qudt:uneceCommonCode "K42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HP_Brake" ;
+  skos:prefLabel "horsepower (brake)" ;
+.
+unit:HP_Electric
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.46e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA537" ;
+  qudt:plainTextDescription "unit of the power according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "K43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HP_Electric" ;
+  skos:prefLabel "horsepower (electric)" ;
+.
+unit:HP_Metric
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.354988e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA534" ;
+  qudt:plainTextDescription "unit of the mechanical power according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "HJ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HP_Metric" ;
+  skos:prefLabel "horsepower (metric)" ;
+.
+unit:HP_Water
+  a qudt:Unit ;
+  dcterms:description "\"Water Horsepower\" is a unit for  'Power' expressed as \\(hp_water\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "746.043"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:symbol "hp_water" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Water Horsepower" ;
+.
+unit:HR
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The hour (common symbol: h or hr) is a unit of measurement of time. In modern usage, an hour comprises 60 minutes, or 3,600 seconds. It is approximately 1/24 of a mean solar day. An hour in the Universal Coordinated Time (UTC) time standard can include a negative or positive leap second, and may therefore have a duration of 3,599 or 3,601 seconds for adjustment purposes. Although it is not a standard defined by the International System of Units, the hour is a unit accepted for use with SI, represented by the symbol h."^^rdf:HTML ;
+  qudt:conversionMultiplier "3600.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hour"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA525" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hour?oldid=495040268"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hour> ;
+  qudt:symbol "hr" ;
+  qudt:ucumCaseInsensitiveCode "HR" ;
+  qudt:ucumCaseSensitiveCode "h" ;
+  qudt:ucumCode "HR" ;
+  qudt:ucumCode "h" ;
+  qudt:uneceCommonCode "K42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hour" ;
+.
+unit:HR-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Hour Square Foot\" is an Imperial unit for  'Area Time' expressed as \\(hr-ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "334.450944"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(hr-ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:ucumCaseInsensitiveCode "HR.[SFT_I]" ;
+  qudt:ucumCaseSensitiveCode "h.[sft_i]" ;
+  qudt:ucumCode "HR.[SFT_I]" ;
+  qudt:ucumCode "h.[sft_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hour Square Foot" ;
+.
+unit:HR_Sidereal
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p>Sidereal time is a time-keeping system astronomers use to keep track of the direction to point their telescopes to view a given star in the night sky. A mean sidereal day is about 23 h 56 m 4.1 s in length. However, due to variations in the rotation rate of the Earth, the rate of an ideal sidereal clock deviates from any simple multiple of a civil clock. In practice, the difference is kept track of by the difference UTC-UT1, which is measured by radio telescopes and kept on file and available to the public at the IERS and at the United States Naval Observatory. A Sidereal Hour is \\(1/24^{th}\\) of a Sidereal Day.</p>
+<p>A mean sidereal day is 23 hours, 56 minutes, 4.0916 seconds (23.9344699 hours or 0.99726958 mean solar days), the time it takes Earth to make one rotation relative to the vernal equinox. (Due to nutation, an actual sidereal day is not quite so constant.) The vernal equinox itself precesses slowly westward relative to the fixed stars, completing one revolution in about 26,000 years, so the misnamed sidereal day (\"sidereal\" is derived from the Latin sidus meaning \"star\") is 0.0084 seconds shorter than Earth's period of rotation relative to the fixed stars.</p>"""^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
+  qudt:isScalingOf unit:DAY_Sidereal ;
+  qudt:symbol "hr" ;
+  qudt:ucumCaseInsensitiveCode "HR" ;
+  qudt:ucumCaseSensitiveCode "h" ;
+  qudt:ucumCode "HR" ;
+  qudt:ucumCode "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sidereal Hour" ;
+.
+unit:HZ
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The hertz (symbol Hz) is the SI unit of frequency defined as the number of cycles per second of a periodic phenomenon. One of its most common uses is the description of the sine wave, particularly those used in radio and audio applications, such as the frequency of musical tones. The word \"hertz\" is named for Heinrich Rudolf Hertz, who was the first to conclusively prove the existence of electromagnetic waves."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hertz"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:iec61360Code "0112/2///62720#UAA170" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/hertz> ;
+  qudt:symbol "Hz" ;
+  qudt:ucumCaseInsensitiveCode "HZ" ;
+  qudt:ucumCode "HZ" ;
+  qudt:ucumCode "Hz" ;
+  qudt:uneceCommonCode "HTZ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hertz" ;
+.
+unit:HZ-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:iec61360Code "0112/2///62720#UAA171" ;
+  qudt:plainTextDescription "product of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:uneceCommonCode "H34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HZ M" ;
+  skos:prefLabel "hertz metre" ;
+.
+unit:HZ-PER-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Hertz per Kelvin</em> is a unit for 'Inverse Time Temperature' expressed as \\(Hz K^{-1}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Hz K^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseTimeTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hertz per Kelvin" ;
+.
+unit:HZ-PER-T
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Hertz per Tesla\" is a unit for  'Electric Charge Per Mass' expressed as \\(Hz T^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Hz T^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hertz per Tesla" ;
+.
+unit:HZ-PER-V
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "In the Hertz per Volt standard the frequency of the note is directly related to the voltage. A pitch of a note goes up one octave when its frequency doubles, meaning that the voltage will have to double for every octave rise. Depending on the footage (octave) selected, nominally one volt gives 1000Hz, two volts 2000Hz and so on. In terms of notes, bottom C would be 0.25 volts, the next C up would be 0.5 volts, then 1V, 2V, 4V, 8V for the following octaves. This system was used mainly by Yamaha and Korg."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Hz V^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseMagneticFlux ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hertz per Volt" ;
+.
+unit:H_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Abhenry is the centimeter-gram-second electromagnetic unit of inductance, equal to one billionth of a henry."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abhenry"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abhenry?oldid=477198643"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abhenry> ;
+  qudt:symbol "abH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abhenry" ;
+.
+unit:H_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Stathenry\" (statH) is a unit in the category of Electric inductance. It is also known as stathenries. This unit is commonly used in the cgs unit system. Stathenry (statH) has a dimension of \\(ML^2T^{-2}I^{-2}\\) where M is mass, L is length, T is time, and I is electric current. It can be converted to the corresponding standard SI unit H by multiplying its value by a factor of \\(8.987552 \\times 10^{11}\\) ."^^qudt:LatexString ;
+  qudt:conversionMultiplier 8.9876E11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_inductance--stathenry.cfm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/stathenry> ;
+  qudt:symbol "statH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stathenry" ;
+.
+unit:H_Stat-PER-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The Stathenry per Centimeter is a unit of measure for the absolute permeability of free space."^^rdf:HTML ;
+  qudt:conversionMultiplier 8.9876E13 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(stath-per-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Permeability ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stathenry per Centimeter" ;
+.
+unit:HaitiGourde
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Haiti"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Haitian_gourde"^^xsd:anyURI ;
+  qudt:expression "\\(HTG\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Haitian_gourde?oldid=486090975"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Haiti Gourde" ;
+.
+unit:HeartBeat
+  a qudt:Unit ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Heart Beat" ;
+.
+unit:Hecto
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'hecta' is a decimal prefix for expressing a value with a scaling of \\(10^{2}\"\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hecto-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hecto-?oldid=494711166"^^xsd:anyURI ;
+  qudt:symbol "h" ;
+  qudt:ucumCaseInsensitiveCode "H" ;
+  qudt:ucumCaseSensitiveCode "h" ;
+  qudt:ucumCode "H" ;
+  qudt:ucumCode "h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hecto" ;
+.
+unit:HectoBAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAB087" ;
+  qudt:plainTextDescription "100-fold of the unit bar" ;
+  qudt:uneceCommonCode "HBA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoBAR" ;
+  skos:prefLabel "hectobar" ;
+.
+unit:HectoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"HectoCoulomb\" is a unit for  'Electric Charge' expressed as \\(hC\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "100.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Hecto ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "hC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:HectoGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB079" ;
+  qudt:plainTextDescription "0,1-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "HGM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoGM" ;
+  skos:prefLabel "hectogram" ;
+.
+unit:HectoL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA533" ;
+  qudt:plainTextDescription "100-fold of the unit litre" ;
+  qudt:uneceCommonCode "HLT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoL" ;
+  skos:prefLabel "hectolitre" ;
+.
+unit:HectoM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB062" ;
+  qudt:plainTextDescription "100-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "HMT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoM" ;
+  skos:prefLabel "hectometre" ;
+.
+unit:HectoPA
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "Hectopascal is a unit of pressure. 1 Pa is approximately the pressure exerted by a 10-g mass resting on a 1-cm2 area. 1013 hPa = 1 atm. There are 100 pascals in 1 hectopascal."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:MilliBAR ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA527" ;
+  qudt:isScalingOf unit:PA ;
+  qudt:symbol "hPa" ;
+  qudt:uneceCommonCode "A97" ;
+  rdfs:comment "Hectopascal is commonly used in meteorology to report values for atmospheric pressure. It is equivalent to millibar." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hectopascal" ;
+.
+unit:HectoPA-L-PER-SEC
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T-3D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ApparentPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ComplexPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ElectricPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:HeatFlowRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:NonActivePower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Power ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:RadiantFlux ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ReactivePower ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA530" ;
+  qudt:plainTextDescription "product out of the 100-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoPA L PER SEC" ;
+  skos:prefLabel "hectopascal litre per second" ;
+.
+unit:HectoPA-M3-PER-SEC
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T-3D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ApparentPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ComplexPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ElectricPower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:HeatFlowRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:NonActivePower ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Power ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:RadiantFlux ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ReactivePower ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA531" ;
+  qudt:plainTextDescription "product out of the 100-fold of the SI unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoPA M3 PER SEC" ;
+  skos:prefLabel "hectopascal metre cubed per second" ;
+.
+unit:HectoPA-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA529" ;
+  qudt:plainTextDescription "100-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:uneceCommonCode "E99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoPA PER BAR" ;
+  skos:prefLabel "hectopascal per bar" ;
+.
+unit:HectoPA-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA528" ;
+  qudt:plainTextDescription "100-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F82" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "HectoPA PER K" ;
+  skos:prefLabel "hectopascal per kelvin" ;
+.
+unit:HongKongDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Hong Kong Special Administrative Region"^^rdf:HTML ;
+  qudt:currencyExponent 1 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Hong_Kong_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(HKD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Hong_Kong_dollar?oldid=495133277"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/HongKongDollar> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hong Kong Dollar" ;
+.
+unit:Hryvnia
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Ukraine"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ukrainian_hryvnia"^^xsd:anyURI ;
+  qudt:expression "\\(UAH\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ukrainian_hryvnia?oldid=493064633"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hryvnia" ;
+.
+unit:Hundredweight_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.080235e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA405" ;
+  qudt:plainTextDescription "out of use unit of the mass according to the Imperial system of units" ;
+  qudt:uneceCommonCode "CWI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hundredweight_UK" ;
+  skos:prefLabel "hundredweight (UK)" ;
+.
+unit:Hundredweight_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.535924e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA406" ;
+  qudt:plainTextDescription "out of use unit of the mass according to the Imperial system of units" ;
+  qudt:uneceCommonCode "CWA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Hundredweight_US" ;
+  skos:prefLabel "hundredweight (US)" ;
+.
+unit:IN
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "An inch is the name of a unit of length in a number of different systems, including Imperial units, and United States customary units. There are 36 inches in a yard and 12 inches in a foot. Corresponding units of area and volume are the square inch and the cubic inch."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.0254"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Inch"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA539" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Inch?oldid=492522790"^^xsd:anyURI ;
+  qudt:symbol "in" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]" ;
+  qudt:ucumCaseSensitiveCode "[in_i]" ;
+  qudt:ucumCode "[IN_I]" ;
+  qudt:ucumCode "[in_i]" ;
+  qudt:uneceCommonCode "INH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inch" ;
+.
+unit:IN-PER-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.572e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA540" ;
+  qudt:plainTextDescription "unit inch according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:uneceCommonCode "K45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN PER DEG_F" ;
+  skos:prefLabel "inch per degree Fahrenheit" ;
+.
+unit:IN-PER-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The inch per second is a unit of speed or velocity. It expresses the distance in inches (in) traveled or displaced, divided by time in seconds (s, or sec). The equivalent SI unit is the metre per second. Abbreviations include in/s, in/sec, ips, and less frequently in s."^^rdf:HTML ;
+  qudt:conversionMultiplier 0.0254e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(in-per-sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA542" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I].S-1" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]/S" ;
+  qudt:ucumCaseSensitiveCode "[in_i].s-1" ;
+  qudt:ucumCaseSensitiveCode "[in_i]/s" ;
+  qudt:ucumCode "[IN_I].S-1" ;
+  qudt:ucumCode "[IN_I]/S" ;
+  qudt:ucumCode "[in_i].s-1" ;
+  qudt:ucumCode "[in_i]/s" ;
+  qudt:uneceCommonCode "IU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inch per Second" ;
+.
+unit:IN-PER-SEC2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Inch per second squared}\\) is an Imperial unit for \\(\\textit{Linear Acceleration}\\) expressed as \\(in/s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0254e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(in/s2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAB044" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I].S-2" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]/S2" ;
+  qudt:ucumCaseSensitiveCode "[in_i].s-2" ;
+  qudt:ucumCaseSensitiveCode "[in_i]/s2" ;
+  qudt:ucumCode "[IN_I].S-2" ;
+  qudt:ucumCode "[IN_I]/S2" ;
+  qudt:ucumCode "[in_i].s-2" ;
+  qudt:ucumCode "[in_i]/s2" ;
+  qudt:uneceCommonCode "IV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inch per second squared" ;
+.
+unit:IN2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A square inch is a unit of area, equal to the area of a square with sides of one inch. The following symbols are used to denote square inches: square in, sq inches, sq inch, sq in inches/-2, inch/-2, in/-2, inches^2, \\(inch^2\\), \\(in^2\\), \\(inches^2\\), \\(inch^2\\), \\(in^2\\) or in some cases \\(\"^2\\). The square inch is a common unit of measurement in the United States and the United Kingdom."^^qudt:LatexString ;
+  qudt:conversionMultiplier 6.4516E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(in^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA547" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]2" ;
+  qudt:ucumCaseInsensitiveCode "[SIN_I]" ;
+  qudt:ucumCaseSensitiveCode "[in_i]2" ;
+  qudt:ucumCaseSensitiveCode "[sin_i]" ;
+  qudt:ucumCode "[IN_I]2" ;
+  qudt:ucumCode "[SIN_I]" ;
+  qudt:ucumCode "[in_i]2" ;
+  qudt:ucumCode "[sin_i]" ;
+  qudt:uneceCommonCode "INK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Inch" ;
+.
+unit:IN2-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.4516e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:KinematicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA548" ;
+  qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "G08" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN2 PER SEC" ;
+  skos:prefLabel "square inch per second" ;
+.
+unit:IN3
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The cubic inch is a unit of measurement for volume in the Imperial units and United States customary units systems. It is the volume of a cube with each of its three sides being one inch long. The cubic inch and the cubic foot are still used as units of volume in the United States, although the common SI units of volume, the liter, milliliter, and cubic meter, are continually replacing them, especially in manufacturing and high technology. One cubic foot is equal to exactly 1728 cubic inches."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.6387064E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(in^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA549" ;
+  qudt:ucumCaseInsensitiveCode "[CIN_I]" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]3" ;
+  qudt:ucumCaseSensitiveCode "[cin_i]" ;
+  qudt:ucumCaseSensitiveCode "[in_i]3" ;
+  qudt:ucumCode "[CIN_I]" ;
+  qudt:ucumCode "[IN_I]3" ;
+  qudt:ucumCode "[cin_i]" ;
+  qudt:ucumCode "[in_i]3" ;
+  qudt:uneceCommonCode "INQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Inch" ;
+.
+unit:IN3-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.551961e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA550" ;
+  qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit hour" ;
+  qudt:uneceCommonCode "G56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN3 PER HR" ;
+  skos:prefLabel "cubic inch per hour" ;
+.
+unit:IN3-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Cubic Inch per Minute\" is an Imperial unit for  'Volume Per Unit Time' expressed as \\(in^{3}/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.7311773333333333E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(in^{3}/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAA551" ;
+  qudt:ucumCaseInsensitiveCode "[CIN_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[CIN_I]/MIN" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]3.MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I]3/MIN" ;
+  qudt:ucumCaseSensitiveCode "[cin_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[cin_i]/min" ;
+  qudt:ucumCaseSensitiveCode "[in_i]3.min-1" ;
+  qudt:ucumCaseSensitiveCode "[in_i]3/min" ;
+  qudt:ucumCode "[CIN_I].MIN-1" ;
+  qudt:ucumCode "[CIN_I]/MIN" ;
+  qudt:ucumCode "[IN_I]3.MIN-1" ;
+  qudt:ucumCode "[IN_I]3/MIN" ;
+  qudt:ucumCode "[cin_i].min-1" ;
+  qudt:ucumCode "[cin_i]/min" ;
+  qudt:ucumCode "[in_i]3.min-1" ;
+  qudt:ucumCode "[in_i]3/min" ;
+  qudt:uneceCommonCode "G57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Inch per Minute" ;
+.
+unit:IN3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.638706e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA552" ;
+  qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "G58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN3 PER SEC" ;
+  skos:prefLabel "cubic inch per second" ;
+.
+unit:IN4
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.162314e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
+  qudt:iec61360Code "0112/2///62720#UAA545" ;
+  qudt:plainTextDescription "power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 4" ;
+  qudt:uneceCommonCode "D69" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN4" ;
+  skos:prefLabel "inch to the fourth power" ;
+.
+unit:IN_AQ
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Inches of water, wc, inch water column (inch WC), inAq, Aq, or inH2O is a non-SI unit for pressure. The units are by convention and due to the historical measurement of certain pressure differentials. It is used for measuring small pressure differences across an orifice, or in a pipeline or shaft. Inches of water can be converted to a pressure unit using the formula for pressure head. It is defined as the pressure exerted by a column of water of 1 inch in height at defined conditions for example \\(39 ^\\circ F\\) at the standard acceleration of gravity; 1 inAq is approximately equal to 249 pascals at \\(0 ^\\circ C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "249.080024"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Inch_of_water"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA553" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Inch_of_water?oldid=466175519"^^xsd:anyURI ;
+  qudt:symbol "inAq" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I'H2O]" ;
+  qudt:ucumCaseSensitiveCode "[in_i'H2)]" ;
+  qudt:ucumCode "[IN_I'H2O]" ;
+  qudt:ucumCode "[in_i'H2)]" ;
+  qudt:uneceCommonCode "F78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inch of Water" ;
+.
+unit:IN_HG
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Inches of mercury, (inHg) is a unit of measurement for pressure. It is still widely used for barometric pressure in weather reports, refrigeration and aviation in the United States, but is seldom used elsewhere. It is defined as the pressure exerted by a column of mercury of 1 inch in height at \\(32 ^\\circ F\\) at the standard acceleration of gravity. 1 inHg = 3,386.389 pascals at \\(0 ^\\circ C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "3386.389"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Inch_of_mercury"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA554" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Inch_of_mercury?oldid=486634645"^^xsd:anyURI ;
+  qudt:symbol "inHg" ;
+  qudt:ucumCaseInsensitiveCode "[IN_I'HG]" ;
+  qudt:ucumCaseSensitiveCode "[in_i'Hg]" ;
+  qudt:ucumCode "[IN_I'HG]" ;
+  qudt:ucumCode "[in_i'Hg]" ;
+  qudt:uneceCommonCode "F79" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inch of Mercury" ;
+.
+unit:IN_Water
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.490889e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA553" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure; 1 in H2O is equivalent to the static pressure, which will be generated from a water column with a heigth of 1 inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:uneceCommonCode "F78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "IN_Water" ;
+  skos:prefLabel "inch of water" ;
+.
+unit:IU
+  a qudt:Unit ;
+  dcterms:description "<p><strong>International Unit</strong> is a unit for <em>'Amount Of Substance'</em> expressed as \\(IU\\)</p>."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/International_unit"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAB603" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/International_unit?oldid=488801913"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/InternationalUnit> ;
+  qudt:symbol "IU" ;
+  qudt:ucumCaseInsensitiveCode "[IU]" ;
+  qudt:ucumCaseSensitiveCode "[iU]" ;
+  qudt:ucumCode "[IU]" ;
+  qudt:ucumCode "[iU]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "International Unit" ;
+.
+unit:IU-PER-L
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"International Unit per Liter\" is a unit for  'Serum Or Plasma Level' expressed as \\(IU/L\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(IU/L\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SerumOrPlasmaLevel ;
+  qudt:ucumCaseInsensitiveCode "[IU].L-1" ;
+  qudt:ucumCaseInsensitiveCode "[IU]/L" ;
+  qudt:ucumCaseSensitiveCode "[iU].l-1" ;
+  qudt:ucumCaseSensitiveCode "[iU]/l" ;
+  qudt:ucumCode "[IU].L-1" ;
+  qudt:ucumCode "[IU]/L" ;
+  qudt:ucumCode "[iU].l-1" ;
+  qudt:ucumCode "[iU]/l" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "International Unit per Liter" ;
+.
+unit:IcelandKrona
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Iceland"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Icelandic_kr%C3%B3na"^^xsd:anyURI ;
+  qudt:expression "\\(ISK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Icelandic_króna?oldid=495457496"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Iceland Krona" ;
+.
+unit:IndianRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bhutan, India"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Indian_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(INR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Indian_rupee?oldid=495120167"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/IndianRupee> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Indian Rupee" ;
+.
+unit:IranianRial
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Iran"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Iranian_rial"^^xsd:anyURI ;
+  qudt:expression "\\(IRR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Iranian_rial?oldid=495299431"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Iranian Rial" ;
+.
+unit:IraqiDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Iraq"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Iraqi_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(IQD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Iraqi_dinar?oldid=494793908"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Iraqi Dinar" ;
+.
+unit:J
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied. Equivalently, since kinetic energy is one half the mass times the square of the velocity, one joule is the kinetic energy of a mass of two kilograms moving at a velocity of \\(1 m/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Joule"^^xsd:anyURI ;
+  qudt:exactMatch unit:N-M ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA172" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Joule?oldid=494340406"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\text{J}\\ \\equiv\\ \\text{joule}\\ \\equiv\\ \\text{CV}\\ \\equiv\\ \\text{coulomb.volt}\\ \\equiv\\ \\frac{\\text{eV}}{1.602\\ 10^{-19}}\\ \\equiv\\ \\frac{\\text{electron.volt}}{1.602\\ 10^{-19}}\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/joule> ;
+  qudt:plainTextDescription "The SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied. Equivalently, since kinetic energy is one half the mass times the square of the velocity, one joule is the kinetic energy of a mass of two kilograms moving at a velocity of 1 m/s. This is the same as 107 ergs in the CGS system, or approximately 0.737 562 foot-pound in the traditional English system. In other energy units, one joule equals about 9.478 170 x 10-4 Btu, 0.238 846 (small) calories, or 2.777 778 x 10-4 watt hour. The joule is named for the British physicist James Prescott Joule (1818-1889), who demonstrated the equivalence of mechanical and thermal energy in a famous experiment in 1843. " ;
+  qudt:symbol "J" ;
+  qudt:ucumCaseInsensitiveCode "J" ;
+  qudt:ucumCode "J" ;
+  qudt:uneceCommonCode "JOU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule" ;
+.
+unit:J-M-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Joule Meter per Mole</em> is a unit for 'Length Molar Energy' expressed as \\(J \\cdot m \\cdot mol^{-1}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J m mol^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LengthMolarEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Meter per Mole" ;
+.
+unit:J-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:TotalAtomicStoppingPower ;
+  qudt:iec61360Code "0112/2///62720#UAA181" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "j-m^2" ;
+  qudt:uneceCommonCode "D73" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Meter Squared" ;
+.
+unit:J-M2-PER-KiloGM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j-m2/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TotalMassStoppingPower ;
+  qudt:iec61360Code "0112/2///62720#UAB487" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "B20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Meter Squared per Kilogram" ;
+.
+unit:J-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB188" ;
+  qudt:plainTextDescription "derived SI unit joule divided by the 0,000 1-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "E43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "J PER CentiM2" ;
+  skos:prefLabel "joule per centimetre squared" ;
+.
+unit:J-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA174" ;
+  qudt:plainTextDescription "SI derived unit joule divided by the 0,001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "D95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "J PER GM" ;
+  skos:prefLabel "joule per gram" ;
+.
+unit:J-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:plainTextDescription "SI derived unit joule divided by the 3600 times the SI base unit second" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "J PER HR" ;
+  skos:prefLabel "joule per hour" ;
+.
+unit:J-PER-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Joule Per Kelvin (J/K) is a unit in the category of Entropy. It is also known as joules per kelvin, joule/kelvin. This unit is commonly used in the SI unit system. Joule Per Kelvin (J/K) has a dimension of \\(ML^{2}T^{-2}Q^{-1}\\( where \\(M\\) is mass, L is length, T is time, and Q is temperature. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA173" ;
+  qudt:uneceCommonCode "JE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Kelvin" ;
+.
+unit:J-PER-KiloGM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Joule Per Kilogram} (\\(J/kg\\)) is a unit in the category of Thermal heat capacity. It is also known as \\textit{joule/kilogram}, \\textit{joules per kilogram}. This unit is commonly used in the SI unit system. The unit has a dimension of \\(L2T^{-2}\\) where \\(L\\) is length, and \\(T\\) is time. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA175" ;
+  qudt:uneceCommonCode "J2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Kilogram" ;
+.
+unit:J-PER-KiloGM-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Specific heat capacity - The heat required to raise unit mass of a substance by unit temperature interval under specified conditions, such as constant pressure: usually measured in joules per kelvin per kilogram. Symbol \\(c_p\\) (for constant pressure) Also called specific heat.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J-per-kgK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA176" ;
+  qudt:latexSymbol "\\(J/(kg \\cdot K)\\)"^^qudt:LatexString ;
+  qudt:uneceCommonCode "B11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Kilogram Kelvin" ;
+.
+unit:J-PER-KiloGM-K-M3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j-per-kg-k-m3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantVolume ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Kilogram Kelvin Cubic Meter" ;
+.
+unit:J-PER-KiloGM-K-PA
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j-per-kg-k-pa\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacityAtConstantPressure ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Kilogram Kelvin per Pascal" ;
+.
+unit:J-PER-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:expression "\\(j/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TotalLinearStoppingPower ;
+  qudt:iec61360Code "0112/2///62720#UAA178" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "B12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Per Meter" ;
+.
+unit:J-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Joule Per Square Meter (\\(J/m^2\\)) is a unit in the category of Energy density. It is also known as joules per square meter, joule per square metre, joule/square meter, joule/square metre. This unit is commonly used in the SI unit system."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA179" ;
+  qudt:uneceCommonCode "B13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Square Meter" ;
+.
+unit:J-PER-M3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Joule Per Cubic Meter}\\) (\\(J/m^{3}\\)) is a unit in the category of Energy density. It is also known as joules per cubic meter, joule per cubic metre, joules per cubic metre, joule/cubic meter, joule/cubic metre. This unit is commonly used in the SI unit system.  It has a dimension of \\(ML^{-1}T^{-2}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j-per-m3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA180" ;
+  qudt:uneceCommonCode "B8" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Cubic Meter" ;
+.
+unit:J-PER-M3-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Joule per Cubic Meter Kelvin</em> is a unit for 'Volumetric Heat Capacity' expressed as \\(J/(m^{3} K)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/(m^{3} K)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Cubic Meter Kelvin" ;
+.
+unit:J-PER-M4
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Joule Per Quartic Meter</em> (\\(J/m^4\\)) is a unit for the spectral concentration of radiant energy density (in terms of wavelength), or the spectral radiant energy density (in terms of wave length). This unit is commonly used in the SI unit system.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/m^4\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA177" ;
+  qudt:uneceCommonCode "B14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Quartic Meter" ;
+.
+unit:J-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The joule per mole (symbol: \\(Jmol^{-1}\\)) is an SI derived unit of energy per amount of material. Energy is measured in joules, and the amount of material is measured in moles. Physical quantities measured in \\(Jmol^{-1}\\)) usually describe quantities of energy transferred during phase transformations or chemical reactions. Division by the number of moles facilitates comparison between processes involving different quantities of material and between similar processes involving different types of materials. The meaning of such a quantity is always context-dependent and, particularly for chemical reactions, is dependent on the (possibly arbitrary) definition of a 'mole' for a particular process.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA183" ;
+  qudt:uneceCommonCode "B15" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Mole" ;
+.
+unit:J-PER-MOL-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "t of one mole of substance, under standard conditions (not standard temperature and pressure STP). the standard molar entropy is usually given the symbol S, and has units of joules per mole kelvin (\\(J mol^{-1} K^{-1}). Unlike standard enthalpies of formation, the value of S is an absolute. That is, an element in its standard state has a nonzero value of S at room temperature.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J/(mol-K)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA184" ;
+  qudt:uneceCommonCode "B16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Mole Kelvin" ;
+.
+unit:J-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:plainTextDescription "SI derived unit joule divided by the SI base unit second" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "J PER SEC" ;
+  skos:prefLabel "joule per second" ;
+.
+unit:J-PER-T
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The magnetic moment of a magnet is a quantity that determines the force that the magnet can exert on electric currents and the torque that a magnetic field will exert on it. A loop of electric current, a bar magnet, an electron, a molecule, and a planet all have magnetic moments. The unit for magnetic moment is not a base unit in the International System of Units (SI) and it can be represented in more than one way. For example, in the current loop definition, the area is measured in square meters and I is measured in amperes, so the magnetic moment is measured in ampere-square meters (A m2). In the equation for torque on a moment, the torque is measured in joules and the magnetic field in tesla, so the moment is measured in Joules per Tesla (J u00b7T-1). These two representations are equivalent: 1 A u00b7m2 = 1 J u00b7T-1. "^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j-per-t\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:iec61360Code "0112/2///62720#UAB336" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Tesla" ;
+.
+unit:J-PER-T2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "A measure of the diamagnetic energy, for a Bohr-radius spread around a magnetic axis, per square Tesla."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J T^{-2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerSquareMagneticFluxDensity ;
+  qudt:informativeReference "http://www.eng.fsu.edu/~dommelen/quantum/style_a/elecmagfld.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule per Square Tesla" ;
+.
+unit:J-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The joule-second is a unit equal to a joule multiplied by a second, used to measure action or angular momentum. The joule-second is the unit used for Planck's constant.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:iec61360Code "0112/2///62720#UAB151" ;
+  qudt:symbol "J s" ;
+  qudt:uneceCommonCode "B18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Second" ;
+.
+unit:J-SEC-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Joule Second per Mole</em> is a unit for 'Molar Angular Momentum' expressed as \\(J s mol^{-1}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(J s mol^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarAngularMomentum ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Joule Second per Mole" ;
+.
+unit:JamaicanDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Jamaica"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Jamaican_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(JMD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Jamaican_dollar?oldid=494039981"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Jamaican Dollar" ;
+.
+unit:JapaneseYen
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Japan"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Japanese_yen"^^xsd:anyURI ;
+  qudt:expression "\\(JPY\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Japanese_yen?oldid=493771966"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/JapaneseYen> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Japanese yen" ;
+.
+unit:JordanianDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Jordan"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Jordanian_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(JOD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Jordanian_dinar?oldid=495270728"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Jordanian Dinar" ;
+.
+unit:K
+  a qudt:BaseUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The SI base unit of temperature, previously called the degree Kelvin. One kelvin represents the same temperature difference as one degree Celsius. In 1967 the General Conference on Weights and Measures defined the temperature of the triple point of water (the temperature at which water exists simultaneously in the gaseous, liquid, and solid states) to be exactly 273.16 kelvins. Since this temperature is also equal to 0.01 u00b0C, the temperature in kelvins is always equal to 273.15 plus the temperature in degrees Celsius. The kelvin equals exactly 1.8 degrees Fahrenheit. The unit is named for the British mathematician and physicist William Thomson (1824-1907), later known as Lord Kelvin after he was named Baron Kelvin of Largs.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kelvin"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAA185" ;
+  qudt:iec61360Code "0112/2///62720#UAD721" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kelvin?oldid=495075694"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kelvin> ;
+  qudt:symbol "K" ;
+  qudt:uneceCommonCode "KEL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin" ;
+.
+unit:K-M-PER-W
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  qudt:iec61360Code "0112/2///62720#UAB488" ;
+  qudt:plainTextDescription "product of the SI base unit kelvin and the SI base unit metre divided by the derived SI unit watt" ;
+  qudt:uneceCommonCode "H35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "K M PER W" ;
+  skos:prefLabel "kelvin metre per watt" ;
+.
+unit:K-PER-HR
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kelvin per Hour</em> is a unit for 'Temperature Per Time' expressed as \\(K / h\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "3600.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K / h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA189" ;
+  qudt:uneceCommonCode "F10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Hour" ;
+.
+unit:K-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TemperatureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA186" ;
+  qudt:plainTextDescription "SI base unit kelvin divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F02" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "K PER K" ;
+  skos:prefLabel "kelvin per kelvin" ;
+.
+unit:K-PER-MIN
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kelvin per Minute</em> is a unit for 'Temperature Per Time' expressed as \\(K / m\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "60.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K / m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA191" ;
+  qudt:uneceCommonCode "F11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Minute" ;
+.
+unit:K-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kelvin per Second</em> is a unit for 'Temperature Per Time' expressed as \\(K / s\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA192" ;
+  qudt:uneceCommonCode "F12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Second" ;
+.
+unit:K-PER-T
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kelvin per Tesla</em> is a unit for 'Temperature Per Magnetic Flux Density' expressed as \\(K T^{-1}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K T^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperaturePerMagneticFluxDensity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Tesla" ;
+.
+unit:K-PER-W
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """Thermal resistance is a heat property and a measure of a temperature difference by which an object or material resists a heat flow (heat per time unit or thermal resistance). Thermal resistance is the reciprocal thermal conductance.
+Absolute thermal resistance is the temperature difference across a structure when a unit of heat energy flows through it in unit time. It is the reciprocal of thermal conductance. The SI units of thermal resistance are kelvins per watt or the equivalent degrees Celsius per watt (the two are the same since as intervals).</p>"""^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K/W\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalResistance ;
+  qudt:iec61360Code "0112/2///62720#UAA187" ;
+  qudt:uneceCommonCode "B21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kelvin per Watt" ;
+.
+unit:KAT
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of catalytic activity used especially in the chemistry of enzymes. A catalyst is a substance that starts or speeds a chemical reaction. Enzymes are proteins that act as catalysts within the bodies of living plants and animals. A catalyst has an activity of one katal if it enables a reaction to proceed at the rate of one mole per second. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Katal"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:CatalyticActivity ;
+  qudt:iec61360Code "0112/2///62720#UAB196" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Katal?oldid=486431865"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/katal> ;
+  qudt:symbol "kat" ;
+  qudt:ucumCaseInsensitiveCode "KATU" ;
+  qudt:ucumCaseSensitiveCode "kat" ;
+  qudt:ucumCode "KATU" ;
+  qudt:ucumCode "kat" ;
+  qudt:uneceCommonCode "KAT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Katal" ;
+.
+unit:KIP_F
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "1000 pound-force"^^rdf:HTML ;
+  qudt:conversionMultiplier "4448.222"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kip"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kip?oldid=492552722"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kip> ;
+  qudt:symbol "kip" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kip" ;
+.
+unit:KIP_F-PER-IN2
+  a qudt:Unit ;
+  dcterms:description "\"Kip per Square Inch\" is a unit for  'Force Per Area' expressed as \\(kip/in^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6894757.89"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kip/in^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB242" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kip per Square Inch" ;
+.
+unit:KN
+  a qudt:Unit ;
+  dcterms:description "The knot (pronounced 'not') is a unit of speed equal to one nautical mile (1.852 km) per hour, approximately 1.151 mph. The abbreviation \\(kn\\) is preferred by the International Hydrographic Organization (IHO), which includes every major sea-faring nation; however, the abbreviations kt (singular) and kts (plural) are also widely used. However, use of the abbreviation kt for knot conflicts with the SI symbol for kilotonne. The knot is a non-SI unit accepted for use with the International System of Units (SI). Worldwide, the knot is used in meteorology, and in maritime and air navigation - for example, a vessel travelling at 1 knot along a meridian travels one minute of geographic latitude in one hour. Etymologically, the term knot derives from counting the number of knots in the line that unspooled from the reel of a chip log in a specific time."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.5144444444444445"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Knot"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB110" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Knot?oldid=495066194"^^xsd:anyURI ;
+  qudt:symbol "kn" ;
+  qudt:ucumCaseInsensitiveCode "[KN_I]" ;
+  qudt:ucumCaseSensitiveCode "[kn_i]" ;
+  qudt:ucumCode "[KN_I]" ;
+  qudt:ucumCode "[kn_i]" ;
+  qudt:uneceCommonCode "KNT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Knot" ;
+  skos:altLabel "kt" ;
+  skos:altLabel "kts" ;
+.
+unit:KN-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Knot per Second}\\) is a unit for 'Linear Acceleration' expressed as \\(kt/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.5144444444444445"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kt/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:ucumCaseInsensitiveCode "[KN_I].S-1" ;
+  qudt:ucumCaseInsensitiveCode "[KN_I]/S" ;
+  qudt:ucumCaseSensitiveCode "[kn_i].s-1" ;
+  qudt:ucumCaseSensitiveCode "[kn_i]/s" ;
+  qudt:ucumCode "[KN_I].S-1" ;
+  qudt:ucumCode "[KN_I]/S" ;
+  qudt:ucumCode "[kn_i].s-1" ;
+  qudt:ucumCode "[kn_i]/s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Knot per Second" ;
+.
+unit:KY
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "100.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kayser"^^xsd:anyURI ;
+  qudt:expression "\\(\\(cm^{-1}\\)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseLength ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kayser?oldid=458489166"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/kayser> ;
+  qudt:ucumCaseInsensitiveCode "KY" ;
+  qudt:ucumCaseSensitiveCode "Ky" ;
+  qudt:ucumCode "KY" ;
+  qudt:ucumCode "Ky" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kayser" ;
+.
+unit:KenyanShilling
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kenya"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kenyan_shilling"^^xsd:anyURI ;
+  qudt:expression "\\(KES\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kenyan_shilling?oldid=489547027"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kenyan Shilling" ;
+.
+unit:Kibi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024\\), or \\(2^{10}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1024"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Ki" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kibi" ;
+.
+unit:Kilo
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"kilo\" is a decimal prefix for expressing a value with a scaling of \\(10^{3}\"\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilo"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilo?oldid=461428121"^^xsd:anyURI ;
+  qudt:symbol "k" ;
+  qudt:ucumCaseInsensitiveCode "K" ;
+  qudt:ucumCaseSensitiveCode "k" ;
+  qudt:ucumCode "K" ;
+  qudt:ucumCode "k" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilo" ;
+.
+unit:KiloA
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.03e-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Kilo ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA557" ;
+  qudt:isScalingOf unit:A ;
+  qudt:symbol "kA" ;
+  qudt:uneceCommonCode "B22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "kiloampere" ;
+.
+unit:KiloA-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAB053" ;
+  qudt:plainTextDescription "product of the 1 000-fold of the SI base unit ampere and the unit hour" ;
+  qudt:uneceCommonCode "TAH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloA HR" ;
+  skos:prefLabel "kiloampere hour" ;
+.
+unit:KiloA-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearElectricCurrent ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA558" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit ampere divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloA PER M" ;
+  skos:prefLabel "kiloampere per metre" ;
+.
+unit:KiloA-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA559" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit ampere divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "B23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloA PER M2" ;
+  skos:prefLabel "kiloampere per metre squared" ;
+.
+unit:KiloBAR
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to 100,000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000 Pa = 1 bar \\approx 750.0616827 Torr\\). Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Kilo ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB088" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BAR ;
+  qudt:symbol "kbar" ;
+  qudt:uneceCommonCode "KBA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilobar" ;
+.
+unit:KiloBIT-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A kilobit per second (kB/s) is a unit of data transfer rate equal to 1,000 bits per second."^^rdf:HTML ;
+  qudt:conversionMultiplier 1e-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
+  qudt:iec61360Code "0112/2///62720#UAA586" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobit_per_second"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BIT-PER-SEC ;
+  qudt:symbol "kbps" ;
+  qudt:uneceCommonCode "C74" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilobit per Second" ;
+.
+unit:KiloBQ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA561" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit becquerel" ;
+  qudt:uneceCommonCode "2Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloBQ" ;
+  skos:prefLabel "kilobecquerel" ;
+.
+unit:KiloBYTE
+  a qudt:BinaryScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The kilobyte is a multiple of the unit byte for digital information equivalent to 1024 bytes. Although the prefix kilo- means 1000, the term kilobyte and symbol kB have historically been used to refer to either 1024 (210) bytes or 1000 (103) bytes, dependent upon context, in the fields of computer science and information technology."^^rdf:HTML ;
+  qudt:conversionMultiplier "1024"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Byte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Kibi ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Byte?oldid=493588918"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "kB" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilo Byte" ;
+.
+unit:KiloBYTE-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A kilobyte per second (kByte/s) is a unit of data transfer rate equal to 8,000 bits per second, or 1,000 bytes per second, or 8 kilobits per second."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAB306" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units#Kilobyte_per_second"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BIT-PER-SEC ;
+  qudt:symbol "kbps" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilobyte per Second" ;
+.
+unit:KiloC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1000.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Kilo ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA563" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "kC" ;
+  qudt:uneceCommonCode "B26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:KiloC-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFluxDensity ;
+  qudt:hasQuantityKind quantitykind:ElectricPolarization ;
+  qudt:iec61360Code "0112/2///62720#UAA564" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "B28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloC PER M2" ;
+  skos:prefLabel "kilocoulomb per metre squared" ;
+.
+unit:KiloC-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeVolumeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA565" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloC PER M3" ;
+  skos:prefLabel "kilocoulomb per metre cubed" ;
+.
+unit:KiloCAL
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kilocalorie} is a unit for \\textit{Energy And Work</em> expressed as \\(kcal\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "4184"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Calorie"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Calorie?oldid=494307622"^^xsd:anyURI ;
+  qudt:symbol "kcal" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie" ;
+.
+unit:KiloCAL-PER-CentiM-SEC-DEG_C
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kilocal-per-cm-sec-degc\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Centimeter Second Degree Celsius" ;
+.
+unit:KiloCAL-PER-CentiM2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilocalorie per Square Centimeter\" is a unit for  'Energy Per Area' expressed as \\(kcal/cm^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.184E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/cm^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Square Centimeter" ;
+.
+unit:KiloCAL-PER-CentiM2-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilocalorie per Square Centimeter Minute\" is a unit for  'Power Per Area' expressed as \\(kcal/(cm^{2}-min)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 6.97333333E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/(cm^{2}-min)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Square Centimeter Minute" ;
+.
+unit:KiloCAL-PER-CentiM2-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilocalorie per Square Centimeter Second\" is a unit for  'Power Per Area' expressed as \\(kcal/(cm^{2}-s)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.184E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/(cm^{2}-s)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Square Centimeter Second" ;
+.
+unit:KiloCAL-PER-GM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilocalorie per Gram\" is a unit for  'Specific Energy' expressed as \\(kcal/gm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.184E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/gm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Gram" ;
+.
+unit:KiloCAL-PER-GM-DEG_C
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Calorie per Gram Degree Celsius</em> is a unit for 'Specific Heat Capacity' expressed as \\(kcal/(gm-degC)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/(gm-degC)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Calorie per Gram Degree Celsius" ;
+.
+unit:KiloCAL-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kilocalorie per Minute} is a unit for \\textit{Heat Flow Rate} and \\textit{Power</em> expressed as \\(kcal/min\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "69.7333333"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie Per Minute" ;
+.
+unit:KiloCAL-PER-MOL
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The kilocalorie per mole is a derived unit of energy per Avogadro's number of particles. It is the quotient of a kilocalorie (1000 thermochemical gram calories) and a mole, mainly used in the United States. In SI units, it is equal to \\(4.184 kJ/mol\\), or \\(6.9477 \\times 10 J per molecule\\). At room temperature it is equal to 1.688 . Physical quantities measured in \\(kcal\\cdot mol\\) are usually thermodynamical quantities; mostly free energies such as: Heat of vaporization Heat of fusion</p>."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Mole" ;
+.
+unit:KiloCAL-PER-MOL-DEG_C
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kilocalorie per Mole Degree Celsius</em> is a unit for 'Molar Heat Capacity' expressed as \\(kcal/(mol-degC)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/(mol-degC)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarHeatCapacity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie per Mole Degree Celsius" ;
+.
+unit:KiloCAL-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kilocalorie per Second} is a unit for \\textit{Heat Flow Rate} and \\textit{Power</em> expressed as \\(kcal/s\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "4184"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kcal/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilocalorie Per Second" ;
+.
+unit:KiloCAL_IT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.1868e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA589" ;
+  qudt:plainTextDescription "1Â 000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:uneceCommonCode "E14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_IT" ;
+  skos:prefLabel "kilocalorie (international table)" ;
+.
+unit:KiloCAL_IT-PER-HR-M-DEG_C
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M1H-1T-3D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThermalConductivity ;
+  qudt:conversionMultiplier 1.163e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA588" ;
+  qudt:plainTextDescription "1 000-fold of the no longer approved unit international calorie for energy divided by the product of the SI base unit metre, the unit hour for time and the unit degree Celsius for temperature" ;
+  qudt:uneceCommonCode "K52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_IT PER HR M DEG_C" ;
+  skos:prefLabel "kilocalorie (international table) per hour metre degree Celsius" ;
+.
+unit:KiloCAL_Mean
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.190e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA587" ;
+  qudt:plainTextDescription "1Â 000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:uneceCommonCode "K51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_Mean" ;
+  skos:prefLabel "kilocalorie (mean)" ;
+.
+unit:KiloCAL_TH
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA590" ;
+  qudt:plainTextDescription "1Â 000-fold of the unit calorie, which is used particularly for calorific values of food" ;
+  qudt:uneceCommonCode "K53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_TH" ;
+  skos:prefLabel "kilocalorie (thermochemical)" ;
+.
+unit:KiloCAL_TH-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.162230555555556e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAB184" ;
+  qudt:plainTextDescription "1 000-fold of the non-legal unit thermochemical calorie divided by the unit hour" ;
+  qudt:uneceCommonCode "E15" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_TH PER HR" ;
+  skos:prefLabel "kilocalorie (thermochemical) per hour" ;
+.
+unit:KiloCAL_TH-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.9733833333333333e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA591" ;
+  qudt:plainTextDescription "1Â 000-fold of the unit calorie divided by the unit minute" ;
+  qudt:uneceCommonCode "K54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_TH PER MIN" ;
+  skos:prefLabel "kilocalorie (thermochemical) per minute" ;
+.
+unit:KiloCAL_TH-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.184e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA592" ;
+  qudt:plainTextDescription "1Â 000-fold of the unit calorie divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCAL_TH PER SEC" ;
+  skos:prefLabel "kilocalorie (thermochemical) per second" ;
+.
+unit:KiloCi
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Activity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:AngularFrequency ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:DataRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:DecayConstant ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Frequency ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB046" ;
+  qudt:plainTextDescription "1 000-fold of the unit curie" ;
+  qudt:uneceCommonCode "2R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloCi" ;
+  skos:prefLabel "kilocurie" ;
+.
+unit:KiloEV
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilo Electron Volt\" is a unit for  'Energy And Work' expressed as \\(keV\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-16 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:symbol "keV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilo Electron Volt" ;
+.
+unit:KiloEV-PER-MicroM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilo Electron Volt per Micrometer\" is a unit for  'Linear Energy Transfer' expressed as \\(keV/microM\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.60217653E-10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(keV/microM\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilo Electron Volt per Micrometer" ;
+.
+unit:KiloGAUSS
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB136" ;
+  qudt:plainTextDescription "1 000-fold of the CGS unit of the magnetic flux density B" ;
+  qudt:uneceCommonCode "78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGAUSS" ;
+  skos:prefLabel "kilogauss" ;
+.
+unit:KiloGM
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:plainTextDescription "The kilogram or kilogramme (SI symbol: kg), also known as the kilo, is the base unit of mass in the International System of Units and is defined as being equal to the mass of the International Prototype Kilogram (IPK), which is almost exactly equal to the mass of one liter of water. The avoirdupois (or international) pound, used in both the Imperial system and U.S. customary units, is defined as exactly 0.45359237 kg, making one kilogram approximately equal to 2.2046 avoirdupois pounds."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilogram"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA594" ;
+  qudt:iec61360Code "0112/2///62720#UAD720" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilogram?oldid=493633626"^^xsd:anyURI ;
+  qudt:symbol "kg" ;
+  qudt:ucumCaseInsensitiveCode "KG" ;
+  qudt:ucumCaseSensitiveCode "kg" ;
+  qudt:ucumCode "KG" ;
+  qudt:ucumCode "kg" ;
+  qudt:uneceCommonCode "KGM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram" ;
+.
+unit:KiloGM-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MomentOfInertia ;
+  qudt:iec61360Code "0112/2///62720#UAA600" ;
+  qudt:plainTextDescription "product of the SI base unit kilogram and the 0 0001fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "F18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM CentiM2" ;
+  skos:prefLabel "kilogram centimetre squared" ;
+.
+unit:KiloGM-K
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Kilogram Kelvin</em> is a unit for 'Mass Temperature' expressed as \\(kg-K\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg-K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Kelvin" ;
+.
+unit:KiloGM-M-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Meter Per Second\" is a unit for  'Linear Momentum' expressed as \\(kg-m/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg-m/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearMomentum ;
+  qudt:iec61360Code "0112/2///62720#UAA615" ;
+  qudt:uneceCommonCode "B31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Meter Per Second" ;
+.
+unit:KiloGM-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Meter Squared\" is a unit for  'Moment Of Inertia' expressed as \\(kg-m^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg-m2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MomentOfInertia ;
+  qudt:iec61360Code "0112/2///62720#UAA622" ;
+  qudt:uneceCommonCode "B32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Meter Squared" ;
+.
+unit:KiloGM-M2-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Meter Squared Per Second\" is a unit for  'Angular Momentum' expressed as \\(kg-m^2-s^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg-m2/sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:iec61360Code "0112/2///62720#UAA623" ;
+  qudt:uneceCommonCode "B33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Meter Squared Per Second" ;
+.
+unit:KiloGM-MilliM2
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L2I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MomentOfInertia ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MomentOfInertia ;
+  qudt:iec61360Code "0112/2///62720#UAA627" ;
+  qudt:plainTextDescription "product of the SI base kilogram and the  0,001-fold of the power of the SI base metre with the exponent 2" ;
+  qudt:uneceCommonCode "F19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM MilliM2" ;
+  skos:prefLabel "kilogram millimetre squared" ;
+.
+unit:KiloGM-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB174" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the 0,000 1-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "D5" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER CentiM2" ;
+  skos:prefLabel "kilogram per centimetre squared" ;
+.
+unit:KiloGM-PER-CentiM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA597" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the 0,000 001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "G31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER CentiM3" ;
+  skos:prefLabel "kilogram per centimetre cubed" ;
+.
+unit:KiloGM-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA601" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the unit day" ;
+  qudt:uneceCommonCode "F30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER DAY" ;
+  skos:prefLabel "kilogram per day" ;
+.
+unit:KiloGM-PER-DeciM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA604" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the 0,001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER DeciM3" ;
+  skos:prefLabel "kilogram per decimetre cubed" ;
+.
+unit:KiloGM-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Kilogram Per Hour (kg/h) is a unit in the category of Mass flow rate. It is also known as kilogram/hour. Kilogram Per Hour (kg/h) has a dimension of MT-1 where M is mass, and T is time. It can be converted to the corresponding standard SI unit kg/s by multiplying its value by a factor of 0.000277777777778."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.000277777778"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA607" ;
+  qudt:uneceCommonCode "E93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Hour" ;
+.
+unit:KiloGM-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA610" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "3H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER KiloGM" ;
+  skos:prefLabel "kilogram per kilogram" ;
+.
+unit:KiloGM-PER-KiloMOL
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A-1E0L0I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MolarMass ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarMass ;
+  qudt:iec61360Code "0112/2///62720#UAA611" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the 1 000-fold of the SI base unit mol" ;
+  qudt:uneceCommonCode "F24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER KiloMOL" ;
+  skos:prefLabel "kilogram per kilomol" ;
+.
+unit:KiloGM-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA612" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the unit litre" ;
+  qudt:uneceCommonCode "B35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER L" ;
+  skos:prefLabel "kilogram per litre" ;
+.
+unit:KiloGM-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kilogram Per Meter (kg/m) is a unit in the category of Linear mass density. It is also known as kilogram/meter, kilogram/metre, kilograms per meter, kilogram per metre, kilograms per metre. This unit is commonly used in the SI unit system. Kilogram Per Meter (kg/m) has a dimension of ML-1 where M is mass, and L is length. This unit is the standard SI unit in this category. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA616" ;
+  qudt:uneceCommonCode "KL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Meter" ;
+.
+unit:KiloGM-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kilogram Per Square Meter (kg/m2) is a unit in the category of Surface density. It is also known as kilograms per square meter, kilogram per square metre, kilograms per square metre, kilogram/square meter, kilogram/square metre. This unit is commonly used in the SI unit system. Kilogram Per Square Meter (kg/m2) has a dimension of ML-2 where M is mass, and L is length. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA617" ;
+  qudt:uneceCommonCode "28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Square Meter" ;
+.
+unit:KiloGM-PER-M3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kilogram per cubic metre is an SI derived unit of density, defined by mass in kilograms divided by volume in cubic metres. The official SI symbolic abbreviation is \\(kg \\cdot m^{-3}\\), or equivalently either \\(kg/m^3\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg/m^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:iec61360Code "0112/2///62720#UAA619" ;
+  qudt:uneceCommonCode "KMQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Cubic Meter" ;
+.
+unit:KiloGM-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA624" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the unit minute" ;
+  qudt:uneceCommonCode "F31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER MIN" ;
+  skos:prefLabel "kilogram per minute" ;
+.
+unit:KiloGM-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>In chemistry, the molar mass M is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance. It is a physical property of a given substance. The base SI unit for molar mass is \\(kg/mol\\). However, for historical reasons, molar masses are almost always expressed in \\(g/mol\\). As an example, the molar mass of water is approximately: \\(18.01528(33) \\; g/mol\\)</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg mol^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarMass ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Mol" ;
+.
+unit:KiloGM-PER-MilliM
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-1I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:BodyMassIndex ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearDensity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerLength ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB070" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the 0,001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "KW" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER MilliM" ;
+  skos:prefLabel "kilogram per millimetre" ;
+.
+unit:KiloGM-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kilogram Per Second (kg/s) is a unit in the category of Mass flow rate. It is also known as kilogram/second, kilograms per second. This unit is commonly used in the SI unit system. Kilogram Per Second (kg/s) has a dimension of \\(MT^{-1}\\) where M is mass, and T is time. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA629" ;
+  qudt:uneceCommonCode "KGS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Second" ;
+.
+unit:KiloGM-PER-SEC-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerAreaTime ;
+  qudt:iec61360Code "0112/2///62720#UAA618" ;
+  qudt:plainTextDescription "SI base unit kilogram divided by the product of the power of the SI base unit metre with the exponent 2 and the SI base unit second" ;
+  qudt:uneceCommonCode "H56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM PER SEC M2" ;
+  skos:prefLabel "kilogram per second metre squared" ;
+.
+unit:KiloGM-PER-SEC2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kg-per-sec2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:latexSymbol "\\(kg \\cdot s^2\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram per Second Squared" ;
+.
+unit:KiloGM-SEC2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kilog-sec2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Second Squared" ;
+.
+unit:KiloGM_F
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Force\" is a unit for  'Force' expressed as \\(kgf\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "9.80665"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilogram-force"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilogram-force?oldid=493375479"^^xsd:anyURI ;
+  qudt:symbol "kgf" ;
+  qudt:ucumCaseInsensitiveCode "KGF" ;
+  qudt:ucumCaseSensitiveCode "kgf" ;
+  qudt:ucumCode "KGF" ;
+  qudt:ucumCode "kgf" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Force" ;
+.
+unit:KiloGM_F-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA634" ;
+  qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre" ;
+  qudt:uneceCommonCode "B38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM_F M" ;
+  skos:prefLabel "kilogram?force metre" ;
+.
+unit:KiloGM_F-M-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB189" ;
+  qudt:plainTextDescription "product of the unit kilogram-force and the SI base unit metre divided by the 0,000 1-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "E44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM_F M PER CentiM2" ;
+  skos:prefLabel "kilogram?force metre per square centimetre" ;
+.
+unit:KiloGM_F-M-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Momentum ;
+  qudt:iec61360Code "0112/2///62720#UAB154" ;
+  qudt:plainTextDescription "product of the SI base unit metre and the unit kilogram-force according to the Anglo-American and Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "B39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM_F M PER SEC" ;
+  skos:prefLabel "kilogram?force metre per second" ;
+.
+unit:KiloGM_F-PER-CentiM2
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Force per Square Centimeter\" is a unit for  'Force Per Area' expressed as \\(kgf/cm^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "98066.5"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kgf/cm^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Force per Square Centimeter" ;
+.
+unit:KiloGM_F-PER-M
+  a qudt:Unit ;
+  dcterms:description "\"Kilogram Force Meter\" is a unit for  'Torque' expressed as \\(kgf-m\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "9.80665"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(kgf-m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilogram Force Meter" ;
+.
+unit:KiloGM_F-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA635" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:uneceCommonCode "B40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM_F PER M2" ;
+  skos:prefLabel "kilogram?force per metre squared" ;
+.
+unit:KiloGM_F-PER-MilliM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA636" ;
+  qudt:plainTextDescription "not SI conform unit of the pressure" ;
+  qudt:uneceCommonCode "E41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloGM_F PER MilliM2" ;
+  skos:prefLabel "kilogram?force per square millimetre" ;
+.
+unit:KiloHZ
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Kilohertz\" is a C.G.S System unit for  'Frequency' expressed as \\(KHz\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:iec61360Code "0112/2///62720#UAA566" ;
+  qudt:symbol "KHz" ;
+  qudt:ucumCaseInsensitiveCode "KHZ" ;
+  qudt:ucumCaseSensitiveCode "kHz" ;
+  qudt:ucumCode "KHZ" ;
+  qudt:ucumCode "kHz" ;
+  qudt:uneceCommonCode "KHZ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilohertz" ;
+.
+unit:KiloHZ-M
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA567" ;
+  qudt:plainTextDescription "product of the 1 000-fold of the SI derived unit hertz and the SI base unit metre" ;
+  qudt:uneceCommonCode "M17" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloHZ M" ;
+  skos:prefLabel "kilohertz metre" ;
+.
+unit:KiloJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA568" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit joule" ;
+  qudt:uneceCommonCode "KJO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloJ" ;
+  skos:prefLabel "kilojoule" ;
+.
+unit:KiloJ-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAA569" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "B41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloJ PER K" ;
+  skos:prefLabel "kilojoule per kelvin" ;
+.
+unit:KiloJ-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:HeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA570" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "B42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloJ PER KiloGM" ;
+  skos:prefLabel "kilojoule per kilogram" ;
+.
+unit:KiloJ-PER-KiloGM-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEntropy ;
+  qudt:iec61360Code "0112/2///62720#UAA571" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the product of the SI base unit kilogram and the SI base unit kelvin" ;
+  qudt:uneceCommonCode "B43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloJ PER KiloGM K" ;
+  skos:prefLabel "kilojoule per kilogram kelvin" ;
+.
+unit:KiloJ-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:IonizationEnergy ;
+  qudt:hasQuantityKind quantitykind:MolarEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA572" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit joule divided by the SI base unit mol" ;
+  qudt:uneceCommonCode "B44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloJ PER MOL" ;
+  skos:prefLabel "kilojoule per mole" ;
+.
+unit:KiloL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB114" ;
+  qudt:plainTextDescription "1 000-fold of the unit litre" ;
+  qudt:uneceCommonCode "K6" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloL" ;
+  skos:prefLabel "kilolitre" ;
+.
+unit:KiloL-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.77777777778e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB121" ;
+  qudt:plainTextDescription "unit of the volume kilolitres divided by the unit hour" ;
+  qudt:uneceCommonCode "4X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloL PER HR" ;
+  skos:prefLabel "kilolitre per hour" ;
+.
+unit:KiloLB_F-FT-PER-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.728302797866667e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAB483" ;
+  qudt:plainTextDescription "product of the Anglo-American unit pound-force and foot divided by the SI base unit ampere" ;
+  qudt:uneceCommonCode "F22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloLB_F FT PER A" ;
+  skos:prefLabel "pound force foot per ampere" ;
+.
+unit:KiloLB_F-FT-PER-LB
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.989067e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB484" ;
+  qudt:plainTextDescription "product of the Anglo-American unit pound-force and the Anglo-American unit foot divided by the Anglo-American unit pound (US)" ;
+  qudt:uneceCommonCode "G20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloLB_F FT PER LB" ;
+  skos:prefLabel "pound force foot per pound" ;
+.
+unit:KiloLB_F-PER-FT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.4593904199475065617e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB192" ;
+  qudt:plainTextDescription "unit of the length-related force" ;
+  qudt:uneceCommonCode "F17" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloLB_F PER FT" ;
+  skos:prefLabel "pound?force per foot" ;
+.
+unit:KiloLB_F-PER-IN2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.0696e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAB138" ;
+  qudt:plainTextDescription "1 000-fold of the unit for pressure psi as a compounded unit pound-force according to the Anglo-American system of units divided by the power of the unit Inch according to the Anglo-American and Imperial system of units by exponent 2" ;
+  qudt:uneceCommonCode "84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloLB_F PER IN2" ;
+  skos:prefLabel "kilopound force per square inch" ;
+.
+unit:KiloM
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A common metric unit of length or distance. One kilometer equals exactly 1000 meters, about 0.621 371 19 mile, 1093.6133 yards, or 3280.8399 feet. Oddly, higher multiples of the meter are rarely used; even the distances to the farthest galaxies are usually measured in kilometers. "^^rdf:HTML ;
+  qudt:conversionMultiplier "1000"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilometre"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometre?oldid=494821851"^^xsd:anyURI ;
+  qudt:symbol "km" ;
+  qudt:ucumCaseInsensitiveCode "KM" ;
+  qudt:ucumCaseSensitiveCode "km" ;
+  qudt:ucumCode "KM" ;
+  qudt:ucumCode "km" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilometer " ;
+.
+unit:KiloM-PER-HR
+  a qudt:Unit ;
+  dcterms:description "\"Kilometer per Hour\" is a C.G.S System unit for  'Linear Velocity' expressed as \\(km/hr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.2777777777777778e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilometres_per_hour"^^xsd:anyURI ;
+  qudt:expression "\\(km/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA638" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilometres_per_hour?oldid=487674812"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "KM.HR-1" ;
+  qudt:ucumCaseInsensitiveCode "KM/HR" ;
+  qudt:ucumCaseSensitiveCode "km.h-1" ;
+  qudt:ucumCaseSensitiveCode "km/h" ;
+  qudt:ucumCode "KM.HR-1" ;
+  qudt:ucumCode "KM/HR" ;
+  qudt:ucumCode "km.h-1" ;
+  qudt:ucumCode "km/h" ;
+  qudt:uneceCommonCode "KMH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilometer per Hour" ;
+.
+unit:KiloM-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "\"Kilometer per Second\" is a C.G.S System unit for  'Linear Velocity' expressed as \\(km/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1000.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(km/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB392" ;
+  qudt:ucumCaseInsensitiveCode "KM.S-1" ;
+  qudt:ucumCaseInsensitiveCode "KM/S" ;
+  qudt:ucumCaseSensitiveCode "km.s-1" ;
+  qudt:ucumCaseSensitiveCode "km/s" ;
+  qudt:ucumCode "KM.S-1" ;
+  qudt:ucumCode "KM/S" ;
+  qudt:ucumCode "km.s-1" ;
+  qudt:ucumCode "km/s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilometer per Second" ;
+.
+unit:KiloM3-PER-SEC2
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Cubic Kilometer per Second Squared}\\) is a unit for \\(\\textit{Standard Gravitational Parameter}\\) expressed as \\(km^3/s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(km^3/s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
+  qudt:ucumCaseInsensitiveCode "KM3.S-2" ;
+  qudt:ucumCaseInsensitiveCode "KM3/S2" ;
+  qudt:ucumCaseSensitiveCode "km3.s-2" ;
+  qudt:ucumCaseSensitiveCode "km3/s2" ;
+  qudt:ucumCode "KM3.S-2" ;
+  qudt:ucumCode "KM3/S2" ;
+  qudt:ucumCode "km3.s-2" ;
+  qudt:ucumCode "km3/s2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Kilometer per Second Squared" ;
+.
+unit:KiloMOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAA640" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit mol" ;
+  qudt:uneceCommonCode "B45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloMOL" ;
+  skos:prefLabel "kilomole" ;
+.
+unit:KiloMOL-PER-HR
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A1E0L0I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:CatalyticActivity ;
+  qudt:conversionMultiplier 2.77777777777778e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA641" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloMOL PER HR" ;
+  skos:prefLabel "kilomole per hour" ;
+.
+unit:KiloMOL-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA642" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B46" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloMOL PER M3" ;
+  skos:prefLabel "kilomole per metre cubed" ;
+.
+unit:KiloMOL-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.694444e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA645" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit mole divided by the unit for time minute" ;
+  qudt:uneceCommonCode "K61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloMOL PER MIN" ;
+  skos:prefLabel "kilomole per minute" ;
+.
+unit:KiloMOL-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA646" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit mol divided by the SI base unit second" ;
+  qudt:uneceCommonCode "E94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloMOL PER SEC" ;
+  skos:prefLabel "kilomole per second" ;
+.
+unit:KiloN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA573" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit newton" ;
+  qudt:uneceCommonCode "B47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloN" ;
+  skos:prefLabel "kilonewton" ;
+.
+unit:KiloN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA574" ;
+  qudt:plainTextDescription "1 000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:uneceCommonCode "B48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloN M" ;
+  skos:prefLabel "kilonewton metre" ;
+.
+unit:KiloOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA555" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "B49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloOHM" ;
+  skos:prefLabel "kiloohm" ;
+.
+unit:KiloP
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Same as kilogramForce"^^rdf:HTML ;
+  qudt:conversionMultiplier "9.80665"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAB059" ;
+  qudt:symbol "kp" ;
+  qudt:uneceCommonCode "B51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilopond" ;
+.
+unit:KiloPA
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kilopascal is a unit of pressure. 1 kPa is approximately the pressure exerted by a 10-g mass resting on a 1-cm2 area. 101.3 kPa = 1 atm. There are 1,000 pascals in 1 kilopascal."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pascal_%28unit%29"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA575" ;
+  qudt:isScalingOf unit:PA ;
+  qudt:symbol "KPa" ;
+  qudt:uneceCommonCode "KPA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilopascal" ;
+.
+unit:KiloPA-M2-PER-GM
+  a qudt:Unit ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Acceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearAcceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleAcceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThrustToMassRatio ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB130" ;
+  qudt:plainTextDescription "sector-specific unit of the burst index as 1 000-fold of the derived unit for pressure pascal related to the substance, represented as a quotient from the 0,001-fold of the SI base unit kilogram divided by the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloPA M2 PER GM" ;
+  skos:prefLabel "kilopascal metre squared per gram" ;
+.
+unit:KiloPA-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e+08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA577" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:uneceCommonCode "F03" ;
+  rdfs:label "KiloPA PER BAR" ;
+  skos:prefLabel "kilopascal per bar" ;
+.
+unit:KiloPA-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA576" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F83" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloPA PER K" ;
+  skos:prefLabel "kilopascal per kelvin" ;
+.
+unit:KiloPA-PER-MilliM
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M1H0T-2D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpectralRadiantEnergyDensity ;
+  qudt:conversionMultiplier 1.0e+05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB060" ;
+  qudt:plainTextDescription "1 000-fold of the derived SI unit pascal divided by the 0,001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloPA PER MilliM" ;
+  skos:prefLabel "kilopascal per millimetre" ;
+.
+unit:KiloPA_A
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Kilopascal Absolute</em> is a SI System unit for 'Force Per Area' expressed as \\(KPaA\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:symbol "KPaA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilopascal Absolute" ;
+.
+unit:KiloPOND
+  a qudt:Unit ;
+  qudt:conversionMultiplier "9.80665"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAB059" ;
+  qudt:plainTextDescription "illegal unit of the weight, defined as mass of 1 kg which receives a weight of 1 kp through gravitation at sea level, which equates to a force of 9,806 65 newton" ;
+  qudt:uneceCommonCode "B51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloPOND" ;
+  skos:prefLabel "kilopond" ;
+.
+unit:KiloR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.58E-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Exposure ;
+  qudt:iec61360Code "0112/2///62720#UAB057" ;
+  qudt:plainTextDescription "1 000-fold of the unit roentgen" ;
+  qudt:uneceCommonCode "KR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloR" ;
+  skos:prefLabel "kiloroentgen" ;
+.
+unit:KiloS
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:iec61360Code "0112/2///62720#UAA578" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit siemens" ;
+  qudt:uneceCommonCode "B53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloS" ;
+  skos:prefLabel "kilosiemens" ;
+.
+unit:KiloS-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA579" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloS PER M" ;
+  skos:prefLabel "kilosiemens per metre" ;
+.
+unit:KiloSEC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Killosecond\" is an Imperial unit for  'Time' expressed as \\(ks\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1000"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Millisecond"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Kilo ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA647" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Millisecond?oldid=495102042"^^xsd:anyURI ;
+  qudt:isScalingOf unit:SEC ;
+  qudt:symbol "ks" ;
+  qudt:ucumCaseInsensitiveCode "KS" ;
+  qudt:ucumCaseSensitiveCode "ks" ;
+  qudt:ucumCode "KS" ;
+  qudt:ucumCode "ks" ;
+  qudt:uneceCommonCode "B52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "kilosecond" ;
+.
+unit:KiloTON
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.071847e+05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB080" ;
+  qudt:plainTextDescription "1 000 000-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "KTN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloTON" ;
+  skos:prefLabel "kilotonne" ;
+.
+unit:KiloV
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Voltage ;
+  qudt:iec61360Code "0112/2///62720#UAA580" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit volt" ;
+  qudt:uneceCommonCode "KVT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV" ;
+  skos:prefLabel "kilovolt" ;
+.
+unit:KiloV-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
+  qudt:iec61360Code "0112/2///62720#UAA581" ;
+  qudt:plainTextDescription "1 000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:uneceCommonCode "KVA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV A" ;
+  skos:prefLabel "kilovolt ampere" ;
+.
+unit:KiloV-A-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAB160" ;
+  qudt:plainTextDescription "product of the 1 000-fold of the unit for apparent by ampere and the unit hour" ;
+  qudt:uneceCommonCode "C79" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV A HR" ;
+  skos:prefLabel "kilovolt ampere hour" ;
+.
+unit:KiloV-A_Reactive
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA648" ;
+  qudt:plainTextDescription "1 000-fold of the unit var" ;
+  qudt:uneceCommonCode "KVR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV A Reactive" ;
+  skos:prefLabel "kilovolt ampere reactive" ;
+.
+unit:KiloV-A_Reactive-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:iec61360Code "0112/2///62720#UAB195" ;
+  qudt:plainTextDescription "product of the 1 000-fold of the unit volt ampere reactive and the unit hour" ;
+  qudt:uneceCommonCode "K3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV A Reactive HR" ;
+  skos:prefLabel "kilovolt ampere reactive hour" ;
+.
+unit:KiloV-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA582" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloV PER M" ;
+  skos:prefLabel "kilovolt per metre" ;
+.
+unit:KiloW
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The kilowatt is a derived unit of power in the International System of Units (SI),  The unit, defined as 1,000 joule per second, measures the rate of energy conversion or transfer.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1000.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Watt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA583" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Watt?oldid=494906356"^^xsd:anyURI ;
+  qudt:symbol "kW" ;
+  qudt:uneceCommonCode "KWT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilowatt" ;
+.
+unit:KiloW-HR
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The kilowatt hour, or kilowatt-hour, (symbol \\(kW \\cdot h\\), \\(kW h\\) or \\(kWh\\)) is a unit of energy equal to 1000 watt hours or 3.6 megajoules. For constant power, energy in watt hours is the product of power in watts and time in hours. The kilowatt hour is most commonly known as a billing unit for energy delivered to consumers by electric utilities."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.6E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kilowatt_hour"^^xsd:anyURI ;
+  qudt:expression "\\(kW-h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kilowatt_hour?oldid=494927235"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kilowatthour" ;
+.
+unit:KiloWB-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
+  qudt:iec61360Code "0112/2///62720#UAA585" ;
+  qudt:plainTextDescription "1 000-fold of the SI derived unit weber divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "KiloWB PER M" ;
+  skos:prefLabel "kiloweber per metre" ;
+.
+unit:Kina
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Papua New Guinea"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kina"^^xsd:anyURI ;
+  qudt:expression "\\(PGK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kina?oldid=477155361"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kina" ;
+.
+unit:Kroon
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Estonia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Estonian_kroon"^^xsd:anyURI ;
+  qudt:expression "\\(EEK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Estonian_kroon?oldid=492626188"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kroon" ;
+.
+unit:KuwaitiDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kuwait"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kuwaiti_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(KWD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kuwaiti_dinar?oldid=489547428"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kuwaiti Dinar" ;
+.
+unit:Kwanza
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Angola"^^rdf:HTML ;
+  qudt:currencyExponent 1 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Angolan_kwanza"^^xsd:anyURI ;
+  qudt:expression "\\(AOA\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Angolan_kwanza?oldid=491748749"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kwanza" ;
+.
+unit:Kyat
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Myanmar"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Myanma_kyat"^^xsd:anyURI ;
+  qudt:expression "\\(MMK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Myanma_kyat?oldid=441109905"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Kyat" ;
+.
+unit:L
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The \\(litre\\) (American spelling: \\(\\textit{liter}\\); SI symbol \\(l\\) or \\(L\\)) is a non-SI metric system unit of volume equal to \\(1 \\textit{cubic decimetre}\\) (\\(dm^3\\)), 1,000 cubic centimetres (\\(cm^3\\)) or \\(1/1000 \\textit{cubic metre}\\). If the lower case \"L\" is used as the symbol, it is sometimes rendered as a cursive \"l\" to help distinguish it from the capital \"I\", although this usage has no official approval by any international bureau.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Litre"^^xsd:anyURI ;
+  qudt:exactMatch unit:L ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Litre?oldid=494846400"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/litre> ;
+  qudt:symbol "L" ;
+  qudt:ucumCaseInsensitiveCode "L" ;
+  qudt:ucumCaseSensitiveCode "l" ;
+  qudt:ucumCode "L" ;
+  qudt:ucumCode "l" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Liter" ;
+  skos:altLabel "litre" ;
+.
+unit:L-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA652" ;
+  qudt:plainTextDescription "unit litre divided by the unit day" ;
+  qudt:uneceCommonCode "LD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER DAY" ;
+  skos:prefLabel "litre per day" ;
+.
+unit:L-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA655" ;
+  qudt:plainTextDescription "Unit litre divided by the unit hour" ;
+  qudt:uneceCommonCode "E32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER HR" ;
+  skos:prefLabel "litre per hour" ;
+.
+unit:L-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA650" ;
+  qudt:plainTextDescription "unit litre divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "G28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER K" ;
+  skos:prefLabel "litre per kelvin" ;
+.
+unit:L-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
+  qudt:iec61360Code "0112/2///62720#UAB380" ;
+  qudt:plainTextDescription "unit of the volume litre divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "H83" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER KiloGM" ;
+  skos:prefLabel "litre per kilogram" ;
+.
+unit:L-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA658" ;
+  qudt:plainTextDescription "volume ratio consisting of the unit litre divided by the unit litre" ;
+  qudt:uneceCommonCode "K62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER L" ;
+  skos:prefLabel "litre per litre" ;
+.
+unit:L-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA659" ;
+  qudt:plainTextDescription "unit litre divided by the unit minute" ;
+  qudt:uneceCommonCode "L2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER MIN" ;
+  skos:prefLabel "litre per minute" ;
+.
+unit:L-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA662" ;
+  qudt:plainTextDescription "unit litre divided by the SI base unit mol" ;
+  qudt:uneceCommonCode "B58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER MOL" ;
+  skos:prefLabel "litre per mole" ;
+.
+unit:L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA664" ;
+  qudt:plainTextDescription "unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "G51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "L PER SEC" ;
+  skos:prefLabel "litre per second" ;
+.
+unit:LA
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The lambert (symbol \\(L\\), \\(la\\) or \\(Lb\\)) is a non-SI unit of luminance. A related unit of luminance, the foot-lambert, is used in the lighting, cinema and flight simulation industries. The SI unit is the candela per square metre (\\(cd/m^2\\))."^^qudt:LatexString ;
+  qudt:conversionMultiplier "3183.09886"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lambert"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
+  qudt:iec61360Code "0112/2///62720#UAB259" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lambert?oldid=494078267"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lambert> ;
+  qudt:symbol "L" ;
+  qudt:ucumCaseInsensitiveCode "LMB" ;
+  qudt:ucumCaseSensitiveCode "Lmb" ;
+  qudt:ucumCode "LMB" ;
+  qudt:ucumCode "Lmb" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lambert" ;
+.
+unit:LB_F
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force\" is an Imperial unit for  'Force' expressed as \\(lbf\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "4.448222"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pound-force"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pound-force?oldid=453191483"^^xsd:anyURI ;
+  qudt:symbol "lbf" ;
+  qudt:ucumCaseInsensitiveCode "[LBF_AV]" ;
+  qudt:ucumCaseSensitiveCode "[lbf_av]" ;
+  qudt:ucumCode "[LBF_AV]" ;
+  qudt:ucumCode "[lbf_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force" ;
+.
+unit:LB_F-FT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force Foot\" is an Imperial unit for  'Torque' expressed as \\(lbf-ft\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.35581807"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf-ft\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force Foot" ;
+.
+unit:LB_F-IN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force Inch\" is an Imperial unit for  'Torque' expressed as \\(lbf-in\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.112984839"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf-in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force Inch" ;
+.
+unit:LB_F-PER-FT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force per Foot\" is an Imperial unit for  'Force Per Length' expressed as \\(lbf/ft\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "14.5939042"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf/ft\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Foot" ;
+.
+unit:LB_F-PER-FT2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "Pounds or Pounds Force per Square Foot is a British (Imperial) and American pressure unit which is directly related to the psi pressure unit by a factor of 144 (1 sq ft = 12 in x 12 in = 144 sq in). 1 Pound per Square Foot equals 47.8803 Pascals. The psf pressure unit is mostly for lower pressure applications such as specifying building structures to withstand a certain wind force or rating a building floor for maximum weight load."^^rdf:HTML ;
+  qudt:conversionMultiplier "47.8802631"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Square Foot" ;
+.
+unit:LB_F-PER-IN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force per Inch\" is an Imperial unit for  'Force Per Length' expressed as \\(lbf/in\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "175.12685"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf/in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Inch" ;
+.
+unit:LB_F-PER-IN2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force per Square Inch\" is an Imperial unit for  'Force Per Area' expressed as \\(psia\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6894.75789"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pounds_per_square_inch"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pounds_per_square_inch?oldid=485678341"^^xsd:anyURI ;
+  qudt:symbol "psia" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Square Inch" ;
+.
+unit:LB_F-PER-IN2-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.241056e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA702" ;
+  qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the unit degree Fahrenheit for temperature" ;
+  qudt:uneceCommonCode "K86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_F PER IN2 DEG_F" ;
+  skos:prefLabel "pound force per square inch degree Fahrenheit" ;
+.
+unit:LB_F-PER-IN2-SEC
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force per Square Inch Second\" is a unit for  'Force Per Area Time' expressed as \\(lbf / in^{2}-s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6894.75789"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf / in^{2}-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Square Inch Second" ;
+.
+unit:LB_F-PER-LB_M
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force per Pound\" is an Imperial unit for  'Thrust To Mass Ratio' expressed as \\(lbf/lb\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "9.80665085"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf/lb\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force per Pound" ;
+.
+unit:LB_F-SEC-PER-FT2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force Second per Square Foot\" is an Imperial unit for  'Dynamic Viscosity' expressed as \\(lbf-s/ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "47.8802631"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf-s/ft^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force Second per Square Foot" ;
+.
+unit:LB_F-SEC-PER-IN2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound Force Second per Square Inch\" is an Imperial unit for  'Dynamic Viscosity' expressed as \\(lbf-s/in^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6894.75789"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lbf-s/in^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Force Second per Square Inch" ;
+.
+unit:LB_M
+  a qudt:CGS-Unit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A pound of mass, based on the international standard definition of the pound as exactly 0.45359237 kg."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.45359237"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "lbm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Mass" ;
+.
+unit:LB_M-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Pound Degree Fahrenheit</em> is an Imperial unit for 'Mass Temperature' expressed as \\(lb-degF\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Degree Fahrenheit" ;
+.
+unit:LB_M-DEG_R
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Pound Degree Rankine</em> is an Imperial unit for 'Mass Temperature' expressed as \\(lb-degR\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb-degR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Degree Rankine" ;
+.
+unit:LB_M-FT2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.214011e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MomentOfInertia ;
+  qudt:iec61360Code "0112/2///62720#UAA671" ;
+  qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 2" ;
+  qudt:uneceCommonCode "K65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB FT2" ;
+  skos:prefLabel "pound mass (avoirdupois) foot squared" ;
+.
+unit:LB_M-IN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.1521246198e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:iec61360Code "0112/2///62720#UAB194" ;
+  qudt:plainTextDescription "unit of the unbalance (product of avoirdupois pound according to the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units)" ;
+  qudt:uneceCommonCode "IA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB IN" ;
+  skos:prefLabel "pound mass (avoirdupois) inch" ;
+.
+unit:LB_M-IN2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.926397e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MomentOfInertia ;
+  qudt:iec61360Code "0112/2///62720#UAA672" ;
+  qudt:plainTextDescription "product of the unit pound according to the avoirdupois system of units and the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 2" ;
+  qudt:uneceCommonCode "F20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB IN2" ;
+  skos:prefLabel "pound mass (avoirdupois) inch squared" ;
+.
+unit:LB_M-MOL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><strong>Pound Mole</strong> is a unit for <em>'Mass Amount Of Substance'</em> expressed as \\(lb-mol\\).</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.45359237e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb-mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassAmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAB402" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Mole" ;
+.
+unit:LB_M-MOL-DEG_F
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Pound Mole Degree Fahrenheit</em> is a unit for 'Mass Amount Of Substance Temperature' expressed as \\(lb-mol-degF\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb-mol-degF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassAmountOfSubstanceTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Mole Degree Fahrenheit" ;
+.
+unit:LB_M-PER-DAY
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M1H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticField ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassFlowRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerTime ;
+  qudt:conversionMultiplier 5.249912e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA673" ;
+  qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "K66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_M PER DAY" ;
+  skos:prefLabel "pound (avoirdupois) per day" ;
+.
+unit:LB_M-PER-FT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Foot\" is an Imperial unit for  'Mass Per Length' expressed as \\(lb/ft\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.4881639435695537e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/ft\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Foot" ;
+.
+unit:LB_M-PER-FT-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Foot Hour\" is an Imperial unit for  'Dynamic Viscosity' expressed as \\(lb/(ft-hr)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.133788732137649E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/(ft-hr)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Foot Hour" ;
+.
+unit:LB_M-PER-FT-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Foot Second\" is an Imperial unit for  'Dynamic Viscosity' expressed as \\(lb/(ft-s)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.4881639435695537e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/(ft-s)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Foot Second" ;
+.
+unit:LB_M-PER-FT2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.882428e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB262" ;
+  qudt:plainTextDescription "unit for areal-related mass as a unit pound according to the avoirdupois system of units divided by the power of the unit foot according to the Anglo-American and Imperial system of units by exponent 2" ;
+  qudt:uneceCommonCode "FP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB PER FT2" ;
+  skos:prefLabel "pound mass (avoirdupois) per square foot" ;
+.
+unit:LB_M-PER-FT3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Cubic Foot\" is an Imperial unit for  'Density' expressed as \\(lb/ft^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 16.018463373960138e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/ft^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Cubic Foot" ;
+.
+unit:LB_M-PER-GAL
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Gallon\" is an Imperial unit for  'Density' expressed as \\(lb/gal\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "99.7763727"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/gal\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Gallon" ;
+.
+unit:LB_M-PER-GAL_UK
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-3I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Density ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWater ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWaterVapour ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassDensity ;
+  qudt:conversionMultiplier 9.977637e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA679" ;
+  qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the unit gallon (UK) according to the Imperial system of units" ;
+  qudt:uneceCommonCode "K71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_M PER GAL_UK" ;
+  skos:prefLabel "pound (avoirdupois) per gallon (UK)" ;
+.
+unit:LB_M-PER-GAL_US
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-3I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Density ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWater ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassConcentrationOfWaterVapour ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassDensity ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA680" ;
+  qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system divided by the unit gallon (US, liq.) according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "GE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_M PER GAL_US" ;
+  skos:prefLabel "pound (avoirdupois) per gallon (US)" ;
+.
+unit:LB_M-PER-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "Pound per hour is a mass flow unit. It is abbreviated as PPH or more conventionally as lb/h. Fuel flow for engines is usually expressed using this unit, it is particularly useful when dealing with gases or liquids as volume flow varies more with temperature and pressure. \\(1 lb/h = 0.4535927 kg/h = 126.00 mg/s\\).  Minimum fuel intake on a jumbojet can be as low as 150 lb/h when idling, however this is not enough to sustain flight."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.2599788055555556E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pound_per_hour"^^xsd:anyURI ;
+  qudt:expression "\\(PPH\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pound_per_hour?oldid=328571072"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Hour" ;
+.
+unit:LB_M-PER-IN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Inch\" is an Imperial unit for  'Mass Per Length' expressed as \\(lb/in\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 17.857967322834646e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/in\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Inch" ;
+.
+unit:LB_M-PER-IN2
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M1H0T0D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerArea ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MeanMassRange ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SurfaceDensity ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB137" ;
+  qudt:plainTextDescription "unit of the areal-related mass as avoirdupois pound according to the avoirdupois system of units related to the area square inch according to the Anglo-American and Imperial system of units" ;
+  qudt:uneceCommonCode "80" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_M PER IN2" ;
+  skos:prefLabel "pound (avoirdupois) per square inch" ;
+.
+unit:LB_M-PER-IN3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Cubic Inch\" is an Imperial unit for  'Density' expressed as \\(lb/in^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 27679.904710203125e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/in^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Cubic Inch" ;
+.
+unit:LB_M-PER-M3
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Cubic Meter\" is a unit for  'Density' expressed as \\(lb/m^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.45359237"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/m^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Cubic Meter" ;
+.
+unit:LB_M-PER-MIN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Minute\" is an Imperial unit for  'Mass Per Time' expressed as \\(lb/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.007559872833333333e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Minute" ;
+.
+unit:LB_M-PER-SEC
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L0I0M1H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticField ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassFlowRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MassPerTime ;
+  qudt:conversionMultiplier 4.535924e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA692" ;
+  qudt:plainTextDescription "unit of the mass avoirdupois pound according to the avoirdupois system of units divided by the SI base unit for time second" ;
+  qudt:uneceCommonCode "K81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "LB_M PER SEC" ;
+  skos:prefLabel "pound (avoirdupois) per second" ;
+.
+unit:LB_M-PER-YD3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Pound per Cubic Yard\" is an Imperial unit for  'Density' expressed as \\(lb/yd^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.5932764212577829e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lb/yd^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound per Cubic Yard" ;
+.
+unit:LB_T
+  a qudt:CGS-Unit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "An obsolete unit of mass; the Troy Pound has been defined as exactly 5760 grains, or 0.3732417216 kg. A Troy Ounce is 1/12th of a Troy Pound."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.3732417216"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "lbt" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Troy" ;
+.
+unit:LM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit for measuring the flux of light being produced by a light source or received by a surface. The intensity of a light source is measured in candelas. One lumen represents the total flux of light emitted, equal to the intensity in candelas multiplied by the solid angle in steradians into which the light is emitted. A full sphere has a solid angle of \\(4\\cdot\\pi\\) steradians. A light source that uniformly radiates one candela in all directions has a total luminous flux of \\(1 cd\\cdot 4 \\pi sr = 4 \\pi cd \\cdot sr \\approx 12.57 \\; \\text{lumens}\\). \"Lumen\" is a Latin word for light."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lumen"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousFlux ;
+  qudt:iec61360Code "0112/2///62720#UAA718" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lumen?oldid=492885414"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lumen> ;
+  qudt:siUnitsExpression "cd.sr" ;
+  qudt:symbol "lm" ;
+  qudt:ucumCaseInsensitiveCode "LM" ;
+  qudt:ucumCaseSensitiveCode "lm" ;
+  qudt:ucumCode "LM" ;
+  qudt:ucumCode "lm" ;
+  qudt:uneceCommonCode "LUM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "lumen" ;
+.
+unit:LM-PER-W
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "A measurement of luminous efficacy, which is the light output in lumens using one watt of electricity."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:expression "\\(lm-per-w\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LuminousEfficacy ;
+  qudt:iec61360Code "0112/2///62720#UAA719" ;
+  qudt:uneceCommonCode "B61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lumen per Watt" ;
+.
+unit:LM-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "In photometry, the lumen second is the SI derived unit of luminous energy. It is based on the lumen, the SI unit of luminous flux, and the second, the SI base unit of time.  The lumen second is sometimes called the talbot (symbol T).  An older name for the lumen second was the lumberg."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(lm s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LuminousEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAA722" ;
+  qudt:uneceCommonCode "B62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "lumen second" ;
+  skos:altLabel "lumberg" ;
+  skos:altLabel "talbot" ;
+.
+unit:LUX
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit for measuring the illumination (illuminance) of a surface. One lux is defined as an illumination of one lumen per square meter or 0.0001 phot. In considering the various light units, it's useful to think about light originating at a point and shining upon a surface. The intensity of the light source is measured in candelas; the total light flux in transit is measured in lumens (1 lumen = 1 candelau00b7steradian); and the amount of light received per unit of surface area is measured in lux (1 lux = 1 lumen/square meter). One lux is equal to approximately 0.09290 foot candle."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lux"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousFluxPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA723" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lux> ;
+  qudt:siUnitsExpression "lm/m^2" ;
+  qudt:symbol "lx" ;
+  qudt:ucumCaseInsensitiveCode "LX" ;
+  qudt:ucumCaseSensitiveCode "lx" ;
+  qudt:ucumCode "LX" ;
+  qudt:ucumCode "lx" ;
+  qudt:uneceCommonCode "LUX" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lux" ;
+.
+unit:LUX-HR
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """The SI unit for measuring the illumination (illuminance) of a surface. One lux is defined as an illumination of one lumen per square meter or 0.0001 phot. In considering the various light units, it's useful to think about light originating at a point and shining upon a surface. The intensity of the light source is measured in candelas; the total light flux in transit is measured in lumens (1 lumen = 1 candelau00b7steradian); and the amount of light received per unit of surface area is measured in lux (1 lux = 1 lumen/square meter). One lux is equal to approximately 0.09290 foot candle.
+Editors note: The quantity kind for LUX-HR needs checking. At first glance it should be a unit of energy rather than flux."""^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lux"^^xsd:anyURI ;
+  qudt:expression "\\(lx hr\\)"^^qudt:LatexString ;
+  qudt:iec61360Code "0112/2///62720#UAA724" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lux?oldid=494700274"^^xsd:anyURI ;
+  qudt:siUnitsExpression "lm-hr/m^2" ;
+  qudt:uneceCommonCode "B63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lux Hour" ;
+.
+unit:LY
+  a qudt:Unit ;
+  dcterms:description "A unit of length defining the distance, in meters, that light travels in a vacuum in one year."^^rdf:HTML ;
+  qudt:conversionMultiplier 9.4607304725808E15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Light-year"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB069" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Light-year?oldid=495083584"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/lightYear> ;
+  qudt:symbol "ly" ;
+  qudt:ucumCaseInsensitiveCode "[LY]" ;
+  qudt:ucumCaseSensitiveCode "[ly]" ;
+  qudt:ucumCode "[LY]" ;
+  qudt:ucumCode "[ly]" ;
+  qudt:uneceCommonCode "B57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Light Year" ;
+.
+unit:LaoKip
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Laos"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:symbol " ₭" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lao kip" ;
+.
+unit:Lari
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Georgia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lari"^^xsd:anyURI ;
+  qudt:expression "\\(GEL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lari?oldid=486808394"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lari" ;
+.
+unit:LatvianLats
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Latvia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Latvian_lats"^^xsd:anyURI ;
+  qudt:expression "\\(LVL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Latvian_lats?oldid=492800402"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Latvian Lats" ;
+.
+unit:LebanesePound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Lebanon"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lebanese_pound"^^xsd:anyURI ;
+  qudt:expression "\\(LBP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lebanese_pound?oldid=495528740"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lebanese Pound" ;
+.
+unit:Lek
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Albania"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lek"^^xsd:anyURI ;
+  qudt:expression "\\(ALL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lek?oldid=495195665"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lek" ;
+.
+unit:Lempira
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Honduras"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lempira"^^xsd:anyURI ;
+  qudt:expression "\\(HNL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lempira?oldid=389955747"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lempira" ;
+.
+unit:Leone
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Sierra Leone"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Sierra_Leonean_leone"^^xsd:anyURI ;
+  qudt:expression "\\(SLL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sierra_Leonean_leone?oldid=493517965"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Leone" ;
+.
+unit:LiberianDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Liberia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Liberian_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(LRD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Liberian_dollar?oldid=489549110"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Liberian Dollar" ;
+.
+unit:LibyanDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Libya"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Libyan_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(LYD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Libyan_dinar?oldid=491421981"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Libyan Dinar" ;
+.
+unit:Lilangeni
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Swaziland"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Swazi_lilangeni"^^xsd:anyURI ;
+  qudt:expression "\\(SZL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Swazi_lilangeni?oldid=490323340"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lilangeni" ;
+.
+unit:LithuanianLitas
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Lithuania"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Lithuanian_litas"^^xsd:anyURI ;
+  qudt:expression "\\(LTL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Lithuanian_litas?oldid=493046592"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lithuanian Litas" ;
+.
+unit:Loti
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Lesotho"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Loti"^^xsd:anyURI ;
+  qudt:expression "\\(LSL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Loti?oldid=384534708"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Loti" ;
+.
+unit:LunarMass
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Moon"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Moon?oldid=494566371"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Lunar mass" ;
+.
+unit:M
+  a qudt:BaseUnit ;
+  a qudt:MKS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The metric and SI base unit of distance.  The 17th General Conference on Weights and Measures in 1983 defined the meter as that distance that makes the speed of light in a vacuum equal to exactly 299 792 458 meters per second. The speed of light in a vacuum, \\(c\\), is one of the fundamental constants of nature. The meter is equal to approximately 1.093 613 3 yards, 3.280 840 feet, or 39.370 079 inches."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Metre"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA726" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Metre?oldid=495145797"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/metre> ;
+  qudt:plainTextDescription "The metric and SI base unit of distance.   The meter is equal to approximately 1.093 613 3 yards, 3.280 840 feet, or 39.370 079 inches." ;
+  qudt:symbol "m" ;
+  qudt:ucumCaseInsensitiveCode "M" ;
+  qudt:ucumCaseSensitiveCode "m" ;
+  qudt:ucumCode "M" ;
+  qudt:ucumCode "m" ;
+  qudt:uneceCommonCode "MTR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter" ;
+.
+unit:M-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Meter Kelvin</em> is a unit for 'Length Temperature' expressed as \\(m K\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LengthTemperature ;
+  qudt:iec61360Code "0112/2///62720#UAB170" ;
+  qudt:symbol "m K" ;
+  qudt:uneceCommonCode "D18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter Kelvin" ;
+.
+unit:M-K-PER-W
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Meter Kelvin per Watt</em> is a unit for 'Thermal Resistivity' expressed as \\(K-m/W\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(K-m/W\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalResistivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter Kelvin per Watt" ;
+.
+unit:M-KiloGM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m-kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:ucumCaseInsensitiveCode "M.KG" ;
+  qudt:ucumCaseSensitiveCode "m.kg" ;
+  qudt:ucumCode "M.KG" ;
+  qudt:ucumCode "m.kg" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter Kilogram" ;
+.
+unit:M-PER-FARAD
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m-per-f\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InversePermittivity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Farad" ;
+.
+unit:M-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Metre per hour is a metric unit of both speed (scalar) and velocity (Vector (geometry)). Its symbol is m/h or mu00b7h-1 (not to be confused with the imperial unit symbol mph. By definition, an object travelling at a speed of 1 m/h for an hour would move 1 metre."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.000277777778"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB328" ;
+  qudt:ucumCaseInsensitiveCode "M.HR-1" ;
+  qudt:ucumCaseInsensitiveCode "M/HR" ;
+  qudt:ucumCaseSensitiveCode "m.h-1" ;
+  qudt:ucumCaseSensitiveCode "m/h" ;
+  qudt:ucumCode "M.HR-1" ;
+  qudt:ucumCode "M/HR" ;
+  qudt:ucumCode "m.h-1" ;
+  qudt:ucumCode "m/h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Hour" ;
+.
+unit:M-PER-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m-per-k\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA728" ;
+  qudt:uneceCommonCode "F52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Kelvin" ;
+.
+unit:M-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Meter Per Minute (m/min) is a unit in the category of Velocity. It is also known as meter/minute, meters per minute, metre per minute, metres per minute. Meter Per Minute (m/min) has a dimension of LT-1 where L is length, and T is time. It can be converted to the corresponding standard SI unit m/s by multiplying its value by a factor of 0.016666666666"^^rdf:HTML ;
+  qudt:conversionMultiplier "0.0166666667"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA732" ;
+  qudt:ucumCaseInsensitiveCode "M.MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "M/MIN" ;
+  qudt:ucumCaseSensitiveCode "m.min-1" ;
+  qudt:ucumCaseSensitiveCode "m/min" ;
+  qudt:ucumCode "M.MIN-1" ;
+  qudt:ucumCode "M/MIN" ;
+  qudt:ucumCode "m.min-1" ;
+  qudt:ucumCode "m/min" ;
+  qudt:uneceCommonCode "2X" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Minute" ;
+.
+unit:M-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """Metre per second is an SI derived unit of both speed (scalar) and velocity (vector quantity which specifies both magnitude and a specific direction), defined by distance in metres divided by time in seconds.
+The official SI symbolic abbreviation is mu00b7s-1, or equivalently either m/s."""^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA733" ;
+  qudt:ucumCaseInsensitiveCode "M.S-1" ;
+  qudt:ucumCaseInsensitiveCode "M/S" ;
+  qudt:ucumCaseSensitiveCode "m.s-1" ;
+  qudt:ucumCaseSensitiveCode "m/s" ;
+  qudt:ucumCode "M.S-1" ;
+  qudt:ucumCode "M/S" ;
+  qudt:ucumCode "m.s-1" ;
+  qudt:ucumCode "m/s" ;
+  qudt:uneceCommonCode "MTS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Second" ;
+.
+unit:M-PER-SEC2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The \\(\\textit{meter per second squared}\\) is the unit of acceleration in the International System of Units (SI). As a derived unit it is composed from the SI base units of length, the metre, and the standard unit of time, the second. Its symbol is written in several forms as \\(m/s^2\\), or \\(m s^{-2}\\). As acceleration, the unit is interpreted physically as change in velocity or speed per time interval, that is, \\(\\textit{metre per second per second}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m/s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAA736" ;
+  qudt:ucumCaseInsensitiveCode "M.S-2" ;
+  qudt:ucumCaseInsensitiveCode "M/S2" ;
+  qudt:ucumCaseSensitiveCode "m.s-2" ;
+  qudt:ucumCaseSensitiveCode "m/s2" ;
+  qudt:ucumCode "M.S-2" ;
+  qudt:ucumCode "M/S2" ;
+  qudt:ucumCode "m.s-2" ;
+  qudt:ucumCode "m/s2" ;
+  qudt:uneceCommonCode "MSK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter per Second Squared" ;
+.
+unit:M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The S I unit of area is the square metre."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Square_metre"^^xsd:anyURI ;
+  qudt:expression "\\(sq-m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA744" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Square_metre?oldid=490945508"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "M2" ;
+  qudt:ucumCaseSensitiveCode "m2" ;
+  qudt:ucumCode "M2" ;
+  qudt:ucumCode "m2" ;
+  qudt:uneceCommonCode "MTK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter" ;
+.
+unit:M2-HR-DEG_C-PER-KiloCAL_IT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 8.59845e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:iec61360Code "0112/2///62720#UAA749" ;
+  qudt:plainTextDescription "product of the power of the SI base unit metre with the exponent 2, of the unit hour for time and the unit degree Celsius for temperature divided by the 1Â 000-fold of the out of use unit for energy international calorie" ;
+  qudt:uneceCommonCode "L14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "M2 HR DEG_C PER KiloCAL_IT" ;
+  skos:prefLabel "metre squared hour degree Celsius per kilocalorie (international table)" ;
+.
+unit:M2-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Meter Kelvin</em> is a unit for 'Area Temperature' expressed as \\(m^{2}-K\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{2}-K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter Kelvin" ;
+.
+unit:M2-K-PER-W
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Square Meter Kelvin per Watt</em> is a unit for 'Thermal Insulance' expressed as \\((K^{2})m/W\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\((K^{2})m/W\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalInsulance ;
+  qudt:iec61360Code "0112/2///62720#UAA746" ;
+  qudt:informativeReference "http://physics.nist.gov/Pubs/SP811/appenB9.html"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter Kelvin per Watt" ;
+.
+unit:M2-PER-J
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:expression "\\(m^2/j\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpectralCross-Section ;
+  qudt:iec61360Code "0112/2///62720#UAA745" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Joule" ;
+.
+unit:M2-PER-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m2-per-k\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaThermalExpansion ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Kelvin" ;
+.
+unit:M2-PER-KiloGM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Square Meter Per Kilogram (m2/kg) is a unit in the category of Specific Area. It is also known as square meters per kilogram, square metre per kilogram, square metres per kilogram, square meter/kilogram, square metre/kilogram. This unit is commonly used in the SI unit system. Square Meter Per Kilogram (m2/kg) has a dimension of M-1L2 where M is mass, and L is length. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^2/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassAttenuationCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA750" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Kilogram" ;
+.
+unit:M2-PER-MOL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Square Meter Per Mole (m2/mol) is a unit in the category of Specific Area. It is also known as square meters per mole, square metre per per, square metres per per, square meter/per, square metre/per. This unit is commonly used in the SI unit system. Square Meter Per Mole (m2/mol) has a dimension of M-1L2 where M is mass, and L is length. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^2/mol\\)"^^qudt:LatexString ;
+  qudt:expression "\\(m^{2}/mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarAttenuationCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA751" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Mole" ;
+.
+unit:M2-PER-N
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Compressibility ;
+  qudt:iec61360Code "0112/2///62720#UAB492" ;
+  qudt:plainTextDescription "power of the SI base unit metre with the exponent 2 divided by the derived SI unit newton" ;
+  qudt:uneceCommonCode "H59" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "M2 PER N" ;
+  skos:prefLabel "metre squared per newton" ;
+.
+unit:M2-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Metres squared per second is the SI derived unit of angular momentum, defined by distance or displacement in metres multiplied by distance again in metres and divided by time in seconds. The unit is written in symbols as m2/s or m2u00b7s-1 or m2s-1. It may be better understood when phrased as \"metres per second times metres\", i.e. the momentum of an object with respect to a position.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{2} s^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA752" ;
+  qudt:uneceCommonCode "S4" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Second" ;
+.
+unit:M2-PER-SR
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:expression "\\(m^2/sr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularCross-Section ;
+  qudt:iec61360Code "0112/2///62720#UAA986" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Steradian?oldid=494317847"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Steradian" ;
+.
+unit:M2-PER-SR-J
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:expression "\\(m^2/sr-j\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpectralAngularCross-Section ;
+  qudt:iec61360Code "0112/2///62720#UAA756" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Steradian Joule" ;
+.
+unit:M2-PER-V-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^2/v-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Mobility ;
+  qudt:iec61360Code "0112/2///62720#UAA748" ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter per Volt Second" ;
+.
+unit:M2-SR
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Square Meter Steradian\" is a unit for  'Area Angle' expressed as \\(m^{2}-sr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{2}-sr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaAngle ;
+  qudt:ucumCaseInsensitiveCode "M2.SR" ;
+  qudt:ucumCaseSensitiveCode "m2.sr" ;
+  qudt:ucumCode "M2.SR" ;
+  qudt:ucumCode "m2.sr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Meter Steradian" ;
+.
+unit:M3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of volume, equal to 106 cm3, 1000 liters, 35.3147 ft3, or 1.307 95 yd3. A cubic meter holds about 264.17 U.S. liquid gallons or 219.99 British Imperial gallons."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Cubic_metre"^^xsd:anyURI ;
+  qudt:expression "\\(m^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA757" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Cubic_metre?oldid=490956678"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "M3" ;
+  qudt:ucumCaseSensitiveCode "m3" ;
+  qudt:ucumCode "M3" ;
+  qudt:ucumCode "m3" ;
+  qudt:uneceCommonCode "MTQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter" ;
+.
+unit:M3-PER-C
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^3/c\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HallCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAB143" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "A38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Meter Cubed per Coulomb" ;
+.
+unit:M3-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA760" ;
+  qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit day" ;
+  qudt:uneceCommonCode "G52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "M3 PER DAY" ;
+  skos:prefLabel "metre cubed per day" ;
+.
+unit:M3-PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Cubic Meter Per Hour (m3/h) is a unit in the category of Volume flow rate. It is also known as cubic meters per hour, cubic metre per hour, cubic metres per hour, cubic meter/hour, cubic metre/hour, cubic meter/hr, cubic metre/hr, flowrate. Cubic Meter Per Hour (m3/h) has a dimension of L3T-1 where L is length, and T is time. It can be converted to the corresponding standard SI unit m3/s by multiplying its value by a factor of 0.00027777777."^^rdf:HTML ;
+  qudt:conversionMultiplier 2.777777777777778E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{3}/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAA763" ;
+  qudt:ucumCaseInsensitiveCode "M3.HR-1" ;
+  qudt:ucumCaseInsensitiveCode "M3/HR" ;
+  qudt:ucumCaseSensitiveCode "m3.h-1" ;
+  qudt:ucumCaseSensitiveCode "m3/h" ;
+  qudt:ucumCode "M3.HR-1" ;
+  qudt:ucumCode "M3/HR" ;
+  qudt:ucumCode "m3.h-1" ;
+  qudt:ucumCode "m3/h" ;
+  qudt:uneceCommonCode "MQH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Hour" ;
+.
+unit:M3-PER-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m3-per-k\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA758" ;
+  qudt:uneceCommonCode "G29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Kelvin" ;
+.
+unit:M3-PER-KiloGM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cubic Meter Per Kilogram (m3/kg) is a unit in the category of Specific volume. It is also known as cubic meters per kilogram, cubic metre per kilogram, cubic metres per kilogram, cubic meter/kilogram, cubic metre/kilogram. This unit is commonly used in the SI unit system. Cubic Meter Per Kilogram (m3/kg) has a dimension of M-1L3 where M is mass, and L is length. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{3}/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA766" ;
+  qudt:ucumCaseInsensitiveCode "M3.KG-1" ;
+  qudt:ucumCaseInsensitiveCode "M3/KG" ;
+  qudt:ucumCaseSensitiveCode "m3.kg-1" ;
+  qudt:ucumCaseSensitiveCode "m3/kg" ;
+  qudt:ucumCode "M3.KG-1" ;
+  qudt:ucumCode "M3/KG" ;
+  qudt:ucumCode "m3.kg-1" ;
+  qudt:ucumCode "m3/kg" ;
+  qudt:uneceCommonCode "A39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Kilogram" ;
+.
+unit:M3-PER-KiloGM-SEC2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{3} kg^{-1} s^{-2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:GravitationalAttraction ;
+  qudt:ucumCaseInsensitiveCode "M3.KG-1.S-2" ;
+  qudt:ucumCaseSensitiveCode "m3.kg-1.s-2" ;
+  qudt:ucumCode "M3.KG-1.S-2" ;
+  qudt:ucumCode "m3.kg-1.s-2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Kilogram Second Squared" ;
+.
+unit:M3-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA767" ;
+  qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "H60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "M3 PER M3" ;
+  skos:prefLabel "metre cubed per metre cubed" ;
+.
+unit:M3-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA768" ;
+  qudt:plainTextDescription "power of the SI base unit metre with the exponent 3 divided by the unit minute" ;
+  qudt:uneceCommonCode "G53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "M3 PER MIN" ;
+  skos:prefLabel "metre cubed per minute" ;
+.
+unit:M3-PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The molar volume, symbol \\(Vm\\), is the volume occupied by one mole of a substance (chemical element or chemical compound) at a given temperature and pressure. It is equal to the molar mass (M) divided by the mass density. It has the SI unit cubic metres per mole \\(m3/mol\\), although it is more practical to use the units cubic decimetres per mole \\(dm3/mol\\) for gases and cubic centimetres per mole \\(cm3/mol\\) for liquids and solids</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{3} mol^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA771" ;
+  qudt:ucumCaseInsensitiveCode "M3/MOL" ;
+  qudt:ucumCaseSensitiveCode "m3/mol" ;
+  qudt:ucumCode "M3/MOL" ;
+  qudt:ucumCode "m3/mol" ;
+  qudt:uneceCommonCode "A40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Mole" ;
+.
+unit:M3-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A cubic metre per second (\\(m^{3}s^{-1}, m^{3}/s\\)), cumecs or cubic meter per second in American English) is a derived SI unit of flow rate equal to that of a stere or cube with sides of one metre ( u0303 39.37 in) in length exchanged or moving each second. It is popularly used for water flow, especially in rivers and streams, and fractions for HVAC values measuring air flow."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{3}/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAA772" ;
+  qudt:ucumCaseInsensitiveCode "M3.S-1" ;
+  qudt:ucumCaseInsensitiveCode "M3/S" ;
+  qudt:ucumCaseSensitiveCode "m3.s-1" ;
+  qudt:ucumCaseSensitiveCode "m3/s" ;
+  qudt:ucumCode "M3.S-1" ;
+  qudt:ucumCode "M3/S" ;
+  qudt:ucumCode "m3.s-1" ;
+  qudt:ucumCode "m3/s" ;
+  qudt:uneceCommonCode "MQS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Second" ;
+.
+unit:M3-PER-SEC2
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Cubic Meter per Second Squared}\\) is a C.G.S System unit for  \\(\\textit{Standard Gravitational Parameter}\\) expressed as \\(m^3/s^2\\)"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^3/s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:StandardGravitationalParameter ;
+  qudt:ucumCaseInsensitiveCode "M3.S-2" ;
+  qudt:ucumCaseInsensitiveCode "M3/S2" ;
+  qudt:ucumCaseSensitiveCode "m3.s-2" ;
+  qudt:ucumCaseSensitiveCode "m3/s2" ;
+  qudt:ucumCode "M3.S-2" ;
+  qudt:ucumCode "M3/S2" ;
+  qudt:ucumCode "m3.s-2" ;
+  qudt:ucumCode "m3/s2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Meter per Second Squared" ;
+.
+unit:M4
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit associated with area moments of inertia."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quartic_metre"^^xsd:anyURI ;
+  qudt:expression "\\(m^{4}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quartic Meter" ;
+.
+unit:MACH
+  a qudt:DimensionlessUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Mach\" is a unit for  'Dimensionless Ratio' expressed as \\(mach\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mach"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MachNumber ;
+  qudt:iec61360Code "0112/2///62720#UAB595" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mach?oldid=492058934"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mach" ;
+.
+unit:MDOLLAR-PER-FLIGHT
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(\\(M\\$/Flight\\)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Million US Dollars per Flight" ;
+.
+unit:MHO
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Mho\" is a C.G.S System unit for  'Electric Conductivity' expressed as \\(mho\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Siemens_%28unit%29"^^xsd:anyURI ;
+  qudt:exactMatch unit:S ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAB200" ;
+  qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/mho> ;
+  qudt:symbol "\\mho" ;
+  qudt:ucumCaseInsensitiveCode "MHO" ;
+  qudt:ucumCaseSensitiveCode "mho" ;
+  qudt:ucumCode "MHO" ;
+  qudt:ucumCode "mho" ;
+  qudt:uneceCommonCode "NQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mho" ;
+.
+unit:MHO_Stat
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"StatMHO\" is the unit of conductance, admittance, and susceptance in the C.G.S e.s.u system of units. One \\(statmho\\) is the conductance between two points in a conductor when a constant potential difference of \\(1 \\; statvolt\\) applied between the points produces in the conductor a current of \\(1 \\; statampere\\), the conductor not being the source of any electromotive force, approximately \\(1.1126 \\times 10^{-12} mho\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.1126e-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:S_Stat ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:informativeReference "http://www.sizes.com/units/statmho.htm"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statmho> ;
+  qudt:symbol "stat\\mho" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statmho" ;
+.
+unit:MI
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The exact length of the land mile varied slightly among English-speaking countries until the international yard and pound agreement in 1959 established the yard as exactly 0.9144 metres, giving a mile of exactly 1,609.344 metres. The United States adopted this international mile for most purposes, but retained the pre-1959 mile for some land-survey data, terming it the US survey mile. In the US, statute mile formally refers to the survey mile, about 3.219 mm (1/8 inch) longer than the international mile (the international mile is exactly 0.0002% less than the US survey mile)."^^rdf:HTML ;
+  qudt:conversionMultiplier "1609.344"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mile"^^xsd:anyURI ;
+  qudt:symbol "mi" ;
+  qudt:ucumCaseInsensitiveCode "[MI_I]" ;
+  qudt:ucumCaseSensitiveCode "[mi_i]" ;
+  qudt:ucumCode "[MI_I]" ;
+  qudt:ucumCode "[mi_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "International Mile" ;
+.
+unit:MI-PER-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "Miles per hour is an imperial unit of speed expressing the number of statute miles covered in one hour. It is currently the standard unit used for speed limits, and to express speeds generally, on roads in the United Kingdom and the United States. A common abbreviation is mph or MPH."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.44704"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Miles_per_hour"^^xsd:anyURI ;
+  qudt:expression "\\(mi/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB111" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Miles_per_hour?oldid=482840548"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "[MI_I].HR-1" ;
+  qudt:ucumCaseInsensitiveCode "[MI_I]/HR" ;
+  qudt:ucumCaseSensitiveCode "[mi_i].h-1" ;
+  qudt:ucumCaseSensitiveCode "[mi_i]/h" ;
+  qudt:ucumCode "[MI_I].HR-1" ;
+  qudt:ucumCode "[MI_I]/HR" ;
+  qudt:ucumCode "[mi_i].h-1" ;
+  qudt:ucumCode "[mi_i]/h" ;
+  qudt:uneceCommonCode "HM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mile per Hour" ;
+.
+unit:MI-PER-MIN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "Miles per minute is an imperial unit of speed expressing the number of statute miles covered in one minute."^^rdf:HTML ;
+  qudt:conversionMultiplier "26.8224"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mi/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB229" ;
+  qudt:ucumCaseInsensitiveCode "[MI_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[MI_I]/MIN" ;
+  qudt:ucumCaseSensitiveCode "[mi_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[mi_i]/min" ;
+  qudt:ucumCode "[MI_I].MIN-1" ;
+  qudt:ucumCode "[MI_I]/MIN" ;
+  qudt:ucumCode "[mi_i].min-1" ;
+  qudt:ucumCode "[mi_i]/min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mile per Minute" ;
+.
+unit:MI2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The square mile (abbreviated as sq mi and sometimes as mi) is an imperial and US unit of measure for an area equal to the area of a square of one statute mile. It should not be confused with miles square, which refers to the number of miles on each side squared. For instance, 20 miles square (20 × 20 miles) is equal to 400 square miles. One square mile is equivalent to: 4,014,489,600 square inches 27,878,400 square feet, 3,097,600 square yards, 640 acres, 258.9988110336 hectares, 2560 roods, 25,899,881,103.36 square centimetres, 2,589,988.110336 square metres, 2.589988110336 square kilometres When applied to a portion of the earth's surface, which is curved rather than flat, 'square mile' is an informal synonym for section."^^rdf:HTML ;
+  qudt:conversionMultiplier "2589988.11"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(square-mile\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB050" ;
+  qudt:ucumCaseInsensitiveCode "[MI_I]2" ;
+  qudt:ucumCaseSensitiveCode "[mi_i]2" ;
+  qudt:ucumCaseSensitiveCode "[mi_us]2" ;
+  qudt:ucumCode "[MI_I]2" ;
+  qudt:ucumCode "[mi_i]2" ;
+  qudt:ucumCode "[mi_us]2" ;
+  qudt:uneceCommonCode "MIK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Mile" ;
+.
+unit:MI3
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A cubic mile is an imperial / U.S. customary unit of volume, used in the United States, Canada, and the United Kingdom. It is defined as the volume of a cube with sides of 1 mile in length. "^^rdf:HTML ;
+  qudt:conversionMultiplier 4.16818183E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mi^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:ucumCaseInsensitiveCode "[MI_I]3" ;
+  qudt:ucumCaseSensitiveCode "[mi_i]3" ;
+  qudt:ucumCode "[MI_I]3" ;
+  qudt:ucumCode "[mi_i]3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Mile" ;
+.
+unit:MIL
+  a qudt:Unit ;
+  dcterms:description "The Mil unit of plane angle, as defined by NATO to be 1/6400 of a circle."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.000490873852"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mil Angle (NATO)" ;
+.
+unit:MIL_Circ
+  a qudt:Unit ;
+  dcterms:description "A circular mil is a unit of area, equal to the area of a circle with a diameter of one mil (one thousandth of an inch). It is a convenient unit for referring to the area of a wire with a circular cross section, because the area in circular mils can be calculated without reference to pi (\\(\\pi\\)). The area in circular mils, A, of a circle with a diameter of d mils, is given by the formula: Electricians in Canada and the United States are familiar with the circular mil because the National Electrical Code (NEC) uses the circular mil to define wire sizes larger than 0000 AWG. In many NEC publications and uses, large wires may be expressed in thousands of circular mils, which is abbreviated in two different ways: MCM or kcmil. For example, one common wire size used in the NEC has a cross-section of 250,000 circular mils, written as 250 kcmil or 250 MCM, which is the first size larger than 0000 AWG used within the NEC. "^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB207" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/circularMil> ;
+  qudt:symbol "cmil" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Circular Mil" ;
+.
+unit:MIN
+  a qudt:Unit ;
+  dcterms:description "A minute is a unit of measurement of time. The minute is a unit of time equal to 1/60 (the first sexagesimal fraction of an hour or 60 seconds. In the UTC time scale, a minute on rare occasions has 59 or 61 seconds; see leap second. The minute is not an SI unit; however, it is accepted for use with SI units. The SI symbol for minute or minutes is min (for time measurement) or the prime symbol after a number, e.g. 5' (for angle measurement, even if it is informally used for time)."^^rdf:HTML ;
+  qudt:conversionMultiplier "60.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:MIN ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA842" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/minute-Time> ;
+  qudt:symbol "min" ;
+  qudt:ucumCaseInsensitiveCode "MIN" ;
+  qudt:ucumCaseSensitiveCode "min" ;
+  qudt:ucumCode "MIN" ;
+  qudt:ucumCode "min" ;
+  qudt:uneceCommonCode "MIN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Minute" ;
+.
+unit:MIN_Angle
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.0002908882"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Angle ;
+  qudt:iec61360Code "0112/2///62720#UAA097" ;
+  qudt:symbol "'" ;
+  qudt:ucumCaseSensitiveCode "'" ;
+  qudt:ucumCode "'" ;
+  qudt:uneceCommonCode "D61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Minute Angle" ;
+.
+unit:MIN_Sidereal
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "Sidereal time is a time-keeping system astronomers use to keep track of the direction to point their telescopes to view a given star in the night sky. A mean sidereal day is about \\(23 h 56 m 4.1 s\\) in length. However, due to variations in the rotation rate of the Earth, the rate of an ideal sidereal clock deviates from any simple multiple of a civil clock. In practice, the difference is kept track of by the difference UTC-UT1, which is measured by radio telescopes and kept on file and available to the public at the IERS and at the United States Naval Observatory. A Sidereal Minute is \\(1/60^{th}\\) of a Sidereal Hour, which is \\(1/24^{th}\\) of a Sidereal Day."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sidereal_time"^^xsd:anyURI ;
+  qudt:isScalingOf unit:HR_Sidereal ;
+  qudt:symbol "min" ;
+  qudt:ucumCaseInsensitiveCode "MIN" ;
+  qudt:ucumCaseSensitiveCode "min" ;
+  qudt:ucumCode "MIN" ;
+  qudt:ucumCode "min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sidereal Minute" ;
+.
+unit:MI_N
+  a qudt:Unit ;
+  dcterms:description "A unit of distance used primarily at sea and in aviation. The nautical mile is defined to be the average distance on the Earth's surface represented by one minute of latitude.  In 1929 an international conference in Monaco redefined the nautical mile to be exactly 1852 meters or 6076.115 49 feet, a distance known as the international nautical mile. The international nautical mile equals about 1.1508 statute miles. There are usually 3 nautical miles in a league. The unit is designed to equal 1/60 degree, although actual degrees of latitude vary from about 59.7 to 60.3 nautical miles. (Note: using data from the Geodetic Reference System 1980, the \"true\" length of a nautical mile would be 1852.216 meters.)"^^rdf:HTML ;
+  qudt:conversionMultiplier "1852.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB065" ;
+  qudt:symbol "n mile" ;
+  qudt:ucumCaseInsensitiveCode "[NMI_I]" ;
+  qudt:ucumCaseSensitiveCode "[nmi_i]" ;
+  qudt:ucumCode "[NMI_I]" ;
+  qudt:ucumCode "[nmi_i]" ;
+  qudt:uneceCommonCode "NMI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nautical Mile" ;
+.
+unit:MI_N-PER-HR
+  a qudt:Unit ;
+  dcterms:description "The knot is a unit of speed equal to one nautical mile (1.852 km) per hour, approximately 1.151 mph. The abbreviation kn is preferred by the International Hydrographic Organization (IHO), which includes every major seafaring nation; but the abbreviations kt (singular) and kts (plural) are also widely used conflicting with the SI symbol for kilotonne which is also \"kt\". The knot is a non-SI unit accepted for use with the International System of Units (SI). Worldwide, the knot is used in meteorology, and in maritime and air navigation-for example, a vessel travelling at 1 knot along a meridian travels one minute of geographic latitude in one hour. "^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:KN ;
+  qudt:expression "\\(nmi/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:ucumCaseInsensitiveCode "[NMI_I].HR-1" ;
+  qudt:ucumCaseInsensitiveCode "[NMI_I]/HR" ;
+  qudt:ucumCaseSensitiveCode "[nmi_i].h-1" ;
+  qudt:ucumCaseSensitiveCode "[nmi_i]/h" ;
+  qudt:ucumCode "[NMI_I].HR-1" ;
+  qudt:ucumCode "[NMI_I]/HR" ;
+  qudt:ucumCode "[nmi_i].h-1" ;
+  qudt:ucumCode "[nmi_i]/h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nautical Mile per Hour" ;
+.
+unit:MI_N-PER-MIN
+  a qudt:Unit ;
+  dcterms:description """The SI derived unit for speed is the meter/second.
+1 meter/second is equal to 0.0323974082073 nautical mile per minute. """^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(nmi/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearVelocity ;
+  qudt:ucumCaseInsensitiveCode "[NMI_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[NMI_I]/MIN" ;
+  qudt:ucumCaseSensitiveCode "[nmi_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[nmi_i]/min" ;
+  qudt:ucumCode "[NMI_I].MIN-1" ;
+  qudt:ucumCode "[NMI_I]/MIN" ;
+  qudt:ucumCode "[nmi_i].min-1" ;
+  qudt:ucumCode "[nmi_i]/min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nautical Mile per Minute" ;
+.
+unit:MI_US
+  a qudt:Unit ;
+  dcterms:description "The exact length of the land mile varied slightly among English-speaking countries until the international yard and pound agreement in 1959 established the yard as exactly 0.9144 metres, giving a mile of exactly 1,609.344 metres. The United States adopted this international mile for most purposes, but retained the pre-1959 mile for some land-survey data, terming it the US survey mile. In the US, statute mile formally refers to the survey mile, about 3.219 mm (1/8 inch) longer than the international mile (the international mile is exactly 0.0002\\% less than the US survey mile)."^^rdf:HTML ;
+  qudt:conversionMultiplier "1609.347"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mile"^^xsd:anyURI ;
+  qudt:symbol "mi" ;
+  qudt:ucumCaseInsensitiveCode "[MI_US]" ;
+  qudt:ucumCaseSensitiveCode "[mi_us]" ;
+  qudt:ucumCode "[MI_US]" ;
+  qudt:ucumCode "[mi_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mile US Statute" ;
+.
+unit:MO
+  a qudt:Unit ;
+  dcterms:description "A unit of time corresponding approximately to one cycle of the moon's phases, or about 30 days or 4 weeks. Also known as the 'Synodic Month' and calculated as 29.53059 days."^^rdf:HTML ;
+  qudt:conversionMultiplier "2551442.976"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Month"^^xsd:anyURI ;
+  qudt:exactMatch unit:MO_Synodic ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA880" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Month?oldid=494371020"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.thefreedictionary.com/Synodal+month"^^xsd:anyURI ;
+  qudt:latexDefinition "mo_{j}"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/month> ;
+  qudt:symbol "mo" ;
+  qudt:ucumCaseInsensitiveCode "MO" ;
+  qudt:ucumCaseSensitiveCode "mo" ;
+  qudt:ucumCode "MO" ;
+  qudt:ucumCode "mo" ;
+  qudt:uneceCommonCode "MON" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Month" ;
+.
+unit:MOL
+  a qudt:BaseUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p>The mole is a unit of measurement used in chemistry to express amounts of a chemical substance. The official definition, adopted as part of the SI system in 1971, is that one mole of a substance contains just as many elementary entities (atoms, molecules, ions, or other kinds of particles) as there are atoms in 12 grams of carbon-12 (carbon-12 is the most common atomic form of carbon, consisting of atoms having 6 protons and 6 neutrons).  This corresponds to a value of \\(6.02214179(30) \\times 1023\\) elementary entities of the substance. It is one of the base units in the International System of Units, and has the unit symbol \\(mol\\)</p>
+
+<p>A Mole is the SI base unit of the amount of a substance (as distinct from its mass or weight). Moles measure the actual number of atoms or molecules in an object. An earlier name is gram molecular weight, because one mole of a chemical compound is the same number of grams as the molecular weight of a molecule of that compound measured in atomic mass units. </p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mole_%28unit%29"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAA882" ;
+  qudt:iec61360Code "0112/2///62720#UAD716" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mole_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/mole> ;
+  qudt:symbol "mol" ;
+  qudt:ucumCaseInsensitiveCode "MOL" ;
+  qudt:ucumCaseSensitiveCode "mol" ;
+  qudt:ucumCode "MOL" ;
+  qudt:ucumCode "mol" ;
+  qudt:uneceCommonCode "C34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mole" ;
+.
+unit:MOL-DEG_C
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Mole Degree Celsius</em> is a C.G.S System unit for 'Temperature Amount Of Substance' expressed as \\(mol-degC\\).</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mol-deg-c\\)"^^qudt:LatexString ;
+  qudt:expression "\\(mol-degC\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mole Degree Celsius" ;
+.
+unit:MOL-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><strong>Mole Kelvin</strong> is a unit for <em>'Temperature Amount Of Substance'</em> expressed as \\(mol-K\\)</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:TemperatureAmountOfSubstance ;
+  qudt:symbol "mol-K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mole Kelvin" ;
+.
+unit:MOL-PER-DeciM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA883" ;
+  qudt:plainTextDescription "SI base unit mol divided by the 0,001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "C35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MOL PER DeciM3" ;
+  skos:prefLabel "mole per decimetre cubed" ;
+.
+unit:MOL-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.77778e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA884" ;
+  qudt:plainTextDescription "SI base unit mole divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MOL PER HR" ;
+  skos:prefLabel "mole per hour" ;
+.
+unit:MOL-PER-KiloGM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>TBD</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mol/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mol per Kilogram" ;
+.
+unit:MOL-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA888" ;
+  qudt:plainTextDescription "SI base unit mol divided by the unit litre" ;
+  qudt:uneceCommonCode "C38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MOL PER L" ;
+  skos:prefLabel "mole per litre" ;
+.
+unit:MOL-PER-M3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI derived unit for amount-of-substance concentration is the mole/cubic meter."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mol/m^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA891" ;
+  qudt:uneceCommonCode "C36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mole per Cubic Meter" ;
+.
+unit:MOL-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.6666667e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA894" ;
+  qudt:plainTextDescription "SI base unit mole divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MOL PER MIN" ;
+  skos:prefLabel "mole per minute" ;
+.
+unit:MOL-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MolarFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA895" ;
+  qudt:plainTextDescription "SI base unit mol divided by the SI base unit second" ;
+  qudt:uneceCommonCode "E95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MOL PER SEC" ;
+  skos:prefLabel "mole per second" ;
+.
+unit:MO_MeanGREGORIAN
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#iso1000"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "MO_G" ;
+  qudt:ucumCaseSensitiveCode "mo_g" ;
+  qudt:ucumCode "MO_G" ;
+  qudt:ucumCode "mo_g" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mean Gregorian Month" ;
+.
+unit:MO_MeanJulian
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#iso1000"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "MO_J" ;
+  qudt:ucumCaseSensitiveCode "mo_j" ;
+  qudt:ucumCode "MO_J" ;
+  qudt:ucumCode "mo_j" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mean Julian Month" ;
+.
+unit:MO_Synodic
+  a qudt:Unit ;
+  dcterms:description "A unit of time corresponding approximately to one cycle of the moon's phases, or about 30 days or 4 weeks and calculated as 29.53059 days."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:MO ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://www.thefreedictionary.com/Synodal+month"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "MO_S" ;
+  qudt:ucumCaseSensitiveCode "mo_s" ;
+  qudt:ucumCode "MO_S" ;
+  qudt:ucumCode "mo_s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Synodic month" ;
+.
+unit:MX
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Maxwell\" is a C.G.S System unit for  'Magnetic Flux' expressed as \\(Mx\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Maxwell"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAB155" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Maxwell?oldid=478391976"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/maxwell> ;
+  qudt:symbol "Mx" ;
+  qudt:ucumCaseInsensitiveCode "MX" ;
+  qudt:ucumCaseSensitiveCode "Mx" ;
+  qudt:ucumCode "MX" ;
+  qudt:ucumCode "Mx" ;
+  qudt:uneceCommonCode "B65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Maxwell" ;
+.
+unit:MalagasyAriary
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Madagascar"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Malagasy_ariary"^^xsd:anyURI ;
+  qudt:expression "\\(MGA\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Malagasy_ariary?oldid=489551279"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Malagasy Ariary" ;
+.
+unit:MalawiKwacha
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Malawi"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(MWK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Malawi Kwacha" ;
+.
+unit:MalaysianRinggit
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Malaysia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Malaysian_ringgit"^^xsd:anyURI ;
+  qudt:expression "\\(MYR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Malaysian_ringgit?oldid=494417091"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Malaysian Ringgit" ;
+.
+unit:MalteseLira
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Malta"^^rdf:HTML ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Maltese_lira"^^xsd:anyURI ;
+  qudt:expression "\\(MTL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Maltese_lira?oldid=493810797"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Maltese Lira" ;
+.
+unit:Manat
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Turkmenistan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Manat"^^xsd:anyURI ;
+  qudt:expression "\\(TMM\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Manat?oldid=486967490"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Manat" ;
+.
+unit:MauritiusRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mauritius"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritian_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(MUR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mauritian_rupee?oldid=487629200"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mauritius Rupee" ;
+.
+unit:Mebi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{2}\\), or \\(2^{20}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1048576"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Mi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mebi" ;
+.
+unit:Mega
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'mega' is a decimal prefix for expressing a value with a scaling of \\(10^{6}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mega"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mega?oldid=494040441"^^xsd:anyURI ;
+  qudt:symbol "M" ;
+  qudt:ucumCaseInsensitiveCode "MA" ;
+  qudt:ucumCaseSensitiveCode "M" ;
+  qudt:ucumCode "M" ;
+  qudt:ucumCode "MA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega" ;
+.
+unit:MegaA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA202" ;
+  qudt:plainTextDescription "1 000 000-fold of the SI base unit ampere" ;
+  qudt:uneceCommonCode "H38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaA" ;
+  skos:prefLabel "megaampere" ;
+.
+unit:MegaA-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA203" ;
+  qudt:plainTextDescription "1 000 000-fold of the SI base unit ampere divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "B66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaA PER M2" ;
+  skos:prefLabel "megaampere per metre squared" ;
+.
+unit:MegaBAR
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to 100,000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000 Pa = 1 bar \\approx 750.0616827 Torr\\). Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Mega ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BAR ;
+  qudt:symbol "Mbar" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megabar" ;
+.
+unit:MegaBIT-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A megabit per second (Mbit/s or Mb/s; not to be confused with mbit/s which means millibit per second, or with Mbitps which means megabit picosecond) is a unit of data transfer rate equal to 1,000,000 bits per second or 1,000 kilobits per second or 125,000 bytes per second or 125 kilobytes per second."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DataRate ;
+  qudt:iec61360Code "0112/2///62720#UAA226" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Data_rate_units"^^xsd:anyURI ;
+  qudt:isScalingOf unit:KiloBIT-PER-SEC ;
+  qudt:symbol "mbps" ;
+  qudt:uneceCommonCode "E20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megabit per Second" ;
+.
+unit:MegaBQ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA205" ;
+  qudt:plainTextDescription "1 000 000-fold of the derived unit becquerel" ;
+  qudt:uneceCommonCode "4N" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaBQ" ;
+  skos:prefLabel "megabecquerel" ;
+.
+unit:MegaBYTE
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The megabyte is a multiple of the unit byte for digital information equivalent to \\(2^{6} bytes\\). Although the prefix mega means \\(10^{6}\\), the term megabyte and symbol \\(mB\\) have historically been used to refer to \\(1024^{3} bytes\\) or \\(2^{30} bytes\\). The megabyte is a multiple of the unit byte for digital information storage or transmission with three different values depending on context: 1048576 bytes generally for computer memory; and one million bytes (10, see prefix mega-) generally for computer storage. In rare cases, it is used to mean \\(1000 \\times 1024 (1024,000) bytes\\). The IEEE Standards Board has confirmed that mega means \\(1000,000\\), with exceptions allowed for the base-two meaning."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1048576"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Megabyte"^^xsd:anyURI ;
+  qudt:exactMatch unit:MegaBYTE ;
+  qudt:hasPrefixUnit unit:Mega ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Megabyte?oldid=487094486"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "mB" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega byte" ;
+.
+unit:MegaBYTE_Memory
+  a qudt:BinaryScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The megabyte is a multiple of the unit byte for digital information equivalent to \\(2^{6} bytes\\). Although the prefix mega means \\(10^{6}\\), the term megabyte and symbol \\(mB\\) have historically been used to refer to \\(1024^{3} bytes\\) or \\(2^{30} bytes\\). The megabyte is a multiple of the unit byte for digital information storage or transmission with three different values depending on context: 1048576 bytes generally for computer memory; and one million bytes (10, see prefix mega-) generally for computer storage. In rare cases, it is used to mean \\(1000 \\times 1024 (1024,000) bytes\\). The IEEE Standards Board has confirmed that mega- means 1000000, with exceptions allowed for the base-two meaning."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1048576"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Megabyte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Exbi ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Megabyte?oldid=487094486"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "mB" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaByte of Memory" ;
+.
+unit:MegaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A MegaCoulomb is \\(10^{6} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e06 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Mega ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA206" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "MC" ;
+  qudt:uneceCommonCode "D77" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:MegaC-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA207" ;
+  qudt:plainTextDescription "1 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "B70" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaC PER M2" ;
+  skos:prefLabel "megacoulomb per metre squared" ;
+.
+unit:MegaC-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA208" ;
+  qudt:plainTextDescription "1 000 000-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B69" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaC PER M3" ;
+  skos:prefLabel "megacoulomb per metre cubed" ;
+.
+unit:MegaEV
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Mega Electron Volt</em> is a unit for  'Energy And Work' expressed as \\(MeV\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-13 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:symbol "MeV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Electron Volt" ;
+.
+unit:MegaEV-FemtoM
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Mega Electron Volt Femtometer</em> is a unit for  'Length Energy' expressed as \\(MeV fm\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.60217653E-28 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Mega ;
+  qudt:hasQuantityKind quantitykind:LengthEnergy ;
+  qudt:symbol "MeV fm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Electron Volt Femtometer" ;
+.
+unit:MegaEV-PER-CentiM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Mega Electron Volt per Centimeter\" is a unit for  'Linear Energy Transfer' expressed as \\(MeV/cm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.6021765314E-11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(MeV/cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearEnergyTransfer ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Electron Volt per Centimeter" ;
+.
+unit:MegaEV-PER-SpeedOfLight
+  a qudt:Unit ;
+  dcterms:description "\"Mega Electron Volt per Speed of Light\" is a unit for  'Linear Momentum' expressed as \\(MeV/c\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(MeV/c\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LinearMomentum ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Electron Volt per Speed of Light" ;
+.
+unit:MegaGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA228" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "2U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaGM" ;
+  skos:prefLabel "megagram" ;
+.
+unit:MegaGM-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA229" ;
+  qudt:plainTextDescription "1 000-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B72" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaGM PER M3" ;
+  skos:prefLabel "megagram per metre cubed" ;
+.
+unit:MegaHZ
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Megahertz\" is a C.G.S System unit for  'Frequency' expressed as \\(MHz\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:iec61360Code "0112/2///62720#UAA209" ;
+  qudt:symbol "MHz" ;
+  qudt:ucumCaseInsensitiveCode "MAHZ" ;
+  qudt:ucumCaseSensitiveCode "MHz" ;
+  qudt:ucumCode "MAHZ" ;
+  qudt:ucumCode "MHz" ;
+  qudt:uneceCommonCode "MHZ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megahertz" ;
+.
+unit:MegaHZ-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Speed ;
+  qudt:iec61360Code "0112/2///62720#UAA210" ;
+  qudt:plainTextDescription "product of the 1 000 000-fold of the SI derived unit hertz and the 1 000-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaHZ M" ;
+  skos:prefLabel "megahertz metre" ;
+.
+unit:MegaHZ-PER-K
+  a qudt:Unit ;
+  dcterms:description "<p><em>Mega Hertz per Kelvin</em> is a unit for 'Inverse Time Temperature' expressed as \\(MHz K^{-1}\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(MHz K^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseTimeTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Hertz per Kelvin" ;
+.
+unit:MegaHZ-PER-T
+  a qudt:Unit ;
+  dcterms:description "\"Mega Hertz per Tesla\" is a unit for  'Electric Charge Per Mass' expressed as \\(MHz T^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(MHz T^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Hertz per Tesla" ;
+.
+unit:MegaJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA211" ;
+  qudt:plainTextDescription "1,000,000-fold of the derived unit joule" ;
+  qudt:uneceCommonCode "3B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaJ" ;
+  skos:prefLabel "megajoule" ;
+.
+unit:MegaJ-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB093" ;
+  qudt:plainTextDescription "1,000,000-fold of the derived SI unit joule divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "JK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaJ PER KiloGM" ;
+  skos:prefLabel "megajoule per kilogram" ;
+.
+unit:MegaJ-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA212" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit joule divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "JM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaJ PER M3" ;
+  skos:prefLabel "megajoule per metre cubed" ;
+.
+unit:MegaJ-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAB177" ;
+  qudt:plainTextDescription "quotient of the 1,000,000-fold of the derived SI unit joule divided by the SI base unit second" ;
+  qudt:uneceCommonCode "D78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaJ PER SEC" ;
+  skos:prefLabel "megajoule per second" ;
+.
+unit:MegaL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB112" ;
+  qudt:plainTextDescription "1 000 000-fold of the unit litre" ;
+  qudt:uneceCommonCode "MAL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaL" ;
+  skos:prefLabel "megalitre" ;
+.
+unit:MegaLB_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.448222E3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pound-force"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pound-force?oldid=453191483"^^xsd:anyURI ;
+  qudt:symbol "Mlbf" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mega Pound Force" ;
+.
+unit:MegaN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA213" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit newton" ;
+  qudt:uneceCommonCode "B73" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaN" ;
+  skos:prefLabel "meganewton" ;
+.
+unit:MegaN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA214" ;
+  qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:uneceCommonCode "B74" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaN M" ;
+  skos:prefLabel "meganewton metre" ;
+.
+unit:MegaOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA198" ;
+  qudt:plainTextDescription "1,000,000-fold of the derived unit ohm" ;
+  qudt:uneceCommonCode "B75" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaOHM" ;
+  skos:prefLabel "megaohm" ;
+.
+unit:MegaPA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA215" ;
+  qudt:plainTextDescription "1,000,000-fold of the derived unit pascal" ;
+  qudt:uneceCommonCode "MPA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaPA" ;
+  skos:prefLabel "megapascal" ;
+.
+unit:MegaPA-L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA218" ;
+  qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F97" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaPA L PER SEC" ;
+  skos:prefLabel "megapascal litre per second" ;
+.
+unit:MegaPA-M3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA219" ;
+  qudt:plainTextDescription "product out of the 1,000,000-fold of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaPA M3 PER SEC" ;
+  skos:prefLabel "megapascal metre cubed per second" ;
+.
+unit:MegaPA-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA217" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit pascal divided by the unit bar" ;
+  qudt:uneceCommonCode "F05" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaPA PER BAR" ;
+  skos:prefLabel "megapascal per bar" ;
+.
+unit:MegaPA-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA216" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit pascal divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaPA PER K" ;
+  skos:prefLabel "megapascal per kelvin" ;
+.
+unit:MegaS-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA220" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B77" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaS PER M" ;
+  skos:prefLabel "megasiemens per metre" ;
+.
+unit:MegaTOE
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">The tonne of oil equivalent (toe) is a unit of energy: the amount of energy released by burning one tonne of crude oil, approximately 42 GJ (as different crude oils have different calorific values, the exact value of the toe is defined by convention; unfortunately there are several slightly different definitions as discussed below). The toe is sometimes used for large amounts of energy, as it can be more intuitive to visualise, say, the energy released by burning 1000 tonnes of oil than 42,000 billion joules (the SI unit of energy).</p>
+<p class=\"lm-para\">Multiples of the toe are used, in particular the megatoe (Mtoe, one million toe) and the gigatoe (Gtoe, one billion toe).</p>"""^^rdf:HTML ;
+  qudt:conversionMultiplier 4.1868E13 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tonne_of_oil_equivalent"^^xsd:anyURI ;
+  qudt:symbol "megatoe" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Megaton of Oil Equivalent" ;
+.
+unit:MegaV
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Voltage ;
+  qudt:iec61360Code "0112/2///62720#UAA221" ;
+  qudt:plainTextDescription "1,000,000-fold of the derived unit volt" ;
+  qudt:uneceCommonCode "B78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaV" ;
+  skos:prefLabel "megavolt" ;
+.
+unit:MegaV-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
+  qudt:iec61360Code "0112/2///62720#UAA222" ;
+  qudt:plainTextDescription "1,000,000-fold of the product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:uneceCommonCode "MVA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaV A" ;
+  skos:prefLabel "megavolt ampere" ;
+.
+unit:MegaV-A_Reactive
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
+  qudt:iec61360Code "0112/2///62720#UAB199" ;
+  qudt:plainTextDescription "1 000 000-fold of the unit volt ampere reactive" ;
+  qudt:uneceCommonCode "MAR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaV A Reactive" ;
+  skos:prefLabel "megavolt ampere reactive" ;
+.
+unit:MegaV-A_Reactive-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Energy ;
+  qudt:iec61360Code "0112/2///62720#UAB198" ;
+  qudt:plainTextDescription "product of the 1 000 000-fold of the unit volt ampere reactive and the unit hour" ;
+  qudt:uneceCommonCode "MAH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaV A Reactive HR" ;
+  skos:prefLabel "megavolt ampere reactive hour" ;
+.
+unit:MegaV-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA223" ;
+  qudt:plainTextDescription "1,000,000-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B79" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaV PER M" ;
+  skos:prefLabel "megavolt per metre" ;
+.
+unit:MegaW
+  a qudt:Unit ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaW" ;
+.
+unit:MegaW-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA225" ;
+  qudt:plainTextDescription "1 000 000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:uneceCommonCode "MWH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MegaW HR" ;
+  skos:prefLabel "megawatt hour" ;
+.
+unit:Metical
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mozambique"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mozambican_metical"^^xsd:anyURI ;
+  qudt:expression "\\(MZN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mozambican_metical?oldid=488225670"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Metical" ;
+.
+unit:MexicanPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mexico"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mexican_peso"^^xsd:anyURI ;
+  qudt:expression "\\(MXN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mexican_peso?oldid=494829813"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/MexicanPeso> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mexican Peso" ;
+.
+unit:MexicanUnidadDeInversion
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mexico"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(MXV\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mexican Unidad de Inversion (UDI) (Funds code)" ;
+.
+unit:Micro
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"micro\" is a decimal prefix for expressing a value with a scaling of \\(10^{-6}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Micro"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Micro?oldid=491618374"^^xsd:anyURI ;
+  qudt:symbol "\\mu" ;
+  qudt:ucumCaseInsensitiveCode "U" ;
+  qudt:ucumCaseSensitiveCode "u" ;
+  qudt:ucumCode "U" ;
+  qudt:ucumCode "u" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Micro" ;
+.
+unit:MicroA
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA057" ;
+  qudt:isScalingOf unit:A ;
+  qudt:latexSymbol "\\(\\mu A\\)"^^qudt:LatexString ;
+  qudt:symbol "µA" ;
+  qudt:uneceCommonCode "B84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "microampere" ;
+.
+unit:MicroBAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAB089" ;
+  qudt:plainTextDescription "0.000001-fold of the unit bar" ;
+  qudt:uneceCommonCode "B85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroBAR" ;
+  skos:prefLabel "microbar" ;
+.
+unit:MicroBQ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA058" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit becquerel" ;
+  qudt:uneceCommonCode "H08" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroBQ" ;
+  skos:prefLabel "microbecquerel" ;
+.
+unit:MicroC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A MicroCoulomb is \\(10^{-6} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-06 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA059" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "\\micro C" ;
+  qudt:uneceCommonCode "B86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:MicroC-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA060" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "B88" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroC PER M2" ;
+  skos:prefLabel "microcoulomb per metre squared" ;
+.
+unit:MicroC-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargeDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA061" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "B87" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroC PER M3" ;
+  skos:prefLabel "microcoulomb per metre cubed" ;
+.
+unit:MicroCi
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "Another commonly used measure of radioactivity, the microcurie: \\(1 \\micro Ci = 3.7 \\times 10 disintegrations per second = 2.22 \\times 10 disintegrations per minute\\). A radiotherapy machine may have roughly 1000 Ci of a radioisotope such as caesium-137 or cobalt-60. This quantity of radioactivity can produce serious health effects with only a few minutes of close-range, un-shielded exposure. The typical human body contains roughly \\(0.1\\micro Ci\\) of naturally occurring potassium-40. "^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.7E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Curie"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA062" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Curie?oldid=495080313"^^xsd:anyURI ;
+  qudt:isScalingOf unit:Ci ;
+  qudt:symbol "Ci" ;
+  qudt:uneceCommonCode "M5" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroCurie" ;
+.
+unit:MicroFARAD
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The \"microfarad\" (symbolized \\(\\mu F\\)) is a unit of capacitance, equivalent to 0.000001 (10 to the -6th power) farad. The microfarad is a moderate unit of capacitance. In utility alternating-current (AC) and audio-frequency (AF) circuits, capacitors with values on the order of \\(1 \\mu F\\) or more are common. At radio frequencies (RF), a smaller unit, the picofarad (pF), is often used."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA063" ;
+  qudt:symbol "microF" ;
+  qudt:uneceCommonCode "4O" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "microfarad" ;
+.
+unit:MicroFARAD-PER-KiloM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA064" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit farad divided by the 1,000-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroFARAD PER KiloM" ;
+  skos:prefLabel "microfarad per kilometre" ;
+.
+unit:MicroFARAD-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA065" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroFARAD PER M" ;
+  skos:prefLabel "microfarad per metre" ;
+.
+unit:MicroG
+  a qudt:Unit ;
+  dcterms:description "\"Microgravity\" is a unit for  'Linear Acceleration' expressed as \\(microG\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 9.80665E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:latexSymbol "\\(\\mu G\\)"^^qudt:LatexString ;
+  qudt:symbol "µG" ;
+  qudt:ucumCaseInsensitiveCode "UGL" ;
+  qudt:ucumCaseSensitiveCode "uGal" ;
+  qudt:ucumCode "UGL" ;
+  qudt:ucumCode "uGal" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Microgravity" ;
+.
+unit:MicroGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA082" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "MC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroGM" ;
+  skos:prefLabel "microgram" ;
+.
+unit:MicroGM-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA083" ;
+  qudt:plainTextDescription "mass ratio as 0.000000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "J33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroGM PER KiloGM" ;
+  skos:prefLabel "microgram per kilogram" ;
+.
+unit:MicroGM-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA084" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:uneceCommonCode "H29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroGM PER L" ;
+  skos:prefLabel "microgram per litre" ;
+.
+unit:MicroGM-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA085" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "GQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroGM PER M3" ;
+  skos:prefLabel "microgram per metre cubed" ;
+.
+unit:MicroH
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The SI derived unit for inductance is the henry. 1 henry is equal to 1000000 microhenry. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:iec61360Code "0112/2///62720#UAA066" ;
+  qudt:symbol "microH" ;
+  qudt:uneceCommonCode "B90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Microhenry" ;
+.
+unit:MicroH-PER-KiloOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA068" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the 1,000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "G98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroH PER KiloOHM" ;
+  skos:prefLabel "microhenry per kiloohm" ;
+.
+unit:MicroH-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permeability ;
+  qudt:iec61360Code "0112/2///62720#UAA069" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "B91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroH PER M" ;
+  skos:prefLabel "microhenry per metre" ;
+.
+unit:MicroH-PER-OHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA067" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:uneceCommonCode "G99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroH PER OHM" ;
+  skos:prefLabel "microhenry per ohm" ;
+.
+unit:MicroIN
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Microinch\" is an Imperial unit for  'Length' expressed as \\(in^{-6}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.54E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:isScalingOf unit:IN ;
+  qudt:latexSymbol "\\(\\mu in\\)"^^qudt:LatexString ;
+  qudt:symbol "µin" ;
+  qudt:ucumCaseInsensitiveCode "U[IN_I]" ;
+  qudt:ucumCaseSensitiveCode "u[in_i]" ;
+  qudt:ucumCode "U[IN_I]" ;
+  qudt:ucumCode "u[in_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Microinch" ;
+.
+unit:MicroL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA088" ;
+  qudt:plainTextDescription "0.000001-fold of the unit litre" ;
+  qudt:uneceCommonCode "4G" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroL" ;
+  skos:prefLabel "microlitre" ;
+.
+unit:MicroL-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA089" ;
+  qudt:plainTextDescription "volume ratio as 0.000001-fold of the unit litre divided by the unit litre" ;
+  qudt:uneceCommonCode "J36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroL PER L" ;
+  skos:prefLabel "microlitre per litre" ;
+.
+unit:MicroM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Micrometer\" is a unit for  'Length' expressed as \\(microm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.000001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Micrometer"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA090" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Micrometer?oldid=491270437"^^xsd:anyURI ;
+  qudt:symbol "\\mu m" ;
+  qudt:ucumCaseInsensitiveCode "UM" ;
+  qudt:ucumCaseSensitiveCode "um" ;
+  qudt:ucumCode "UM" ;
+  qudt:ucumCode "um" ;
+  qudt:uneceCommonCode "4H" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Micrometer" ;
+.
+unit:MicroM-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA091" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroM PER K" ;
+  skos:prefLabel "micrometre per kelvin" ;
+.
+unit:MicroM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA092" ;
+  qudt:plainTextDescription "0.000000000001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "H30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroM2" ;
+  skos:prefLabel "micrometre squared" ;
+.
+unit:MicroMHO
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAB201" ;
+  qudt:plainTextDescription "0.000001-fold of the obsolete unit mho of the electric conductance" ;
+  qudt:uneceCommonCode "NR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroMHO" ;
+  skos:prefLabel "micromho" ;
+.
+unit:MicroMOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAA093" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit mol" ;
+  qudt:uneceCommonCode "FH" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroMOL" ;
+  skos:prefLabel "micromole" ;
+.
+unit:MicroN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA070" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit newton" ;
+  qudt:uneceCommonCode "B92" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroN" ;
+  skos:prefLabel "micronewton" ;
+.
+unit:MicroN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA071" ;
+  qudt:plainTextDescription "0.000001-fold of the product out of the derived SI newton and the SI base unit metre" ;
+  qudt:uneceCommonCode "B93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroN M" ;
+  skos:prefLabel "micronewton metre" ;
+.
+unit:MicroOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA055" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "B94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroOHM" ;
+  skos:prefLabel "microohm" ;
+.
+unit:MicroPA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA073" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit pascal" ;
+  qudt:uneceCommonCode "B96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroPA" ;
+  skos:prefLabel "micropascal" ;
+.
+unit:MicroPOISE
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA072" ;
+  qudt:plainTextDescription "0.000001-fold of the CGS unit of the dynamic viscosity poise" ;
+  qudt:uneceCommonCode "J32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroPOISE" ;
+  skos:prefLabel "micropoise" ;
+.
+unit:MicroRAD
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA094" ;
+  qudt:isScalingOf unit:RAD ;
+  qudt:symbol "microrad" ;
+  qudt:ucumCaseInsensitiveCode "URAD" ;
+  qudt:ucumCaseSensitiveCode "urad" ;
+  qudt:ucumCode "URAD" ;
+  qudt:ucumCode "urad" ;
+  qudt:uneceCommonCode "B97" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "microradian" ;
+.
+unit:MicroS
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA074" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit siemens" ;
+  qudt:uneceCommonCode "B99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroS" ;
+  skos:prefLabel "microsiemens" ;
+.
+unit:MicroS-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA075" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit Siemens divided by the 0,01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "G42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroS PER CentiM" ;
+  skos:prefLabel "microsiemens per centimetre" ;
+.
+unit:MicroS-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA076" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "G43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroS PER M" ;
+  skos:prefLabel "microsiemens per metre" ;
+.
+unit:MicroSEC
+  a qudt:DecimalScaledUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Microsecond\" is a unit for  'Time' expressed as \\(microsec\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.000001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA095" ;
+  qudt:isScalingOf unit:SEC ;
+  qudt:symbol "microsec" ;
+  qudt:ucumCaseInsensitiveCode "US" ;
+  qudt:ucumCaseSensitiveCode "us" ;
+  qudt:ucumCode "US" ;
+  qudt:ucumCode "us" ;
+  qudt:uneceCommonCode "B98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "microsecond" ;
+.
+unit:MicroT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA077" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit tesla" ;
+  qudt:uneceCommonCode "D81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroT" ;
+  skos:prefLabel "microtesla" ;
+.
+unit:MicroTORR
+  a qudt:Unit ;
+  dcterms:description "\"MicroTorr\" is a unit for  'Force Per Area' expressed as \\(microtorr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.33322E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:symbol "\\mu torr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroTorr" ;
+.
+unit:MicroV
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Voltage ;
+  qudt:iec61360Code "0112/2///62720#UAA078" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit volt" ;
+  qudt:uneceCommonCode "D82" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroV" ;
+  skos:prefLabel "microvolt" ;
+.
+unit:MicroV-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA079" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroV PER M" ;
+  skos:prefLabel "microvolt per metre" ;
+.
+unit:MicroW
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA080" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit watt" ;
+  qudt:uneceCommonCode "D80" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroW" ;
+  skos:prefLabel "microwatt" ;
+.
+unit:MicroW-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA081" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit watt divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "D85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MicroW PER M2" ;
+  skos:prefLabel "microwatt per metre squared" ;
+.
+unit:MilLength
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Mil Length\" is a C.G.S System unit for  'Length' expressed as \\(mil\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:symbol "mil" ;
+  qudt:ucumCaseInsensitiveCode "[MIL_I]" ;
+  qudt:ucumCaseSensitiveCode "[mil_i]" ;
+  qudt:ucumCode "[MIL_I]" ;
+  qudt:ucumCode "[mil_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mil Length" ;
+.
+unit:Milli
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'milli' is a decimal prefix for expressing a value with a scaling of \\(10^{-3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Milli-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Milli-?oldid=467190544"^^xsd:anyURI ;
+  qudt:symbol "m" ;
+  qudt:ucumCaseInsensitiveCode "M" ;
+  qudt:ucumCaseSensitiveCode "m" ;
+  qudt:ucumCode "M" ;
+  qudt:ucumCode "m" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Milli" ;
+.
+unit:MilliA
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Micro ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA775" ;
+  qudt:isScalingOf unit:A ;
+  qudt:symbol "mA" ;
+  qudt:uneceCommonCode "4K" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliAmpere" ;
+.
+unit:MilliA-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA777" ;
+  qudt:plainTextDescription "product of the 0.001-fold of the SI base unit ampere and the unit hour" ;
+  qudt:uneceCommonCode "E09" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliA HR" ;
+  skos:prefLabel "milliampere hour" ;
+.
+unit:MilliA-PER-IN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.937008e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA778" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit ampere divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:uneceCommonCode "F08" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliA PER IN" ;
+  skos:prefLabel "milliampere per inch" ;
+.
+unit:MilliA-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA781" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit ampere  divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "F76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliA PER MilliM" ;
+  skos:prefLabel "milliampere per millimetre" ;
+.
+unit:MilliARCSEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A minute of arc, arcminute, or minute arc (MOA), is a unit of angular measurement equal to one sixtieth (1/60) of one degree (circle/21,600), or \\(\\pi /10,800 radians\\). In turn, a second of arc or arcsecond is one sixtieth (1/60) of one minute of arc. Since one degree is defined as one three hundred and sixtieth (1/360) of a rotation, one minute of arc is 1/21,600 of a rotation.  the milliarcsecond, abbreviated mas, is used in astronomy."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.290888209e-06 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:RAD ;
+  qudt:hasQuantityKind quantitykind:AngularMeasurement ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Minute_of_arc"^^xsd:anyURI ;
+  qudt:symbol "mas" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Milli ArcSecond" ;
+.
+unit:MilliBAR
+  a qudt:CGS-Unit ;
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The bar is a non-SI unit of pressure, defined by the IUPAC as exactly equal to 100,000 Pa. It is about equal to the atmospheric pressure on Earth at sea level, and since 1982 the IUPAC has recommended that the standard for atmospheric pressure should be harmonized to \\(100,000 Pa = 1 bar \\approx 750.0616827 Torr\\). Units derived from the bar are the megabar (symbol: Mbar), kilobar (symbol: kbar), decibar (symbol: dbar), centibar (symbol: cbar), and millibar (symbol: mbar or mb). They are not SI or cgs units, but they are accepted for use with the SI."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Milli ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA810" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bar_(unit)"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BAR ;
+  qudt:symbol "mbar" ;
+  qudt:uneceCommonCode "MBR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millibar" ;
+.
+unit:MilliBAR-L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA813" ;
+  qudt:plainTextDescription "product out of the 0.001-fold of the unit bar and the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliBAR L PER SEC" ;
+  skos:prefLabel "millibar litre per second" ;
+.
+unit:MilliBAR-M3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA327" ;
+  qudt:plainTextDescription "product of the unit bar and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F92" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliBAR M3 PER SEC" ;
+  skos:prefLabel "millibar metre cubed per second" ;
+.
+unit:MilliBAR-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA812" ;
+  qudt:plainTextDescription "0.01-fold of the unit bar divided by the unit bar" ;
+  qudt:uneceCommonCode "F04" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliBAR PER BAR" ;
+  skos:prefLabel "millibar per bar" ;
+.
+unit:MilliBAR-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumetricHeatCapacity ;
+  qudt:iec61360Code "0112/2///62720#UAA811" ;
+  qudt:plainTextDescription "0.001-fold of the unit bar divided by the unit temperature kelvin" ;
+  qudt:uneceCommonCode "F84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliBAR PER K" ;
+  skos:prefLabel "millibar per kelvin" ;
+.
+unit:MilliC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A MilliCoulomb is \\(10^{-3} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Milli ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA782" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "mC" ;
+  qudt:uneceCommonCode "D86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:MilliC-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  qudt:iec61360Code "0112/2///62720#UAA783" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "C8" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliC PER KiloGM" ;
+  skos:prefLabel "millicoulomb per kilogram" ;
+.
+unit:MilliC-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA784" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "D89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliC PER M2" ;
+  skos:prefLabel "millicoulomb per metre squared" ;
+.
+unit:MilliC-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA785" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit coulomb divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "D88" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliC PER M3" ;
+  skos:prefLabel "millicoulomb per metre cubed" ;
+.
+unit:MilliCi
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.7e+07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Activity ;
+  qudt:iec61360Code "0112/2///62720#UAA786" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit curie" ;
+  qudt:uneceCommonCode "MCU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliCi" ;
+  skos:prefLabel "millicurie" ;
+.
+unit:MilliDEG_C
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Millidegree Celsius is a scaled unit of measurement for temperature.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1E-03 ;
+  qudt:conversionOffset "273.15"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Celsius"^^xsd:anyURI ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec04.html#4.2.1.1\">SP811 section 4.2.1.1</a></p>"^^rdf:HTML ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec06.html#6.2.8\">SP811 section 6.2.8</a></p>"^^rdf:HTML ;
+  qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Celsius?oldid=494152178"^^xsd:anyURI ;
+  qudt:isScalingOf unit:DEG_C ;
+  qudt:latexDefinition "millieDegree Celsius"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millidegree Celsius" ;
+.
+unit:MilliFARAD
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA787" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit farad" ;
+  qudt:uneceCommonCode "C10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliFARAD" ;
+  skos:prefLabel "millifarad" ;
+.
+unit:MilliG
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Milligravity\" is a unit for  'Linear Acceleration' expressed as \\(mG\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 9.80665E-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LinearAcceleration ;
+  qudt:symbol "mG" ;
+  qudt:ucumCaseInsensitiveCode "MGL" ;
+  qudt:ucumCaseSensitiveCode "mGal" ;
+  qudt:ucumCode "MGL" ;
+  qudt:ucumCode "mGal" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Milligravity" ;
+.
+unit:MilliGAL
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-2D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Acceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearAcceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleAcceleration ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ThrustToMassRatio ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Acceleration ;
+  qudt:iec61360Code "0112/2///62720#UAB043" ;
+  qudt:plainTextDescription "0.001-fold of the unit of acceleration called gal according to the CGS system of units" ;
+  qudt:uneceCommonCode "C11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGAL" ;
+  skos:prefLabel "milligal" ;
+.
+unit:MilliGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA815" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "MGM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM" ;
+  skos:prefLabel "milligram" ;
+.
+unit:MilliGM-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA818" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 0.0001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "H63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER CentiM2" ;
+  skos:prefLabel "milligram per centimetre squared" ;
+.
+unit:MilliGM-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-11 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA819" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit day" ;
+  qudt:uneceCommonCode "F32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER DAY" ;
+  skos:prefLabel "milligram per day" ;
+.
+unit:MilliGM-PER-DeciL
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A derived unit for amount-of-substance concentration measured in mg/dL."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.01"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mg/L\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "milligrams per decilitre" ;
+.
+unit:MilliGM-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA822" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "H64" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER GM" ;
+  skos:prefLabel "milligram per gram" ;
+.
+unit:MilliGM-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-10 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA823" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit hour" ;
+  qudt:uneceCommonCode "4M" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER HR" ;
+  skos:prefLabel "milligram per hour" ;
+.
+unit:MilliGM-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA826" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER KiloGM" ;
+  skos:prefLabel "milligram per kilogram" ;
+.
+unit:MilliGM-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA827" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit litre" ;
+  qudt:uneceCommonCode "M1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER L" ;
+  skos:prefLabel "milligram per litre" ;
+.
+unit:MilliGM-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA828" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER M" ;
+  skos:prefLabel "milligram per metre" ;
+.
+unit:MilliGM-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA829" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "GO" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER M2" ;
+  skos:prefLabel "milligram per metre squared" ;
+.
+unit:MilliGM-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA830" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "GP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER M3" ;
+  skos:prefLabel "milligram per metre cubed" ;
+.
+unit:MilliGM-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA833" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the unit minute" ;
+  qudt:uneceCommonCode "F33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER MIN" ;
+  skos:prefLabel "milligram per minute" ;
+.
+unit:MilliGM-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA836" ;
+  qudt:plainTextDescription "0.000001-fold of the SI base unit kilogram divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGM PER SEC" ;
+  skos:prefLabel "milligram per second" ;
+.
+unit:MilliGRAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDose ;
+  qudt:iec61360Code "0112/2///62720#UAA788" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit gray" ;
+  qudt:uneceCommonCode "C13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliGRAY" ;
+  skos:prefLabel "milligray" ;
+.
+unit:MilliH
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of inductance equal to one thousandth of a henry. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:iec61360Code "0112/2///62720#UAA789" ;
+  qudt:symbol "milliH" ;
+  qudt:uneceCommonCode "C14" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millihenry" ;
+.
+unit:MilliH-PER-KiloOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA791" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the 1 000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "H05" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliH PER KiloOHM" ;
+  skos:prefLabel "millihenry per kiloohm" ;
+.
+unit:MilliH-PER-OHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA790" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit henry divided by the SI derived unit ohm" ;
+  qudt:uneceCommonCode "H06" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliH PER OHM" ;
+  skos:prefLabel "millihenry per ohm" ;
+.
+unit:MilliIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.54e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA841" ;
+  qudt:plainTextDescription "0.001-fold of the unit inch according to the Anglo-American and Imperial system of units" ;
+  qudt:uneceCommonCode "77" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliIN" ;
+  skos:prefLabel "milli?inch" ;
+.
+unit:MilliJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA792" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit joule" ;
+  qudt:uneceCommonCode "C15" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliJ" ;
+  skos:prefLabel "millijoule" ;
+.
+unit:MilliL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA844" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre" ;
+  qudt:uneceCommonCode "MLT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL" ;
+  skos:prefLabel "millilitre" ;
+.
+unit:MilliL-PER-CentiM2-MIN
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:ConductionSpeed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:GroupSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:LinearVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:PhaseSpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundParticleVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Speed ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfLight ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SpeedOfSound ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Velocity ;
+  qudt:conversionMultiplier 1.6666667e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA858" ;
+  qudt:plainTextDescription "quotient of the 0.001-fold of the unit litre and the unit minute divided by the 0,0001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER CentiM2 MIN" ;
+  skos:prefLabel "millilitre per centimetre squared minute" ;
+.
+unit:MilliL-PER-CentiM2-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAB085" ;
+  qudt:plainTextDescription "unit of the volume flow rate millilitre divided by second related to the transfer area as 0.0001-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER CentiM2 SEC" ;
+  skos:prefLabel "millilitre per centimetre squared second" ;
+.
+unit:MilliL-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-11 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA847" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit day" ;
+  qudt:uneceCommonCode "G54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER DAY" ;
+  skos:prefLabel "millilitre per day" ;
+.
+unit:MilliL-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-10 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA850" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit hour" ;
+  qudt:uneceCommonCode "G55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER HR" ;
+  skos:prefLabel "millilitre per hour" ;
+.
+unit:MilliL-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA845" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "G30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER K" ;
+  skos:prefLabel "millilitre per kelvin" ;
+.
+unit:MilliL-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificVolume ;
+  qudt:iec61360Code "0112/2///62720#UAB095" ;
+  qudt:plainTextDescription "0.001-fold of the unit of the volume litre divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "KX" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER KiloGM" ;
+  skos:prefLabel "millilitre per kilogram" ;
+.
+unit:MilliL-PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA853" ;
+  qudt:plainTextDescription "volume ratio consisting of the 0.001-fold of the unit litre divided by the unit litre" ;
+  qudt:uneceCommonCode "L19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER L" ;
+  skos:prefLabel "millilitre per litre" ;
+.
+unit:MilliL-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA854" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "H65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER M3" ;
+  skos:prefLabel "millilitre per metre cubed" ;
+.
+unit:MilliL-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA855" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the unit minute" ;
+  qudt:uneceCommonCode "41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER MIN" ;
+  skos:prefLabel "millilitre per minute" ;
+.
+unit:MilliL-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA859" ;
+  qudt:plainTextDescription "0.001-fold of the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliL PER SEC" ;
+  skos:prefLabel "millilitre per second" ;
+.
+unit:MilliM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The millimetre (International spelling as used by the International Bureau of Weights and Measures) or millimeter (American spelling) (SI unit symbol mm) is a unit of length in the metric system, equal to one thousandth of a metre, which is the SI base unit of length. It is equal to 1000 micrometres or 1000000 nanometres. A millimetre is equal to exactly 5/127 (approximately 0.039370) of an inch."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Millimetre"^^xsd:anyURI ;
+  qudt:expression "\\(mm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA862" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Millimetre?oldid=493032457"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "MM" ;
+  qudt:ucumCaseSensitiveCode "mm" ;
+  qudt:ucumCode "MM" ;
+  qudt:ucumCode "mm" ;
+  qudt:uneceCommonCode "MMT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millimeter" ;
+.
+unit:MilliM-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.777778e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAA866" ;
+  qudt:plainTextDescription "0001-fold of the SI base unit metre divided by the unit hour" ;
+  qudt:uneceCommonCode "H67" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM PER HR" ;
+  skos:prefLabel "millimetre per hour" ;
+.
+unit:MilliM-PER-K
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAA864" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit kelvin" ;
+  qudt:uneceCommonCode "F53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM PER K" ;
+  skos:prefLabel "millimetre per kelvin" ;
+.
+unit:MilliM-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAB378" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit minute" ;
+  qudt:uneceCommonCode "H81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM PER MIN" ;
+  skos:prefLabel "millimetre per minute" ;
+.
+unit:MilliM-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAA867" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "C16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM PER SEC" ;
+  skos:prefLabel "millimetre per second" ;
+.
+unit:MilliM-PER-YR
+  a qudt:Unit ;
+  qudt:conversionMultiplier .171e-11 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAA868" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit metre divided by the unit year" ;
+  qudt:uneceCommonCode "H66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM PER YR" ;
+  skos:prefLabel "millimetre per year" ;
+.
+unit:MilliM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAA871" ;
+  qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "MMK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM2" ;
+  skos:prefLabel "millimetre squared" ;
+.
+unit:MilliM2-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AreaPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA872" ;
+  qudt:plainTextDescription "0.000001-fold of the power of the SI base unit metre with the exponent 2 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "C17" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM2 PER SEC" ;
+  skos:prefLabel "millimetre squared per second" ;
+.
+unit:MilliM3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A metric measure of volume or capacity equal to a cube 1 millimeter on each edge"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mm^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA873" ;
+  qudt:ucumCaseInsensitiveCode "MM3" ;
+  qudt:ucumCaseSensitiveCode "mm3" ;
+  qudt:ucumCode "MM3" ;
+  qudt:ucumCode "mm3" ;
+  qudt:uneceCommonCode "MMQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Millimeter" ;
+.
+unit:MilliM3-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFraction ;
+  qudt:iec61360Code "0112/2///62720#UAA874" ;
+  qudt:plainTextDescription "volume ratio consisting of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3 divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "L21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM3 PER M3" ;
+  skos:prefLabel "millimetre cubed per metre cubed" ;
+.
+unit:MilliM4
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SecondAxialMomentOfArea ;
+  qudt:hasQuantityKind quantitykind:SecondPolarMomentOfArea ;
+  qudt:iec61360Code "0112/2///62720#UAA869" ;
+  qudt:plainTextDescription "0.001-fold of the power of the SI base unit metre with the exponent 4" ;
+  qudt:uneceCommonCode "G77" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM4" ;
+  skos:prefLabel "millimetre to the fourth power" ;
+.
+unit:MilliMOL
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstance ;
+  qudt:iec61360Code "0112/2///62720#UAA877" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit mol" ;
+  qudt:uneceCommonCode "C18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliMOL" ;
+  skos:prefLabel "millimole" ;
+.
+unit:MilliMOL-PER-GM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:IonicStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA878" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the 0.001-fold of the SI base unit kilogram" ;
+  qudt:uneceCommonCode "H68" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliMOL PER GM" ;
+  skos:prefLabel "millimole per gram" ;
+.
+unit:MilliMOL-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitMass ;
+  qudt:hasQuantityKind quantitykind:IonicStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA879" ;
+  qudt:plainTextDescription "0.001-fold of the SI base unit mol divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "D87" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliMOL PER KiloGM" ;
+  skos:prefLabel "millimole per kilogram" ;
+.
+unit:MilliMOL-PER-L
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI derived unit for amount-of-substance concentration is the mmo/L."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mmo/L\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AmountOfSubstancePerUnitVolume ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "millimoles per litre" ;
+.
+unit:MilliM_HG
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The millimeter of mercury is defined as the pressure exerted at the base of a column of fluid exactly 1 mm high, when the density of the fluid is exactly \\(13.5951 g/cm^{3}\\), at a place where the acceleration of gravity is exactly \\(9.80665 m/s^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "86014.2806"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Torr"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Torr?oldid=495199381"^^xsd:anyURI ;
+  qudt:symbol "mmHg" ;
+  qudt:ucumCaseInsensitiveCode "MM[HG]" ;
+  qudt:ucumCaseSensitiveCode "mm[Hg]" ;
+  qudt:ucumCode "MM[HG]" ;
+  qudt:ucumCode "mm[Hg]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millimeter of Mercury" ;
+.
+unit:MilliM_HGA
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Millimeters of Mercury inclusive of atmospheric pressure"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:symbol "mmHgA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Millimeter of Mercury - Absolute" ;
+.
+unit:MilliM_Water
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.80665e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA875" ;
+  qudt:plainTextDescription "unit of the pressure - 1 mmH2O accords the static pressure, which is produced from a water column with a height of 1 mm" ;
+  qudt:uneceCommonCode "HP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliM_Water" ;
+  skos:prefLabel "conventional millimetre of water" ;
+.
+unit:MilliN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA793" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit newton" ;
+  qudt:uneceCommonCode "C20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliN" ;
+  skos:prefLabel "millinewton" ;
+.
+unit:MilliN-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA794" ;
+  qudt:plainTextDescription "0.001-fold of the product of the SI derived unit newton and the SI base unit metre" ;
+  qudt:uneceCommonCode "D83" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliN M" ;
+  skos:prefLabel "millinewton metre" ;
+.
+unit:MilliN-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA795" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit newton divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C22" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliN PER M" ;
+  skos:prefLabel "millinewton per metre" ;
+.
+unit:MilliOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA741" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "E45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliOHM" ;
+  skos:prefLabel "milliohm" ;
+.
+unit:MilliPA
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA796" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit pascal" ;
+  qudt:uneceCommonCode "74" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliPA" ;
+  skos:prefLabel "millipascal" ;
+.
+unit:MilliPA-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA797" ;
+  qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second" ;
+  qudt:uneceCommonCode "C24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliPA SEC" ;
+  skos:prefLabel "millipascal second" ;
+.
+unit:MilliPA-SEC-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA799" ;
+  qudt:plainTextDescription "0.001-fold of the product of the SI derived unit pascal and the SI base unit second divided by the unit of the pressure bar" ;
+  qudt:uneceCommonCode "L16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliPA SEC PER BAR" ;
+  skos:prefLabel "millipascal second per bar" ;
+.
+unit:MilliR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.58E-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DoseEquivalent ;
+  qudt:iec61360Code "0112/2///62720#UAA898" ;
+  qudt:iec61360Code "0112/2///62720#UAB056" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen_(unit)"^^xsd:anyURI ;
+  qudt:plainTextDescription "0.001-fold of the unit roentgen for the effective dose equivalent" ;
+  qudt:uneceCommonCode "2Y" ;
+  qudt:uneceCommonCode "L31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliR" ;
+  skos:prefLabel "milliroentgen equivalent in man" ;
+  skos:prefLabel "milliroentgen" ;
+.
+unit:MilliRAD
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-3 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:guidance "<http://physics.nist.gov/Pubs/SP811/sec07.html#7.10>"^^rdf:HTML ;
+  qudt:hasPrefixUnit unit:Milli ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA897" ;
+  qudt:isScalingOf unit:RAD ;
+  qudt:symbol "mrad" ;
+  qudt:ucumCaseInsensitiveCode "MRAD" ;
+  qudt:ucumCaseSensitiveCode "mrad" ;
+  qudt:ucumCode "MRAD" ;
+  qudt:ucumCode "mrad" ;
+  qudt:uneceCommonCode "C25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "milliradian" ;
+.
+unit:MilliR_man
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.58E-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DoseEquivalent ;
+  qudt:iec61360Code "0112/2///62720#UAA898" ;
+  qudt:iec61360Code "0112/2///62720#UAB056" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Roentgen_equivalent_man"^^xsd:anyURI ;
+  qudt:plainTextDescription "The roentgen equivalent man (or rem) is a CGS unit of equivalent dose, effective dose, and committed dose, which are measures of the health effect of low levels of ionizing radiation on the human body." ;
+  qudt:uneceCommonCode "L31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliR equivalent man" ;
+  skos:prefLabel "milliroentgen equivalent man" ;
+.
+unit:MilliS
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductance ;
+  qudt:iec61360Code "0112/2///62720#UAA800" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit siemens" ;
+  qudt:uneceCommonCode "C27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliS" ;
+  skos:prefLabel "millisiemens" ;
+.
+unit:MilliS-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA801" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliS PER CentiM" ;
+  skos:prefLabel "millisiemens per centimetre" ;
+.
+unit:MilliSEC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Millisecond\" is an Imperial unit for 'Time' expressed as \\(ms\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Millisecond"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Milli ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA899" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Millisecond?oldid=495102042"^^xsd:anyURI ;
+  qudt:isScalingOf unit:SEC ;
+  qudt:symbol "ms" ;
+  qudt:ucumCaseInsensitiveCode "MS" ;
+  qudt:ucumCaseSensitiveCode "ms" ;
+  qudt:ucumCode "MS" ;
+  qudt:ucumCode "ms" ;
+  qudt:uneceCommonCode "C26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "millisecond" ;
+.
+unit:MilliSV
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:DoseEquivalent ;
+  qudt:iec61360Code "0112/2///62720#UAA802" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit sievert" ;
+  qudt:uneceCommonCode "C28" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliSV" ;
+  skos:prefLabel "millisievert" ;
+.
+unit:MilliT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA803" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit tesla" ;
+  qudt:uneceCommonCode "C29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliT" ;
+  skos:prefLabel "millitesla" ;
+.
+unit:MilliTORR
+  a qudt:Unit ;
+  dcterms:description "\"MilliTorr\" is a unit for  'Force Per Area' expressed as \\(utorr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.133322"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:symbol "utorr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliTorr" ;
+.
+unit:MilliV
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Voltage ;
+  qudt:iec61360Code "0112/2///62720#UAA804" ;
+  qudt:plainTextDescription "0,001-fold of the SI derived unit volt" ;
+  qudt:uneceCommonCode "2Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliV" ;
+  skos:prefLabel "millivolt" ;
+.
+unit:MilliV-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA805" ;
+  qudt:plainTextDescription "0.000001-fold of the SI derived unit volt divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliV PER M" ;
+  skos:prefLabel "millivolt per metre" ;
+.
+unit:MilliV-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.666667e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA806" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit volt divided by the unit minute" ;
+  qudt:uneceCommonCode "H62" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliV PER MIN" ;
+  skos:prefLabel "millivolt per minute" ;
+.
+unit:MilliW
+  a qudt:Unit ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliW" ;
+.
+unit:MilliW-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA808" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit weber divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "C32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliW PER M2" ;
+  skos:prefLabel "milliwatt per metre squared" ;
+.
+unit:MilliWB
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAA809" ;
+  qudt:plainTextDescription "0.001-fold of the SI derived unit weber" ;
+  qudt:uneceCommonCode "C33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "MilliWB" ;
+  skos:prefLabel "milliweber" ;
+.
+unit:MillionUSD
+  a qudt:CurrencyUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0E6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Million US Dollars" ;
+.
+unit:MillionUSD-PER-YR
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:expression "\\(\\(M\\$/yr\\)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Million US Dollars per Year" ;
+.
+unit:MoldovanLeu
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Moldova"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Moldovan_leu"^^xsd:anyURI ;
+  qudt:expression "\\(MDL\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Moldovan_leu?oldid=490027766"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Moldovan Leu" ;
+.
+unit:MoroccanDirham
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Morocco, Western Sahara"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Moroccan_dirham"^^xsd:anyURI ;
+  qudt:expression "\\(MAD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Moroccan_dirham?oldid=490560557"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Moroccan Dirham" ;
+.
+unit:N
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The \"Newton\" is the SI unit of force. A force of one newton will accelerate a mass of one kilogram at the rate of one meter per second per second. The newton is named for Isaac Newton (1642-1727), the British mathematician, physicist, and natural philosopher. He was the first person to understand clearly the relationship between force (F), mass (m), and acceleration (a) expressed by the formula \\(F = m \\cdot a\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Newton"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAA235" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Newton?oldid=488427661"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/newton> ;
+  qudt:symbol "N" ;
+  qudt:ucumCaseInsensitiveCode "N" ;
+  qudt:ucumCode "N" ;
+  qudt:uneceCommonCode "NEW" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton" ;
+.
+unit:N-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA237" ;
+  qudt:plainTextDescription "product of the SI derived unit newton and the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "F88" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N CentiM" ;
+  skos:prefLabel "newton centimetre" ;
+.
+unit:N-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Torque\" is the tendency of a force to cause a rotation, is the product of the force and the distance from the center of rotation to the point where the force is applied. Torque has the same units as work or energy, but it is a different physical concept. To stress the difference, scientists measure torque in newton meters rather than in joules, the SI unit of work. One newton meter is approximately 0.737562 pound foot."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Newton_metre"^^xsd:anyURI ;
+  qudt:exactMatch unit:J ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  qudt:iec61360Code "0112/2///62720#UAA239" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Newton_metre?oldid=493923333"^^xsd:anyURI ;
+  qudt:siUnitsExpression "N.m" ;
+  qudt:symbol "N-m" ;
+  qudt:uneceCommonCode "NU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton Meter" ;
+.
+unit:N-M-PER-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAA241" ;
+  qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the SI base unit ampere" ;
+  qudt:uneceCommonCode "F90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N M PER A" ;
+  skos:prefLabel "newton metre per ampere" ;
+.
+unit:N-M-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpecificEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB490" ;
+  qudt:plainTextDescription "product of the derived SI unit newton and the SI base unit metre divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "G19" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N M PER KiloGM" ;
+  skos:prefLabel "newton metre per kilogram" ;
+.
+unit:N-M-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA244" ;
+  qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit metre divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "H86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N M PER M2" ;
+  skos:prefLabel "newton metre per square metre" ;
+.
+unit:N-M-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI derived unit of angular momentum. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Newton_metre"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AngularMomentum ;
+  qudt:iec61360Code "0112/2///62720#UAA245" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/SI_derived_unit"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:siUnitsExpression "N.m.sec" ;
+  qudt:symbol "N-m-sec" ;
+  qudt:uneceCommonCode "C53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton Meter Second" ;
+.
+unit:N-M2-PER-KiloGM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:GravitationalConstant ;
+  qudt:iec61360Code "0112/2///62720#UAB491" ;
+  qudt:plainTextDescription "unit of gravitational constant as product of the derived SI unit newton, the power of the SI base unit metre with the exponent 2 divides by the power of the SI base unit kilogram with the exponent 2" ;
+  qudt:uneceCommonCode "C54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N M2 PER KiloGM2" ;
+  skos:prefLabel "newton metre squared per kilogram squared" ;
+.
+unit:N-PER-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  qudt:iec61360Code "0112/2///62720#UAA236" ;
+  qudt:plainTextDescription "SI derived unit newton divided by the SI base unit ampere" ;
+  qudt:uneceCommonCode "H40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N PER A" ;
+  skos:prefLabel "newton per ampere" ;
+.
+unit:N-PER-C
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Newton Per Coulomb ( N/C) is a unit in the category of Electric field strength. It is also known as newtons/coulomb. Newton Per Coulomb ( N/C) has a dimension of MLT-3I-1 where M is mass, L is length, T is time, and I is electric current. It essentially the same as the corresponding standard SI unit V/m."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(N/C\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerElectricCharge ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton per Coulomb" ;
+.
+unit:N-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA238" ;
+  qudt:plainTextDescription "SI derived unit newton divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "M23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N PER CentiM" ;
+  skos:prefLabel "newton per centimetre" ;
+.
+unit:N-PER-CentiM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAB183" ;
+  qudt:plainTextDescription "derived SI unit newton divided by the 0,000 1-fold of the power of the SI base unit metre by exponent 2" ;
+  qudt:uneceCommonCode "E01" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N PER CentiM2" ;
+  skos:prefLabel "newton per centimetre squared" ;
+.
+unit:N-PER-KiloGM
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Gravitational field strength at a point is the gravitational force per unit mass at that point. It is a vector and its S.I. unit is N kg-1."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(N/kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThrustToMassRatio ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton per Kilogram" ;
+.
+unit:N-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Newton Per Meter (N/m) is a unit in the category of Surface tension. It is also known as newtons per meter, newton per metre, newtons per metre, newton/meter, newton/metre. This unit is commonly used in the SI unit system. Newton Per Meter (N/m) has a dimension of MT-2 where M is mass, and T is time. This unit is the standard SI unit in this category."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(N/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA246" ;
+  qudt:uneceCommonCode "4P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton per Meter" ;
+.
+unit:N-PER-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of pressure. The pascal is the standard pressure unit in the MKS metric system, equal to one newton per square meter or one \"kilogram per meter per second per second.\" The unit is named for Blaise Pascal (1623-1662), French philosopher and mathematician, who was the first person to use a barometer to measure differences in altitude."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pascal"^^xsd:anyURI ;
+  qudt:exactMatch unit:PA ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31889"^^xsd:anyURI ;
+  qudt:siUnitsExpression "N/m^2" ;
+  qudt:symbol "Pa" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N-PER-M2" ;
+.
+unit:N-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA249" ;
+  qudt:plainTextDescription "SI derived unit newton divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "F47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N PER MilliM" ;
+  skos:prefLabel "newton per millimetre" ;
+.
+unit:N-PER-MilliM2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Pressure ;
+  qudt:iec61360Code "0112/2///62720#UAA250" ;
+  qudt:plainTextDescription "SI derived unit newton divided by the 0.000001-fold of the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "C56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N PER MilliM2" ;
+  skos:prefLabel "newton per millimetre squared" ;
+.
+unit:N-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearMomentum ;
+  qudt:iec61360Code "0112/2///62720#UAA251" ;
+  qudt:plainTextDescription "product of the SI derived unit newton and the SI base unit second" ;
+  qudt:uneceCommonCode "C57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "N SEC" ;
+  skos:prefLabel "newton second" ;
+.
+unit:N-SEC-PER-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(N-s/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MechanicalSurfaceImpedance ;
+  qudt:iec61360Code "0112/2///62720#UAA252" ;
+  qudt:uneceCommonCode "C58" ;
+  rdfs:isDefinedBy unit:acoustics ;
+  rdfs:label "Newton Second per Meter" ;
+.
+unit:N-SEC-PER-M3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of specific acoustic impedance. When sound waves pass through any physical substance the pressure of the waves causes the particles of the substance to move. The sound specific impedance is the ratio between the sound pressure and the particle velocity it produces. The specific impedance is \\(1 N \\cdot s \\cdot m^{-3} \\) if unit pressure produces unit velocity."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(N \\cdot s \\cdot m^{-3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
+  qudt:latexSymbol "\\(N \\cdot s \\cdot m^{-3}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Newton second per Cubic Meter" ;
+.
+unit:NAT
+  a qudt:Unit ;
+  dcterms:description "A nat is a logarithmic unit of information or entropy, based on natural logarithms and powers of e, rather than the powers of 2 and base 2 logarithms which define the bit. The nat is the natural unit for information entropy. Physical systems of natural units which normalize Boltzmann's constant to 1 are effectively measuring thermodynamic entropy in nats."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nat"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nat?oldid=474010287"^^xsd:anyURI ;
+  qudt:symbol "nat" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nat" ;
+.
+unit:NAT-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "\"Nat per Second\" is information rate in natural units."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(nat-per-sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nat?oldid=474010287"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nat per Second" ;
+.
+unit:NP
+  a qudt:DimensionlessUnit ;
+  a qudt:LogarithmicUnit ;
+  a qudt:Unit ;
+  dcterms:description "The neper is a logarithmic unit for ratios of measurements of physical field and power quantities, such as gain and loss of electronic signals. It has the unit symbol Np. The unit's name is derived from the name of John Napier, the inventor of logarithms. As is the case for the decibel and bel, the neper is not a unit in the International System of Units (SI), but it is accepted for use alongside the SI. Like the decibel, the neper is a unit in a logarithmic scale. While the bel uses the decadic (base-10) logarithm to compute ratios, the neper uses the natural logarithm, based on Euler's number"^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Neper"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAA253" ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Neper"^^xsd:anyURI ;
+  qudt:symbol "Np" ;
+  qudt:ucumCaseInsensitiveCode "NEP" ;
+  qudt:ucumCaseSensitiveCode "Np" ;
+  qudt:ucumCode "NEP" ;
+  qudt:ucumCode "Np" ;
+  qudt:uneceCommonCode "C50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Neper" ;
+.
+unit:NTU
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Nephelometry Turbidity Unit\" is a C.G.S System unit for  'Turbidity' expressed as \\(NTU\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Turbidity ;
+  qudt:symbol "NTU" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nephelometry Turbidity Unit" ;
+.
+unit:NUM
+  a qudt:CountingUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Number\" is a unit for  'Dimensionless' expressed as (\\\\#\\)."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "\\#" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Number" ;
+.
+unit:NUM-PER-YR
+  a qudt:CGS-Unit ;
+  a qudt:CountingUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Number per Year\" is a unit for  'Frequency' expressed as \\(\\#/yr\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(\\#/yr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Number per Year" ;
+.
+unit:Naira
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Nigeria"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nigerian_naira"^^xsd:anyURI ;
+  qudt:expression "\\(NGN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nigerian_naira?oldid=493462003"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Naira" ;
+.
+unit:Nakfa
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Eritrea"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nakfa"^^xsd:anyURI ;
+  qudt:expression "\\(ERN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nakfa?oldid=415286274"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nakfa" ;
+.
+unit:NamibianDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Namibia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Namibian_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(NAD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Namibian_dollar?oldid=495250023"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Namibian Dollar" ;
+.
+unit:Nano
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'nano' is a  decimal prefix for expressing a value with a scaling of \\(10^{-9}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nano"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nano?oldid=489001692"^^xsd:anyURI ;
+  qudt:symbol "n" ;
+  qudt:ucumCaseInsensitiveCode "N" ;
+  qudt:ucumCaseSensitiveCode "n" ;
+  qudt:ucumCode "N" ;
+  qudt:ucumCode "n" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nano" ;
+.
+unit:NanoA
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Nano ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA901" ;
+  qudt:isScalingOf unit:A ;
+  qudt:symbol "nA" ;
+  qudt:uneceCommonCode "C39" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "nanoampere" ;
+.
+unit:NanoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A NanoCoulomb is \\(10^{-9} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-09 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Nano ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA902" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "nC" ;
+  qudt:uneceCommonCode "C40" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:NanoFARAD
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A common metric unit of electric capacitance equal to \\(10^{-9} farad\\). This unit was previously called the \\(millimicrofarad\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Farad"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA903" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Farad?oldid=493070876"^^xsd:anyURI ;
+  qudt:symbol "nF" ;
+  qudt:uneceCommonCode "C41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nanofarad" ;
+.
+unit:NanoFARAD-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA904" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoFARAD PER M" ;
+  skos:prefLabel "nanofarad per metre" ;
+.
+unit:NanoGM-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA911" ;
+  qudt:plainTextDescription "mass ratio consisting of the 0.000000000001-fold of the SI base unit kilogram divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "L32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoGM PER KiloGM" ;
+  skos:prefLabel "nanogram per kilogram" ;
+.
+unit:NanoH
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:hasQuantityKind quantitykind:Permeance ;
+  qudt:iec61360Code "0112/2///62720#UAA905" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry" ;
+  qudt:uneceCommonCode "C43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoH" ;
+  skos:prefLabel "nanohenry" ;
+.
+unit:NanoH-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permeability ;
+  qudt:iec61360Code "0112/2///62720#UAA906" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit henry divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoH PER M" ;
+  skos:prefLabel "nanohenry per metre" ;
+.
+unit:NanoM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA912" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "C45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoM" ;
+  skos:prefLabel "nanometre" ;
+.
+unit:NanoS-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA907" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens by the 0.01 fol of the SI base unit metre" ;
+  qudt:uneceCommonCode "G44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoS PER CentiM" ;
+  skos:prefLabel "nanosiemens per centimetre" ;
+.
+unit:NanoS-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA908" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "G45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoS PER M" ;
+  skos:prefLabel "nanosiemens per metre" ;
+.
+unit:NanoSEC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A nanosecond is a SI unit of time equal to one billionth of a second (10−9 or 1/1,000,000,000 s). One nanosecond is to one second as one second is to 31.69 years. The word nanosecond is formed by the prefix nano and the unit second."^^rdf:HTML ;
+  qudt:conversionMultiplier 1e-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nanosecond"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Nano ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA913" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nanosecond?oldid=919778950"^^xsd:anyURI ;
+  qudt:isScalingOf unit:SEC ;
+  qudt:symbol "ms" ;
+  qudt:ucumCaseInsensitiveCode "NS" ;
+  qudt:ucumCaseSensitiveCode "ns" ;
+  qudt:ucumCode "NS" ;
+  qudt:ucumCode "ns" ;
+  qudt:uneceCommonCode "C47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "nanosecond" ;
+.
+unit:NanoT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA909" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit tesla" ;
+  qudt:uneceCommonCode "C48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoT" ;
+  skos:prefLabel "nanotesla" ;
+.
+unit:NanoW
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA910" ;
+  qudt:plainTextDescription "0.000000001-fold of the SI derived unit watt" ;
+  qudt:uneceCommonCode "C49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "NanoW" ;
+  skos:prefLabel "nanowatt" ;
+.
+unit:NepaleseRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Nepal"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Nepalese_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(NPR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Nepalese_rupee?oldid=476894226"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nepalese Rupee" ;
+.
+unit:NetherlandsAntillianGuilder
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Netherlands Antilles"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Netherlands_Antillean_guilder"^^xsd:anyURI ;
+  qudt:expression "\\(ANG\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Netherlands_Antillean_guilder?oldid=490030382"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Netherlands Antillian Guilder" ;
+.
+unit:NewIsraeliShekel
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Israel"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Israeli_new_sheqel"^^xsd:anyURI ;
+  qudt:expression "\\(ILS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Israeli_new_sheqel?oldid=316213924"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "New Israeli Shekel" ;
+.
+unit:NewTaiwanDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Taiwan and other islands that are under the effective control of the Republic of China (ROC)"^^rdf:HTML ;
+  qudt:currencyExponent 1 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/New_Taiwan_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(TWD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/New_Taiwan_dollar?oldid=493996933"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "New Taiwan Dollar" ;
+.
+unit:NewTurkishLira
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Turkey"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Turkish_lira"^^xsd:anyURI ;
+  qudt:expression "\\(TRY\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Turkish_lira?oldid=494097764"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "New Turkish Lira" ;
+.
+unit:NewZealandDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cook Islands, New Zealand, Niue, Pitcairn, Tokelau"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/New_Zealand_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(NZD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/New_Zealand_dollar?oldid=495487722"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/NewZealandDollar> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "New Zealand Dollar" ;
+.
+unit:Ngultrum
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Bhutan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Bhutanese_ngultrum"^^xsd:anyURI ;
+  qudt:expression "\\(BTN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Bhutanese_ngultrum?oldid=491579260"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ngultrum" ;
+.
+unit:NorthKoreanWon
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "North Korea"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/North_Korean_won"^^xsd:anyURI ;
+  qudt:expression "\\(KPW\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/North_Korean_won?oldid=495081686"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "North Korean Won" ;
+.
+unit:NorwegianKrone
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Norway"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Norwegian_krone"^^xsd:anyURI ;
+  qudt:expression "\\(NOK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Norwegian_krone?oldid=495283934"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/NorwegianKrone> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Norwegian Krone" ;
+.
+unit:NuevoSol
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Peru"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Peruvian_nuevo_sol"^^xsd:anyURI ;
+  qudt:expression "\\(PEN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Peruvian_nuevo_sol?oldid=494237249"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Nuevo Sol" ;
+.
+unit:OCT
+  a qudt:DimensionlessUnit ;
+  a qudt:LogarithmicUnit ;
+  a qudt:Unit ;
+  dcterms:description "An octave is a doubling or halving of a frequency.  One oct is the logarithmic frequency interval between \\(f1\\) and \\(f2\\) when \\(f2/f1 = 2\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Octave"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Octave_(electronics)"^^xsd:anyURI ;
+  qudt:symbol "oct" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Oct" ;
+.
+unit:OERSTED
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Oersted (abbreviated as Oe) is the unit of magnetizing field (also known as H-field, magnetic field strength or intensity) in the CGS system of units."^^rdf:HTML ;
+  qudt:conversionMultiplier "79.5774715"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Oersted"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AuxillaryMagneticField ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAB134" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Oersted?oldid=491396460"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/oersted> ;
+  qudt:symbol "Oe" ;
+  qudt:ucumCaseInsensitiveCode "OE" ;
+  qudt:ucumCaseSensitiveCode "Oe" ;
+  qudt:ucumCode "OE" ;
+  qudt:ucumCode "Oe" ;
+  qudt:uneceCommonCode "66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Oersted" ;
+  prov:wasDerivedFrom unit:Gs ;
+.
+unit:OERSTED-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Oersted Centimeter\" is a C.G.S System unit for  'Magnetomotive Force' expressed as \\(Oe-cm\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.795774715"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Oe-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagnetomotiveForce ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Oersted Centimeter" ;
+.
+unit:OHM
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p>The <em>ohm</em> is the SI derived unit of electrical resistance, named after German physicist Georg Simon Ohm.</p>
+<p>\\(\\Omega \\equiv\\ \\frac{\\text{V}}{\\text{A}}\\ \\equiv\\ \\frac{\\text{volt}}{\\text{amp}}\\ \\equiv\\ \\frac{\\text{W}}{\\text {A}^{2}}\\ \\equiv\\ \\frac{\\text{watt}}{\\text{amp}^{2}}\\ \\equiv\\ \\frac{\\text{H}}{\\text {s}}\\ \\equiv\\ \\frac{\\text{henry}}{\\text{second}}\\)</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ohm"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA017" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ohm?oldid=494685555"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/ohm> ;
+  qudt:siUnitsExpression "V/A" ;
+  qudt:symbol "\\ohm" ;
+  qudt:ucumCaseInsensitiveCode "OHM" ;
+  qudt:ucumCaseSensitiveCode "Ohm" ;
+  qudt:ucumCode "OHM" ;
+  qudt:ucumCode "Ohm" ;
+  qudt:uneceCommonCode "OHM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ohm" ;
+.
+unit:OHM-M
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ResidualResistivity ;
+  qudt:iec61360Code "0112/2///62720#UAA020" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "C61" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ohm Meter" ;
+.
+unit:OHM_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{abohm}\\) is the basic unit of electrical resistance in the emu-cgs system of units. One abohm is equal to \\(10^{-9} ohms\\) in the SI system of units; one abohm is a nano ohm."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abohm"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abohm?oldid=480725336"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abohm> ;
+  qudt:symbol "abOhm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abohm" ;
+.
+unit:OHM_M
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of mechanical mobility for sound waves, being the reciprocal of the mechanical ohm unit of impedance, i.e., for an acoustic medium, the ratio of the flux or volumic speed (area times particle speed) of the resulting waves through it to the effective sound pressure (i.e. force) causing them, the unit being qualified, according to the units used, as m.k.s. or c.g.s. The mechanical ohm is equivalent to \\(1\\,dyn\\cdot\\,s\\cdot cm^{-1}\\) or \\(10^{-3} N\\cdot s\\cdot m^{-1}\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(mohm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MechanicalMobility ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-914"^^xsd:anyURI ;
+  qudt:latexDefinition """\\SI{1}{mohm_{c.g.s}} = \\SI{1}{cm.dyn^{-1}.s^{-1}}, (\\SI{e3}{km.N^{-1}.s^{-1}} in base c.g.s terms),
+
+\\SI{1}{mohm_{m.k.s}} = \\SI{1}{m.N^{-1}.s^{-1}}, (\\si{s.kg^{-1}} in base m.k.s. terms)"""^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Mohm" ;
+.
+unit:OHM_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"StatOHM\" is the unit of resistance, reactance, and impedance in the electrostatic C.G.S system of units, equal to the resistance between two points of a conductor when a constant potential difference of 1 statvolt between these points produces a current of 1 statampere; it is equal to approximately \\(8.9876 \\times 10^{11} ohms\\). The statohm is an extremely large unit of resistance. In fact, an object with a resistance of 1 stat W would make an excellent insulator or dielectric . In practical applications, the ohm, the kilohm (k W ) and the megohm (M W or M) are most often used to quantify resistance."^^qudt:LatexString ;
+  qudt:conversionMultiplier 8.9876E11 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:informativeReference "http://whatis.techtarget.com/definition/statohm-stat-W"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(stat\\Omega\\)"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statohm> ;
+  qudt:symbol "stat Ω " ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statohm" ;
+.
+unit:OZ_F
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce Force\" is an Imperial unit for  'Force' expressed as \\(ozf\\)."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.278013875"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:symbol "ozf" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Ounce Force" ;
+.
+unit:OZ_F-IN
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce Force Inch\" is an Imperial unit for  'Torque' expressed as \\(ozf-in\\)."^^rdf:HTML ;
+  qudt:conversionMultiplier 7.06155243E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Torque ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Ounce Force Inch" ;
+.
+unit:OZ_M
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "An ounce of mass is 1/16th of a pound of mass, based on the international standard definition of the pound as exactly 0.45359237 kg."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.028349523125"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "ozm" ;
+  qudt:ucumCaseInsensitiveCode "[OZ_AV]" ;
+  qudt:ucumCaseSensitiveCode "[oz_av]" ;
+  qudt:ucumCode "[OZ_AV]" ;
+  qudt:ucumCode "[oz_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ounce Mass" ;
+.
+unit:OZ_M-FT
+  a qudt:Unit ;
+  qudt:conversionMultiplier 8.6409e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:iec61360Code "0112/2///62720#UAB133" ;
+  qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and foot according to the Anglo-American and Imperial system of units" ;
+  qudt:uneceCommonCode "4R" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M_US FT" ;
+  skos:prefLabel "ounce (avoirdupois) foot" ;
+.
+unit:OZ_M-IN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.94563e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthMass ;
+  qudt:iec61360Code "0112/2///62720#UAB132" ;
+  qudt:plainTextDescription "unit of the unbalance as a product of avoirdupois ounce according to  the avoirdupois system of units and inch according to the Anglo-American and Imperial system of units" ;
+  qudt:uneceCommonCode "4Q" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M_US IN" ;
+  skos:prefLabel "ounce (avoirdupois) inch" ;
+.
+unit:OZ_M-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.2812e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA919" ;
+  qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "L33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER DAY" ;
+  skos:prefLabel "ounce (avoirdupois) per day" ;
+.
+unit:OZ_M-PER-GAL_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.8125e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA924" ;
+  qudt:informativeReference "https://cdd.iec.ch/cdd/iec61360/iec61360.nsf/Units/0112-2---62720%23UAA924"^^xsd:anyURI ;
+  qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "L38" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER GAL_US" ;
+  skos:prefLabel "ounce (avoirdupois) per gallon (US)" ;
+.
+unit:OZ_M-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.87487e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA920" ;
+  qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER HR" ;
+  skos:prefLabel "ounce (avoirdupois) per hour" ;
+.
+unit:OZ_M-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.72492e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA921" ;
+  qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER MIN" ;
+  skos:prefLabel "ounce (avoirdupois) per minute" ;
+.
+unit:OZ_M-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.834952e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA922" ;
+  qudt:plainTextDescription "traditional unit of the mass avoirdupois ounce according to the avoirdupois system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER SEC" ;
+  skos:prefLabel "ounce (avoirdupois) per second" ;
+.
+unit:OZ_M-PER-YD3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.70798e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA918" ;
+  qudt:plainTextDescription "unit ounce  according to the avoirdupois system of units divided by the power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:uneceCommonCode "G32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER YD3" ;
+  skos:prefLabel "ounce (avoirdupois) per cubic yard" ;
+.
+unit:OZ_M_PER-FT2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce per Square Foot\" is an Imperial unit for  'Mass Per Area' expressed as \\(oz/ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.305151727"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "oz/ft^{2}" ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Mass Ounce per Square Foot" ;
+.
+unit:OZ_M_PER-GAL
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce per Gallon\" is an Imperial unit for  'Density' expressed as \\(oz/gal\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6.23602329"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "oz/gal" ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Mass Ounce per Gallon" ;
+.
+unit:OZ_M_PER-GAL_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.2360e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA923" ;
+  qudt:plainTextDescription "unit of the density according to the Imperial system of units" ;
+  qudt:uneceCommonCode "L37" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_M PER GAL_UK" ;
+  skos:prefLabel "ounce (avoirdupois) per gallon (UK)" ;
+.
+unit:OZ_M_PER-IN3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce per Cubic Inch\" is an Imperial unit for  'Density' expressed as \\(oz/in^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1729.99404"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "oz/in^{3}" ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Mass Ounce per Cubic Inch" ;
+.
+unit:OZ_M_PER-YD2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Ounce per Square Yard\" is an Imperial unit for  'Mass Per Area' expressed as \\(oz/yd^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0339057474748823e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "oz/yd^{2}" ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Mass Ounce per Square Yard" ;
+.
+unit:OZ_TROY
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "An obsolete unit of mass; the Troy Ounce is 1/12th of a Troy Pound. Based on the international definition of a Troy Pound as 5760 grains, the Troy Ounce is exactly 480 grains, or 0.0311034768 kg."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.0311034768"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:symbol "oz" ;
+  qudt:ucumCaseInsensitiveCode "[OZ_TR]" ;
+  qudt:ucumCaseSensitiveCode "[oz_tr]" ;
+  qudt:ucumCode "[OZ_TR]" ;
+  qudt:ucumCode "[oz_tr]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ounce Troy" ;
+.
+unit:OZ_VOL_UK
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Imperial Ounce}\\) is an Imperial unit for  'Liquid Volume' expressed as \\(oz\\)."^^rdf:HTML ;
+  qudt:conversionMultiplier 2.84130625E-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA431" ;
+  qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:ucumCaseInsensitiveCode "[OZ_AV]" ;
+  qudt:ucumCaseSensitiveCode "[oz_av]" ;
+  qudt:ucumCode "[OZ_AV]" ;
+  qudt:ucumCode "[oz_av]" ;
+  qudt:uneceCommonCode "OZI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_VOL_UK (liquid volume)" ;
+  skos:prefLabel "fluid ounce (UK)" ;
+.
+unit:OZ_VOL_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.87487e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA432" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "J95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_UK PER DAY" ;
+  skos:prefLabel "ounce (UK fluid) per day" ;
+.
+unit:OZ_VOL_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.87487e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA433" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "J96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_UK PER HR" ;
+  skos:prefLabel "ounce (UK fluid) per hour" ;
+.
+unit:OZ_VOL_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.72492e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA434" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "J97" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_UK PER MIN" ;
+  skos:prefLabel "ounce (UK fluid) per minute" ;
+.
+unit:OZ_VOL_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.84e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA435" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (UK) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "J98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_UK PER SEC" ;
+  skos:prefLabel "ounce (UK fluid) per second" ;
+.
+unit:OZ_VOL_US
+  a qudt:Unit ;
+  dcterms:description "\"US Liquid Ounce\" is a unit for  'Liquid Volume' expressed as \\(oz\\)."^^rdf:HTML ;
+  qudt:conversionMultiplier 2.95735296E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "oz" ;
+  qudt:ucumCaseInsensitiveCode "[FOZ_US]" ;
+  qudt:ucumCaseSensitiveCode "[foz_us]" ;
+  qudt:ucumCode "[FOZ_US]" ;
+  qudt:ucumCode "[foz_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Liquid Ounce" ;
+.
+unit:OZ_VOL_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.42286e-10 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA436" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by unit for time day" ;
+  qudt:uneceCommonCode "J99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_VOL_US PER DAY" ;
+  skos:prefLabel "ounce (US fluid) per day" ;
+.
+unit:OZ_VOL_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 8.214869e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA437" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_VOL_US PER HR" ;
+  skos:prefLabel "ounce (US fluid) per hour" ;
+.
+unit:OZ_VOL_US-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.92892e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA438" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "K11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_VOL_US PER MIN" ;
+  skos:prefLabel "ounce (US fluid) per minute" ;
+.
+unit:OZ_VOL_US-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.95735296E-5 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA439" ;
+  qudt:plainTextDescription "unit of the volume fluid ounce (US) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "OZ_VOL_US PER SEC" ;
+  skos:prefLabel "ounce (US fluid) per second" ;
+.
+unit:OmaniRial
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Oman"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Omani_rial"^^xsd:anyURI ;
+  qudt:expression "\\(OMR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Omani_rial?oldid=491748879"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rial Omani" ;
+.
+unit:Ouguiya
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mauritania"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mauritanian_ouguiya"^^xsd:anyURI ;
+  qudt:expression "\\(MRO\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mauritanian_ouguiya?oldid=490027072"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ouguiya" ;
+.
+unit:PA
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of pressure. The pascal is the standard pressure unit in the MKS metric system, equal to one newton per square meter or one \"kilogram per meter per second per second.\" The unit is named for Blaise Pascal (1623-1662), French philosopher and mathematician, who was the first person to use a barometer to measure differences in altitude."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pascal"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA258" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/pascal> ;
+  qudt:siUnitsExpression "N/m^2" ;
+  qudt:symbol "Pa" ;
+  qudt:ucumCaseInsensitiveCode "PAL" ;
+  qudt:ucumCaseSensitiveCode "Pa" ;
+  qudt:ucumCode "PAL" ;
+  qudt:ucumCode "Pa" ;
+  qudt:uneceCommonCode "PAL" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal" ;
+.
+unit:PA-L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA261" ;
+  qudt:plainTextDescription "product out of the SI derived unit pascal and the unit litre divided by the SI base unit second" ;
+  qudt:uneceCommonCode "F99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PA L PER SEC" ;
+  skos:prefLabel "pascal litre per second" ;
+.
+unit:PA-M3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA264" ;
+  qudt:plainTextDescription "product out of the SI derived unit pascal and the power of the SI base unit metre with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "G01" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PA M3 PER SEC" ;
+  skos:prefLabel "pascal metre cubed per second" ;
+.
+unit:PA-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA260" ;
+  qudt:plainTextDescription "SI derived unit pascal divided by the unit bar" ;
+  qudt:uneceCommonCode "F07" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PA PER BAR" ;
+  skos:prefLabel "pascal per bar" ;
+.
+unit:PA-PER-HR
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A rate of change of pressure measured as the number of Pascals in a period of one hour."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.000277777778"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(P / hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:isScalingOf unit:PA-PER-MIN ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal per Hour" ;
+.
+unit:PA-PER-K
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(pascal-per-kelvin\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PressureCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAA259" ;
+  qudt:uneceCommonCode "C64" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal per Kelvin" ;
+.
+unit:PA-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:SpectralRadiantEnergyDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA262" ;
+  qudt:plainTextDescription "SI derived unit pascal divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "H42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PA PER M" ;
+  skos:prefLabel "pascal per metre" ;
+.
+unit:PA-PER-MIN
+  a qudt:CGS-Unit ;
+  a qudt:ScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A rate of change of pressure measured as the number of Pascals in a period of one minute."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.0166666667"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(P / min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:isScalingOf unit:PA-PER-SEC ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal per Minute" ;
+.
+unit:PA-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "A rate of change of pressure measured as the number of Pascals in a period of one second."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(P / s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal per Second" ;
+.
+unit:PA-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of dynamic viscosity, equal to 10 poises or 1000 centipoises. "^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Pa-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA265" ;
+  qudt:siUnitsExpression "Pa.s" ;
+  qudt:uneceCommonCode "C65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal Second" ;
+.
+unit:PA-SEC-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA267" ;
+  qudt:plainTextDescription "product out of the SI derived unit pascal and the SI base unit second divided by the unit bar" ;
+  qudt:uneceCommonCode "H07" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PA SEC PER BAR" ;
+  skos:prefLabel "pascal second per bar" ;
+.
+unit:PA-SEC-PER-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Pascal Second Per Meter (\\(Pa-s/m\\)) is a unit in the category of Specific acoustic impedance. It is also known as pascal-second/meter. Pascal Second Per Meter has a dimension of \\(ML^2T^{-1}\\) where M is mass, L is length, and T is time. It essentially the same as the corresponding standard SI unit \\(kg/m2\\cdot s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Pa-s/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA268" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
+  qudt:siUnitsExpression "Pa.s/m" ;
+  qudt:uneceCommonCode "C67" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal Second Per Meter" ;
+.
+unit:PA-SEC-PER-M3
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Pascal Second Per Cubic Meter}\\) (\\(Pa-s/m^3\\)) is a unit in the category of Acoustic impedance. It is also known as \\(\\textit{pascal-second/cubic meter}\\). It has a dimension of \\(ML^{-4}T^{-1}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Pa-s/m3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AcousticImpedance ;
+  qudt:iec61360Code "0112/2///62720#UAA263" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--acoustic_impedance--pascal_second_per_cubic_meter.cfm"^^xsd:anyURI ;
+  qudt:siUnitsExpression "Pa.s/m3" ;
+  qudt:uneceCommonCode "C66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal Second Per Cubic Meter" ;
+.
+unit:PA2-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Pascal Squared Second (\\(Pa^2\\cdot s\\)) is a unit in the category of sound exposure."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Pa2-s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SoundExposure ;
+  qudt:iec61360Code "0112/2///62720#UAB339" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--specific_acoustic_impedance--pascal_second_per_meter.cfm"^^xsd:anyURI ;
+  qudt:siUnitsExpression "Pa2.s" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pascal Squared Second" ;
+.
+unit:PAB
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Panama"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Balboa"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Balboa?oldid=482550791"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Balboa" ;
+.
+unit:PARSEC
+  a qudt:Unit ;
+  dcterms:description "The parsec (parallax of one arcsecond; symbol: pc) is a unit of length, equal to just under 31 trillion (\\(31 \\times 10^{12}\\)) kilometres (about 19 trillion miles), 206265 AU, or about 3.26 light-years. The parsec measurement unit is used in astronomy. It is defined as the length of the adjacent side of an imaginary right triangle in space. The two dimensions that specify this triangle are the parallax angle (defined as 1 arcsecond) and the opposite side (defined as 1 astronomical unit (AU), the distance from the Earth to the Sun). Given these two measurements, along with the rules of trigonometry, the length of the adjacent side (the parsec) can be found."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.085678E16 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB067" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/parsec> ;
+  qudt:symbol "pc" ;
+  qudt:ucumCaseInsensitiveCode "PRS" ;
+  qudt:ucumCaseSensitiveCode "pc" ;
+  qudt:ucumCode "PRS" ;
+  qudt:ucumCode "pc" ;
+  qudt:uneceCommonCode "C63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parsec" ;
+.
+unit:PCA
+  a qudt:Unit ;
+  dcterms:description "A pica is a typographic unit of measure corresponding to 1/72 of its respective foot, and therefore to 1/6 of an inch. The pica contains 12 point units of measure. Notably, Adobe PostScript promoted the pica unit of measure that is the standard in contemporary printing, as in home computers and printers. Usually, pica measurements are represented with an upper-case 'P' with an upper-right-to-lower-left virgule (slash) starting in the upper right portion of the 'P' and ending at the lower left of the upright portion of the 'P'; essentially drawing a virgule (/) through a 'P'.  Note that these definitions are different from a typewriter's pica setting, which denotes a type size of ten characters per horizontal inch."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pica"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB606" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pica?oldid=458102937"^^xsd:anyURI ;
+  qudt:symbol "PCA" ;
+  qudt:ucumCaseInsensitiveCode "[PCA]" ;
+  qudt:ucumCaseSensitiveCode "[pca]" ;
+  qudt:ucumCode "[PCA]" ;
+  qudt:ucumCode "[pca]" ;
+  qudt:uneceCommonCode "R1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pica" ;
+.
+unit:PDL
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The poundal is a unit of force that is part of the foot-pound-second system of units, in Imperial units introduced in 1877, and is from the specialized subsystem of English absolute (a coherent system). The poundal is defined as the force necessary to accelerate 1 pound-mass to 1 foot per second per second. \\(1 pdl = 0.138254954376 N\\) exactly."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.138254954376"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Poundal"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAB233" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Poundal?oldid=494626458"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/poundal> ;
+  qudt:symbol "pdl" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Poundal" ;
+.
+unit:PDL-PER-FT2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "Poundal Per Square Foot (\\(pdl/ft^2\\)) is a unit in the category of Pressure. It is also known as poundals per square foot, poundal/square foot. This unit is commonly used in the UK, US unit systems. Poundal Per Square Foot has a dimension of \\(ML^{-1}T^{-2}\\), where M is mass, L is length, and T is time. It can be converted to the corresponding standard SI unit \\si{Pa} by multiplying its value by a factor of 1.488163944."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.48816443"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(pdl/ft^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB243" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--pressure--poundal_per_square_foot.cfm"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Poundal per Square Foot" ;
+.
+unit:PER-ANGSTROM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseLength ;
+  qudt:iec61360Code "0112/2///62720#UAB058" ;
+  qudt:plainTextDescription "reciprocal of the unit angstrom" ;
+  qudt:uneceCommonCode "C85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER ANGSTROM" ;
+  skos:prefLabel "reciprocal Ã¥ngstrÃ¶m" ;
+.
+unit:PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Compressibility ;
+  qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:iec61360Code "0112/2///62720#UAA328" ;
+  qudt:plainTextDescription "reciprocal of the metrical unit with the name bar" ;
+  qudt:uneceCommonCode "F58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER BAR" ;
+  skos:prefLabel "reciprocal bar" ;
+.
+unit:PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseLength ;
+  qudt:iec61360Code "0112/2///62720#UAA382" ;
+  qudt:plainTextDescription "reciprocal of the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "E90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER CentiM" ;
+  skos:prefLabel "reciprocal centimetre" ;
+.
+unit:PER-CentiM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA383" ;
+  qudt:plainTextDescription "reciprocal of the 0.000001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "H50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER CentiM3" ;
+  skos:prefLabel "reciprocal centimetre cubed" ;
+.
+unit:PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.157407e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseTime ;
+  qudt:iec61360Code "0112/2///62720#UAA408" ;
+  qudt:plainTextDescription "reciprocal of the unit day" ;
+  qudt:uneceCommonCode "E91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER DAY" ;
+  skos:prefLabel "reciprocal day" ;
+.
+unit:PER-FT3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.531466e+01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA453" ;
+  qudt:plainTextDescription "reciprocal value of the power of the unit foot according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:uneceCommonCode "K20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER FT3" ;
+  skos:prefLabel "reciprocal cubic foot" ;
+.
+unit:PER-GigaEV2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Per Square Giga Electron Volt Unit is a a demominator unit with dimensions \\(/GeV^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.89564405E19 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/GeV^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseSquareEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Square Giga Electron Volt Unit" ;
+.
+unit:PER-H
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Henry" ;
+.
+unit:PER-HR
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A reciprocal unit of time for \\(\\textit{reciprocal hour}\\) or \"inverse hour\"."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.6e2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:ucumCaseInsensitiveCode "HR-1" ;
+  qudt:ucumCaseSensitiveCode "h-1" ;
+  qudt:ucumCode "HR-1" ;
+  qudt:ucumCode "h-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Hour" ;
+.
+unit:PER-IN3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.102376e+04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA546" ;
+  qudt:plainTextDescription "reciprocal value of the power of the unit inch according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:uneceCommonCode "K49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER IN3" ;
+  skos:prefLabel "reciprocal cubic inch" ;
+.
+unit:PER-J-M3
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(j^{-1}-m^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyDensityOfStates ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Joule Cubic Meter" ;
+.
+unit:PER-K
+  a qudt:Unit ;
+  dcterms:description "<p>Per Kelvin Unit is a demominator unit with dimensions \\(/k\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Kelvin Unit" ;
+.
+unit:PER-KiloV-A-HR
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L-2I0M-1H0T2D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:InverseEnergy ;
+  qudt:conversionMultiplier 1e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA098" ;
+  qudt:plainTextDescription "reciprocal of the 1,000-fold of the product of the SI derived unit volt and the SI base unit ampere and the unit hour" ;
+  qudt:uneceCommonCode "M21" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER KiloV A HR" ;
+  skos:prefLabel "reciprocal kilovolt ampere hour" ;
+.
+unit:PER-L
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA667" ;
+  qudt:plainTextDescription "reciprocal value of the unit litre" ;
+  qudt:uneceCommonCode "K63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER L" ;
+  skos:prefLabel "reciprocal litre" ;
+.
+unit:PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Per Meter Unit is a a demominator unit with dimensions \\(/m\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(per-meter\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseLength ;
+  qudt:ucumCaseInsensitiveCode "M-1" ;
+  qudt:ucumCaseSensitiveCode "m-1" ;
+  qudt:ucumCode "M-1" ;
+  qudt:ucumCode "m-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Meter" ;
+.
+unit:PER-M-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>Per Meter Kelvin Unit is a denominator unit with dimensions \\(/m.k\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/m.k\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseLengthTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Meter Kelvin Unit" ;
+.
+unit:PER-M2
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Per Meter Squared Unit\" is a demominator unit with dimensions \\(/m^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ParticleFluence ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  qudt:symbol "m^{-2}" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Square Meter" ;
+.
+unit:PER-M2-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{-2}-s^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ParticleFluenceRate ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Square Meter Second" ;
+.
+unit:PER-M3
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Per Cubic Meter\" is a demominator unit with dimensions \\(/m^3\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/m^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:NumberDensity ;
+  qudt:ucumCaseInsensitiveCode "M-3" ;
+  qudt:ucumCaseSensitiveCode "m-3" ;
+  qudt:ucumCode "M-3" ;
+  qudt:ucumCode "m-3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Cubic Meter" ;
+.
+unit:PER-M3-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{-3}-s^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Slowing-DownDensity ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Cubic Meter Second" ;
+.
+unit:PER-MI-PER-PSI
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L1I0M-1H0T2D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:InversePressure ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:IsothermalCompressibility ;
+  qudt:conversionMultiplier 1.450377e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Compressibility ;
+  qudt:iec61360Code "0112/2///62720#UAA016" ;
+  qudt:plainTextDescription "thousandth divided by the composed unit for pressure (pound-force per square inch)" ;
+  qudt:uneceCommonCode "J12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER MI PER PSI" ;
+  skos:prefLabel "per mille per psi" ;
+.
+unit:PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A reciprocal unit of time for \\(\\textit{reciprocal minute}\\) or \\(\\textit{inverse minute}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "60.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(m^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:ucumCaseInsensitiveCode "MIN-1" ;
+  qudt:ucumCaseSensitiveCode "min-1" ;
+  qudt:ucumCode "MIN-1" ;
+  qudt:ucumCode "min-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Minute" ;
+.
+unit:PER-MO
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.91935077e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseTime ;
+  qudt:iec61360Code "0112/2///62720#UAA881" ;
+  qudt:plainTextDescription "reciprocal of the unit month" ;
+  qudt:uneceCommonCode "H11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER MO" ;
+  skos:prefLabel "reciprocal month" ;
+.
+unit:PER-MOL
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><strong>Per Mole Unit</strong> is a a demominator unit with dimensions \\(mol^{-1}\\)</p>."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseAmountOfSubstance ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Mole Unit" ;
+.
+unit:PER-MilliM3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA870" ;
+  qudt:plainTextDescription "reciprocal value of the 0.000000001-fold of the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "L20" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER MilliM3" ;
+  skos:prefLabel "reciprocal millimetre cubed" ;
+.
+unit:PER-PA
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pascal"^^xsd:anyURI ;
+  qudt:expression "\\(/Pa\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:hasQuantityKind quantitykind:IsothermalCompressibility ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pascal?oldid=492989202"^^xsd:anyURI ;
+  qudt:siUnitsExpression "m^2/N" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Pascal" ;
+.
+unit:PER-PSI
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.450377e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InversePressure ;
+  qudt:iec61360Code "0112/2///62720#UAA709" ;
+  qudt:plainTextDescription "reciprocal value of the composed unit for pressure (pound-force per square inch)" ;
+  qudt:uneceCommonCode "K93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER PSI" ;
+  skos:prefLabel "reciprocal psi" ;
+.
+unit:PER-PlanckMass2
+  a qudt:BaseUnit ;
+  dcterms:description "In physics, the Planck mass, denoted by \\(m_P\\), is the unit of mass in the system of natural units known as Planck units. It is defined so that \\(\\approx  1.2209 \\times 10 GeV/c_0 = 2.17651(13) \\times 10 kg\\), (or \\(21.7651 \\mu g\\)), where \\(c_0\\) is the speed of light in a vacuum, \\(G\\) is the gravitational constant, and \\(\\hbar\\) is the reduced Planck constant. Particle physicists and cosmologists often use the reduced Planck mass, which is \\(\\approx  4.341 \\times 10 kg = 2.435  \\times 10 GeV/c\\). The added factor of \\(1/{\\sqrt{8\\pi}}\\) simplifies a number of equations in general relativity. Quantum effects are typified by the magnitude of Planck's constant."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.111089e15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_mass"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:InverseSquareMass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_mass?oldid=493648632"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(m_P = \\sqrt{\\frac{ \\hbar c^3}{G}} \\approx 1.2209 \\times 10^{19} GeV/c^2 = 2.17651(13) \\times 10^{-8}\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Inverse Square Planck Mass" ;
+.
+unit:PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A reciprical unit of time for \\(\\textit{reciprocal second}\\) or \\(\\textit{inverse second}\\). The \\(\\textit{Per Second}\\) is a unit of rate."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:HZ ;
+  qudt:expression "\\(sec^{-1}}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:ucumCaseInsensitiveCode "S-1" ;
+  qudt:ucumCaseSensitiveCode "s-1" ;
+  qudt:ucumCode "S-1" ;
+  qudt:ucumCode "s-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Second" ;
+.
+unit:PER-SEC-M2
+  a qudt:Unit ;
+  dcterms:description "\\(\\textit{Per Second Meter Squared Unit}\\) is a demominator unit with dimensions \\(/sec-m^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(per-sec-m^2\\)"^^qudt:LatexString ;
+  qudt:ucumCaseInsensitiveCode "S-1.M-2" ;
+  qudt:ucumCaseSensitiveCode "s-1.m-2" ;
+  qudt:ucumCode "S-1.M-2" ;
+  qudt:ucumCode "s-1.m-2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Second Meter Squared Unit" ;
+.
+unit:PER-SEC-M2-SR
+  a qudt:Unit ;
+  dcterms:description "Per Second Meter Squared Steradian Unit is a a demominator unit with dimensions \\(/sec-m^2-sr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/sec-m^2-sr\\)"^^qudt:LatexString ;
+  qudt:ucumCaseInsensitiveCode "S-1.M-2.SR-1" ;
+  qudt:ucumCaseSensitiveCode "s-1.m-2.sr-1" ;
+  qudt:ucumCode "S-1.M-2.SR-1" ;
+  qudt:ucumCode "s-1.m-2.sr-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Second Meter Squared Steradian Unit" ;
+.
+unit:PER-SEC-SR
+  a qudt:Unit ;
+  dcterms:description "Per Second Steradian Unit is a a demominator unit with dimensions \\(/sec-sr\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/sec-sr\\)"^^qudt:LatexString ;
+  qudt:ucumCaseInsensitiveCode "S-1.SR-1" ;
+  qudt:ucumCaseSensitiveCode "s-1.sr-1" ;
+  qudt:ucumCode "S-1.SR-1" ;
+  qudt:ucumCode "s-1.sr-1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Second Steradian Unit" ;
+.
+unit:PER-T-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Per Tesla Meter Unit is a a demominator unit with dimensions \\(/m .\\cdot T\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:MagneticReluctivity ;
+  qudt:latexSymbol "\\(m^{-1} \\cdot T^{-1}\\)"^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Tesla Meter" ;
+.
+unit:PER-T-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Per Tesla Second Unit is a a demominator unit with dimensions \\(/s . T\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(/s . T\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricChargePerMass ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Tesla Second Unit" ;
+.
+unit:PER-WB
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Wb^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InverseMagneticFlux ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Per Weber" ;
+.
+unit:PER-WK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.653439e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseTime ;
+  qudt:iec61360Code "0112/2///62720#UAA099" ;
+  qudt:plainTextDescription "reciprocal of the unit week" ;
+  qudt:uneceCommonCode "H85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER WK" ;
+  skos:prefLabel "reciprocal week" ;
+.
+unit:PER-YD3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.307951e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseVolume ;
+  qudt:iec61360Code "0112/2///62720#UAB033" ;
+  qudt:plainTextDescription "reciprocal value of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3" ;
+  qudt:uneceCommonCode "M10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER YD3" ;
+  skos:prefLabel "reciprocal cubic yard" ;
+.
+unit:PER-YR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.1709792e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseTime ;
+  qudt:iec61360Code "0112/2///62720#UAB027" ;
+  qudt:plainTextDescription "reciprocal of the unit year" ;
+  qudt:uneceCommonCode "H09" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PER YR" ;
+  skos:prefLabel "reciprocal year" ;
+.
+unit:PERCENT
+  a qudt:CountingUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Percent\" is a unit for  'Dimensionless Ratio' expressed as \\(\\%\\)."^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Percentage"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA000" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Percentage?oldid=495284540"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/percent> ;
+  qudt:symbol "\\%" ;
+  qudt:ucumCaseSensitiveCode "%" ;
+  qudt:ucumCode "%" ;
+  qudt:uneceCommonCode "P1" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Percent" ;
+.
+unit:PERCENT-BAR-PER-BAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressurePercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA010" ;
+  qudt:plainTextDescription "hundredth relating to the unit bar" ;
+  qudt:uneceCommonCode "H96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT BAR PER BAR" ;
+  skos:prefLabel "percent per bar" ;
+.
+unit:PERCENT-HectoBAR-PER-HectoBAR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressurePercentage ;
+  qudt:iec61360Code "0112/2///62720#UAB373" ;
+  qudt:plainTextDescription "hundredths relating to the 100-fold of unit bar" ;
+  qudt:uneceCommonCode "H72" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT HectoBAR PER HectoBAR" ;
+  skos:prefLabel "percent hectobar per hectobar" ;
+.
+unit:PERCENT-IN-PER-IN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.93701e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthPercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA012" ;
+  qudt:plainTextDescription "hundredth divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:uneceCommonCode "H98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT IN PER IN" ;
+  skos:prefLabel "percent inch per inch" ;
+.
+unit:PERCENT-M-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthPercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA013" ;
+  qudt:plainTextDescription "hundredth relating to the SI base unit metre" ;
+  qudt:uneceCommonCode "H99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT M PER M" ;
+  skos:prefLabel "percent metre per metre" ;
+.
+unit:PERCENT-MO-PER-MO
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.919351e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:TimePercentage ;
+  qudt:iec61360Code "0112/2///62720#UAB372" ;
+  qudt:plainTextDescription "hundredths relating to the unit month" ;
+  qudt:uneceCommonCode "H71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT MO PER MO" ;
+  skos:prefLabel "percent month per month" ;
+.
+unit:PERCENT-MilliM-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LengthPercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA014" ;
+  qudt:plainTextDescription "hundredth relating to the 0.001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "J10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT MilliM PER MilliM" ;
+  skos:prefLabel "percent millimeter per millimetre" ;
+.
+unit:PERCENT-OHM-PER-OHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ResistancePercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA001" ;
+  qudt:plainTextDescription "hundredth relating to the SI unit ohm" ;
+  qudt:uneceCommonCode "H89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT OHM PER OHM" ;
+  skos:prefLabel "percent ohm per ohm" ;
+.
+unit:PERCENT-V-PER-V
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VoltagePercentage ;
+  qudt:iec61360Code "0112/2///62720#UAA009" ;
+  qudt:plainTextDescription "hundredth relating to the SI unit volt" ;
+  qudt:uneceCommonCode "H95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PERCENT V PER V" ;
+  skos:prefLabel "percent volt per volt" ;
+.
+unit:PERMEABILITY_REL
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>In multiphase flow in porous media, the relative permeability of a phase is a dimensionless measure of the effective permeability of that phase. It is the ratio of the effective permeability of that phase to the absolute permeability. It can be viewed as an adaptation of Darcy's law to multiphase flow. For two-phase flow in porous media given steady-state conditions, we can write where is the flux, is the pressure drop, is the viscosity.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.25663706E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Relative_permeability"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Permeability ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_permeability"^^xsd:anyURI ;
+  qudt:symbol "\\(\\mu\\,r\\)" ;
+  qudt:ucumCaseInsensitiveCode "[MU_0]" ;
+  qudt:ucumCaseSensitiveCode "[mu_0]" ;
+  qudt:ucumCode "[MU_0]" ;
+  qudt:ucumCode "[mu_0]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Relative Permeability" ;
+.
+unit:PERMITTIVITY_REL
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """<p>The <em>relative permittivity</em> of a material under given conditions reflects the extent to which it concentrates electrostatic lines of flux. In technical terms, it is the ratio of the amount of electrical energy stored in a material by an applied voltage, relative to that stored in a vacuum. Likewise, it is also the ratio of the capacitance of a capacitor using that material as a dielectric, compared to a similar capacitor that has a vacuum as its dielectric. Relative permittivity is a dimensionless number that is in general complex. The imaginary portion of the permittivity corresponds to a phase shift of the polarization P relative to E and leads to the attenuation of electromagnetic waves passing through the medium.</p>
+<p>\\(\\epsilon_r(w) = \\frac{\\epsilon(w)}{\\epsilon_O}\\)\\\\</p>
+<p>where \\(\\epsilon_r(w)\\) is the complex frequency-dependent absolute permittivity of the material, and \\(\\epsilon_O\\) is the vacuum permittivity.</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 8.854187817E-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Relative_static_permittivity"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_permittivity?oldid=489664437"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Relative_static_permittivity?oldid=334224492"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.ncert.nic.in/html/learning_basket/electricity/electricity/charges%20&%20fields/absolute_permittivity.htm"^^xsd:anyURI ;
+  qudt:symbol "\\(\\epsilon r\\)" ;
+  qudt:ucumCaseInsensitiveCode "[EPS_0]" ;
+  qudt:ucumCaseSensitiveCode "[eps_0]" ;
+  qudt:ucumCode "[EPS_0]" ;
+  qudt:ucumCode "[eps_0]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Relative Permittivity" ;
+.
+unit:PINT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Imperial Pint\" is an Imperial unit for  'Volume' expressed as \\(pint\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 5.6826125E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:symbol "pi" ;
+  qudt:ucumCaseInsensitiveCode "[PT_BR]" ;
+  qudt:ucumCaseSensitiveCode "[pt_br]" ;
+  qudt:ucumCode "[PT_BR]" ;
+  qudt:ucumCode "[pt_br]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Imperial Pint" ;
+.
+unit:PINT_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.682613e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA952" ;
+  qudt:plainTextDescription "unit of the volume (both for fluids and for dry measures) according to the Imperial system of units" ;
+  qudt:uneceCommonCode "PTI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_UK" ;
+  skos:prefLabel "pint (UK)" ;
+.
+unit:PINT_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.577098e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA953" ;
+  qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "L53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_UK PER DAY" ;
+  skos:prefLabel "pint (UK) per day" ;
+.
+unit:PINT_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.578504e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA954" ;
+  qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_UK PER HR" ;
+  skos:prefLabel "pint (UK) per hour" ;
+.
+unit:PINT_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.471022e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA955" ;
+  qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_UK PER MIN" ;
+  skos:prefLabel "pint (UK) per minute" ;
+.
+unit:PINT_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.682613e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA956" ;
+  qudt:plainTextDescription "unit of the volume pint (UK) (both for fluids and for dry measures) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L56" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_UK PER SEC" ;
+  skos:prefLabel "pint (UK) per second" ;
+.
+unit:PINT_US
+  a qudt:Unit ;
+  dcterms:description "\"US Liquid Pint\" is a unit for  'Liquid Volume' expressed as \\(pt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.731765E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "pt" ;
+  qudt:ucumCaseInsensitiveCode "[PT_US]" ;
+  qudt:ucumCaseSensitiveCode "[pt_us]" ;
+  qudt:ucumCode "[PT_US]" ;
+  qudt:ucumCode "[pt_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Liquid Pint" ;
+.
+unit:PINT_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.47658e-09 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA958" ;
+  qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "L57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_US PER DAY" ;
+  skos:prefLabel "pint (US liquid) per day" ;
+.
+unit:PINT_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.314379e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA959" ;
+  qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L58" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_US PER HR" ;
+  skos:prefLabel "pint (US liquid) per hour" ;
+.
+unit:PINT_US-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 7.886275e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA960" ;
+  qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L59" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_US PER MIN" ;
+  skos:prefLabel "pint (US liquid) per minute" ;
+.
+unit:PINT_US-PER-SEC
+  a qudt:Unit ;
+  <http://qudt.org/schema/baseUnitDimensions> qkdv:A0E0L3I0M0H0T-1D0 ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:RecombinationCoefficient ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:SoundVolumeVelocity ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:VolumeFlowRate ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:VolumePerUnitTime ;
+  qudt:conversionMultiplier 4.731765e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA961" ;
+  qudt:plainTextDescription "unit of the volume pint (US liquid) according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PINT_US PER SEC" ;
+  skos:prefLabel "pint (US liquid) per second" ;
+.
+unit:PINT_US_DRY
+  a qudt:Unit ;
+  dcterms:description "\"US Dry Pint\" is a C.G.S System unit for  'Dry Volume' expressed as \\(dry_pt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 5.50610471E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:symbol "dry_pt" ;
+  qudt:ucumCaseInsensitiveCode "[DPT_US]" ;
+  qudt:ucumCaseSensitiveCode "[dpt_us]" ;
+  qudt:ucumCode "[DPT_US]" ;
+  qudt:ucumCode "[dpt_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pint US Dry" ;
+  rdfs:label "US Dry Pint" ;
+.
+unit:PK_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.092181e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:CartesianVolume ;
+  qudt:iec61360Code "0112/2///62720#UAA939" ;
+  qudt:plainTextDescription "unit of the volume according to the Imperial system of units" ;
+  qudt:uneceCommonCode "L43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_UK" ;
+  skos:prefLabel "peck (UK)" ;
+.
+unit:PK_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.05233576e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA940" ;
+  qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "L44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_UK PER DAY" ;
+  skos:prefLabel "peck (UK) per day" ;
+.
+unit:PK_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.525605833e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA941" ;
+  qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_UK PER HR" ;
+  skos:prefLabel "peck (UK) per hour" ;
+.
+unit:PK_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.5153635e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA942" ;
+  qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L46" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_UK PER MIN" ;
+  skos:prefLabel "peck (UK) per minute" ;
+.
+unit:PK_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 9.092181e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA943" ;
+  qudt:plainTextDescription "unit of the volume peck (UK) according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_UK PER SEC" ;
+  skos:prefLabel "peck (UK) per second" ;
+.
+unit:PK_US_DRY
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A peck is an imperial and U.S. customary unit of dry volume, equivalent to 2 gallons or 8 dry quarts or 16 dry pints. Two pecks make a kenning (obsolete), and four pecks make a bushel. In Scotland, the peck was used as a dry measure until the introduction of imperial units as a result of the Weights and Measures Act of 1824. The peck was equal to about 9 litres (in the case of certain crops, such as wheat, peas, beans and meal) and about 13 litres (in the case of barley, oats and malt). A firlot was equal to 4 pecks and the peck was equal to 4 lippies or forpets. "^^rdf:HTML ;
+  qudt:conversionMultiplier "0.00880976754"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:symbol "pk" ;
+  qudt:ucumCaseInsensitiveCode "[PK_US]" ;
+  qudt:ucumCaseSensitiveCode "[pk_us]" ;
+  qudt:ucumCode "[PK_US]" ;
+  qudt:ucumCode "[pk_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Peck" ;
+.
+unit:PK_US_DRY-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.01964902e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA944" ;
+  qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "L48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_US_DRY PER DAY" ;
+  skos:prefLabel "peck (US dry) per day" ;
+.
+unit:PK_US_DRY-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.447157651e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA945" ;
+  qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "L49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_US_DRY PER HR" ;
+  skos:prefLabel "peck (US dry) per hour" ;
+.
+unit:PK_US_DRY-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.46829459067e-04 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA946" ;
+  qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_US_DRY PER MIN" ;
+  skos:prefLabel "peck (US dry) per minute" ;
+.
+unit:PK_US_DRY-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00880976754"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA947" ;
+  qudt:plainTextDescription "unit of the volume peck (US dry) as dry measure according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PK_US_DRY PER SEC" ;
+  skos:prefLabel "peck (US dry) per second" ;
+.
+unit:POISE
+  a qudt:Unit ;
+  dcterms:description "The poise is the unit of dynamic viscosity in the centimetre gram second system of units. It is named after Jean Louis Marie Poiseuille."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-1 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Poise"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA255" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Poise?oldid=487835641"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/poise> ;
+  qudt:symbol "P" ;
+  qudt:ucumCaseInsensitiveCode "P" ;
+  qudt:ucumCode "P" ;
+  qudt:uneceCommonCode "89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Poise" ;
+.
+unit:POISE-PER-BAR
+  a qudt:Unit ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:Time ;
+  qudt:conversionMultiplier 1e-06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA257" ;
+  qudt:plainTextDescription "CGS unit poise divided by the unit bar" ;
+  qudt:uneceCommonCode "F06" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "POISE PER BAR" ;
+  skos:prefLabel "poise per bar" ;
+.
+unit:PPB
+  a qudt:Unit ;
+  dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
+  qudt:symbol "ppb" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts per billion" ;
+.
+unit:PPM
+  a qudt:Unit ;
+  dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/partsPerMillion> ;
+  qudt:symbol "ppm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts per million" ;
+.
+unit:PPTH
+  a qudt:Unit ;
+  dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.001"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
+  qudt:symbol "ppth" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts per thousand" ;
+.
+unit:PPTR
+  a qudt:Unit ;
+  dcterms:description "Dimensionless unit for concentration. Recommended practice is to use specific units such as \\(ug/l\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DimensionlessRatio ;
+  qudt:informativeReference "http://aurora.regenstrief.org/~ucum/ucum.html#section-Derived-Unit-Atoms"^^xsd:anyURI ;
+  qudt:symbol "pptr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Parts per trillion" ;
+.
+unit:PSI-IN3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.129848e-01 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA703" ;
+  qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic inch per second)" ;
+  qudt:uneceCommonCode "K87" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PSI IN3 PER SEC" ;
+  skos:prefLabel "psi cubic inch per second" ;
+.
+unit:PSI-L-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.894757e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA704" ;
+  qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (litre per second)" ;
+  qudt:uneceCommonCode "K88" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PSI L PER SEC" ;
+  skos:prefLabel "psi litre per second" ;
+.
+unit:PSI-M3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 6.894757e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA705" ;
+  qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the composed unit for volume flow (cubic metre per second)" ;
+  qudt:uneceCommonCode "K89" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PSI M3 PER SEC" ;
+  skos:prefLabel "psi metre cubed per second" ;
+.
+unit:PSI-PER-PSI
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PressureRatio ;
+  qudt:iec61360Code "0112/2///62720#UAA951" ;
+  qudt:plainTextDescription "composed unit for pressure (pound-force per square inch) divided by the composed unit for pressure (pound-force per square inch)" ;
+  qudt:uneceCommonCode "L52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PSI PER PSI" ;
+  skos:prefLabel "psi per psi" ;
+.
+unit:PSI-YD3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 5.27142e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA706" ;
+  qudt:plainTextDescription "product of the composed unit for pressure (pound-force per square inch) and the square inch) and the composed unit for volume flow (cubic yard per second)" ;
+  qudt:uneceCommonCode "K90" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PSI YD3 PER SEC" ;
+  skos:prefLabel "psi cubic yard per second" ;
+.
+unit:PT
+  a qudt:Unit ;
+  dcterms:description "In typography, a point is the smallest unit of measure, being a subdivision of the larger pica. It is commonly abbreviated as pt. The point has long been the usual unit for measuring font size and leading and other minute items on a printed page."^^rdf:HTML ;
+  qudt:conversionMultiplier 2.54E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB605" ;
+  qudt:symbol "pt" ;
+  qudt:ucumCaseInsensitiveCode "[PNT]" ;
+  qudt:ucumCaseSensitiveCode "[pnt]" ;
+  qudt:ucumCode "[PNT]" ;
+  qudt:ucumCode "[pnt]" ;
+  qudt:uneceCommonCode "N3" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Point" ;
+.
+unit:Paanga
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Tonga"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tongan_pa%CA%BBanga"^^xsd:anyURI ;
+  qudt:expression "\\(TOP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tongan_paʻanga?oldid=482738012"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pa'anga" ;
+.
+unit:PakistanRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Pakistan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pakistani_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(PKR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pakistani_rupee?oldid=494937873"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pakistan Rupee" ;
+.
+unit:Palladium-OunceTroy
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  qudt:expression "\\(XPD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Palladium (one Troy ounce)" ;
+.
+unit:Pataca
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Macau Special Administrative Region"^^rdf:HTML ;
+  qudt:currencyExponent 1 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pataca"^^xsd:anyURI ;
+  qudt:expression "\\(MOP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pataca?oldid=482490442"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pataca" ;
+.
+unit:Pebi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{5}\\), or \\(2^{50}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "125899906842624"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Pi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pebi" ;
+.
+unit:PebiBYTE
+  a qudt:BinaryScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The pebibyte is a standards-based binary multiple (prefix pebi, symbol Pi) of the byte, a unit of digital information storage. The pebibyte unit symbol is PiB. 1 pebibyte =  1125899906842624bytes = 1024 tebibytes The pebibyte is closely related to the petabyte, which is defined as \\(10^{15} bytes = 1,000,000,000,000,000 bytes\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1125899906842624"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pebibyte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Pebi ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAA274" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pebibyte?oldid=492685015"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "PiB" ;
+  qudt:uneceCommonCode "E60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PebiByte" ;
+.
+unit:Pennyweight
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.555174e-03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB182" ;
+  qudt:plainTextDescription "non SI-conforming unit of mass which comes from the Anglo-American Troy or Apothecaries' Weight System of units according to NIST of 1 pwt = 1.555174 10^3 kg" ;
+  qudt:uneceCommonCode "DWT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pennyweight" ;
+  skos:prefLabel "pennyweight" ;
+.
+unit:Peta
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'peta' is a decimal prefix for expressing a value with a scaling of \\(10^{15}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Peta"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Peta?oldid=488263435"^^xsd:anyURI ;
+  qudt:symbol "P" ;
+  qudt:ucumCaseInsensitiveCode "PT" ;
+  qudt:ucumCaseSensitiveCode "P" ;
+  qudt:ucumCode "P" ;
+  qudt:ucumCode "PT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Peta" ;
+.
+unit:PetaBYTE
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "A petabyte is a unit of information equal to one quadrillion bytes, or 1024 terabytes. The unit symbol for the petabyte is PB. The prefix peta (P) indicates the fifth power to 1000: 1 PB = 1000000000000000B, 1 million gigabytes = 1 thousand terabytes The pebibyte (PiB), using a binary prefix, is the corresponding power of 1024, which is more than \\(12\\% \\)greater (\\(2^{50} bytes = 1,125,899,906,842,624 bytes\\))."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Petabyte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Peta ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAB187" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Petabyte?oldid=494735969"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "PB" ;
+  qudt:uneceCommonCode "E36" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PetaByte" ;
+.
+unit:PetaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A PetaCoulomb is \\(10^{15} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e15 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Peta ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "PC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PetaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:PetaJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+15 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:iec61360Code "0112/2///62720#UAB123" ;
+  qudt:plainTextDescription "1,000,000,000,000,000-fold of the derived SI unit joule" ;
+  qudt:uneceCommonCode "C68" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PetaJ" ;
+  skos:prefLabel "petajoule" ;
+.
+unit:PhilippinePeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Philippines"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Philippine_peso"^^xsd:anyURI ;
+  qudt:expression "\\(PHP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Philippine_peso?oldid=495411811"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Philippine Peso" ;
+.
+unit:Phot
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A phot (ph) is a photometric unit of illuminance, or luminous flux through an area. It is not an SI unit, but rather is associated with the older centimetre gram second system of units.  Metric dimensions: \\(illuminance = luminous intensity \\times solid angle / length\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Phot"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LuminousFluxPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB255" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Phot?oldid=477198725"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/phot> ;
+  qudt:symbol "ph" ;
+  qudt:ucumCaseInsensitiveCode "PHT" ;
+  qudt:ucumCaseSensitiveCode "ph" ;
+  qudt:ucumCode "PHT" ;
+  qudt:ucumCode "ph" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Phot" ;
+.
+unit:Pico
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'pico' is a decimal prefix for expressing a value with a scaling of \\(10^{-12}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pico"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pico?oldid=485697614"^^xsd:anyURI ;
+  qudt:symbol "p" ;
+  qudt:ucumCaseInsensitiveCode "P" ;
+  qudt:ucumCaseSensitiveCode "p" ;
+  qudt:ucumCode "P" ;
+  qudt:ucumCode "p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pico" ;
+.
+unit:PicoA
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.0e-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Pico ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:iec61360Code "0112/2///62720#UAA928" ;
+  qudt:isScalingOf unit:A ;
+  qudt:symbol "pA" ;
+  qudt:uneceCommonCode "C70" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "picoampere" ;
+.
+unit:PicoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A PicoCoulomb is \\(10^{-12} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Pico ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA929" ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "pC" ;
+  qudt:uneceCommonCode "C71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:PicoFARAD
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"PicoF\" is a common unit of electric capacitance equal to \\(10^{-12} farad\\). This unit was formerly called the micromicrofarad."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Farad"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Capacitance ;
+  qudt:iec61360Code "0112/2///62720#UAA930" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Farad?oldid=493070876"^^xsd:anyURI ;
+  qudt:symbol "pF" ;
+  qudt:uneceCommonCode "4T" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Picofarad" ;
+.
+unit:PicoFARAD-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Permittivity ;
+  qudt:iec61360Code "0112/2///62720#UAA931" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit farad divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "C72" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoFARAD PER M" ;
+  skos:prefLabel "picofarad per metre" ;
+.
+unit:PicoH
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Inductance ;
+  qudt:iec61360Code "0112/2///62720#UAA932" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit henry" ;
+  qudt:uneceCommonCode "C73" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoH" ;
+  skos:prefLabel "picohenry" ;
+.
+unit:PicoM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA949" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "C52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoM" ;
+  skos:prefLabel "picometre" ;
+.
+unit:PicoPA-PER-KiloM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-15 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyPerArea ;
+  qudt:hasQuantityKind quantitykind:ForcePerLength ;
+  qudt:iec61360Code "0112/2///62720#UAA933" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit pascal divided by the 1 000-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H69" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoPA PER KiloM" ;
+  skos:prefLabel "picopascal per kilometre" ;
+.
+unit:PicoS-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA934" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit Siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "L42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoS PER M" ;
+  skos:prefLabel "picosiemens per metre" ;
+.
+unit:PicoSEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA950" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI base unit second" ;
+  qudt:uneceCommonCode "H70" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoSEC" ;
+  skos:prefLabel "picosecond" ;
+.
+unit:PicoW
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA935" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit watt" ;
+  qudt:uneceCommonCode "C75" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoW" ;
+  skos:prefLabel "picowatt" ;
+.
+unit:PicoW-PER-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e-12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA936" ;
+  qudt:plainTextDescription "0.000000000001-fold of the SI derived unit watt divided by the power of the SI base unit metre with the exponent 2" ;
+  qudt:uneceCommonCode "C76" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PicoW PER M2" ;
+  skos:prefLabel "picowatt per metre squared" ;
+.
+unit:PlanckArea
+  a qudt:Unit ;
+  qudt:conversionMultiplier 2.61223E-70 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Area" ;
+.
+unit:PlanckCharge
+  a qudt:BaseUnit ;
+  dcterms:description "In physics, the Planck charge, denoted by, is one of the base units in the system of natural units called Planck units. It is a quantity of electric charge defined in terms of fundamental physical constants. The Planck charge is defined as: coulombs, where: is the speed of light in the vacuum, is Planck's constant, is the reduced Planck constant, is the permittivity of free space is the elementary charge = (137.03599911) is the fine structure constant. The Planck charge is times greater than the elementary charge \\(e\\) carried by an electron."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.875545870E-18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:symbol "Q_p" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Charge" ;
+.
+unit:PlanckConstant
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:ucumCaseInsensitiveCode "[H]" ;
+  qudt:ucumCaseSensitiveCode "[h]" ;
+  qudt:ucumCode "[H]" ;
+  qudt:ucumCode "[h]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "planck-constant" ;
+.
+unit:PlanckCurrent
+  a qudt:Unit ;
+  dcterms:description "The Planck current is the unit of electric current, denoted by IP, in the system of natural units known as Planck units. \\(\\approx 3.479 \\times 10 A\\), where:  the Planck time is the permittivity in vacuum and the reduced Planck constant G is the gravitational constant c is the speed of light in vacuum. The Planck current is that current which, in a conductor, carries a Planck charge in Planck time. Alternatively, the Planck current is that constant current which, if maintained in two straight parallel conductors of infinite length and negligible circular cross-section, and placed a Planck length apart in vacuum, would produce between these conductors a force equal to a Planck force per Planck length."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.4789E25 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_current"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrent ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_current?oldid=493640689"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Current" ;
+.
+unit:PlanckCurrentDensity
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.331774E95 ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricCurrentDensity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Current Density" ;
+.
+unit:PlanckDensity
+  a qudt:Unit ;
+  dcterms:description "The Planck density is the unit of density, denoted by \\(\\rho P\\), in the system of natural units known as Planck units. \\(1 rho P is \\approx 5.1 \\times 10 kg/m\\). This is a unit which is very large, about equivalent to 10 solar masses squeezed into the space of a single atomic nucleus. At one unit of Planck time after the Big Bang, the mass density of the universe is thought to have been approximately one unit of Planck density."^^qudt:LatexString ;
+  qudt:conversionMultiplier 5.15500E96 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_density"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_density?oldid=493642128"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Density" ;
+.
+unit:PlanckEnergy
+  a qudt:Unit ;
+  dcterms:description "In physics, the unit of energy in the system of natural units known as Planck units is called the Planck energy, denoted by \\(E_\\rho\\). \\(E_\\rho\\) is a derived, as opposed to basic, Planck unit. An equivalent definition is: where is the Planck time. Also: where is the Planck mass."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.9561E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_energy"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_energy?oldid=493639955"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(E_\\rho = \\sqrt{\\frac{ \\hbar c^5}{G}} \\approx 1.936 \\times 10^9 J \\approx 1.22 \\times 10^{28} eV \\approx 0.5433 MWh\\), where  \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant."^^qudt:LatexString ;
+  qudt:symbol "E_\\rho" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Energy" ;
+.
+unit:PlanckForce
+  a qudt:Unit ;
+  dcterms:description "Planck force is the derived unit of force resulting from the definition of the base Planck units for time, length, and mass. It is equal to the natural unit of momentum divided by the natural unit of time."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.21027E44 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_force"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_force?oldid=493643031"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Force" ;
+.
+unit:PlanckFrequency
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.85487E43 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_angular_frequency"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_angular_frequency?oldid=493641308"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Frequency" ;
+.
+unit:PlanckFrequency_Ang
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_angular_frequency"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AngularFrequency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Angular Frequency" ;
+.
+unit:PlanckImpedance
+  a qudt:Unit ;
+  dcterms:description "The Planck impedance is the unit of electrical resistance, denoted by ZP, in the system of natural units known as Planck units. The Planck impedance is directly coupled to the impedance of free space, Z0, and differs in value from Z0 only by a factor of \\(4\\pi\\). If the Planck charge were instead defined to normalize the permittivity of free space, \\(\\epsilon_0\\), rather than the Coulomb constant, \\(1/(4\\pi\\epsilon_0)\\), then the Planck impedance would be identical to the characteristic impedance of free space."^^qudt:LatexString ;
+  qudt:conversionMultiplier "29.9792458"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_impedance"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(Z_P = \\frac{V_P}{I_P}= \\frac{1}{4\\pi\\epsilon_0c}=\\frac{\\mu_oc}{4\\pi}=\\frac{Z_0}{4\\pi}=29.9792458\\Omega\\)\\\\where \\(V_P\\) is the Planck voltage, \\(I_P\\) is the Planck current, \\(c\\) is the speed of light in a vacuum, \\(\\epsilon_0\\) is the permittivity of free space, \\(\\mu_0\\) is the permeability of free space, and \\(Z_0\\) is the impedance of free space."^^qudt:LatexString ;
+  qudt:symbol "ZP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Impedance" ;
+.
+unit:PlanckLength
+  a qudt:BaseUnit ;
+  dcterms:description "In physics, the Planck length, denoted \\(\\ell_P\\), is a unit of length, equal to \\(1.616199(97)×10 metres\\). It is a base unit in the system of Planck units. The Planck length can be defined from three fundamental physical constants: the speed of light in a vacuum, Planck's constant, and the gravitational constant. "^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.616252E-35 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_length"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_length?oldid=495093067"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(\\ell_P = \\sqrt{\\frac{ \\hbar G}{c^3}} \\approx 1.616199(97)) \\times 10^{-35} m\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
+  qudt:symbol "l_P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Length" ;
+.
+unit:PlanckMass
+  a qudt:BaseUnit ;
+  dcterms:description "In physics, the Planck mass, denoted by \\(m_P\\), is the unit of mass in the system of natural units known as Planck units. It is defined so that \\(\\approx  1.2209 \\times 10 GeV/c_0 = 2.17651(13) \\times 10 kg\\), (or \\(21.7651 \\mu g\\)), where \\(c_0\\) is the speed of light in a vacuum, \\(G\\) is the gravitational constant, and \\(\\hbar\\) is the reduced Planck constant. Particle physicists and cosmologists often use the reduced Planck mass, which is \\(\\approx  4.341 \\times 10 kg = 2.435  \\times 10 GeV/c\\). The added factor of \\(1/{\\sqrt{8\\pi}}\\) simplifies a number of equations in general relativity. Quantum effects are typified by the magnitude of Planck's constant."^^qudt:LatexString ;
+  qudt:conversionMultiplier 2.17644E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_mass"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_mass?oldid=493648632"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(m_P = \\sqrt{\\frac{ \\hbar c^3}{G}} \\approx 1.2209 \\times 10^{19} GeV/c^2 = 2.17651(13) \\times 10^{-8}\\), where \\(c\\) is the speed of light in a vacuum, \\(\\hbar\\) is the reduced Planck's constant, and \\(G\\) is the gravitational constant. The two digits enclosed by parentheses are the estimated standard error associated with the reported numerical value."^^qudt:LatexString ;
+  qudt:symbol "m_P" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Mass" ;
+.
+unit:PlanckMomentum
+  a qudt:Unit ;
+  dcterms:description "Planck momentum is the unit of momentum in the system of natural units known as Planck units. It has no commonly used symbol of its own, but can be denoted by, where is the Planck mass and is the speed of light in a vacuum. Then where is the reduced Planck's constant, is the Planck length, is the gravitational constant. In SI units Planck momentum is \\(\\approx 6.5 kg m/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6.52485"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_momentum"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:LinearMomentum ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_momentum?oldid=493644981"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Momentum" ;
+.
+unit:PlanckPower
+  a qudt:Unit ;
+  dcterms:description "The Planck energy divided by the Planck time is the Planck power \\(P_p \\), equal to about \\(3.62831 \\times 10^{52} W\\). This is an extremely large unit; even gamma-ray bursts, the most luminous phenomena known, have output on the order of \\(1 \\times 10^{45} W\\), less than one ten-millionth of the Planck power."^^qudt:LatexString ;
+  qudt:conversionMultiplier 3.62831E52 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_power"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_power?oldid=493642483"^^xsd:anyURI ;
+  qudt:latexDefinition "\\(P_p = {\\frac{ c^5}{G}}\\), where \\(c\\) is the speed of light in a vacuum, and \\(G\\) is the gravitational constant."^^qudt:LatexString ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Power" ;
+.
+unit:PlanckPressure
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.63309E113 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_pressure"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_pressure?oldid=493640883"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Pressure" ;
+.
+unit:PlanckTemperature
+  a qudt:BaseUnit ;
+  qudt:hasQuantityKind quantitykind:ThermodynamicTemperature ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "PlanckTemperature" ;
+.
+unit:PlanckTime
+  a qudt:BaseUnit ;
+  dcterms:description """<p class=\"lm-para\">In physics, the Planck time, denoted by \\(tP\\), is the unit of time in the system of natural units known as Planck units. It is the time required for light to travel, in a vacuum, a distance of 1 Planck length. The unit is named after Max Planck, who was the first to propose it.</p>
+
+<dd class=\"size-14\">\\(t_p \\equiv  \\sqrt{\\frac{\\hbar G}{c^5}} \\approx 5.39106(32) \\times 10^{-44} s\\)</dd>
+
+<p class=\"lm-para\">where,</p>
+<dd class=\"size-14\">\\(c\\) is the speed of light in a vacuum, </dd>
+<dd class=\"size-14\">\\(\\hbar\\) is the reduced Planck's constant (defined as \\(\\hbar = \\frac{h}{2 \\pi}\\)), and</dd>
+<dd class=\"size-14\">\\(G\\) is the gravitational constant.</dd>
+<p class=\"lm-para\">The two digits between parentheses denote the standard error of the estimated value.</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 5.39124E-44 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Planck_time"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Planck_time?oldid=495362103"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Planck_units"^^xsd:anyURI ;
+  qudt:symbol "tP" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Time" ;
+.
+unit:PlanckVolt
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.04295E27 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Volt" ;
+.
+unit:PlanckVolume
+  a qudt:Unit ;
+  qudt:conversionMultiplier 4.22419E-105 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Planck Volume" ;
+.
+unit:Platinum-OunceTroy
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  qudt:expression "\\(XPT\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Platinum (one Troy ounce)" ;
+.
+unit:PoundSterling
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "United Kingdom"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pound_sterling"^^xsd:anyURI ;
+  qudt:expression "\\(GBP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pound_sterling?oldid=495524329"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/poundSterling> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pound Sterling" ;
+.
+unit:Pula
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Botswana"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Pula"^^xsd:anyURI ;
+  qudt:expression "\\(BWP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Pula?oldid=495207177"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Pula" ;
+.
+unit:QT
+  a qudt:Unit ;
+  dcterms:description "A unit of volume (for either the imperial or United States customary units) equal to a quarter of a gallon (hence the name quart), two pints, or four cups. Since gallons of various sizes have historically been in use, quarts of various sizes have also existed; see gallon for further discussion. Three of these kinds of quarts remain in current use, all approximately equal to one litre. Its usual abbreviation is qt."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.00113652"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quart" ;
+.
+unit:QT_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.0011365225"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA963" ;
+  qudt:plainTextDescription "unit of the volume for fluids according to the Imperial system of units" ;
+  qudt:uneceCommonCode "QTI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_UK" ;
+  skos:prefLabel "quart (UK)" ;
+.
+unit:QT_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.31542e-08 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA710" ;
+  qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "K94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_UK PER DAY" ;
+  skos:prefLabel "quart (UK liquid) per day" ;
+.
+unit:QT_UK-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.157007e-07 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA711" ;
+  qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_UK PER HR" ;
+  skos:prefLabel "quart (UK liquid) per hour" ;
+.
+unit:QT_UK-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1.894205e-05 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA712" ;
+  qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "K96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_UK PER MIN" ;
+  skos:prefLabel "quart (UK liquid) per minute" ;
+.
+unit:QT_UK-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.0011365225"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA713" ;
+  qudt:plainTextDescription "unit of the volume quart (UK liquid) for fluids according to the Imperial system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "K97" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_UK PER SEC" ;
+  skos:prefLabel "quart (UK liquid) per second" ;
+.
+unit:QT_US
+  a qudt:Unit ;
+  dcterms:description "\"US Liquid Quart\" is a unit for  'Liquid Volume' expressed as \\(qt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 9.46353E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:LiquidVolume ;
+  qudt:symbol "qt" ;
+  qudt:ucumCaseInsensitiveCode "[QT_US]" ;
+  qudt:ucumCaseSensitiveCode "[qt_us]" ;
+  qudt:ucumCode "[QT_US]" ;
+  qudt:ucumCode "[qt_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Liquid Quart" ;
+.
+unit:QT_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00000001095316"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA714" ;
+  qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time day" ;
+  qudt:uneceCommonCode "K98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_US PER DAY" ;
+  skos:prefLabel "quart (US liquid) per day" ;
+.
+unit:QT_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.000000262875833"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA715" ;
+  qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time hour" ;
+  qudt:uneceCommonCode "K99" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_US PER HR" ;
+  skos:prefLabel "quart (US liquid) per hour" ;
+.
+unit:QT_US-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00001577255"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA716" ;
+  qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_US PER MIN" ;
+  skos:prefLabel "quart (US liquid) per minute" ;
+.
+unit:QT_US-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.000946353"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA717" ;
+  qudt:plainTextDescription "unit fo the volume quart (US liquid) for fluids according to the Anglo-American system of units divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QT_US PER SEC" ;
+  skos:prefLabel "quart (US liquid) per second" ;
+.
+unit:QT_US_DRY
+  a qudt:Unit ;
+  dcterms:description "\"US Dry Quart\" is a unit for  'Dry Volume' expressed as \\(dry_qt\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.001101220942715"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DryVolume ;
+  qudt:symbol "dry_qt" ;
+  qudt:ucumCaseInsensitiveCode "[DQT_US]" ;
+  qudt:ucumCaseSensitiveCode "[dqt_us]" ;
+  qudt:ucumCode "[DQT_US]" ;
+  qudt:ucumCode "[dqt_us]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Dry Quart" ;
+.
+unit:QUAD
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A quad is a unit of energy equal to \\(10 BTU\\), or \\(1.055 \\times \\SI{10}{\\joule}\\), which is \\(1.055 exajoule\\) or \\(EJ\\) in SI units. The unit is used by the U.S. Department of Energy in discussing world and national energy budgets. Some common types of an energy carrier approximately equal 1 quad are: 8,007,000,000 Gallons (US) of gasoline 293,083,000,000 Kilowatt-hours (kWh) 36,000,000 Tonnes of coal 970,434,000,000 Cubic feet of natural gas 5,996,000,000 UK gallons of diesel oil 25,200,000 Tonnes of oil 252,000,000 tonnes of TNT or five times the energy of the Tsar Bomba nuclear test."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.055E18 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quad"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quad?oldid=492086827"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/quad> ;
+  qudt:symbol "quad" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quad" ;
+.
+unit:QatariRial
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Qatar"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Qatari_riyal"^^xsd:anyURI ;
+  qudt:expression "\\(QAR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Qatari_riyal?oldid=491747452"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Qatari Rial" ;
+.
+unit:Quarter_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier "12.70058636"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB202" ;
+  qudt:plainTextDescription "unit of the mass according to the avoirdupois system of units: 1 qr. l. = 28 lb" ;
+  qudt:uneceCommonCode "QTR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quarter (UK)" ;
+  skos:prefLabel "quarter (UK)" ;
+.
+unit:Quetzal
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Guatemala"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Quetzal"^^xsd:anyURI ;
+  qudt:expression "\\(GTQ\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Quetzal?oldid=489813522"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Quetzal" ;
+.
+unit:R
+  a qudt:CGS-Unit ;
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "Not to be confused with roentgen equivalent man or roentgen equivalent physical The roentgen (symbol R) is an obsolete unit of measurement for the kerma of X-rays and gamma rays up to 3 MeV."^^rdf:HTML ;
+  qudt:conversionMultiplier 2.58E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Roentgen"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Exposure ;
+  qudt:iec61360Code "0112/2///62720#UAA275" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Roentgen?oldid=491213233"^^xsd:anyURI ;
+  qudt:symbol "R" ;
+  qudt:ucumCaseInsensitiveCode "R" ;
+  qudt:ucumCaseInsensitiveCode "ROE" ;
+  qudt:ucumCode "R" ;
+  qudt:ucumCode "ROE" ;
+  qudt:uneceCommonCode "2C" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Roentgen" ;
+.
+unit:RAD
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The radian is the standard unit of angular measure, used in many areas of mathematics. It describes the plane angle subtended by a circular arc as the length of the arc divided by the radius of the arc. In the absence of any symbol radians are assumed, and when degrees are meant the symbol \\(^{\\ circ}\\) is used. "^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Radian"^^xsd:anyURI ;
+  qudt:exactMatch unit:ARCMIN ;
+  qudt:guidance "<p>See NIST section <a href=\"http://physics.nist.gov/Pubs/SP811/sec07.html#7.10\">SP811 section7.10</a></p>"^^rdf:HTML ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA966" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Radian?oldid=492309312"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/radian> ;
+  qudt:plainTextDescription "The radian is the standard unit of angular measure, used in many areas of mathematics. It describes the plane angle subtended by a circular arc as the length of the arc divided by the radius of the arc. The unit was formerly a SI supplementary unit, but this category was abolished in 1995 and the radian is now considered a SI derived unit. The SI unit of solid angle measurement is the steradian.  The radian is represented by the symbol \"rad\" or, more rarely, by the superscript c (for \"circular measure\"). For example, an angle of 1.2 radians would be written as \"1.2 rad\" or \"1.2c\" (the second symbol is often mistaken for a degree: \"1.2u00b0\"). As the ratio of two lengths, the radian is a \"pure number\" that needs no unit symbol, and in mathematical writing the symbol \"rad\" is almost always omitted. In the absence of any symbol radians are assumed, and when degrees are meant the symbol u00b0 is used. [Wikipedia]" ;
+  qudt:symbol "rad" ;
+  qudt:ucumCaseInsensitiveCode "RAD" ;
+  qudt:ucumCaseSensitiveCode "rad" ;
+  qudt:ucumCode "RAD" ;
+  qudt:ucumCode "rad" ;
+  qudt:uneceCommonCode "C81" ;
+  rdfs:comment "The radian and steradian are special names for the number one that may be used to convey information about the quantity concerned. In practice the symbols rad and sr are used where appropriate, but the symbol for the derived unit one is generally omitted in specifying the values of dimensionless quantities." ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian" ;
+.
+unit:RAD-M2-PER-KiloGM
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad m^2 / kg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SpecificOpticalRotatoryPower ;
+  qudt:iec61360Code "0112/2///62720#UAB162" ;
+  qudt:uneceCommonCode "C83" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian Meter Squared per Kilogram" ;
+.
+unit:RAD-M2-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad m^2 / mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarOpticalRotatoryPower ;
+  qudt:iec61360Code "0112/2///62720#UAB161" ;
+  qudt:uneceCommonCode "C82" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian Meter Squared per Mole" ;
+.
+unit:RAD-PER-HR
+  a qudt:Unit ;
+  dcterms:description "\"Radian per Hour\" is a unit for  'Angular Velocity' expressed as \\(rad/h\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "3600.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:ucumCaseInsensitiveCode "RAD.HR-1" ;
+  qudt:ucumCaseInsensitiveCode "RAD/HR" ;
+  qudt:ucumCaseSensitiveCode "rad.h-1" ;
+  qudt:ucumCaseSensitiveCode "rad/h" ;
+  qudt:ucumCode "RAD.HR-1" ;
+  qudt:ucumCode "RAD/HR" ;
+  qudt:ucumCode "rad.h-1" ;
+  qudt:ucumCode "rad/h" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian per Hour" ;
+.
+unit:RAD-PER-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularWavenumber ;
+  qudt:hasQuantityKind quantitykind:FermiAngularWavenumber ;
+  qudt:iec61360Code "0112/2///62720#UAA967" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "C84" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian per Meter" ;
+.
+unit:RAD-PER-MIN
+  a qudt:Unit ;
+  dcterms:description "Radian Per Minute (rad/min) is a unit in the category of Angular velocity. It is also known as radians per minute, radian/minute. Radian Per Minute (rad/min) has a dimension of aT-1 where T is time. It can be converted to the corresponding standard SI unit rad/s by multiplying its value by a factor of 0.0166666666667. "^^rdf:HTML ;
+  qudt:conversionMultiplier "60.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:ucumCaseInsensitiveCode "RAD.MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "RAD/MIN" ;
+  qudt:ucumCaseSensitiveCode "rad.min-1" ;
+  qudt:ucumCaseSensitiveCode "rad/min" ;
+  qudt:ucumCode "RAD.MIN-1" ;
+  qudt:ucumCode "RAD/MIN" ;
+  qudt:ucumCode "rad.min-1" ;
+  qudt:ucumCode "rad/min" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian per Minute" ;
+.
+unit:RAD-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Radian per Second\" is the SI unit of rotational speed (angular velocity), and, also the unit of angular frequency. The radian per second is defined as the change in the orientation of an object, in radians, every second."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAA968" ;
+  qudt:ucumCaseInsensitiveCode "RAD.S-1" ;
+  qudt:ucumCaseInsensitiveCode "RAD/S" ;
+  qudt:ucumCaseSensitiveCode "rad.s-1" ;
+  qudt:ucumCaseSensitiveCode "rad/s" ;
+  qudt:ucumCode "RAD.S-1" ;
+  qudt:ucumCode "RAD/S" ;
+  qudt:ucumCode "rad.s-1" ;
+  qudt:ucumCode "rad/s" ;
+  qudt:uneceCommonCode "2A" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "radian per second" ;
+.
+unit:RAD-PER-SEC2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Angular acceleration is the rate of change of angular velocity. In SI units, it is measured in radians per second squared (\\(rad/s^2\\)), and is usually denoted by the Greek letter \\(\\alpha\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rad/s2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularAcceleration ;
+  qudt:iec61360Code "0112/2///62720#UAA969" ;
+  qudt:ucumCaseInsensitiveCode "RAD/S2" ;
+  qudt:ucumCaseSensitiveCode "rad/s2" ;
+  qudt:ucumCode "RAD/S2" ;
+  qudt:ucumCode "rad/s2" ;
+  qudt:uneceCommonCode "2B" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Radian per Second Squared" ;
+.
+unit:RAD_R
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The \\(rad\\) is a deprecated unit of absorbed radiation dose, defined as \\(1 rad = 0.01\\,Gy = 0.01 J/kg\\). It was originally defined in CGS units in 1953 as the dose causing 100 ergs of energy to be absorbed by one gram of matter. It has been replaced by the gray in most of the world. A related unit, the \\(roentgen\\), was formerly used to quantify the number of rad deposited into a target when it was exposed to radiation. The F-factor can used to convert between rad and roentgens. The material absorbing the radiation can be human tissue or silicon microchips or any other medium (for example, air, water, lead shielding, etc.)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/RAD"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:AbsorbedDose ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/RAD?oldid=493716376"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/rad> ;
+  qudt:symbol "rad" ;
+  qudt:ucumCaseInsensitiveCode "RAD" ;
+  qudt:ucumCaseInsensitiveCode "[RAD]" ;
+  qudt:ucumCode "RAD" ;
+  qudt:ucumCode "[RAD]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rad" ;
+.
+unit:RAYL
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">\\(\\textit{Rayl}\\) is one of two units of specific acoustic impedance. When sound waves pass through any physical substance the pressure of the waves causes the particles of the substance to move. The sound specific impedance is the ratio between the sound pressure and the particle velocity it produces. The specific impedance is one rayl if unit pressure produces unit velocity.</p>
+<p class=\"lm-para\">It is defined as follows: \\(1\\; rayl = 1 dyn\\cdot s\\cdot cm^{-3}\\)</p>
+<p class=\"lm-para\">Or in SI as: \\(1 \\; rayl = 10^{-1}Pa\\cdot s\\cdot m^{-1}\\), which equals \\(10\\,N \\cdot s\\cdot m^{-3}\\).</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Rayl"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:SpecificAcousticImpedance ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Rayl?oldid=433570842"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rayl" ;
+.
+unit:REM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A Rem is a deprecated unit used to measure the biological effects of ionizing radiation. The rem is defined as equal to 0.01 sievert, which is the more commonly used unit outside of the United States. Equivalent dose, effective dose, and committed dose can all be measured in units of rem. These quantities are products of the absorbed dose in rads and weighting factors. These factors must be selected for each exposure situation; there is no universally applicable conversion constant from rad to rem. A rem is a large dose of radiation, so the millirem (mrem), which is one thousandth of a rem, is often used for the dosages commonly encountered, such as the amount of radiation received from medical x-rays and background sources."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-2 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:DoseEquivalent ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Roentgen_equivalent_man"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/rem> ;
+  qudt:symbol "rem" ;
+  qudt:ucumCaseInsensitiveCode "REM" ;
+  qudt:ucumCaseInsensitiveCode "[REM]" ;
+  qudt:ucumCode "REM" ;
+  qudt:ucumCode "[REM]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rem" ;
+.
+unit:REV
+  a qudt:Unit ;
+  dcterms:description "\"Revolution\" is a unit for  'Plane Angle' expressed as \\(rev\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6.28318531"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Revolution"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:PlaneAngle ;
+  qudt:iec61360Code "0112/2///62720#UAB206" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Revolution?oldid=494110330"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/revolution> ;
+  qudt:symbol "rev" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Revolution" ;
+.
+unit:REV-PER-HR
+  a qudt:Unit ;
+  dcterms:description "\"Revolution per Hour\" is a unit for  'Angular Velocity' expressed as \\(rev/h\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.00174532925"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rev/h\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Revolution per Hour" ;
+.
+unit:REV-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Revolution per Minute\" is a unit for  'Angular Velocity' expressed as \\(rev/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.104719755"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rev/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  qudt:iec61360Code "0112/2///62720#UAB231" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Revolution per Minute" ;
+.
+unit:REV-PER-SEC
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Revolution per Second\" is a unit for  'Angular Velocity' expressed as \\(rev/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6.28318531"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rev/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularVelocity ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Revolution per Second" ;
+.
+unit:REV-PER-SEC2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"Revolution per Second Squared\" is a C.G.S System unit for  'Angular Acceleration' expressed as \\(rev-per-s^2\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "6.28318531"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(rev/s2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AngularAcceleration ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Revolution per Second Squared" ;
+.
+unit:ROD
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of distance equal to 5.5 yards (16 feet 6 inches)."^^rdf:HTML ;
+  qudt:conversionMultiplier "5.029210"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Rod"^^xsd:anyURI ;
+  qudt:expression "\\(rd\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAA970" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Rod?oldid=492590086"^^xsd:anyURI ;
+  qudt:ucumCaseInsensitiveCode "[RD_BR]" ;
+  qudt:ucumCaseSensitiveCode "[rd_br]" ;
+  qudt:ucumCode "[RD_BR]" ;
+  qudt:ucumCode "[rd_br]" ;
+  qudt:uneceCommonCode "F49" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rod" ;
+.
+unit:RT
+  a qudt:Unit ;
+  dcterms:description "The register ton is a unit of volume used for the cargo capacity of a ship, defined as 100 cubic feet (roughly 2.83 cubic metres)."^^rdf:HTML ;
+  qudt:conversionMultiplier "2.8316846592"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:symbol "RT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Register Ton" ;
+.
+unit:Riel
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cambodia"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Riel"^^xsd:anyURI ;
+  qudt:expression "\\(KHR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Riel?oldid=473309240"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Riel" ;
+.
+unit:RomanianNeLeu
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Romania"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(RON\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Romanian New Leu" ;
+.
+unit:Rufiyaa
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Maldives"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Maldivian_rufiyaa"^^xsd:anyURI ;
+  qudt:expression "\\(MVR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Maldivian_rufiyaa?oldid=491578728"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rufiyaa" ;
+.
+unit:Rupiah
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Indonesia"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Indonesian_rupiah"^^xsd:anyURI ;
+  qudt:expression "\\(IDR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Indonesian_rupiah?oldid=489729458"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rupiah" ;
+.
+unit:RussianRuble
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Russia, Abkhazia, South Ossetia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Russian_ruble"^^xsd:anyURI ;
+  qudt:expression "\\(RUB\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Russian_ruble?oldid=494336467"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Russian Ruble" ;
+.
+unit:RwandaFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Rwanda"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Rwandan_franc"^^xsd:anyURI ;
+  qudt:expression "\\(RWF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Rwandan_franc?oldid=489727903"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Rwanda Franc" ;
+.
+unit:S
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p><em>Siemens</em> is the SI unit of electric conductance, susceptance, and admittance. The most important property of a conductor is the amount of current it will carry when a voltage is applied. Current flow is opposed by resistance in all circuits, and by also by reactance and impedance in alternating current circuits. Conductance, susceptance, and admittance are the inverses of resistance, reactance, and impedance, respectively. To measure these properties, the siemens is the reciprocal of the ohm. In other words, the conductance, susceptance, or admittance, in siemens, is simply 1 divided by the resistance, reactance or impedance, respectively, in ohms. The unit is named for the German electrical engineer Werner von Siemens (1816-1892).</p>
+<p>\\(\\ \\equiv\\ \\text{siemens}\\ \\equiv\\ \\frac{\\text{A}}{\\text{V}}\\ \\equiv\\ \\frac{\\text{amp}}{\\text{volt}}\\ \\equiv\\ \\frac{\\text{F}}{\\text {s}}\\ \\equiv\\ \\frac{\\text{farad}}{\\text{second}}\\)</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA277" ;
+  qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Siemens_(unit)"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/siemens> ;
+  qudt:siUnitsExpression "A/V" ;
+  qudt:symbol "S" ;
+  qudt:ucumCaseInsensitiveCode "S" ;
+  qudt:ucumCaseInsensitiveCode "SIE" ;
+  qudt:ucumCode "S" ;
+  qudt:ucumCode "SIE" ;
+  qudt:uneceCommonCode "SIE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Siemens" ;
+.
+unit:S-M2-PER-MOL
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(s-m2-per-mol\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MolarConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA280" ;
+  qudt:uneceCommonCode "D12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Siemens meter squared per mole" ;
+.
+unit:S-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier "100.0"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA278" ;
+  qudt:plainTextDescription "SI derived unit Siemens divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "H43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "S PER CentiM" ;
+  skos:prefLabel "siemens per centimetre" ;
+.
+unit:S-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(s-per-m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Conductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA279" ;
+  qudt:plainTextDescription "SI derived unit siemens divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "D10" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "S PER M" ;
+  rdfs:label "Siemens per meter" ;
+  skos:prefLabel "siemens per metre" ;
+.
+unit:SAMPLE-PER-SEC
+  a qudt:CountingUnit ;
+  a qudt:Unit ;
+  dcterms:description "The number of discrete samples of some thing per second."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(sample-per-sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sample per second" ;
+.
+unit:SEC
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description """The \\(Second\\) (symbol: \\(s\\)) is the base unit of time in the International System of Units (SI) and is also a unit of time in other systems of measurement. Between the years1000 (when al-Biruni used seconds) and 1960 the second was defined as \\(1/86400\\) of a mean solar day (that definition still applies in some astronomical and legal contexts). Between 1960 and 1967, it was defined in terms of the period of the Earth's orbit around the Sun in 1900, but it is now defined more precisely in atomic terms.
+Under the International System of Units (via the International Committee for Weights and Measures, or CIPM), since 1967 the second has been defined as the duration of \\({9192631770}\\) periods of the radiation corresponding to the transition between the two hyperfine levels of the ground state of the caesium 133 atom.In 1997 CIPM added that the periods would be defined for a caesium atom at rest, and approaching the theoretical temperature of absolute zero, and in 1999, it included corrections from ambient radiation."""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Second"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAA972" ;
+  qudt:iec61360Code "0112/2///62720#UAD722" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Second?oldid=495241006"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/second-Time> ;
+  qudt:symbol "s" ;
+  qudt:ucumCaseInsensitiveCode "S" ;
+  qudt:ucumCaseSensitiveCode "s" ;
+  qudt:ucumCode "S" ;
+  qudt:ucumCode "s" ;
+  qudt:uneceCommonCode "SEC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Second" ;
+.
+unit:SEC-FT2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Second Square Foot\" is an Imperial unit for  'Area Time' expressed as \\(s-ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.09290304"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(s-ft^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:AreaTime ;
+  qudt:ucumCaseInsensitiveCode "S.[FT_I]2" ;
+  qudt:ucumCaseInsensitiveCode "S.[SFT_I]" ;
+  qudt:ucumCaseSensitiveCode "s.[ft_i]2" ;
+  qudt:ucumCaseSensitiveCode "s.[sft_i]" ;
+  qudt:ucumCode "S.[FT_I]2" ;
+  qudt:ucumCode "S.[SFT_I]" ;
+  qudt:ucumCode "s.[ft_i]2" ;
+  qudt:ucumCode "s.[sft_i]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Second Square Foot" ;
+.
+unit:SEC-PER-RAD-M3
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(sec/rad-m^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DensityOfStates ;
+  qudt:iec61360Code "0112/2///62720#UAB352" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Second per Radian Cubic Meter" ;
+.
+unit:SEC2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Second Squared\" is a unit for  'Time Squared' expressed as \\(s^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(s^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:TimeSquared ;
+  qudt:ucumCaseInsensitiveCode "S2" ;
+  qudt:ucumCaseSensitiveCode "s2" ;
+  qudt:ucumCode "S2" ;
+  qudt:ucumCode "s2" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "second squared" ;
+.
+unit:SH
+  a qudt:Unit ;
+  dcterms:description "A shake is an informal unit of time equal to 10 nanoseconds. It has applications in nuclear physics, helping to conveniently express the timing of various events in a nuclear explosion. The typical time required for one step in the chain reaction (i.e. the typical time for each neutron to cause a fission event which releases more neutrons) is of order 1 shake, and the chain reaction is typically complete by 50 to 100 shakes."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Shake"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB226" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Shake?oldid=494796779"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/shake> ;
+  qudt:symbol "Sh" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Shake" ;
+.
+unit:SHANNON
+  a qudt:Unit ;
+  dcterms:description "The \"Shannon\" is a unit of information."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Sh\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InformationEntropy ;
+  qudt:iec61360Code "0112/2///62720#UAB343" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/shannon> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Shannon" ;
+.
+unit:SHANNON-PER-SEC
+  a qudt:Unit ;
+  dcterms:description "The \"Shannon per Second\" is a unit of information rate."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(Sh/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:InformationFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB346" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ban_(information)"^^xsd:anyURI ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31898"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Shannon per Second" ;
+.
+unit:SLUG
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The slug is a unit of mass associated with Imperial units. It is a mass that accelerates by \\(1 ft/s\\) when a force of one pound-force (\\(lbF\\)) is exerted on it. With standard gravity \\(gc = 9.80665 m/s\\), the international foot of \\(0.3048 m\\) and the avoirdupois pound of \\(0.45359237 kg\\), one slug therefore has a mass of approximately \\(32.17405 lbm\\) or \\(14.593903 kg\\). At the surface of the Earth, an object with a mass of 1 slug exerts a force of about \\(32.17 lbF\\) or \\(143 N\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "14.593903"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Slug"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAA978" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Slug?oldid=495010998"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/slug> ;
+  qudt:symbol "slug" ;
+  qudt:uneceCommonCode "F13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug" ;
+.
+unit:SLUG-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00016891087963"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA979" ;
+  qudt:plainTextDescription "unit slug for mass according to an English engineering system divided by the unit day" ;
+  qudt:uneceCommonCode "L63" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "SLUG PER DAY" ;
+  skos:prefLabel "slug per day" ;
+.
+unit:SLUG-PER-FT
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Slug per Foot\" is an Imperial unit for  'Mass Per Length' expressed as \\(slug/ft\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 47.8802591863517e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(slug/ft\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug per Foot" ;
+.
+unit:SLUG-PER-FT-SEC
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Slug per Foot Second</em> is a unit for  'Dynamic Viscosity' expressed as \\(slug/(ft-s)\\).</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 47.8802591863517e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(slug/(ft-s)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:DynamicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA980" ;
+  qudt:uneceCommonCode "L64" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug per Foot Second" ;
+.
+unit:SLUG-PER-FT2
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Slug per Square Foot\" is an Imperial unit for  'Mass Per Area' expressed as \\(slug/ft^{2}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 157.08746452215124e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(slug/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug per Square Foot" ;
+.
+unit:SLUG-PER-FT3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Slug per Cubic Foot\" is an Imperial unit for  'Density' expressed as \\(slug/ft^{3}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 515.3788206107324e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(slug/ft^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  qudt:iec61360Code "0112/2///62720#UAA981" ;
+  qudt:uneceCommonCode "L65" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug per Cubic Foot" ;
+.
+unit:SLUG-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.004053861111111"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA982" ;
+  qudt:plainTextDescription "unit slug for mass slug according to the English engineering system divided by the unit hour" ;
+  qudt:uneceCommonCode "L66" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "SLUG PER HR" ;
+  skos:prefLabel "slug per hour" ;
+.
+unit:SLUG-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.243231666666667"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA983" ;
+  qudt:plainTextDescription "unit slug for the mass according to the English engineering system divided by the unit minute" ;
+  qudt:uneceCommonCode "L67" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "SLUG PER MIN" ;
+  skos:prefLabel "slug per minute" ;
+.
+unit:SLUG-PER-SEC
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Slug per Second\" is an Imperial unit for  'Mass Per Time' expressed as \\(slug/s\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 14.593903e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(slug/s\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  qudt:iec61360Code "0112/2///62720#UAA984" ;
+  qudt:uneceCommonCode "L68" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slug per Second" ;
+.
+unit:SR
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The steradian (symbol: sr) is the SI unit of solid angle. It is used to describe two-dimensional angular spans in three-dimensional space, analogous to the way in which the radian describes angles in a plane. The radian and steradian are special names for the number one that may be used to convey information about the quantity concerned. In practice the symbols rad and sr are used where appropriate, but the symbol for the derived unit one is generally omitted in specifying the values of dimensionless quantities."^^rdf:HTML ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Steradian"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:SolidAngle ;
+  qudt:iec61360Code "0112/2///62720#UAA986" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Steradian?oldid=494317847"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/steradian> ;
+  qudt:symbol "sr" ;
+  qudt:ucumCaseInsensitiveCode "SR" ;
+  qudt:ucumCaseSensitiveCode "sr" ;
+  qudt:ucumCode "SR" ;
+  qudt:ucumCode "sr" ;
+  qudt:uneceCommonCode "D27" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Steradian" ;
+.
+unit:ST
+  a qudt:Unit ;
+  dcterms:description "The stere is a unit of volume in the original metric system equal to one cubic metre.  The stere is typically used for measuring large quantities of firewood or other cut wood, while the cubic meter is used for uncut wood. It is not part of the modern metric system (SI). In Dutch there's also a kuub, short for kubieke meter which is similar but different."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/St%C3%A8re"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAA987" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stère?oldid=393570287"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/stere> ;
+  qudt:symbol "st" ;
+  qudt:ucumCaseInsensitiveCode "STR" ;
+  qudt:ucumCaseSensitiveCode "st" ;
+  qudt:ucumCode "STR" ;
+  qudt:ucumCode "st" ;
+  qudt:uneceCommonCode "G26" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stere" ;
+.
+unit:STILB
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The <em>stilb (sb)</em> is the CGS unit of luminance for objects that are not self-luminous. It is equal to one candela per square centimeter or 10 nits (candelas per square meter). The name was coined by the French physicist A. Blondel around 1920. It comes from the Greek word stilbein meaning 'to glitter'. It was in common use in Europe up to World War I. In North America self-explanatory terms such as candle per square inch and candle per square meter were more common. The unit has since largely been replaced by the SI unit: candela per square meter.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 10000.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Stilb"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Luminance ;
+  qudt:iec61360Code "0112/2///62720#UAB260" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stilb?oldid=375748497"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/stilb> ;
+  qudt:symbol "sb" ;
+  qudt:ucumCaseInsensitiveCode "SB" ;
+  qudt:ucumCaseSensitiveCode "sb" ;
+  qudt:ucumCode "SB" ;
+  qudt:ucumCode "sb" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stilb" ;
+.
+unit:SV
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Although the sievert has the same dimensions as the gray (i.e. joules per kilogram), it measures a different quantity. To avoid any risk of confusion between the absorbed dose and the equivalent dose, the corresponding special units, namely the gray instead of the joule per kilogram for absorbed dose and the sievert instead of the joule per kilogram for the dose equivalent, should be used."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Sievert"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:DoseEquivalent ;
+  qudt:iec61360Code "0112/2///62720#UAA284" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sievert?oldid=495474333"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1284"^^xsd:anyURI ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/sievert> ;
+  qudt:siUnitsExpression "J/kg" ;
+  qudt:symbol "Sv" ;
+  qudt:ucumCaseInsensitiveCode "SV" ;
+  qudt:ucumCaseSensitiveCode "Sv" ;
+  qudt:ucumCode "SV" ;
+  qudt:ucumCode "Sv" ;
+  qudt:uneceCommonCode "D13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sievert" ;
+.
+unit:S_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The CGS electromagnetic unit of conductance; one absiemen is the conductance at which a potential of one abvolt forces a current of one abampere; equal to \\(10^{9}\\) siemens. One siemen is the conductance at which a potential of one volt forces a current of one ampere and named for Karl Wilhem Siemens."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:informativeReference "http://wordinfo.info/unit/4266"^^xsd:anyURI ;
+  qudt:symbol "aS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Absiemen" ;
+.
+unit:S_Stat
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The unit of conductance, admittance, and susceptance in the centimeter-gram-second electrostatic system of units."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.1126500561e-12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:MHO_Stat ;
+  qudt:hasQuantityKind quantitykind:ElectricConductivity ;
+  qudt:informativeReference "http://www.knowledgedoor.com/2/units_and_constants_handbook/statsiemens.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.sizes.com/units/statmho.htm"^^xsd:anyURI ;
+  qudt:informativeReference "http://www3.wolframalpha.com/input/?i=statsiemens"^^xsd:anyURI ;
+  qudt:symbol "statS" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statsiemens" ;
+  skos:altLabel "statmho" ;
+.
+unit:SaintHelenaPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Saint Helena"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Saint_Helena_pound"^^xsd:anyURI ;
+  qudt:expression "\\(SHP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Saint_Helena_pound?oldid=490152057"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Saint Helena Pound" ;
+.
+unit:SamoanTala
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Samoa"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Samoan_tala"^^xsd:anyURI ;
+  qudt:expression "\\(WST\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Samoan_tala?oldid=423898531"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Samoan Tala" ;
+.
+unit:SaudiRiyal
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Saudi Arabia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Saudi_riyal"^^xsd:anyURI ;
+  qudt:expression "\\(SAR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Saudi_riyal?oldid=491092981"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Saudi Riyal" ;
+.
+unit:SerbianDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Serbia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Serbian_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(RSD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Serbian_dinar?oldid=495146650"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Serbian Dinar" ;
+.
+unit:SeychellesRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Seychelles"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Seychellois_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(SCR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Seychellois_rupee?oldid=492242185"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Seychelles Rupee" ;
+.
+unit:Silver-OunceTroy
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  qudt:expression "\\(XAG\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Silver (one Troy ounce)" ;
+.
+unit:SingaporeDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Singapore"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Singapore_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(SGD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Singapore_dollar?oldid=492228311"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/SingaporeDollar> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Singapore Dollar" ;
+.
+unit:SlovakKoruna
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Slovakia"^^rdf:HTML ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Slovak_koruna"^^xsd:anyURI ;
+  qudt:expression "\\(SKK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Slovak_koruna?oldid=492625951"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Slovak Koruna" ;
+.
+unit:SolarMass
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The astronomical unit of mass is the solar mass.The symbol \\(S\\) is often used in astronomy to refer to this unit, although \\(M_{\\odot}\\) is also common. The solar mass, \\(1.98892 \\time 1030 kg\\), is a standard way to express mass in astronomy, used to describe the masses of other stars and galaxies. It is equal to the mass of the Sun, about 333,000 times the mass of the Earth or 1,048 times the mass of Jupiter. In practice, the masses of celestial bodies appear in the dynamics of the solar system only through the products GM, where G is the constant of gravitation.</p>"^^qudt:LatexString ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Solar_mass"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Solar_mass?oldid=494074016"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/solarMass> ;
+  qudt:symbol "S" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Solar mass" ;
+.
+unit:SolomonIslandsDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Solomon Islands"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Solomon_Islands_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(SBD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Solomon_Islands_dollar?oldid=490313285"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Solomon Islands Dollar" ;
+.
+unit:Som
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kyrgyzstan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Som"^^xsd:anyURI ;
+  qudt:expression "\\(KGS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Som?oldid=495411674"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Som" ;
+.
+unit:SomaliShilling
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Somalia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Somali_shilling"^^xsd:anyURI ;
+  qudt:expression "\\(SOS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Somali_shilling?oldid=494434126"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Somali Shilling" ;
+.
+unit:Somoni
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Tajikistan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tajikistani_somoni"^^xsd:anyURI ;
+  qudt:expression "\\(TJS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tajikistani_somoni?oldid=492500781"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Somoni" ;
+.
+unit:SouthAfricanRand
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "South Africa"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/South_African_rand"^^xsd:anyURI ;
+  qudt:expression "\\(ZAR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/South_African_rand?oldid=493780395"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/SouthAfricanRand> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "South African Rand" ;
+.
+unit:SouthKoreanWon
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "South Korea"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/South_Korean_won"^^xsd:anyURI ;
+  qudt:expression "\\(KRW\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/South_Korean_won?oldid=494404062"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/SouthKoreanWon> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "South Korean Won" ;
+.
+unit:SpecialDrawingRights
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "International Monetary Fund"^^rdf:HTML ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Special_Drawing_Rights"^^xsd:anyURI ;
+  qudt:expression "\\(XDR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Special_Drawing_Rights?oldid=467224374"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Special Drawing Rights" ;
+.
+unit:SriLankaRupee
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Sri Lanka"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Sri_Lankan_rupee"^^xsd:anyURI ;
+  qudt:expression "\\(LKR\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sri_Lankan_rupee?oldid=495359963"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sri Lanka Rupee" ;
+.
+unit:St
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Stokes (St)</em> is a unit in the category of Kinematic viscosity. This unit is commonly used in the cgs unit system. Stokes (St) has a dimension of \\(L^2T^{-1}\\) where \\(L\\) is length, and \\(T\\) is time. It can be converted to the corresponding standard SI unit \\(m^2/s\\) by multiplying its value by a factor of 0.0001.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Stokes"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:KinematicViscosity ;
+  qudt:iec61360Code "0112/2///62720#UAA281" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Stokes?oldid=426159512"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--kinematic_viscosity--stokes.cfm"^^xsd:anyURI ;
+  qudt:isDerivedCoherentUnitOfSystem qudt:SOU_CGS-MECHANICS ;
+  qudt:latexDefinition "\\((cm^2/s\\))"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/stokes> ;
+  qudt:symbol "St" ;
+  qudt:symbol "v" ;
+  qudt:ucumCaseInsensitiveCode "ST" ;
+  qudt:ucumCaseSensitiveCode "St" ;
+  qudt:ucumCode "ST" ;
+  qudt:ucumCode "St" ;
+  qudt:uneceCommonCode "91" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stokes" ;
+.
+unit:Standard
+  a qudt:Unit ;
+  qudt:conversionMultiplier "4.672"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB116" ;
+  qudt:plainTextDescription "non SI-conform unit of the volume of readily finished wood material : 1 standard = 1,980 board feet or approximate 4.672 cubic metre" ;
+  qudt:uneceCommonCode "WSD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Standard" ;
+  skos:prefLabel "standard" ;
+.
+unit:Stone_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier "6.35029318"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB081" ;
+  qudt:plainTextDescription "unit of the mass which is commonly used for the determination of the weight of living beings regarding to the conversion to the avoirdupois system of units: 1 st = 14 lb (av)" ;
+  qudt:uneceCommonCode "STI" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Stone_UK" ;
+  skos:prefLabel "stone (UK)" ;
+.
+unit:SudanesePound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Sudan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Sudanese_pound"^^xsd:anyURI ;
+  qudt:expression "\\(SDG\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Sudanese_pound?oldid=495263707"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sudanese Pound" ;
+.
+unit:SurinamDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Suriname"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Surinamese_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(SRD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Surinamese_dollar?oldid=490316270"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Surinam Dollar" ;
+.
+unit:SwedishKrona
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Sweden"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Swedish_krona"^^xsd:anyURI ;
+  qudt:expression "\\(SEK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Swedish_krona?oldid=492703602"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/SwedishKrona> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Swedish Krona" ;
+.
+unit:SwissFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Switzerland, Liechtenstein"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Swiss_franc"^^xsd:anyURI ;
+  qudt:expression "\\(CHF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Swiss_franc?oldid=492548706"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/SwissFranc> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Swiss Franc" ;
+.
+unit:SyrianPound
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Syria"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Syrian_pound"^^xsd:anyURI ;
+  qudt:expression "\\(SYP\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Syrian_pound?oldid=484294722"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Syrian Pound" ;
+.
+unit:T
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p>The SI unit of flux density (or field intensity) for magnetic fields (also called the magnetic induction). The intensity of a magnetic field can be measured by placing a current-carrying conductor in the field. The magnetic field exerts a force on the conductor, a force which depends on the amount of the current and on the length of the conductor. One tesla is defined as the field intensity generating one newton of force per ampere of current per meter of conductor. Equivalently, one tesla represents a magnetic flux density of one weber per square meter of area. A field of one tesla is quite strong: the strongest fields available in laboratories are about 20 teslas, and the Earth's magnetic flux density, at its surface, is about 50 microteslas. The tesla, defined in 1958, honors the Serbian-American electrical engineer Nikola Tesla (1856-1943), whose work in electromagnetic induction led to the first practical generators and motors using alternating current.</p>
+<p>\\(T =  V\\ s \\ m^{-2} = N\\ A^{-1} m^{-1} = Wb m^{-1} = kg \\  C^{-1} s^{-1} A^{-1} = kg \\ s^{-2} A^{-1} = N \\ s \\ C^{-1}m^{-1}\\)</p>
+<p>where, \\(A\\) = ampere, \\(C\\)=coulomb, \\(m\\) = meter,  \\(N\\) = newton, \\(s\\) = second, \\(T\\) = tesla, \\(Wb\\) = weber</p>"""^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tesla"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA285" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tesla?oldid=481198244"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tesla_(unit)"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1406?rskey=AzXBLd"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/tesla> ;
+  qudt:siUnitsExpression "Wb/m^2" ;
+  qudt:symbol "T" ;
+  qudt:ucumCaseInsensitiveCode "T" ;
+  qudt:ucumCode "T" ;
+  qudt:uneceCommonCode "D33" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tesla" ;
+.
+unit:T-M
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxPerUnitLength ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "T-M" ;
+.
+unit:T-SEC
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:MassPerElectricCharge ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "T-SEC" ;
+.
+unit:TBSP
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "In the US and parts of Canada, a tablespoon is the largest type of spoon used for eating from a bowl. In the UK and most Commonwealth countries, a tablespoon is a type of large spoon usually used for serving. In countries where a tablespoon is a serving spoon, the nearest equivalent to the US tablespoon is either the dessert spoon or the soup spoon. A tablespoonful, nominally the capacity of one tablespoon, is commonly used as a measure of volume in cooking. It is abbreviated as T, tb, tbs, tbsp, tblsp, or tblspn. The capacity of ordinary tablespoons is not regulated by law and is subject to considerable variation. In most countries one level tablespoon is approximately 15 mL; in Australia it is 20 mL."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.47867656E-5 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tablespoon"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB006" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tablespoon?oldid=494615208"^^xsd:anyURI ;
+  qudt:symbol "tbsp" ;
+  qudt:ucumCaseInsensitiveCode "[TBS_US]" ;
+  qudt:ucumCaseSensitiveCode "[tbs_us]" ;
+  qudt:ucumCode "[TBS_US]" ;
+  qudt:ucumCode "[tbs_us]" ;
+  qudt:uneceCommonCode "G24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tablespoon" ;
+.
+unit:TEX
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\"><em>Tex</em> is a unit of measure for the linear mass density of fibers and is defined as the mass in grams per 1000 meters. Tex is more likely to be used in Canada and Continental Europe, while denier remains more common in the United States and United Kingdom. The unit code is 'tex'. The most commonly used unit is actually the decitex, abbreviated dtex, which is the mass in grams per 10,000 meters. When measuring objects that consist of multiple fibers the term 'filament tex' is sometimes used, referring to the mass in grams per 1000 meters of a single filament. Tex is used for measuring fiber size in many products, including cigarette filters, optical cable, yarn, and fabric.</em>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tex"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MassPerLength ;
+  qudt:iec61360Code "0112/2///62720#UAB246" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tex?oldid=457265525"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Units_of_textile_measurement"^^xsd:anyURI ;
+  qudt:symbol "tex" ;
+  qudt:ucumCaseInsensitiveCode "TEX" ;
+  qudt:ucumCaseSensitiveCode "tex" ;
+  qudt:ucumCode "TEX" ;
+  qudt:ucumCode "tex" ;
+  qudt:uneceCommonCode "D34" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tex" ;
+.
+unit:THB
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Thailand"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Thai_baht"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thai_baht?oldid=493286022"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Baht" ;
+.
+unit:THM_EEC
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(therm-eec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "THM_EEC" ;
+.
+unit:THM_US
+  a qudt:Unit ;
+  dcterms:description "<p><em>Therm</em> (symbol \\(thm\\)) is a non-SI unit of heat energy. It was defined in the United States in 1968 as the energy equivalent of burning 100 cubic feet of natural gas at standard temperature and pressure. In the US gas industry its SI equivalent is defined as exactly \\(100,000 BTU59^\\circ F\\) or \\(105.4804 megajoules\\). Public utilities in the U.S. use the therm unit for measuring customer usage of gas and calculating the monthly bills.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "105480400"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:hasQuantityKind quantitykind:ThermalEnergy ;
+  qudt:informativeReference "http://www.convertunits.com/info/therm%2B%5BU.S.%5D"^^xsd:anyURI ;
+  qudt:symbol "thm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Therm US" ;
+.
+unit:TOE
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">The tonne of oil equivalent (toe) is a unit of energy: the amount of energy released by burning one tonne of crude oil, approximately 42 GJ (as different crude oils have different calorific values, the exact value of the toe is defined by convention; unfortunately there are several slightly different definitions as discussed below). The toe is sometimes used for large amounts of energy, as it can be more intuitive to visualise, say, the energy released by burning 1000 tonnes of oil than 42,000 billion joules (the SI unit of energy).</p>
+<p class=\"lm-para\">Multiples of the toe are used, in particular the megatoe (Mtoe, one million toe) and the gigatoe (Gtoe, one billion toe).</p>"""^^rdf:HTML ;
+  qudt:conversionMultiplier 4.1868E10 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tonne_of_oil_equivalent"^^xsd:anyURI ;
+  qudt:symbol "toe" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ton of Oil Equivalent" ;
+.
+unit:TON_Assay
+  a qudt:NonSI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">In the United States, a unit of mass, approximately \\(29.167\\, grams\\). The number of milligrams of precious metal in one assay ton of the ore being tested is equal to the number of troy ounces of pure precious metal in one 2000-pound ton of the ore. i.e. a bead is obtained that weights 3 milligrams, thus the precious metals in the bead would equal three troy ounces to each ton of ore with the understanding that this varies considerably in the real world as the amount of precious values in each ton of ore varies considerably.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "0.02916667"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://www.assaying.org/assayton.htm"^^xsd:anyURI ;
+  qudt:symbol "AT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Assay Ton" ;
+.
+unit:TON_FG
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "12000 btu per hour</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "3517"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ton_of_refrigeration"^^xsd:anyURI ;
+  qudt:expression "\\(t/fg\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ton_of_refrigeration?oldid=494342824"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/tonOfRefrigeration> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ton of Refrigeration" ;
+.
+unit:TON_F_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier "8896.443230521"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Force ;
+  qudt:iec61360Code "0112/2///62720#UAB021" ;
+  qudt:plainTextDescription "unit of the force according to the American system of units" ;
+  qudt:uneceCommonCode "L94" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_F_US" ;
+  skos:prefLabel "ton?force (US short)" ;
+.
+unit:TON_LONG
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">Long ton (weight ton or imperial ton) is the name for the unit called the \"ton\" in the avoirdupois or Imperial system of measurements, as used in the United Kingdom and several other Commonwealth countries. One long ton is equal to 2,240 pounds (1,016 kg), 1.12 times as much as a short ton, or 35 cubic feet (0.9911 m3) of salt water with a density of 64 lb/ft3 (1.025 g/ml).</p>
+<p class=\"lm-para\">It has some limited use in the United States, most commonly in measuring the displacement of ships, and was the unit prescribed for warships by the Washington Naval Treaty 1922-for example battleships were limited to a mass of 35,000 long tons (36,000 t; 39,000 short tons).</p>"""^^rdf:HTML ;
+  qudt:conversionMultiplier "1016.0469088"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Long_ton"^^xsd:anyURI ;
+  qudt:symbol "ton" ;
+  qudt:ucumCaseInsensitiveCode "[LTON_AV]" ;
+  qudt:ucumCaseSensitiveCode "[lton_av]" ;
+  qudt:ucumCode "[LTON_AV]" ;
+  qudt:ucumCode "[lton_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Long Ton" ;
+.
+unit:TON_LONG-PER-YD3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The long ton per cubic yard density measurement unit is used to measure volume in cubic yards in order to estimate weight or mass in long tons."^^rdf:HTML ;
+  qudt:conversionMultiplier 1328.9391836174336e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ton/yd^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Long Ton per Cubic Yard" ;
+.
+unit:TON_M
+  a qudt:CGS-Unit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The tonne (SI unit symbol: t) is a metric system unit of mass equal to 1,000 kilograms (2,204.6 pounds). It is a non-SI unit accepted for use with SI. To avoid confusion with the ton, it is also known as the metric tonne and metric ton in the United States[3] and occasionally in the United Kingdom. In SI units and prefixes, the tonne is a megagram (Mg), a rarely-used symbol, easily confused with mg, for milligram."^^rdf:HTML ;
+  qudt:conversionMultiplier "1000"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tonne"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tonne?oldid=492526238"^^xsd:anyURI ;
+  qudt:symbol "mT" ;
+  qudt:ucumCaseInsensitiveCode "TNE" ;
+  qudt:ucumCaseSensitiveCode "t" ;
+  qudt:ucumCode "TNE" ;
+  qudt:ucumCode "t" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Metric Ton" ;
+  skos:altLabel "metric-tonne" ;
+.
+unit:TON_Metric-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.011574074074074"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA991" ;
+  qudt:plainTextDescription "metric unit ton divided by the unit for time day" ;
+  qudt:uneceCommonCode "L71" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_Metric PER DAY" ;
+  skos:prefLabel "tonne per day" ;
+.
+unit:TON_Metric-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAA997" ;
+  qudt:plainTextDescription "unit tonne divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "D41" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_Metric PER M3" ;
+  skos:prefLabel "tonne per metre cubed" ;
+.
+unit:TON_Metric-PER-MIN
+  a qudt:Unit ;
+  qudt:conversionMultiplier "16.666666666666667"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB000" ;
+  qudt:plainTextDescription "unit ton divided by the unit for time minute" ;
+  qudt:uneceCommonCode "L78" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_Metric PER MIN" ;
+  skos:prefLabel "tonne per minute" ;
+.
+unit:TON_Metric-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1000"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB003" ;
+  qudt:plainTextDescription "unit ton divided by the SI base unit second" ;
+  qudt:uneceCommonCode "L81" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_Metric PER SEC" ;
+  skos:prefLabel "tonne per second (metric ton)" ;
+.
+unit:TON_SHIPPING_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.1326"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB011" ;
+  qudt:plainTextDescription "traditional unit for volume of cargo, especially in shipping" ;
+  qudt:uneceCommonCode "L86" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_SHIPPING_US" ;
+  skos:prefLabel "ton (US shipping)" ;
+.
+unit:TON_SHORT
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The short ton is a unit of mass equal to 2,000 pounds (907.18474 kg). In the United States it is often called simply ton without distinguishing it from the metric ton (tonne, 1,000 kilograms / 2,204.62262 pounds) or the long ton (2,240 pounds / 1,016.0469088 kilograms); rather, the other two are specifically noted. There are, however, some U.S. applications for which unspecified tons normally means long tons.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "907.18474"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Short_ton"^^xsd:anyURI ;
+  qudt:symbol "ton" ;
+  qudt:ucumCaseInsensitiveCode "[STON_AV]" ;
+  qudt:ucumCaseSensitiveCode "[ston_av]" ;
+  qudt:ucumCode "[STON_AV]" ;
+  qudt:ucumCode "[ston_av]" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Short Ton" ;
+.
+unit:TON_SHORT-PER-HR
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The short Ton per Hour is a unit used to express a weight processed in a period of time."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.251995761"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ton/hr\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MassPerTime ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Short Ton per Hour" ;
+.
+unit:TON_SHORT-PER-YD3
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "The short ton per cubic yard density measurement unit is used to measure volume in cubic yards in order to estimate weight or mass in short tons."^^rdf:HTML ;
+  qudt:conversionMultiplier 1186.552842515566e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(ton/yd^3\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Density ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Short Ton per Cubic Yard" ;
+.
+unit:TON_UK
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1016"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB008" ;
+  qudt:iec61360Code "0112/2///62720#UAB009" ;
+  qudt:plainTextDescription "traditional unit for volume of cargo, especially in the shipping" ;
+  qudt:plainTextDescription "unit of the mass according to the Imperial system of units" ;
+  qudt:uneceCommonCode "L84" ;
+  qudt:uneceCommonCode "LTN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_UK" ;
+  skos:prefLabel "ton (UK shipping)" ;
+  skos:prefLabel "ton (UK)" ;
+.
+unit:TON_UK-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.011759259259259"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB010" ;
+  qudt:plainTextDescription "unit British ton according to the Imperial system of units divided by the unit day" ;
+  qudt:uneceCommonCode "L85" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_UK PER DAY" ;
+  skos:prefLabel "long ton (uk) per day" ;
+.
+unit:TON_UK-PER-YD3
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1328.877829223422507"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB018" ;
+  qudt:plainTextDescription "unit of the density according the Imperial system of units" ;
+  qudt:uneceCommonCode "L92" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_UK PER YD3" ;
+  skos:prefLabel "long ton (UK) per cubic yard" ;
+.
+unit:TON_US
+  a qudt:Unit ;
+  qudt:conversionMultiplier "907.1847"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB012" ;
+  qudt:plainTextDescription "unit of the mass according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "STN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON" ;
+  skos:prefLabel "ton (US)" ;
+.
+unit:TON_US-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.010497685185185"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB014" ;
+  qudt:plainTextDescription "unit American ton according to the Anglo-American system of units divided by the unit day" ;
+  qudt:uneceCommonCode "L88" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_US PER DAY" ;
+  skos:prefLabel "short ton (us) per day" ;
+.
+unit:TON_US-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.251944444444444"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAA994" ;
+  qudt:iec61360Code "0112/2///62720#UAB019" ;
+  qudt:plainTextDescription "unit ton divided by the unit for time hour" ;
+  qudt:uneceCommonCode "4W" ;
+  qudt:uneceCommonCode "E18" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_US PER HR" ;
+  skos:prefLabel "ton (US) per hour" ;
+.
+unit:TON_US-PER-YD3
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1186.311211718153754"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MassDensity ;
+  qudt:iec61360Code "0112/2///62720#UAB020" ;
+  qudt:plainTextDescription "unit of the density according to the Anglo-American system of units" ;
+  qudt:uneceCommonCode "L93" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TON_US PER YD3" ;
+  skos:prefLabel "short ton (US) per cubic yard" ;
+.
+unit:TORR
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The <em>torr</em> is a non-SI unit of pressure with the ratio of 760 to 1 standard atmosphere, chosen to be roughly equal to the fluid pressure exerted by a millimeter of mercury, i.e. , a pressure of 1 torr is approximately equal to one millimeter of mercury. Note that the symbol (Torr) is spelled exactly the same as the unit (torr), but the letter case differs. The unit is written lower-case, while the symbol of the unit (Torr) is capitalized (as upper-case), as is customary in metric units derived from names. Thus, it is correctly written either way, and is only incorrect when specification is first made that the word is being used as a unit, or else a symbol of the unit, and then the incorrect letter case for the specified use is employed.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier "133.322"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Torr"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:ForcePerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB022" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Torr?oldid=495199381"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/torr> ;
+  qudt:symbol "torr" ;
+  qudt:uneceCommonCode "UA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Torr" ;
+.
+unit:TSP
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A teaspoon is a unit of volume. In the United States one teaspoon as a unit of culinary measure is \\(1/3\\) tablespoon , that is, \\(\\approx 4.93 mL\\); it is exactly \\(1/6 U.S. fl. oz\\), \\(1/48 \\; cup\\), and \\(1/768 \\; U.S. liquid gallon\\) (see United States customary units for relative volumes of these other measures) and approximately \\(1/3 cubic inch\\). For nutritional labeling on food packages in the U.S., the teaspoon is defined as precisely \\(5 mL\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 4.92892187E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Teaspoon"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB007" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Teaspoon?oldid=490940468"^^xsd:anyURI ;
+  qudt:symbol "tsp" ;
+  qudt:ucumCaseInsensitiveCode "[TSP_US]" ;
+  qudt:ucumCaseSensitiveCode "[tsp_us]" ;
+  qudt:ucumCode "[TSP_US]" ;
+  qudt:ucumCode "[tsp_us]" ;
+  qudt:uneceCommonCode "G25" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Teaspoon" ;
+.
+unit:T_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The unit of magnetic induction in the cgs system, \\(10^{-4}\\,tesla\\). Also known as the gauss."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:Gs ;
+  qudt:hasQuantityKind quantitykind:AuxillaryMagneticField ;
+  qudt:hasQuantityKind quantitykind:MagneticFieldStrength ;
+  qudt:hasQuantityKind quantitykind:MagneticFluxDensity ;
+  qudt:informativeReference "http://www.diracdelta.co.uk/science/source/g/a/gauss/source.html"^^xsd:anyURI ;
+  qudt:symbol "abT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abtesla" ;
+.
+unit:TanzanianShilling
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Tanzania"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tanzanian_shilling"^^xsd:anyURI ;
+  qudt:expression "\\(TZS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tanzanian_shilling?oldid=492257527"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tanzanian Shilling" ;
+.
+unit:Tebi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^4}\\), or \\(2^{40}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1099511627776"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Ti" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tebi" ;
+.
+unit:Tenge
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Kazakhstan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Kazakhstani_tenge"^^xsd:anyURI ;
+  qudt:expression "\\(KZT\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Kazakhstani_tenge?oldid=490523058"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tenge" ;
+.
+unit:Tera
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'tera' is a decimal prefix for expressing a value with a scaling of \\(10^{12}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tera"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tera?oldid=494204788"^^xsd:anyURI ;
+  qudt:symbol "T" ;
+  qudt:ucumCaseInsensitiveCode "TR" ;
+  qudt:ucumCaseSensitiveCode "T" ;
+  qudt:ucumCode "T" ;
+  qudt:ucumCode "TR" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tera" ;
+.
+unit:TeraBYTE
+  a qudt:DecimalScaledUnit ;
+  a qudt:Unit ;
+  dcterms:description "The terabyte is a multiple of the unit byte for digital information. The prefix tera means 10 in the International System of Units (SI), and therefore 1 terabyte is 1000000000000bytes, or 1 trillion bytes, or 1000 gigabytes. 1 terabyte in binary prefixes is 0.9095 tebibytes, or 931.32 gibibytes. The unit symbol for the terabyte is TB or TByte, but not Tb (lower case b) which refers to terabit."^^rdf:HTML ;
+  qudt:conversionMultiplier "1048576"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Terabyte"^^xsd:anyURI ;
+  qudt:hasPrefixUnit unit:Tera ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:iec61360Code "0112/2///62720#UAB186" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Terabyte?oldid=494671550"^^xsd:anyURI ;
+  qudt:isScalingOf unit:BYTE ;
+  qudt:symbol "TB" ;
+  qudt:uneceCommonCode "E35" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraByte" ;
+.
+unit:TeraC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A TeraCoulomb is \\(10^{12} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e12 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Tera ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "TC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:TeraHZ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Frequency ;
+  qudt:iec61360Code "0112/2///62720#UAA287" ;
+  qudt:plainTextDescription "1 000 000 000 000-fold of the SI derived unit hertz" ;
+  qudt:uneceCommonCode "D29" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraHZ" ;
+  skos:prefLabel "terahertz" ;
+.
+unit:TeraJ
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA288" ;
+  qudt:plainTextDescription "1 000 000 000 000-fold of the SI derived unit joule" ;
+  qudt:uneceCommonCode "D30" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraJ" ;
+  skos:prefLabel "terajoule" ;
+.
+unit:TeraOHM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Resistance ;
+  qudt:iec61360Code "0112/2///62720#UAA286" ;
+  qudt:plainTextDescription "1,000,000,000,000-fold of the SI derived unit ohm" ;
+  qudt:uneceCommonCode "H44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraOHM" ;
+  skos:prefLabel "teraohm" ;
+.
+unit:TeraW
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+12 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ActivePower ;
+  qudt:iec61360Code "0112/2///62720#UAA289" ;
+  qudt:plainTextDescription "1,000,000,000,000-fold of the SI derived unit watt" ;
+  qudt:uneceCommonCode "D31" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraW" ;
+  skos:prefLabel "terawatt" ;
+.
+unit:TeraW-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier 3.6e+15 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA290" ;
+  qudt:plainTextDescription "1,000,000,000,000-fold of the product of the SI derived unit watt and the unit hour" ;
+  qudt:uneceCommonCode "D32" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "TeraW HR" ;
+  skos:prefLabel "terawatt hour" ;
+.
+unit:TonEnergy
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Energy equivalent of one ton of TNT"^^rdf:HTML ;
+  qudt:conversionMultiplier 4.184E9 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(t/lbf\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Ton Energy" ;
+.
+unit:TrinidadAndTobagoDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Trinidad and Tobago"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Trinidad_and_Tobago_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(TTD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Trinidad_and_Tobago_dollar?oldid=490325306"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Trinidad and Tobago Dollar" ;
+.
+unit:Tugrik
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mongolia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Mongolian_t%C3%B6gr%C3%B6g"^^xsd:anyURI ;
+  qudt:expression "\\(MNT\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Mongolian_tögrög?oldid=495408271"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tugrik" ;
+.
+unit:TunisianDinar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Tunisia"^^rdf:HTML ;
+  qudt:currencyExponent 3 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Tunisian_dinar"^^xsd:anyURI ;
+  qudt:expression "\\(TND\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Tunisian_dinar?oldid=491218035"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tunisian Dinar" ;
+.
+unit:U
+  a qudt:Unit ;
+  dcterms:description "<p class=\"lm-para\">The unified atomic mass unit (symbol: \\(u\\)) or dalton (symbol: \\(Da\\)) is the standard unit that is used for indicating mass on an atomic or molecular scale (atomic mass). It is defined as one twelfth of the mass of an unbound neutral atom of carbon-12 in its nuclear and electronic ground state,[ and has a value of \\(1.660538921(73) \\times 10^{-27} kg\\). One dalton is approximately equal to the mass of one nucleon; an equivalence of saying \\(1 g mol^{-1}\\). The CIPM have categorised it as a 'non-SI unit' because units values in SI units must be obtained experimentally.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.66053878283e-27 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Atomic_mass_unit"^^xsd:anyURI ;
+  qudt:exactMatch unit:AMU ;
+  qudt:exactMatch unit:Da ;
+  qudt:hasQuantityKind quantitykind:Mass ;
+  qudt:iec61360Code "0112/2///62720#UAB083" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_mass_unit"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/unifiedAtomicMassUnit> ;
+  qudt:symbol "u" ;
+  qudt:ucumCode "AMU" ;
+  qudt:ucumCode "u" ;
+  qudt:uneceCommonCode "D43" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Unified Atomic Mass Unit" ;
+.
+unit:UAEDirham
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "United Arab Emirates"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/United_Arab_Emirates_dirham"^^xsd:anyURI ;
+  qudt:expression "\\(AED\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/United_Arab_Emirates_dirham?oldid=491806142"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "United Arab Emirates dirham" ;
+.
+unit:UICFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "International Union of Railways"^^rdf:HTML ;
+  qudt:expression "\\(XFU\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "UIC franc (special settlement currency)" ;
+.
+unit:UNITLESS
+  a qudt:BaseUnit ;
+  a qudt:CGS-Unit ;
+  a qudt:DimensionlessUnit ;
+  a qudt:Unit ;
+  dcterms:description "An explicit unit to say something has no units."^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "U" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Unitless" ;
+.
+unit:USDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "American Samoa, British Indian Ocean Territory, Ecuador, El Salvador, Guam, Haiti, Marshall Islands, Micronesia, Northern Mariana Islands, Palau, Panama, Puerto Rico, East Timor, Turks and Caicos Islands, United States, Virgin Islands"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:symbol "\\" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "US Dollar" ;
+.
+unit:USDollar-NextDay
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "United States"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(USN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "United States Dollar (next day) (funds code)" ;
+.
+unit:USDollar-SameDay
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "United States"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "United States Dollar (same day) (funds code)" ;
+.
+unit:UgandaShilling
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Uganda"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Ugandan_shilling"^^xsd:anyURI ;
+  qudt:expression "\\(UGX\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Ugandan_shilling?oldid=495383966"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Uganda Shilling" ;
+.
+unit:UnidadDeValorReal
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Colombia"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(COU\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Unidad de Valor Real" ;
+.
+unit:UnidadesDeFormento
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Chile"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:expression "\\(CLF\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Unidades de formento (Funds code)" ;
+.
+unit:UnitPole
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A magnetic pole is a unit pole if it exerts a force of one dyne on another pole of equal strength at a distance of 1 cm. The strength of any given pole in cgs units is therefore numerically equal to the force in dynes which it exerts on a unit pole 1 cm away."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.256637E-7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(U/nWb\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAB214" ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/unitPole> ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Unit Pole" ;
+.
+unit:UruguayPeso
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Uruguay"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Uruguayan_peso"^^xsd:anyURI ;
+  qudt:expression "\\(UYU\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Uruguayan_peso?oldid=487528781"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Peso Uruguayo" ;
+.
+unit:UzbekistanSom
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Uzbekistan"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Uzbekistani_som"^^xsd:anyURI ;
+  qudt:expression "\\(UZS\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Uzbekistani_som?oldid=490522228"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Uzbekistan Som" ;
+.
+unit:V
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Volt</em> is the SI unit of electric potential. Separating electric charges creates potential energy, which can be measured in energy units such as joules. Electric potential is defined as the amount of potential energy present per unit of charge. Electric potential is measured in volts, with one volt representing a potential of one joule per coulomb of charge. The name of the unit honors the Italian scientist Count Alessandro Volta (1745-1827), the inventor of the first battery.  The volt also may be expressed with a variety of other units. For example, a volt is also equal to one watt per ampere (W/A) and one joule per ampere per second (J/A/s).</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Volt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA296" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Volt?oldid=494812083"^^xsd:anyURI ;
+  qudt:latexDefinition "\\text{V}\\ \\equiv\\ \\text{volt}\\ \\equiv\\ \\frac{\\text{J}}{\\text{C}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{coulomb}}\\ \\equiv\\ \\frac{\\text{W.s}}{\\text{C}}\\ \\equiv\\ \\frac{\\text{watt.second}}{\\text{coulomb}}\\ \\equiv\\ \\frac{\\text{W}}{\\text{A}}\\ \\equiv\\ \\frac{\\text{watt}}{\\text{amp}}"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/volt> ;
+  qudt:siUnitsExpression "W/A" ;
+  qudt:symbol "V" ;
+  qudt:ucumCaseInsensitiveCode "V" ;
+  qudt:ucumCode "V" ;
+  qudt:uneceCommonCode "VLT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt" ;
+.
+unit:V-A
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ApparentPower ;
+  qudt:iec61360Code "0112/2///62720#UAA298" ;
+  qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit ampere" ;
+  qudt:uneceCommonCode "D46" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V A" ;
+  rdfs:label "V-A" ;
+  skos:prefLabel "volt ampere" ;
+.
+unit:V-A_Reactive
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ReactivePower ;
+  qudt:iec61360Code "0112/2///62720#UAB023" ;
+  qudt:plainTextDescription "unit with special name for reactive power" ;
+  qudt:uneceCommonCode "D44" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V A Reactive" ;
+  skos:prefLabel "volt ampere reactive" ;
+.
+unit:V-M
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricFlux ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V-M" ;
+.
+unit:V-PER-CentiM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+02 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAB054" ;
+  qudt:plainTextDescription "derived SI unit volt divided by the 0.01-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "D47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V PER CentiM" ;
+  skos:prefLabel "volt per centimetre" ;
+.
+unit:V-PER-IN
+  a qudt:Unit ;
+  qudt:conversionMultiplier "39.37007874015748"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA300" ;
+  qudt:plainTextDescription "SI derived unit volt divided by the unit inch according to the Anglo-American and the Imperial system of units" ;
+  qudt:uneceCommonCode "H23" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V PER IN" ;
+  skos:prefLabel "volt per inch" ;
+.
+unit:V-PER-K
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(v/k\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:SeebeckCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAB173" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D48" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt per Kelvin" ;
+.
+unit:V-PER-M
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Volt Per Meter (V/m) is a unit in the category of Electric field strength. It is also known as volts per meter, volt/meter, volt/metre, volt per metre, volts per metre. This unit is commonly used in the SI unit system. Volt Per Meter (V/m) has a dimension of \\(MLT^{-3}I^{-1}\\) where M is mass, L is length, T is time, and I is electric current. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(V/m\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA301" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--electric_field_strength--volt_per_meter.cfm"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D50" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt per Meter" ;
+.
+unit:V-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "The divergence at a particular point in a vector field is (roughly) how much the vector field 'spreads out' from that point. Operationally, we take the partial derivative of each of the field with respect to each of its space variables and add all the derivatives together to get the divergence. Electric field (V/m) differentiated with respect to distance (m) yields \\(V/(m^2)\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(V m^{-2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EnergyPerAreaElectricCharge ;
+  qudt:informativeReference "http://www.funtrivia.com/en/subtopics/Physical-Quantities-310909.html"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt per Square Meter" ;
+.
+unit:V-PER-MicroSEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+06 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:PowerPerElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA297" ;
+  qudt:plainTextDescription "SI derived unit volt divided by the 0.000001-fold of the SI base unit second" ;
+  qudt:uneceCommonCode "H24" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V PER MicroSEC" ;
+  skos:prefLabel "volt per microsecond" ;
+.
+unit:V-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:iec61360Code "0112/2///62720#UAA302" ;
+  qudt:plainTextDescription "SI derived unit volt divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "D51" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V PER MilliM" ;
+  skos:prefLabel "volt per millimetre" ;
+.
+unit:V-PER-SEC
+  a qudt:DerivedCoherentUnit ;
+  a qudt:Unit ;
+  dcterms:description "'Volt per Second' is a unit of magnetic flux equaling one weber. This is the flux passing through a conducting loop and reduced to zero at a uniform rate in one second inducing an electric potential of one volt in the loop. "^^rdf:HTML ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(V / sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerElectricCharge ;
+  qudt:iec61360Code "0112/2///62720#UAA304" ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1512"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.thefreedictionary.com/Webers"^^xsd:anyURI ;
+  qudt:uneceCommonCode "H46" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt per second" ;
+.
+unit:V-SEC-PER-M
+  a qudt:Unit ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:MagneticFluxPerUnitLength ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
+  qudt:hasQuantityKind quantitykind:ScalarMagneticPotential ;
+  qudt:iec61360Code "0112/2///62720#UAA303" ;
+  qudt:plainTextDescription "product of the SI derived unit volt and the SI base unit second divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "H45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V SEC PER M" ;
+  skos:prefLabel "volt second per metre" ;
+.
+unit:V2-PER-K2
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(v^2/k^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:LorenzCoefficient ;
+  qudt:iec61360Code "0112/2///62720#UAB172" ;
+  qudt:informativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31897"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D45" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Volt Squared per Kelvin Squared" ;
+.
+unit:V_Ab
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "A unit of electrical potential equal to one hundred millionth of a volt (\\(10^{-8}\\,volts\\)), used in the centimeter-gram-second (CGS) system of units. One abV is the potential difference that exists between two points when the work done to transfer one abcoulomb of charge between them equals: \\(1\\,erg\\cdot\\,1\\,abV\\,=\\,10\\,nV\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Abvolt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Abvolt?oldid=477198646"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.lexic.us/definition-of/abvolt"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-27"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/abvolt> ;
+  qudt:symbol "abV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abvolt" ;
+.
+unit:V_Ab-PER-CentiM
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "In the electromagnetic centimeter-gram-second system of units, 'abvolt per centimeter' is the unit of electric field strength."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E-6 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:informativeReference "http://www.endmemo.com/convert/electric%20field%20strength.php"^^xsd:anyURI ;
+  qudt:symbol "abV/cm" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abvolt per centimeter" ;
+.
+unit:V_Ab-SEC
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The magnetic flux whose expenditure in 1 second produces 1 abvolt per turn of a linked circuit. Technically defined in a three-dimensional system, it corresponds in the four-dimensional electromagnetic sector of the SI system to 10 nWb, and is an impractically small unit. In use for some years, the name was agreed by the International Electrotechnical Committee in 1930, along with a corresponding practical unit, the pramaxwell (or pro-maxwell) = \\(10^{8}\\) maxwell."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-8 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(abv-sec\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-820"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Abvolt Second" ;
+.
+unit:V_Stat
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "\"statvolt\" is a unit of voltage and electrical potential used in the cgs system of units. The conversion to the SI system is \\(1 statvolt = 299.792458 volts\\). The conversion factor 299.792458 is simply the numerical value of the speed of light in m/s divided by 106. The statvolt is also defined in the cgs system as \\(1 erg / esu\\). It is a useful unit for electromagnetism because one statvolt per centimetre is equal in magnitude to one gauss. Thus, for example, an electric field of one statvolt/cm has the same energy density as a magnetic field of one gauss. Likewise, a plane wave propagating in a vacuum has perpendicular electric and magnetic fields such that for every gauss of magnetic field intensity there is one statvolt/cm of electric field intensity. The abvolt is another option for a unit of voltage in the cgs system."^^qudt:LatexString ;
+  qudt:conversionMultiplier "299.792458"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Statvolt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:EnergyPerElectricCharge ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Statvolt"^^xsd:anyURI ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Statvolt?oldid=491769750"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/statvolt> ;
+  qudt:symbol "statV" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statvolt" ;
+.
+unit:V_Stat-CentiM
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(statvolt-centimeter\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricFlux ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "V_Stat-CentiM" ;
+.
+unit:V_Stat-PER-CentiM
+  a qudt:Unit ;
+  dcterms:description """One statvolt per centimetre is equal in magnitude to one gauss. For example, an electric field of one statvolt/cm has the same energy density as a magnetic field of one gauss. Likewise, a plane wave propagating in a vacuum has perpendicular electric and magnetic fields such that for every gauss of magnetic field intensity there is one statvolt/cm of electric field intensity.
+The abvolt is another option for a unit of voltage in the cgs system."""^^rdf:HTML ;
+  qudt:conversionMultiplier 2.99792458E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(statv-per-cm\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ElectricFieldStrength ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Statvolt"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Statvolt per Centimeter" ;
+.
+unit:Vatu
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Vanuatu"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Vanuatu_vatu"^^xsd:anyURI ;
+  qudt:expression "\\(VUV\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Vanuatu_vatu?oldid=494667103"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Vatu" ;
+.
+unit:VenezuelanBolvar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Venezuela"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(VEB\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Venezuelan bolvar" ;
+.
+unit:VietnameseDong
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Vietnam"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:expression "\\(VND\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Vietnamese ??ng" ;
+.
+unit:W
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p>The SI unit of power. Power is the rate at which work is done, or (equivalently) the rate at which energy is expended. One watt is equal to a power rate of one joule of work per second of time. This unit is used both in mechanics and in electricity, so it links the mechanical and electrical units to one another. In mechanical terms, one watt equals about 0.001 341 02 horsepower (hp) or 0.737 562 foot-pound per second (lbf/s). In electrical terms, one watt is the power produced by a current of one ampere flowing through an electric potential of one volt. The name of the unit honors James Watt (1736-1819), the British engineer whose improvements to the steam engine are often credited with igniting the Industrial Revolution.</p>"^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Watt"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:HeatFlowRate ;
+  qudt:hasQuantityKind quantitykind:Power ;
+  qudt:iec61360Code "0112/2///62720#UAA306" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Watt?oldid=494906356"^^xsd:anyURI ;
+  qudt:latexDefinition "\\text{W}\\ \\equiv\\ \\text{watt}\\ \\equiv\\ \\frac{\\text{J}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{joule}}{\\text{second}}\\ \\equiv\\ \\frac{\\text{N.m}}{\\text{s}}\\ \\equiv\\ \\frac{\\text{newton.metre}}{\\text{second}}\\ \\equiv\\ \\text{V.A}\\ \\equiv\\ \\text{volt.amp}\\ \\equiv\\ \\Omega\\text{.A}^{2}\\ \\equiv\\ \\text{ohm.amp}^{2}"^^qudt:LatexString ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/watt> ;
+  qudt:symbol "W" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt" ;
+.
+unit:W-HR
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "The watt hour is a unit of energy, equal to 3,600 joule."^^rdf:HTML ;
+  qudt:conversionMultiplier 3600.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:symbol "W-hr" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watthour" ;
+.
+unit:W-M2
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:PowerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "W-M2" ;
+.
+unit:W-M2-PER-SR
+  a qudt:Unit ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:PowerAreaPerSolidAngle ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "W-M2-PER-SR" ;
+.
+unit:W-PER-CentiM2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Square Centimeter is a unit of heat flux or thermal flux, the rate of heat energy transfer through a given surface."^^rdf:HTML ;
+  qudt:conversionMultiplier 1.0E4 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB224" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Centimeter" ;
+.
+unit:W-PER-FT2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Square Foot is a unit of heat flux or thermal flux, the rate of heat energy transfer through a given surface."^^rdf:HTML ;
+  qudt:conversionMultiplier "10.7639104"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/ft^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Foot" ;
+.
+unit:W-PER-IN2
+  a qudt:CGS-Unit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Square Inch is a unit of heat flux or thermal flux, the rate of heat energy transfer through a given surface."^^rdf:HTML ;
+  qudt:conversionMultiplier "1550.0031"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/in^{2}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAB225" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Inch" ;
+.
+unit:W-PER-K
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Kelvin (\\(W/K\\)) is a unit in the category of Thermal conductivity."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(w-per-K\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductance ;
+  qudt:iec61360Code "0112/2///62720#UAA307" ;
+  qudt:uneceCommonCode "D52" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Kelvin" ;
+.
+unit:W-PER-KiloGM
+  a qudt:Unit ;
+  <http://qudt.org/schema/hasQuantityKind> quantitykind:AbsorbedDoseRate ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:iec61360Code "0112/2///62720#UAA316" ;
+  qudt:plainTextDescription "SI derived unit watt divided by the SI base unit kilogram" ;
+  qudt:uneceCommonCode "WA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "W PER KiloGM" ;
+  skos:prefLabel "watt per kilogram" ;
+.
+unit:W-PER-M-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W-per-MK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:ThermalConductivity ;
+  qudt:iec61360Code "0112/2///62720#UAA309" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Thermal_conductivity"^^xsd:anyURI ;
+  qudt:latexSymbol "\\(W \\cdot m^{-1} \\cdot K^{-1}\\)"^^qudt:LatexString ;
+  qudt:uneceCommonCode "D53" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Meter Kelvin" ;
+.
+unit:W-PER-M2
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Watt per Square Meter} is a unit of irradiance defined as the power received per area. This is a unit in the category of Energy flux. It is also known as watts per square meter, watt per square metre, watts per square metre, watt/square meter, watt/square metre. This unit is commonly used in the SI unit system. Watt Per Square Meter (\\(W/m^2\\)) has a dimension of \\(MT^{-3\"\\) where M is mass, and T is time. This unit is the standard SI unit in this category."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/m^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerArea ;
+  qudt:iec61360Code "0112/2///62720#UAA310" ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--energy_flux--watt_per_square_meter.cfm"^^xsd:anyURI ;
+  qudt:uneceCommonCode "D54" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Meter" ;
+.
+unit:W-PER-M2-K
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Watt Per Square Meter Per Kelvin </em>(\\(W m^{-2} K^{-1}\\)) is a unit in the category of Thermal heat transfer coefficient. It is also known as watt/square meter-kelvin. This unit is commonly used in the SI unit system. Watt Per Square Meter Per Kelvin (\\(W m^{-2} K^{-1}\\)) has a dimension of \\(MT^{-1}Q^{-1}\\) where \\(M\\) is mass, \\(T\\) is time, and \\(Q\\) is temperature. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/(m^{2}-K)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:CoefficientOfHeatTransfer ;
+  qudt:iec61360Code "0112/2///62720#UAA311" ;
+  qudt:uneceCommonCode "D55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Meter Kelvin" ;
+.
+unit:W-PER-M2-K4
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Square Meter Per Quartic Kelvin (\\(W/m2\\cdotK4)\\) is a unit in the category of light."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/(m^2.K^4)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerPerAreaQuarticTemperature ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Meter Quartic Kelvin" ;
+.
+unit:W-PER-M2-PA
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "Watt Per Square Meter Per Pascal (\\(W/m^2-pa\\)) is a unit of Evaporative Heat Transfer."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/(m^2.pa)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:EvaporativeHeatTransferCoefficient ;
+  qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=43012"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Meter Pascal" ;
+.
+unit:W-PER-M2-SR
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:SI-Unit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Watt per steradian per square metrer </em> is the SI unit of radiance (\\(W·sr^{−1}·m^{−2}\\)), while that of spectral radiance in frequency is the watt per steradian per square metre per hertz (\\(W·sr^{−1}·m^{−2}·Hz^{−1}\\)) and that of spectral radiance in wavelength is the watt per steradian per square metre, per metre (\\(W·sr^{−1}·m^{−3}\\)), commonly the watt per steradian per square metre per nanometre (\\(W·sr^{−1}·m^{−2}·nm^{−1}\\)). It has a dimension of \\(ML^{-4}T^{-3}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(W/(m^2.sr)\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:PowerAreaPerSolidAngle ;
+  qudt:hasQuantityKind quantitykind:Radiance ;
+  qudt:informativeReference "http://asd-www.larc.nasa.gov/Instrument/ceres_units.html"^^xsd:anyURI ;
+  qudt:informativeReference "http://www.efunda.com/glossary/units/units--radiance--watt_per_square_meter_per_steradian.cfm"^^xsd:anyURI ;
+  qudt:informativeReference "https://en.wikipedia.org/wiki/Radiance"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Square Meter Steradian" ;
+.
+unit:W-PER-M3
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:ForcePerAreaTime ;
+  qudt:iec61360Code "0112/2///62720#UAA312" ;
+  qudt:plainTextDescription "SI derived unit watt divided by the power of the SI base unit metre with the exponent 3" ;
+  qudt:uneceCommonCode "H47" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "W PER M3" ;
+  skos:prefLabel "watt per metre cubed" ;
+.
+unit:W-PER-SR
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "<p><em>Watt Per Steradian (W/sr)</em> is the unit in the category of Radiant intensity. It is also known as watts per steradian. This unit is commonly used in the SI unit system. Watt Per Steradian (W/sr) has a dimension of \\(M\\cdot L^{-2}\\cdot T^{-3}\\) where \\(M\\) is mass, \\(L\\) is length, and \\(T\\) is time. This unit is the standard SI unit in this category.</p>"^^qudt:LatexString ;
+  qudt:conversionMultiplier "1"^^xsd:double ;
+  qudt:conversionOffset "0"^^xsd:double ;
+  qudt:expression "\\(W sr^{-1}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:RadiantIntensity ;
+  qudt:iec61360Code "0112/2///62720#UAA314" ;
+  qudt:uneceCommonCode "D57" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Watt per Steradian" ;
+.
+unit:W-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:EnergyAndWork ;
+  qudt:iec61360Code "0112/2///62720#UAA313" ;
+  qudt:plainTextDescription "product of the SI derived unit watt and SI base unit second" ;
+  qudt:uneceCommonCode "J55" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "W SEC" ;
+  skos:prefLabel "watt second" ;
+.
+unit:WB
+  a qudt:DerivedCoherentUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "The SI unit of magnetic flux. \"Flux\" is the rate (per unit of time) at which something crosses a surface perpendicular to the flow. The weber is a large unit, equal to \\(10^{8}\\) maxwells, and practical fluxes are usually fractions of one weber. The weber is the magnetic flux which, linking a circuit of one turn, would produce in it an electromotive force of 1 volt if it were reduced to zero at a uniform rate in 1 second. In SI base units, the dimensions of the weber are \\((kg \\cdot m^2)/(s^2 \\cdot A)\\). The weber is commonly expressed in terms of other derived units as the Tesla-square meter (\\(T \\cdot m^2\\)), volt-seconds (\\(V \\cdot s\\)), or joules per ampere (\\(J/A\\))."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Weber"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:MagneticFlux ;
+  qudt:iec61360Code "0112/2///62720#UAA317" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Weber?oldid=491210387"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/weber> ;
+  qudt:siUnitsExpression "V.s" ;
+  qudt:symbol "Wb" ;
+  qudt:ucumCaseInsensitiveCode "WB" ;
+  qudt:ucumCaseSensitiveCode "Wb" ;
+  qudt:ucumCode "WB" ;
+  qudt:ucumCode "Wb" ;
+  qudt:uneceCommonCode "WEB" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Weber" ;
+.
+unit:WB-M
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:MagneticDipoleMoment ;
+  qudt:iec61360Code "0112/2///62720#UAB333" ;
+  qudt:informativeReference "http://www.simetric.co.uk/siderived.htm"^^xsd:anyURI ;
+  qudt:symbol "WbM" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Weber Meter" ;
+.
+unit:WB-PER-M
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
+  qudt:iec61360Code "0112/2///62720#UAA318" ;
+  qudt:plainTextDescription "SI derived unit weber divided by the SI base unit metre" ;
+  qudt:uneceCommonCode "D59" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "WB PER M" ;
+  skos:prefLabel "weber per metre" ;
+.
+unit:WB-PER-MilliM
+  a qudt:Unit ;
+  qudt:conversionMultiplier 1e+03 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:MagneticVectorPotential ;
+  qudt:iec61360Code "0112/2///62720#UAB074" ;
+  qudt:plainTextDescription "derived SI unit weber divided by the 0.001-fold of the SI base unit metre" ;
+  qudt:uneceCommonCode "D60" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "WB PER MilliM" ;
+  skos:prefLabel "weber per millimetre" ;
+.
+unit:WIREuro
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Switzerland"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(CHE\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "WIR Euro (complementary currency)" ;
+.
+unit:WIRFranc
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Switzerland"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:expression "\\(CHW\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "WIR Franc (complementary currency)" ;
+.
+unit:WK
+  a qudt:Unit ;
+  dcterms:description "Mean solar week"^^rdf:HTML ;
+  qudt:conversionMultiplier "604800.0"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Week"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB024" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Week?oldid=493867029"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/week> ;
+  qudt:symbol "wk" ;
+  qudt:ucumCaseInsensitiveCode "WK" ;
+  qudt:ucumCaseSensitiveCode "wk" ;
+  qudt:ucumCode "WK" ;
+  qudt:ucumCode "wk" ;
+  qudt:uneceCommonCode "WEE" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Week" ;
+.
+unit:XAF
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Cameroon, Central African Republic, Congo, Chad, Equatorial Guinea, Gabon"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CFA Franc BEAC" ;
+.
+unit:XOF
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Currency of Benin, Burkina Faso, CÔte d'Ivoire, Guinea-Bissau, Mali, Niger, Senegal, Togo"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CFA Franc BCEAO" ;
+.
+unit:XPF
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "French Polynesia, New Caledonia, Wallis and Futuna"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "CFP franc" ;
+.
+unit:YD
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "A yard is a unit of length in several different systems including United States customary units, Imperial units and the former English units. It is equal to 3 feet or 36 inches. Under an agreement in 1959 between Australia, Canada, New Zealand, South Africa, the United Kingdom and the United States, the yard (known as the \"international yard\" in the United States) was legally defined to be exactly 0.9144 metres."^^rdf:HTML ;
+  qudt:conversionMultiplier "0.9144"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Yard"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Length ;
+  qudt:iec61360Code "0112/2///62720#UAB030" ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Yard?oldid=492334628"^^xsd:anyURI ;
+  qudt:symbol "yd" ;
+  qudt:ucumCaseInsensitiveCode "[YD_I]" ;
+  qudt:ucumCaseSensitiveCode "[yd_i]" ;
+  qudt:ucumCode "[YD_I]" ;
+  qudt:ucumCode "[yd_i]" ;
+  qudt:uneceCommonCode "YRD" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yard" ;
+.
+unit:YD-PER-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.6459200164592"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:LinearThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAB031" ;
+  qudt:plainTextDescription "unit yard according to the Anglo-American and the Imperial system of units divided by the unit for temperature degree Fahrenheit" ;
+  qudt:uneceCommonCode "L98" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YD PER DEG_F" ;
+  skos:prefLabel "yard per degree Fahrenheit" ;
+.
+unit:YD2
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "The square yard is an imperial/US customary unit of area, formerly used in most of the English-speaking world but now generally replaced by the square metre outside of the U.S. , Canada and the U.K. It is defined as the area of a square with sides of one yard in length. (Gaj in Hindi)."^^rdf:HTML ;
+  qudt:conversionMultiplier 0.83612736e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(yd^2\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Area ;
+  qudt:iec61360Code "0112/2///62720#UAB034" ;
+  qudt:ucumCaseInsensitiveCode "[SYD_I]" ;
+  qudt:ucumCaseInsensitiveCode "[YD_I]2" ;
+  qudt:ucumCaseSensitiveCode "[syd_i]" ;
+  qudt:ucumCaseSensitiveCode "[yd_i]2" ;
+  qudt:ucumCode "[SYD_I]" ;
+  qudt:ucumCode "[YD_I]2" ;
+  qudt:ucumCode "[syd_i]" ;
+  qudt:ucumCode "[yd_i]2" ;
+  qudt:uneceCommonCode "YDK" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Square Yard" ;
+.
+unit:YD3
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:US-CustomaryUnit ;
+  a qudt:Unit ;
+  dcterms:description "A cubic yard is an Imperial / U.S. customary unit of volume, used in the United States, Canada, and the UK. It is defined as the volume of a cube with sides of 1 yard in length."^^rdf:HTML ;
+  qudt:conversionMultiplier 0.764554857984e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(yd^{3}\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Volume ;
+  qudt:iec61360Code "0112/2///62720#UAB035" ;
+  qudt:ucumCaseInsensitiveCode "[CYD_I]" ;
+  qudt:ucumCaseInsensitiveCode "[YD_I]3" ;
+  qudt:ucumCaseSensitiveCode "[cyd_i]" ;
+  qudt:ucumCaseSensitiveCode "[yd_i]3" ;
+  qudt:ucumCode "[CYD_I]" ;
+  qudt:ucumCode "[YD_I]3" ;
+  qudt:ucumCode "[cyd_i]" ;
+  qudt:ucumCode "[yd_i]3" ;
+  qudt:uneceCommonCode "YDQ" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Yard" ;
+.
+unit:YD3-PER-DAY
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00000884901456"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:hasQuantityKind quantitykind:VolumeFlowRate ;
+  qudt:iec61360Code "0112/2///62720#UAB037" ;
+  qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for time day" ;
+  qudt:uneceCommonCode "M12" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YD3 PER DAY" ;
+  skos:prefLabel "cubic yard per day" ;
+.
+unit:YD3-PER-DEG_F
+  a qudt:Unit ;
+  qudt:conversionMultiplier "1.376198881991088"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:VolumeThermalExpansion ;
+  qudt:iec61360Code "0112/2///62720#UAB036" ;
+  qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for temperature degree Fahrenheit" ;
+  qudt:uneceCommonCode "M11" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YD3 PER DEG_F" ;
+  skos:prefLabel "cubic yard per degree Fahrenheit" ;
+.
+unit:YD3-PER-HR
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.00021237634944"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAB038" ;
+  qudt:plainTextDescription "power of the unit yard according to the Anglo-American and the Imperial system of units with the exponent 3 divided by the unit for the time hour" ;
+  qudt:uneceCommonCode "M13" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YD3 PER HR" ;
+  skos:prefLabel "cubic yard per hour" ;
+.
+unit:YD3-PER-MIN
+  a qudt:DerivedUnit ;
+  a qudt:ImperialUnit ;
+  a qudt:Unit ;
+  dcterms:description "\"Cubic Yard per Minute\" is an Imperial unit for  'Volume Per Unit Time' expressed as \\(yd^{3}/min\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 0.0127425809664e0 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:expression "\\(yd^{3}/min\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:VolumePerUnitTime ;
+  qudt:iec61360Code "0112/2///62720#UAB040" ;
+  qudt:ucumCaseInsensitiveCode "[CYD_I].MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[CYD_I]/MIN" ;
+  qudt:ucumCaseInsensitiveCode "[YD_I]3.MIN-1" ;
+  qudt:ucumCaseInsensitiveCode "[YD_I]3/MIN" ;
+  qudt:ucumCaseSensitiveCode "[cyd_i].min-1" ;
+  qudt:ucumCaseSensitiveCode "[cyd_i]/min" ;
+  qudt:ucumCaseSensitiveCode "[yd_i]3.min-1" ;
+  qudt:ucumCaseSensitiveCode "[yd_i]3/min" ;
+  qudt:ucumCode "[CYD_I].MIN-1" ;
+  qudt:ucumCode "[CYD_I]/MIN" ;
+  qudt:ucumCode "[YD_I]3.MIN-1" ;
+  qudt:ucumCode "[YD_I]3/MIN" ;
+  qudt:ucumCode "[cyd_i].min-1" ;
+  qudt:ucumCode "[cyd_i]/min" ;
+  qudt:ucumCode "[yd_i]3.min-1" ;
+  qudt:ucumCode "[yd_i]3/min" ;
+  qudt:uneceCommonCode "M15" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Cubic Yard per Minute" ;
+.
+unit:YD3-PER-SEC
+  a qudt:Unit ;
+  qudt:conversionMultiplier "0.764554857984"^^xsd:double ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:Velocity ;
+  qudt:iec61360Code "0112/2///62720#UAB041" ;
+  qudt:plainTextDescription "power of the unit and the Anglo-American and Imperial system of units with the exponent 3 divided by the SI base unit second" ;
+  qudt:uneceCommonCode "M16" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YD3 PER SEC" ;
+  skos:prefLabel "cubic yard per second" ;
+.
+unit:YR
+  a qudt:Unit ;
+  dcterms:description "A year is any of the various periods equated with one passage of Earth about the Sun, and hence of roughly 365 days. The familiar calendar has a mixture of 365- and 366-day years, reflecting the fact that the time for one complete passage takes about 365¼ days; the precise value for this figure depends on the manner of defining the year."^^rdf:HTML ;
+  qudt:conversionMultiplier "31557600"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB026" ;
+  qudt:informativeReference "http://www.oxfordreference.com/view/10.1093/acref/9780198605225.001.0001/acref-9780198605225-e-1533?rskey=b94Fd6"^^xsd:anyURI ;
+  qudt:omUnit <http://www.ontology-of-units-of-measure.org/resource/om-2/year> ;
+  qudt:symbol "yr" ;
+  qudt:ucumCaseInsensitiveCode "ANN" ;
+  qudt:ucumCaseSensitiveCode "a" ;
+  qudt:ucumCode "ANN" ;
+  qudt:ucumCode "a" ;
+  qudt:uneceCommonCode "ANN" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Year" ;
+.
+unit:YR_Common
+  a qudt:Unit ;
+  qudt:conversionMultiplier "31536000.00"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB025" ;
+  qudt:plainTextDescription "31,536,000-fold of the SI base unit second according a common year with 365 days" ;
+  qudt:uneceCommonCode "L95" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YR_Common" ;
+  skos:prefLabel "common year" ;
+.
+unit:YR_Sidereal
+  a qudt:Unit ;
+  dcterms:description "A sidereal year is the time taken for Sun to return to the same position with respect to the stars of the celestial sphere."^^rdf:HTML ;
+  qudt:conversionMultiplier "31558149.7632"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB028" ;
+  qudt:symbol "yr" ;
+  qudt:ucumCaseInsensitiveCode "ANN" ;
+  qudt:ucumCaseSensitiveCode "a" ;
+  qudt:ucumCode "ANN" ;
+  qudt:ucumCode "a" ;
+  qudt:uneceCommonCode "L96" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Sidereal Year" ;
+.
+unit:YR_TROPICAL
+  a qudt:Unit ;
+  dcterms:description """<p class=\"lm-para\">A tropical year (also known as a solar year), for general purposes, is the length of time that the Sun takes to return to the same position in the cycle of seasons, as seen from Earth; for example, the time from vernal equinox to vernal equinox, or from summer solstice to summer solstice. Because of the precession of the equinoxes, the seasonal cycle does not remain exactly synchronised with the position of the Earth in its orbit around the Sun. </p>
+<p class=\"lm-para\">As a consequence, the tropical year is about 20 minutes shorter than the time it takes Earth to complete one full orbit around the Sun as measured with respect to the fixed stars. </p>
+<p class=\"lm-para\">Since antiquity, astronomers have progressively refined the definition of the tropical year, and currently define it as the time required for the mean Sun's tropical longitude (longitudinal position along the ecliptic relative to its position at the vernal equinox) to increase by 360 degrees (that is, to complete one full seasonal circuit).</p>"""^^rdf:HTML ;
+  qudt:conversionMultiplier 3.1556925216e7 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:exactMatch unit:YR_TROPICAL ;
+  qudt:hasQuantityKind quantitykind:Time ;
+  qudt:iec61360Code "0112/2///62720#UAB029" ;
+  qudt:symbol "a_{t}" ;
+  qudt:ucumCaseInsensitiveCode "ANN_T" ;
+  qudt:ucumCaseSensitiveCode "a_t" ;
+  qudt:ucumCode "ANN_T" ;
+  qudt:ucumCode "a_t" ;
+  qudt:uneceCommonCode "D42" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Tropical Year" ;
+  skos:altLabel "solar year" ;
+.
+unit:YemeniRial
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Yemen"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Yemeni_rial"^^xsd:anyURI ;
+  qudt:expression "\\(YER\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Yemeni_rial?oldid=494507603"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yemeni Rial" ;
+.
+unit:Yobi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{8}\\), or \\(2^{80}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1208925819614629174706176"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Yi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yobi" ;
+.
+unit:Yocto
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'yocto' is a decimal prefix for expressing a value with a scaling of \\(10^{-24}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-24 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Yocto-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Yocto-?oldid=488155799"^^xsd:anyURI ;
+  qudt:symbol "y" ;
+  qudt:ucumCaseInsensitiveCode "YO" ;
+  qudt:ucumCaseSensitiveCode "y" ;
+  qudt:ucumCode "YO" ;
+  qudt:ucumCode "y" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yocto" ;
+.
+unit:YoctoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A YoctoCoulomb is \\(10^{-24} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-24 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Yocto ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "yC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YoctoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:Yotta
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'yotta' is a decimal prefix for expressing a value with a scaling of \\(10^{24}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E24 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Yotta-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Yotta-?oldid=494538119"^^xsd:anyURI ;
+  qudt:symbol "Y" ;
+  qudt:ucumCaseInsensitiveCode "YA" ;
+  qudt:ucumCaseSensitiveCode "Y" ;
+  qudt:ucumCode "Y" ;
+  qudt:ucumCode "YA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yotta" ;
+.
+unit:YottaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A YottaCoulomb is \\(10^{24} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e24 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Yotta ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "YC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "YottaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:YuanRenminbi
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Mainland China"^^rdf:HTML ;
+  qudt:currencyExponent 1 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Renminbi"^^xsd:anyURI ;
+  qudt:expression "\\(CNY\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Renminbi?oldid=494799454"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Yuan Renminbi" ;
+.
+unit:Z
+  a qudt:CGS-Unit ;
+  a qudt:CountingUnit ;
+  a qudt:Unit ;
+  dcterms:description "In chemistry and physics, the atomic number (also known as the proton number) is the number of protons found in the nucleus of an atom and therefore identical to the charge number of the nucleus. It is conventionally represented by the symbol Z. The atomic number uniquely identifies a chemical element. In an atom of neutral charge, the atomic number is also equal to the number of electrons."^^rdf:HTML ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Atomic_number"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Atomic_number?oldid=490723437"^^xsd:anyURI ;
+  qudt:symbol "Z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "atomic-number" ;
+.
+unit:ZambianKwacha
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Zambia"^^rdf:HTML ;
+  qudt:currencyExponent 0 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Zambian_kwacha"^^xsd:anyURI ;
+  qudt:expression "\\(ZMK\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Zambian_kwacha?oldid=490328608"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zambian Kwacha" ;
+.
+unit:Zebi
+  a qudt:BinaryPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "A binary prefix for expressing a value with a scaling of \\(1024^{7}\\), or \\(2^{70}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier "1180591620717411303424"^^xsd:double ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:symbol "Zi" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zebi" ;
+.
+unit:Zepto
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'zepto' is a decimal prefix for expressing a value with a scaling of \\(10^{-21}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E-21 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Zepto-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Zepto-?oldid=476974663"^^xsd:anyURI ;
+  qudt:symbol "z" ;
+  qudt:ucumCaseInsensitiveCode "ZO" ;
+  qudt:ucumCaseSensitiveCode "z" ;
+  qudt:ucumCode "ZO" ;
+  qudt:ucumCode "z" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zepto" ;
+.
+unit:ZeptoC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A ZeptoCoulomb is \\(10^{-21} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e-21 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Zepto ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "zC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ZeptoCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:Zetta
+  a qudt:DecimalPrefixUnit ;
+  a qudt:Unit ;
+  dcterms:description "'zetta' is a decimal prefix for expressing a value with a scaling of \\(10^{21}\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0E21 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Zetta-"^^xsd:anyURI ;
+  qudt:hasQuantityKind quantitykind:Dimensionless ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Zetta-?oldid=495223080"^^xsd:anyURI ;
+  qudt:symbol "Z" ;
+  qudt:ucumCaseInsensitiveCode "ZA" ;
+  qudt:ucumCaseSensitiveCode "Z" ;
+  qudt:ucumCode "Z" ;
+  qudt:ucumCode "ZA" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zetta" ;
+.
+unit:ZettaC
+  a qudt:DecimalScaledUnit ;
+  a qudt:DerivedUnit ;
+  a qudt:Unit ;
+  dcterms:description "A ZettaCoulomb is \\(10^{21} C\\)."^^qudt:LatexString ;
+  qudt:conversionMultiplier 1.0e21 ;
+  qudt:conversionOffset "0.0"^^xsd:double ;
+  qudt:hasPrefixUnit unit:Zetta ;
+  qudt:hasQuantityKind quantitykind:ElectricCharge ;
+  qudt:isDerivedUnitOfSystem qudt:SOU_SI ;
+  qudt:isScalingOf unit:C ;
+  qudt:symbol "ZC" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "ZettaCoulomb" ;
+  prov:wasDerivedFrom unit:C ;
+.
+unit:ZimbabweDollar
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Zimbabwe"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Zimbabwean_dollar"^^xsd:anyURI ;
+  qudt:expression "\\(ZWD\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Zimbabwean_dollar?oldid=491532675"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zimbabwe Dollar" ;
+.
+unit:Zloty
+  a qudt:CurrencyUnit ;
+  a qudt:Unit ;
+  dcterms:description "Poland"^^rdf:HTML ;
+  qudt:currencyExponent 2 ;
+  qudt:dbpediaMatch "http://dbpedia.org/resource/Polish_z%C5%82oty"^^xsd:anyURI ;
+  qudt:expression "\\(PLN\\)"^^qudt:LatexString ;
+  qudt:hasQuantityKind quantitykind:Currency ;
+  qudt:informativeReference "http://en.wikipedia.org/wiki/Polish_złoty?oldid=492697733"^^xsd:anyURI ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "Zloty" ;
+.
+unit:failures-in-time
+  a qudt:Unit ;
+  qudt:conversionMultiplier 0e+00 ;
+  qudt:conversionOffset 0e+00 ;
+  qudt:hasQuantityKind quantitykind:InverseTime ;
+  qudt:iec61360Code "0112/2///62720#UAB403" ;
+  qudt:plainTextDescription "unit of failure rate" ;
+  qudt:uneceCommonCode "FIT" ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "failures in time" ;
+  skos:prefLabel "failures in time" ;
+.
+voag:QUDT-UNITS-VocabCatalogEntry
+  a vaem:CatalogEntry ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "QUDT UNITS Vocab Catalog Entry" ;
+.
+vaem:GMD_QUDT-UNITS-ALL
+  a vaem:GraphMetaData ;
+  dcterms:contributor "Jack Hodges" ;
+  dcterms:contributor "Steve Ray" ;
+  dcterms:created "2019-07-30"^^xsd:date ;
+  dcterms:creator "Steve Ray" ;
+  dcterms:modified "2020-04-06T12:07:42.880-07:00"^^xsd:dateTime ;
+  dcterms:rights "The QUDT Ontologies are issued under a Creative Commons Attribution 4.0 International License (CC BY 4.0), available at https://creativecommons.org/licenses/by/4.0/. Attribution should be made to QUDT.org" ;
+  dcterms:subject "Units-All" ;
+  dcterms:title "ALL UNITS Version 2.1.2 Graph Metadata" ;
+  vaem:description "Standard units of measure for all units." ;
+  vaem:graphName "qudt" ;
+  vaem:graphTitle "All Units Ontology Version 2.1.2" ;
+  vaem:hasGraphRole vaem:VocabularyGraph ;
+  vaem:hasOwner <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
+  vaem:hasSteward <http://www.linkedmodel.org/schema/vaem#QUDT.org> ;
+  vaem:intent "To provide a vocabulary of all units." ;
+  vaem:isMetadataFor <http://qudt.org/2.1/vocab/unit> ;
+  vaem:latestPublishedVersion "http://www.qudt.org/doc/2020/04/DOC_VOCAB-UNITS-ALL-v2.1.html"^^xsd:anyURI ;
+  vaem:logo "http://www.linkedmodel.org/lib/lm/images/logos/qudt_logo-300x110.png"^^xsd:anyURI ;
+  vaem:namespace "http://qudt.org/vocab/unit/" ;
+  vaem:namespacePrefix "unit" ;
+  vaem:owner "QUDT.org" ;
+  vaem:previousPublishedVersion "http://www.qudt.org/doc/2020/03/DOC_VOCAB-UNITS-ALL-v2.1.html"^^xsd:anyURI ;
+  vaem:revision "2.1.2" ;
+  vaem:turtleFileURL "http://qudt.org/2.1/vocab/unit"^^xsd:anyURI ;
+  vaem:usesNonImportedResource dcterms:abstract ;
+  vaem:usesNonImportedResource dcterms:created ;
+  vaem:usesNonImportedResource dcterms:creator ;
+  vaem:usesNonImportedResource dcterms:modified ;
+  vaem:usesNonImportedResource dcterms:title ;
+  rdfs:isDefinedBy <http://qudt.org/2.1/vocab/unit> ;
+  rdfs:label "All Units Ontology Version 2.1.2" ;
+.

--- a/tests/test_class_structure.py
+++ b/tests/test_class_structure.py
@@ -4,7 +4,7 @@ import brickschema
 from rdflib import RDF, OWL, RDFS, Namespace, BNode
 
 sys.path.append("..")
-from bricksrc.namespaces import BRICK, TAG, SOSA, VCARD, SKOS  # noqa: E402
+from bricksrc.namespaces import BRICK, TAG, SOSA, VCARD, SKOS, UNIT, QUDT  # noqa: E402
 
 
 BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
@@ -65,6 +65,8 @@ def test_subclasses():
             OWL.Class,
             VCARD.Address,
             SKOS.Concept,
+            UNIT.Unit,
+            QUDT.QuantityKind,
         ]
     )
 

--- a/tests/test_class_structure.py
+++ b/tests/test_class_structure.py
@@ -4,7 +4,7 @@ import brickschema
 from rdflib import RDF, OWL, RDFS, Namespace, BNode
 
 sys.path.append("..")
-from bricksrc.namespaces import BRICK, TAG, SOSA, VCARD  # noqa: E402
+from bricksrc.namespaces import BRICK, TAG, SOSA, VCARD, SKOS  # noqa: E402
 
 
 BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
@@ -64,6 +64,7 @@ def test_subclasses():
             RDF.Property,
             OWL.Class,
             VCARD.Address,
+            SKOS.Concept,
         ]
     )
 

--- a/tests/test_measures_inference.py
+++ b/tests/test_measures_inference.py
@@ -43,12 +43,6 @@ def test_measurable_hierarchy():
         res = list(g.query(query))
         assert (BRICK[klass],) in res
 
-    # check quantity classes
-    for klass, subklass in _get_subclasses(quantity_definitions):
-        query = f"SELECT ?x WHERE {{ <{BRICK[subklass]}> rdfs:subClassOf ?x }}"
-        res = list(g.query(query))
-        assert (BRICK[klass],) in res
-
 
 def test_measures_infers():
     g = rdflib.Graph()

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -2,6 +2,7 @@ from rdflib import Namespace
 import re
 import brickschema
 from collections import defaultdict
+import warnings
 import sys
 
 sys.path.append("..")
@@ -106,3 +107,22 @@ def test_quantity_units():
              ?q qudt:applicableUnit ?unit}"
     )
     assert len(quantities_with_units) > 0
+
+
+def test_all_quantities_have_units():
+    g = brickschema.graph.Graph()
+    g.load_file("Brick.ttl")
+    g.g.bind("qudt", QUDT)
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
+
+    # test the definitions by making sure that some quantities have applicable
+    # units
+    quantities_without_units = g.query(
+        "SELECT ?q WHERE { \
+             ?q rdf:type brick:Quantity .\
+             FILTER NOT EXISTS {?q qudt:applicableUnit ?unit} }"
+    )
+    if len(quantities_without_units) > 0:
+        warnings.warn(
+            f"The following quantities do not have associated units: {quantities_without_units}"
+        )

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,116 @@
+import rdflib
+from rdflib import RDF, OWL, RDFS, Namespace, BNode
+import re
+import brickschema
+from .util import make_readable
+from collections import defaultdict
+import sys
+
+sys.path.append("..")
+from bricksrc.namespaces import A, BRICK, TAG, QUDT  # noqa: E402
+
+BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
+
+
+def test_quantity_has_one_quantitykind():
+    """
+    In the current implementation, using owl:sameAs to align Brick Quantity
+    with QUDT QuantityKinds, we need to make sure that through RDFS subclassing
+    that a Brick Quantity does not end up with more than 1 QuantityKind
+    """
+    g = brickschema.graph.Graph()
+    g.load_file("Brick.ttl")
+    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+    g.g.bind("qudt", QUDT)
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
+    quantity_qk = g.query(
+        "SELECT ?quantity ?kind WHERE {\
+            ?quantity   a   brick:Quantity .\
+            ?quantity   owl:sameAs ?kind }"
+    )
+    assert len(quantity_qk) > 0
+    seen = defaultdict(list)
+    for quant, quantkind in quantity_qk:
+        if "Brick" not in quant:
+            continue
+        if "qudt" not in quantkind:
+            continue
+        seen[quant].append(quantkind)
+    for quant, kindlist in seen.items():
+        if len(kindlist) > 1:
+            raise Exception(
+                f"Quantity {quant} has more than one associated \
+QuantityKind! {kindlist}"
+            )
+
+
+def test_instances_measure_correct_units():
+    """
+    Tests that the units associated with instances are properly linked
+    through the QuantityKinds
+
+    Recall that the Brick unit model is such:
+
+    Brick class ---measures---> Brick quantity ---sameAs---> QUDT QuantityKind
+        |                                                           |
+        |                            +-----applicableUnit-----------+
+        |                            |
+        v                            v
+     Instance --- hasUnit --->   QUDT unit
+
+    We create an instance of each Brick class which 'measures' a quantity
+    and associate that instance with one of the applicable units as defined
+    by QUDT. We then verify that all of those units are associated with the
+    correct quantity
+    """
+
+    g = brickschema.graph.Graph()
+    g.load_file("Brick.ttl")
+    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+    g.g.bind("qudt", QUDT)
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
+
+    # test the definitions by making sure that some quantities have applicable
+    # units
+    classes_with_quantities = g.query(
+        "SELECT ?class ?quantity ?unit WHERE { \
+             ?class a   brick:Class .\
+             ?class brick:measures ?quantity .\
+             ?quantity qudt:applicableUnit ?unit }"
+    )
+    triples = []
+    for brickclass, quantity, unit in classes_with_quantities:
+        class_name = re.split("/|#", brickclass)[-1]
+        unit_name = re.split("/|#", unit)[-1]
+        instance_name = f"Instance_of_{class_name}_{unit_name}"
+        triples.append((BLDG[instance_name], A, brickclass))
+        triples.append((BLDG[instance_name], BRICK.hasUnit, unit))
+    g.add(*triples)
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
+
+    instances = g.query(
+        "SELECT ?inst ?quantity ?unit WHERE {\
+             ?inst   rdf:type        brick:Sensor .\
+             ?inst   rdf:type/brick:measures  ?quantity .\
+             ?quantity    a   brick:Quantity .\
+             ?inst   brick:hasUnit   ?unit .}"
+    )
+
+    assert len(instances) == len(classes_with_quantities)
+
+
+def test_quantity_units():
+    g = brickschema.graph.Graph()
+    g.load_file("Brick.ttl")
+    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
+    g.g.bind("qudt", QUDT)
+    g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
+
+    # test the definitions by making sure that some quantities have applicable
+    # units
+    quantities_with_units = g.query(
+        "SELECT ?q WHERE { \
+             ?q rdf:type brick:Quantity .\
+             ?q qudt:applicableUnit ?unit}"
+    )
+    assert len(quantities_with_units) > 0

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -45,7 +45,7 @@ def test_instances_measure_correct_units():
 
     Recall that the Brick unit model is such:
 
-    Brick class ---measures---> Brick quantity ---equivCls---> QuantityKind
+    Brick class ---measures---> Brick quantity -- sameAs --> QuantityKind
         |                                                           |
         |                            +-----applicableUnit-----------+
         |                            |

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -29,17 +29,14 @@ def test_quantity_has_one_quantitykind():
     assert len(quantity_qk) > 0
     seen = defaultdict(list)
     for quant, quantkind in quantity_qk:
-        if "Brick" not in quant:
+        if quant == quantkind:
             continue
-        if "qudt" not in quantkind:
-            continue
-        seen[quant].append(quantkind)
+        if "Brick" in quant and "qudt" in quantkind:
+            seen[quant].append(quantkind)
     for quant, kindlist in seen.items():
-        if len(kindlist) > 1:
-            raise Exception(
-                f"Quantity {quant} has more than one associated \
-QuantityKind! {kindlist}"
-            )
+        assert (
+            len(kindlist) == 1
+        ), f"Quantity {quant} has more than one associated QuantityKind! {kindlist}"
 
 
 def test_instances_measure_correct_units():
@@ -74,7 +71,7 @@ def test_instances_measure_correct_units():
         "SELECT ?class ?quantity ?unit WHERE { \
              ?class a   brick:Class .\
              ?class brick:measures ?quantity .\
-             ?quantity owl:equivalentClass/qudt:applicableUnit ?unit }"
+             ?quantity qudt:applicableUnit ?unit }"
     )
     triples = []
     for brickclass, quantity, unit in classes_with_quantities:
@@ -109,6 +106,6 @@ def test_quantity_units():
     quantities_with_units = g.query(
         "SELECT ?q WHERE { \
              ?q rdf:type brick:Quantity .\
-             ?q owl:equivalentClass/qudt:applicableUnit ?unit}"
+             ?q qudt:applicableUnit ?unit}"
     )
     assert len(quantities_with_units) > 0

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,8 +1,6 @@
-import rdflib
-from rdflib import RDF, OWL, RDFS, Namespace, BNode
+from rdflib import Namespace
 import re
 import brickschema
-from .util import make_readable
 from collections import defaultdict
 import sys
 
@@ -14,7 +12,7 @@ BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
 
 def test_quantity_has_one_quantitykind():
     """
-    In the current implementation, using owl:sameAs to align Brick Quantity
+    In the current implementation, using owl:equivalentClass to align Quantity
     with QUDT QuantityKinds, we need to make sure that through RDFS subclassing
     that a Brick Quantity does not end up with more than 1 QuantityKind
     """
@@ -26,7 +24,7 @@ def test_quantity_has_one_quantitykind():
     quantity_qk = g.query(
         "SELECT ?quantity ?kind WHERE {\
             ?quantity   a   brick:Quantity .\
-            ?quantity   owl:sameAs ?kind }"
+            ?quantity   owl:equivalentClass ?kind }"
     )
     assert len(quantity_qk) > 0
     seen = defaultdict(list)
@@ -51,7 +49,7 @@ def test_instances_measure_correct_units():
 
     Recall that the Brick unit model is such:
 
-    Brick class ---measures---> Brick quantity ---sameAs---> QUDT QuantityKind
+    Brick class ---measures---> Brick quantity ---equivCls---> QuantityKind
         |                                                           |
         |                            +-----applicableUnit-----------+
         |                            |
@@ -76,7 +74,7 @@ def test_instances_measure_correct_units():
         "SELECT ?class ?quantity ?unit WHERE { \
              ?class a   brick:Class .\
              ?class brick:measures ?quantity .\
-             ?quantity qudt:applicableUnit ?unit }"
+             ?quantity owl:equivalentClass/qudt:applicableUnit ?unit }"
     )
     triples = []
     for brickclass, quantity, unit in classes_with_quantities:
@@ -111,6 +109,6 @@ def test_quantity_units():
     quantities_with_units = g.query(
         "SELECT ?q WHERE { \
              ?q rdf:type brick:Quantity .\
-             ?q qudt:applicableUnit ?unit}"
+             ?q owl:equivalentClass/qudt:applicableUnit ?unit}"
     )
     assert len(quantities_with_units) > 0

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -18,13 +18,12 @@ def test_quantity_has_one_quantitykind():
     """
     g = brickschema.graph.Graph()
     g.load_file("Brick.ttl")
-    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
     g.g.bind("qudt", QUDT)
     g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
     quantity_qk = g.query(
         "SELECT ?quantity ?kind WHERE {\
             ?quantity   a   brick:Quantity .\
-            ?quantity   owl:equivalentClass ?kind }"
+            ?quantity   owl:sameAs ?kind }"
     )
     assert len(quantity_qk) > 0
     seen = defaultdict(list)
@@ -61,7 +60,6 @@ def test_instances_measure_correct_units():
 
     g = brickschema.graph.Graph()
     g.load_file("Brick.ttl")
-    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
     g.g.bind("qudt", QUDT)
     g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
 
@@ -97,7 +95,6 @@ def test_instances_measure_correct_units():
 def test_quantity_units():
     g = brickschema.graph.Graph()
     g.load_file("Brick.ttl")
-    g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
     g.g.bind("qudt", QUDT)
     g = brickschema.inference.OWLRLInferenceSession(load_brick=False).expand(g)
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -12,9 +12,9 @@ BLDG = Namespace("https://brickschema.org/schema/ExampleBuilding#")
 
 def test_quantity_has_one_quantitykind():
     """
-    In the current implementation, using owl:equivalentClass to align Quantity
-    with QUDT QuantityKinds, we need to make sure that through RDFS subclassing
-    that a Brick Quantity does not end up with more than 1 QuantityKind
+    In the current implementation, using owl:sameAs to align Quantity
+    with QUDT QuantityKinds, we need to make sure that  a Brick Quantity
+    does not end up with more than 1 QuantityKind
     """
     g = brickschema.graph.Graph()
     g.load_file("Brick.ttl")

--- a/tools/convert/requirements.txt
+++ b/tools/convert/requirements.txt
@@ -4,3 +4,4 @@ pyparsing==2.4.2
 rdflib==4.2.2
 six==1.12.0
 tqdm==4.36.1
+requests


### PR DESCRIPTION
# Units Prototype

Basic model structure is as follows

```
                brick:measures          brick:associatedQuantityKind
  ╔════════════╗      |      ╔════════════════╗      |      +-------------------+
  ║Brick Point ║════════════>║ Brick Quantity ║════════════>| QUDT QuantityKind |
  ║   Class    ║             ╚══════╦═════════╝             +---------+---------+
  ╚════════════╝                    ║                                 |
        |                           ║ qudt:applicableUnit             |
        | rdf:type                  ║ (compiled into Brick def)       |
        v                           ║                                 |
  ┌─────────┐                       v                                 |
  │Point    │ brick:hasUnit   +---------+     qudt:applicableUnit     |
  │Instance │────────────────>|QUDT Unit| <---------------------------+
  └─────────┘                 +---------+

```

- Bolded (double-line) boxes, edges are defined in the Brick schema 
- Smooth (single-line) boxes, edges are defined in a Brick model (an instance of a building)
- Dashed boxes, edges are defined in QUDT and are *not* included in the Brick distribution


The high-level idea is thus:

- Brick Point classes are associated with a Brick Quantity:
  - currently the association is done for most Sensors (this implementation was done in Brick v1.1)
  - association is done via the `brick:measures` relationship
  - the idea is that knowing the Quantity associated with a Point class should help with:
    - a process can verify that the units associated with an instance of a point are valid/consistent with the Quantity of that point's class
    - user interfaces/libraries can look up associated/applicable units to suggest for instances of the point
- `bricksrc/quantity.py` associates Brick Quantity classes (arranged in a hierarchy) with QUDT QuantityKind classes (a flat namespace)
    - the association between a Quantity and a QuantityKind is done through the `brick:associatedQuantityKind` property
    - the actual property here can change depending on the answer to the below issues
- `generate_brick.py` uses the `brick:associatedQuantityKind` property to pull in the `qudt:applicableUnit` properties to the Brick quantity classes
    - this is arguably brittle because our mapping between quantities, quantitykinds and units might diverge from QUDT if it were to change
    - however, by pulling the `qudt:applicableUnit` property into the Brick ontology definition, we don't need to import the QUDT graph


## Implementation Issues

**Issue**: QuantityKinds are a flat namespace and the Brick Quantity namespace is hierarchical

First question is: does the Brick Quantity namespace have to be hierarchical?
It is helpful to group quantities by general subject (e.g. "Luminous Flux" and
"Luminous Intensity" are related to "Luminance"). It may be that a more
appropriate organization uses `skos:broader`/`skos:narrower` or `rdfs:seeAlso`
or something else. I'm open here! It is safe to say that we are not currently
making use of the existing subclass relationship between Quantities.  The
choice to make them subclasses was driven by the Haystack v4 quantity/substance
organization.

We cannot use `owl:equivalentClass` to associate Brick Quantities with QUDT
QuantityKinds because QuantityKinds are not classes!

Because we are using `rdfs:subClassOf`, we can't use `owl:sameAs` to associate
Brick Quantities with QUDT QuantityKinds because all of the Quantity subclasses
will be inferred to be the same entity! This is bad for many reasons.

**Question**: why the indirection of Brick Quantity? Why not use QUDT QuantityKinds directly?

QUDT QuantityKinds do not all have applicable units; there is some relation of
concepts in QUDT that isn't super clean (e.g. QUDT ElectricPower vs QUDT
ActivePower, ReactivePower, etc; the latter concepts are "independent" of the
electrical context but there is no way to compose them). I argue it is helpful
for Brick to provide an organization of quantities that is more specialized for
the built environment domain. We have the most control over this by defining our
own concepts (Brick Quantities) and relating them to the QUDT ontology.

## Reflection and Next Steps

This implementation is provided as a record of the current attempt. Moving
forward, I think the best choice is to use `skos:broader`, `skos:narrower` (or
an analogous pair of properties) to relate Brick Quantities to one another.
Then, we can use `owl:sameAs` to relate Brick Quantities with QUDT
QuantityKinds, which makes the 'inheritance' of properties from QUDT QuantityKinds
more automatic and easier to maintain. 

We might still want to replicate `qudt:applicableUnit` in the Brick ontology
definition (or develop our own analogous property) in order to avoid needing
the QUDT ontology loaded in.
