### PR TITLE
Fix typo in conversion script

### DIFF
--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,39 @@
+import json
+import os
+import sys
+
+from rdflib import Graph, Namespace
+
+sys.path.append("..")
+
+g = Graph()
+
+
+def test_queries():
+    conversion_scripts = {}
+    malformed_queries = []
+
+    path = os.path.join("tools", "convert", "conversions")
+
+    # load conversion data
+    for filename in os.listdir(path):
+        if filename[-4:] == "json":
+            filepath = os.path.join(path, filename)
+            with open(filepath, "r") as f:
+                conversion_scripts[filename[:-4]] = json.load(f)
+
+    for filename, conversion_data in conversion_scripts.items():
+        # initialize namespaces used in the queries
+        namespaces = {}
+        for prefix, namespace in conversion_data["namespaces"].items():
+            namespaces[prefix] = Namespace(namespace)
+            g.bind(prefix, Namespace(namespace), override=True)
+
+        # execute queries
+        for operation in conversion_data["operations"]:
+            try:
+                g.update(operation["query"], initNs=namespaces)
+            except Exception as e:
+                malformed_queries.append(f"{filename}: {operation['description']}")
+
+    assert malformed_queries == []

--- a/tools/convert/conversions/1.0.3-1.1.json
+++ b/tools/convert/conversions/1.0.3-1.1.json
@@ -144,12 +144,12 @@
       "query": "DELETE{ ?subject ?predicate brickframe:usesTag . } INSERT{ ?subject ?predicate brick:hasTag . } WHERE { ?subject  ?predicate  brickframe:usesTag . }"
     },
     {
-      "description": "hasLocation => hasLocation,",
-      "query": "DELETE{ ?subject brickframe:hasLocation ?object . } INSERT{ ?subject brick:hasLocation, ?object . } WHERE { ?subject brickframe:hasLocation ?object . }"
+      "description": "hasLocation => hasLocation",
+      "query": "DELETE{ ?subject brickframe:hasLocation ?object . } INSERT{ ?subject brick:hasLocation ?object . } WHERE { ?subject brickframe:hasLocation ?object . }"
     },
     {
-      "description": "hasLocation => hasLocation,",
-      "query": "DELETE{ ?subject ?predicate brickframe:hasLocation . } INSERT{ ?subject ?predicate brick:hasLocation, . } WHERE { ?subject  ?predicate  brickframe:hasLocation . }"
+      "description": "hasLocation => hasLocation",
+      "query": "DELETE{ ?subject ?predicate brickframe:hasLocation . } INSERT{ ?subject ?predicate brick:hasLocation . } WHERE { ?subject  ?predicate  brickframe:hasLocation . }"
     },
     {
       "description": "AHU => AHU",


### PR DESCRIPTION
An erroneous comma was added, causing conversions from 1.0.3 to fail due to syntax errors in the update query.

@shreyasnagare do you know how this got caused? I'd like to try and fix the root cause of this so we don't hit this kind of bug in the future