### PR TITLE
Refining class structure and names

### DIFF
--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -86,8 +86,8 @@ alarm_definitions = {
                     },
                 },
             },
-            "Liquid_Detected_Alarm": {
-                "tags": [TAG.Point, TAG.Liquid, TAG.Detected, TAG.Alarm],
+            "Liquid_Detection_Alarm": {
+                "tags": [TAG.Point, TAG.Liquid, TAG.Detection, TAG.Alarm],
             },
             "Luminance_Alarm": {"tags": [TAG.Point, TAG.Luminance, TAG.Alarm]},
             "Maintenance_Required_Alarm": {
@@ -233,16 +233,16 @@ alarm_definitions = {
             "Smoke_Alarm": {
                 "tags": [TAG.Point, TAG.Smoke, TAG.Alarm],
                 "subclasses": {
-                    "Smoke_Detected_Alarm": {
-                        "tags": [TAG.Point, TAG.Smoke, TAG.Detected, TAG.Alarm],
+                    "Smoke_Detection_Alarm": {
+                        "tags": [TAG.Point, TAG.Smoke, TAG.Detection, TAG.Alarm],
                         "subclasses": {
-                            "Discharge_Air_Smoke_Detected_Alarm": {
+                            "Discharge_Air_Smoke_Detection_Alarm": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Discharge,
                                     TAG.Air,
                                     TAG.Smoke,
-                                    TAG.Detected,
+                                    TAG.Detection,
                                     TAG.Alarm,
                                 ],
                                 "parents": [BRICK.Air_Alarm],

--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -47,16 +47,6 @@ alarm_definitions = {
                     "Emergency_Generator_Alarm": {
                         "tags": [TAG.Point, TAG.Generator, TAG.Emergency, TAG.Alarm],
                     },
-                    "Emergency_Power_Loss_Alarm": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Power,
-                            TAG.Loss,
-                            TAG.Emergency,
-                            TAG.Alarm,
-                        ],
-                        "parents": [BRICK.Power_Loss_Alarm],
-                    },
                 },
             },
             "Failure_Alarm": {

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -8,20 +8,7 @@ command_definitions = {
         ),
         "tags": [TAG.Point, TAG.Command],
         "subclasses": {
-            "Cooling_Command": {
-                "tags": [TAG.Point, TAG.Cool, TAG.Command],
-                "subclasses": {
-                    "Highest_Zone_Cooling_Command": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Highest,
-                            TAG.Zone,
-                            TAG.Cool,
-                            TAG.Command,
-                        ],
-                    },
-                },
-            },
+            "Cooling_Command": {"tags": [TAG.Point, TAG.Cool, TAG.Command]},
             "Heating_Command": {"tags": [TAG.Point, TAG.Heat, TAG.Command]},
             "Luminance_Command": {"tags": [TAG.Point, TAG.Luminance, TAG.Command]},
             "Bypass_Command": {"tags": [TAG.Point, TAG.Bypass, TAG.Command]},
@@ -322,40 +309,12 @@ command_definitions = {
                             "An Off Command controls or reports the binary 'off' status of a control loop, relay or equipment activity. It can only be used to stop/terminate/deactivate an associated equipment or process, or determine that the related entity is 'off'"
                         ),
                         "tags": [TAG.Point, TAG.Off, TAG.Command],
-                        "subclasses": {
-                            "Exhaust_Fan_Fire_Control_Panel_Off_Command": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Exhaust,
-                                    TAG.Fan,
-                                    TAG.Fire,
-                                    TAG.Control,
-                                    TAG.Panel,
-                                    TAG.Off,
-                                    TAG.Command,
-                                ],
-                            }
-                        },
                     },
                     "On_Command": {
                         SKOS.definition: Literal(
                             "An On Command controls or reports the binary 'on' status of a control loop, relay or equipment activity. It can only be used to start/activate an associated equipment or process, or determine that the related entity is 'on'"
                         ),
                         "tags": [TAG.Point, TAG.On, TAG.Command],
-                        "subclasses": {
-                            "Exhaust_Fan_Fire_Control_Panel_On_Command": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Exhaust,
-                                    TAG.Fan,
-                                    TAG.Fire,
-                                    TAG.Control,
-                                    TAG.Panel,
-                                    TAG.On,
-                                    TAG.Command,
-                                ],
-                            }
-                        },
                     },
                     "Lead_On_Off_Command": {
                         "tags": [TAG.Point, TAG.Lead, TAG.On, TAG.Off, TAG.Command],

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import TAG, OWL, SKOS, BRICK
+from .namespaces import TAG, OWL, SKOS, BRICK, RDFS
 
 """
 Set up subclasses of the equipment superclass
@@ -280,6 +280,13 @@ hvac_subclasses = {
             "Condenser_Heat_Exchanger": {
                 "tags": [TAG.Condenser, TAG.Equipment, TAG.Heat, TAG.Exchanger],
             },
+            "Heat_Wheel": {
+                "tags": [TAG.Equipment, TAG.Heat, TAG.Wheel],
+                SKOS.definition: Literal(
+                    "A type of energy recovery heat exchanger positioned within the supply and exhaust air streams of an air-handling system or in the exhaust gases of an industrial process, in order to recover the heat energy"
+                ),
+                RDFS.seeAlso: Literal("https://en.wikipedia.org/wiki/Thermal_wheel"),
+            },
         },
     },
     "HX": {"tags": [TAG.Equipment, TAG.HX]},
@@ -550,15 +557,15 @@ security_subclasses = {
     },
     "Intrusion_Detection_Equipment": {
         "tags": [TAG.Equipment, TAG.Security, TAG.Intrusion, TAG.Detection],
-            # TODO
-            # Motion sensor - but maybe to Points, but still need a way to represent security motion sensors
-            # Security Control Panel: The central hub of a security system. All devices are connected to the security panel for easy
-            #    and efficient access for different security protocols (i.e. Intrusion security) and events. Question: How’s this different from
-            #    Access Panel? Is this specific to Intrusion detection system or more general?
-            # Glass_Break_Sensor: a sensor used in electronic alarms that detect if pane of glass has been shattered or is broken.
-            # Duress_Button: Panic button, an electronic input device used to help alerting someone in emergency situations.
-            # Door_Contacts: Door contact sensor, a peripheral security sensor that lets an alarm system know whether a door is
-            # open or closed.
+        # TODO
+        # Motion sensor - but maybe to Points, but still need a way to represent security motion sensors
+        # Security Control Panel: The central hub of a security system. All devices are connected to the security panel for easy
+        #    and efficient access for different security protocols (i.e. Intrusion security) and events. Question: How’s this different from
+        #    Access Panel? Is this specific to Intrusion detection system or more general?
+        # Glass_Break_Sensor: a sensor used in electronic alarms that detect if pane of glass has been shattered or is broken.
+        # Duress_Button: Panic button, an electronic input device used to help alerting someone in emergency situations.
+        # Door_Contacts: Door contact sensor, a peripheral security sensor that lets an alarm system know whether a door is
+        # open or closed.
     },
     "Intercom_Equipment": {
         "tags": [TAG.Equipment, TAG.Security, TAG.Intercom],

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -202,7 +202,6 @@ hvac_subclasses = {
         "tags": [TAG.Equipment, TAG.VFD],
         "subclasses": {
             "Heat_Wheel_VFD": {"tags": [TAG.Equipment, TAG.Heat, TAG.Wheel, TAG.VFD]},
-            "Preheat_Valve_VFD": {"tags": [TAG.Equipment, TAG.Preheat, TAG.VFD]},
         },
     },
     "Thermostat": {

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -84,6 +84,66 @@ parameter_definitions = {
                             TAG.Parameter,
                         ],
                     },
+                    "Lockout_Temperature_Differential_Parameter": {
+                        SKOS.definition: Literal(
+                            "Parameters determining a range of temperature during which a process cannot be activated (cool-down period)",
+                        ),
+                        "tags": [
+                            TAG.Point,
+                            TAG.Lockout,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Sensor,
+                        ],
+                        "subclasses": {
+                            "Outside_Air_Lockout_Temperature_Differential_Parameter": {
+                                SKOS.definition: Literal(
+                                    "Parameters determining a range of outside air temperature during which a process cannot be activated (cool-down period)",
+                                ),
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Lockout,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Parameter,
+                                ],
+                                "subclasses": {
+                                    "Low_Outside_Air_Lockout_Temperature_Differential_Parameter": {
+                                        SKOS.definition: Literal(
+                                            "The lower bound of the outside air temperature lockout range",
+                                        ),
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Low,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Lockout,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Parameter,
+                                        ],
+                                    },
+                                    "High_Outside_Air_Lockout_Temperature_Differential_Parameter": {
+                                        SKOS.definition: Literal(
+                                            "The upper bound of the outside air temperature lockout range",
+                                        ),
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.High,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Lockout,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Parameter,
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
                 },
             },
             "PID_Parameter": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -559,6 +559,7 @@ sensor_definitions = {
             },
             "Frost_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Frost],
+                "parents": [BRICK.Temperature_Sensor],
                 "substances": [
                     [BRICK.measures, BRICK.Frost],
                     [BRICK.measures, BRICK.Temperature],

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1352,43 +1352,6 @@ sensor_definitions = {
                                             },
                                         },
                                     },
-                                    "Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Lockout,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Sensor,
-                                        ],
-                                        "subclasses": {
-                                            "Low_Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Low,
-                                                    TAG.Outside,
-                                                    TAG.Air,
-                                                    TAG.Lockout,
-                                                    TAG.Temperature,
-                                                    TAG.Differential,
-                                                    TAG.Sensor,
-                                                ],
-                                            },
-                                            "High_Outside_Air_Lockout_Temperature_Differential_Sensor": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.High,
-                                                    TAG.Outside,
-                                                    TAG.Air,
-                                                    TAG.Lockout,
-                                                    TAG.Temperature,
-                                                    TAG.Differential,
-                                                    TAG.Sensor,
-                                                ],
-                                            },
-                                        },
-                                    },
                                 },
                             },
                         },

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -14,9 +14,6 @@ sensor_definitions = {
             "Adjust_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Adjust],
                 "subclasses": {
-                    "Temperature_Adjust_Sensor": {
-                        "tags": [TAG.Point, TAG.Sensor, TAG.Adjust, TAG.Temperature],
-                    },
                     "Warm_Cool_Adjust_Sensor": {
                         "tags": [TAG.Point, TAG.Sensor, TAG.Adjust, TAG.Warm, TAG.Cool],
                     },

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -559,7 +559,10 @@ sensor_definitions = {
             },
             "Frost_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Frost],
-                "substances": [[BRICK.measures, BRICK.Frost]],
+                "substances": [
+                    [BRICK.measures, BRICK.Frost],
+                    [BRICK.measures, BRICK.Temperature],
+                ],
             },
             "Gas_Sensor": {
                 SKOS.definition: Literal(
@@ -584,10 +587,16 @@ sensor_definitions = {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Humidity],
                 "substances": [[BRICK.measures, BRICK.Humidity]],
                 "subclasses": {
-                    "Air_Humidity_Sensor": {
-                        "tags": [TAG.Point, TAG.Sensor, TAG.Humidity, TAG.Air],
+                    "Relative_Humidity_Sensor": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Sensor,
+                            TAG.Humidity,
+                            TAG.Air,
+                            TAG.Relative,
+                        ],
                         "substances": [
-                            [BRICK.measures, BRICK.Humidity],
+                            [BRICK.measures, BRICK.Relative_Humidity],
                             [BRICK.measures, BRICK.Air],
                         ],
                         "subclasses": {
@@ -596,11 +605,12 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Discharge,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
+                                    [BRICK.measures, BRICK.Relative_Humidity],
                                     [BRICK.measures, BRICK.Discharge_Air],
                                 ],
                             },
@@ -609,11 +619,12 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Exhaust,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
+                                    [BRICK.measures, BRICK.Relative_Humidity],
                                     [BRICK.measures, BRICK.Exhaust_Air],
                                 ],
                             },
@@ -622,25 +633,13 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Outside,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
-                                    [BRICK.measures, BRICK.Outside_Air],
-                                ],
-                            },
-                            "Relative_Humidity_Sensor": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Sensor,
-                                    TAG.Humidity,
-                                    TAG.Air,
-                                    TAG.Relative,
-                                ],
-                                "substances": [
                                     [BRICK.measures, BRICK.Relative_Humidity],
-                                    [BRICK.measures, BRICK.Air],
+                                    [BRICK.measures, BRICK.Outside_Air],
                                 ],
                             },
                             "Return_Air_Humidity_Sensor": {
@@ -648,11 +647,12 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Return,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
+                                    [BRICK.measures, BRICK.Relative_Humidity],
                                     [BRICK.measures, BRICK.Return_Air],
                                 ],
                             },
@@ -661,11 +661,12 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Supply,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
+                                    [BRICK.measures, BRICK.Relative_Humidity],
                                     [BRICK.measures, BRICK.Supply_Air],
                                 ],
                             },
@@ -674,16 +675,17 @@ sensor_definitions = {
                                     TAG.Point,
                                     TAG.Sensor,
                                     TAG.Humidity,
+                                    TAG.Relative,
                                     TAG.Air,
                                     TAG.Zone,
                                 ],
                                 "substances": [
-                                    [BRICK.measures, BRICK.Humidity],
+                                    [BRICK.measures, BRICK.Relative_Humidity],
                                     [BRICK.measures, BRICK.Zone_Air],
                                 ],
                             },
                         },
-                    }
+                    },
                 },
             },
             "Illuminance_Sensor": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -985,6 +985,7 @@ sensor_definitions = {
             "Rain_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Rain],
                 # TODO: substances
+                "substances": [[BRICK.measures, BRICK.Precipitation]],
                 "subclasses": {
                     "Rain_Duration_Sensor": {
                         "tags": [TAG.Point, TAG.Sensor, TAG.Rain, TAG.Duration],
@@ -1003,6 +1004,7 @@ sensor_definitions = {
                     },
                     "On_Timer_Sensor": {
                         "tags": [TAG.Point, TAG.On, TAG.Timer, TAG.Sensor],
+                        OWL.equivalentClass: BRICK.Run_Time_Sensor,
                     },
                 },
             },

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -117,22 +117,6 @@ setpoint_definitions = {
                                 },
                             },
                             "Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
-                                "subclasses": {
-                                    "Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Thermal,
-                                            TAG.Energy,
-                                            TAG.Storage,
-                                            TAG.Discharge,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Deadband,
-                                            TAG.Setpoint,
-                                        ],
-                                    }
-                                },
                                 "tags": [
                                     TAG.Point,
                                     TAG.Discharge,
@@ -144,22 +128,6 @@ setpoint_definitions = {
                                 ],
                             },
                             "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                                "subclasses": {
-                                    "Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Thermal,
-                                            TAG.Energy,
-                                            TAG.Storage,
-                                            TAG.Supply,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Deadband,
-                                            TAG.Setpoint,
-                                        ],
-                                    }
-                                },
                                 "tags": [
                                     TAG.Point,
                                     TAG.Supply,
@@ -488,15 +456,6 @@ setpoint_definitions = {
                                     TAG.Setpoint,
                                 ],
                             },
-                            "Fan_Air_Flow_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Fan,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                            },
                             "Outside_Air_Flow_Setpoint": {
                                 "tags": [
                                     TAG.Point,
@@ -631,20 +590,6 @@ setpoint_definitions = {
                 "tags": [TAG.Point, TAG.Load, TAG.Setpoint],
             },
             "Luminance_Setpoint": {"tags": [TAG.Point, TAG.Luminance, TAG.Setpoint]},
-            "Mode_Setpoint": {
-                "subclasses": {
-                    "Dual_Band_Mode_Setpoint": {
-                        "tags": [TAG.Point, TAG.Dual, TAG.Band, TAG.Mode, TAG.Setpoint],
-                    },
-                    "Unoccupied_Mode_Setpoint": {
-                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Mode, TAG.Setpoint],
-                    },
-                    "Occupied_Mode_Setpoint": {
-                        "tags": [TAG.Point, TAG.Occupied, TAG.Mode, TAG.Setpoint],
-                    },
-                },
-                "tags": [TAG.Point, TAG.Mode, TAG.Setpoint],
-            },
             "Pressure_Setpoint": {
                 "subclasses": {
                     "Differential_Pressure_Setpoint": {
@@ -775,39 +720,6 @@ setpoint_definitions = {
                     },
                 },
                 "tags": [TAG.Point, TAG.Pressure, TAG.Setpoint],
-            },
-            "Request_Setpoint": {
-                "tags": [TAG.Point, TAG.Request, TAG.Setpoint],
-                "subclasses": {
-                    "Cooling_Request_Setpoint": {
-                        "tags": [TAG.Point, TAG.Cool, TAG.Request, TAG.Setpoint],
-                        "subclasses": {
-                            "Cooling_Request_Percent_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Cool,
-                                    TAG.Request,
-                                    TAG.Percent,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                    "Heating_Request_Setpoint": {
-                        "tags": [TAG.Point, TAG.Heat, TAG.Request, TAG.Setpoint],
-                        "subclasses": {
-                            "Heating_Request_Percent_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Heat,
-                                    TAG.Request,
-                                    TAG.Percent,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                },
             },
             "Reset_Setpoint": {
                 "tags": [TAG.Point, TAG.Reset, TAG.Setpoint],
@@ -1066,38 +978,6 @@ setpoint_definitions = {
                     },
                     "Differential_Speed_Setpoint": {
                         "tags": [TAG.Point, TAG.Differential, TAG.Speed, TAG.Setpoint],
-                        "subclasses": {
-                            "Discharge_Fan_Differential_Speed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Discharge,
-                                    TAG.Fan,
-                                    TAG.Differential,
-                                    TAG.Speed,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Return_Fan_Differential_Speed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Return,
-                                    TAG.Fan,
-                                    TAG.Differential,
-                                    TAG.Speed,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Fan_Differential_Speed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Fan,
-                                    TAG.Differential,
-                                    TAG.Speed,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
                     },
                 },
             },
@@ -1410,18 +1290,6 @@ setpoint_definitions = {
             "CO2_Setpoint": {
                 "subclasses": {
                     "Return_Air_CO2_Setpoint": {
-                        "subclasses": {
-                            "Max_Return_Air_CO2_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Max,
-                                    TAG.Return,
-                                    TAG.Air,
-                                    TAG.CO2,
-                                    TAG.Setpoint,
-                                ],
-                            }
-                        },
                         "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
                     }
                 },

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -26,54 +26,6 @@ status_definitions = {
             "Emergency_Generator_Status": {
                 "tags": [TAG.Point, TAG.Emergency, TAG.Generator, TAG.Status],
             },
-            "Emergency_Power_Off_System_Status": {
-                "tags": [
-                    TAG.Point,
-                    TAG.Emergency,
-                    TAG.Power,
-                    TAG.Off,
-                    TAG.System,
-                    TAG.Status,
-                ],
-                "parents": [BRICK.Off_Status],
-                "subclasses": {
-                    "Emergency_Power_Off_System_Activated_By_High_Temperature_Status": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Emergency,
-                            TAG.Power,
-                            TAG.Off,
-                            TAG.System,
-                            TAG.High,
-                            TAG.Temperature,
-                            TAG.Status,
-                        ],
-                    },
-                    "Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Emergency,
-                            TAG.Power,
-                            TAG.Off,
-                            TAG.System,
-                            TAG.Leak,
-                            TAG.Detection,
-                            TAG.Status,
-                        ],
-                    },
-                    "Emergency_Power_Off_System_Enable_Status": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Emergency,
-                            TAG.Power,
-                            TAG.Off,
-                            TAG.System,
-                            TAG.Enable,
-                            TAG.Status,
-                        ],
-                    },
-                },
-            },
             "Emergency_Push_Button_Status": {
                 "tags": [TAG.Point, TAG.Emergency, TAG.Push, TAG.Button, TAG.Status],
             },
@@ -481,6 +433,54 @@ status_definitions = {
                             TAG.System,
                             TAG.Status,
                         ],
+                    },
+                    "Emergency_Power_Off_System_Status": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Emergency,
+                            TAG.Power,
+                            TAG.Off,
+                            TAG.System,
+                            TAG.Status,
+                        ],
+                        "parents": [BRICK.Off_Status],
+                        "subclasses": {
+                            "Emergency_Power_Off_System_Activated_By_High_Temperature_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Emergency,
+                                    TAG.Power,
+                                    TAG.Off,
+                                    TAG.System,
+                                    TAG.High,
+                                    TAG.Temperature,
+                                    TAG.Status,
+                                ],
+                            },
+                            "Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Emergency,
+                                    TAG.Power,
+                                    TAG.Off,
+                                    TAG.System,
+                                    TAG.Leak,
+                                    TAG.Detection,
+                                    TAG.Status,
+                                ],
+                            },
+                            "Emergency_Power_Off_System_Enable_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Emergency,
+                                    TAG.Power,
+                                    TAG.Off,
+                                    TAG.System,
+                                    TAG.Enable,
+                                    TAG.Status,
+                                ],
+                            },
+                        },
                     },
                 },
             },

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -23,60 +23,54 @@ status_definitions = {
             "Drive_Ready_Status": {
                 "tags": [TAG.Point, TAG.Drive, TAG.Ready, TAG.Status],
             },
-            "Emergency_Air_Flow_Status": {
-                "tags": [TAG.Point, TAG.Emergency, TAG.Air, TAG.Flow, TAG.Status],
-            },
             "Emergency_Generator_Status": {
                 "tags": [TAG.Point, TAG.Emergency, TAG.Generator, TAG.Status],
             },
-            "Emergency_Power_Off_Status": {
-                "tags": [TAG.Point, TAG.Emergency, TAG.Power, TAG.Off, TAG.Status],
+            "Emergency_Power_Off_System_Status": {
+                "tags": [
+                    TAG.Point,
+                    TAG.Emergency,
+                    TAG.Power,
+                    TAG.Off,
+                    TAG.System,
+                    TAG.Status,
+                ],
                 "parents": [BRICK.Off_Status],
                 "subclasses": {
-                    "Emergency_Power_Off_Activated_By_High_Temperature_Status": {
+                    "Emergency_Power_Off_System_Activated_By_High_Temperature_Status": {
                         "tags": [
                             TAG.Point,
                             TAG.Emergency,
                             TAG.Power,
                             TAG.Off,
+                            TAG.System,
                             TAG.High,
                             TAG.Temperature,
                             TAG.Status,
                         ],
                     },
-                    "Emergency_Power_Off_Activated_By_Leak_Detection_System_Status": {
+                    "Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status": {
                         "tags": [
                             TAG.Point,
                             TAG.Emergency,
                             TAG.Power,
                             TAG.Off,
+                            TAG.System,
                             TAG.Leak,
                             TAG.Detection,
                             TAG.Status,
                         ],
                     },
-                    "Emergency_Power_Off_Enable_Status": {
+                    "Emergency_Power_Off_System_Enable_Status": {
                         "tags": [
                             TAG.Point,
                             TAG.Emergency,
                             TAG.Power,
                             TAG.Off,
+                            TAG.System,
                             TAG.Enable,
                             TAG.Status,
                         ],
-                        "subclasses": {
-                            "Emergency_Power_Off_System_Enable_Status": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Emergency,
-                                    TAG.Power,
-                                    TAG.Off,
-                                    TAG.System,
-                                    TAG.Enable,
-                                    TAG.Status,
-                                ],
-                            },
-                        },
                     },
                 },
             },

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -42,10 +42,6 @@ status_definitions = {
                         ],
                         "parents": [BRICK.System_Status],
                     },
-                    "Run_Enable_Status": {
-                        "tags": [TAG.Point, TAG.Run, TAG.Enable, TAG.Status],
-                        "parents": [BRICK.Run_Status],
-                    },
                 },
                 "tags": [TAG.Point, TAG.Enable, TAG.Status],
             },
@@ -55,9 +51,6 @@ status_definitions = {
             "Fan_Status": {"tags": [TAG.Point, TAG.Fan, TAG.Status]},
             "Fault_Status": {
                 "subclasses": {
-                    "Fault_Indicator_Status": {
-                        "tags": [TAG.Point, TAG.Indicator, TAG.Fault, TAG.Status],
-                    },
                     "Humidifier_Fault_Status": {
                         "tags": [TAG.Point, TAG.Humidifier, TAG.Fault, TAG.Status],
                     },
@@ -224,10 +217,6 @@ status_definitions = {
                     "Occupied_Mode_Status": {
                         "tags": [TAG.Point, TAG.Occupied, TAG.Mode, TAG.Status],
                     },
-                    "System_Mode_Status": {
-                        "tags": [TAG.Point, TAG.System, TAG.Mode, TAG.Status],
-                        "parents": [BRICK.System_Status],
-                    },
                     "Operating_Mode_Status": {
                         "subclasses": {
                             "Vent_Operating_Mode_Status": {
@@ -361,22 +350,8 @@ status_definitions = {
                 "tags": [TAG.Point, TAG.On, TAG.Off, TAG.Status],
                 "parents": [BRICK.On_Status, BRICK.Off_Status],
             },
-            "Off_Status": {
-                "tags": [TAG.Point, TAG.Off, TAG.Status],
-                "subclasses": {
-                    "Turn_Off_Status": {
-                        "tags": [TAG.Point, TAG.Turn, TAG.Off, TAG.Status],
-                    },
-                },
-            },
-            "On_Status": {
-                "tags": [TAG.Point, TAG.On, TAG.Status],
-                "subclasses": {
-                    "Turn_On_Status": {
-                        "tags": [TAG.Point, TAG.Turn, TAG.On, TAG.Status],
-                    },
-                },
-            },
+            "Off_Status": {"tags": [TAG.Point, TAG.Off, TAG.Status]},
+            "On_Status": {"tags": [TAG.Point, TAG.On, TAG.Status]},
             "Overridden_Status": {
                 "subclasses": {
                     "Overridden_Off_Status": {
@@ -466,17 +441,6 @@ status_definitions = {
                                     TAG.System,
                                     TAG.Leak,
                                     TAG.Detection,
-                                    TAG.Status,
-                                ],
-                            },
-                            "Emergency_Power_Off_System_Enable_Status": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Emergency,
-                                    TAG.Power,
-                                    TAG.Off,
-                                    TAG.System,
-                                    TAG.Enable,
                                     TAG.Status,
                                 ],
                             },

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -124,7 +124,6 @@ status_definitions = {
                 "tags": [TAG.Point, TAG.Filter, TAG.Status],
             },
             "Freeze_Status": {"tags": [TAG.Point, TAG.Freeze, TAG.Status]},
-            "Hand_Auto_Status": {"tags": [TAG.Point, TAG.Hand, TAG.Auto, TAG.Status]},
             "Hold_Status": {"tags": [TAG.Point, TAG.Hold, TAG.Status]},
             "Load_Shed_Status": {
                 "subclasses": {
@@ -304,32 +303,15 @@ status_definitions = {
             },
             "On_Off_Status": {
                 "subclasses": {
-                    "Cooling_On_Off_Status": {
-                        "tags": [TAG.Point, TAG.Cool, TAG.On, TAG.Off, TAG.Status],
+                    "Fan_On_Off_Status": {
+                        "tags": [TAG.Point, TAG.Fan, TAG.On, TAG.Off, TAG.Status],
+                        "parents": [BRICK.Fan_Status],
                     },
-                    "Dehumidification_On_Off_Status": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Dehumidification,
-                            TAG.On,
-                            TAG.Off,
-                            TAG.Status,
-                        ],
+                    "Motor_On_Off_Status": {
+                        "tags": [TAG.Point, TAG.Motor, TAG.On, TAG.Off, TAG.Status],
                     },
-                    "EconCycle_On_Off_Status": {
-                        "tags": [TAG.Point, TAG.Econcycle, TAG.On, TAG.Off, TAG.Status],
-                    },
-                    "Heating_On_Off_Status": {
-                        "tags": [TAG.Point, TAG.Heat, TAG.On, TAG.Off, TAG.Status],
-                    },
-                    "Humidification_On_Off_Status": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidification,
-                            TAG.On,
-                            TAG.Off,
-                            TAG.Status,
-                        ],
+                    "Pump_On_Off_Status": {
+                        "tags": [TAG.Point, TAG.Pump, TAG.On, TAG.Off, TAG.Status],
                     },
                     "Locally_On_Off_Status": {
                         "tags": [TAG.Point, TAG.Locally, TAG.On, TAG.Off, TAG.Status],
@@ -362,29 +344,46 @@ status_definitions = {
                     },
                     "Start_Stop_Status": {
                         "subclasses": {
-                            "Fan_Start_Stop_Status": {
+                            "Cooling_Start_Stop_Status": {
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Fan,
-                                    TAG.Start,
-                                    TAG.Stop,
-                                    TAG.Status,
-                                ],
-                                "parents": [BRICK.Fan_Status],
-                            },
-                            "Motor_Start_Stop_Status": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Motor,
+                                    TAG.Cool,
                                     TAG.Start,
                                     TAG.Stop,
                                     TAG.Status,
                                 ],
                             },
-                            "Pump_Start_Stop_Status": {
+                            "Dehumidification_Start_Stop_Status": {
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Pump,
+                                    TAG.Dehumidification,
+                                    TAG.Start,
+                                    TAG.Stop,
+                                    TAG.Status,
+                                ],
+                            },
+                            "EconCycle_Start_Stop_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Econcycle,
+                                    TAG.Start,
+                                    TAG.Stop,
+                                    TAG.Status,
+                                ],
+                            },
+                            "Heating_Start_Stop_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Heat,
+                                    TAG.Start,
+                                    TAG.Stop,
+                                    TAG.Status,
+                                ],
+                            },
+                            "Humidification_Start_Stop_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidification,
                                     TAG.Start,
                                     TAG.Stop,
                                     TAG.Status,
@@ -470,7 +469,21 @@ status_definitions = {
                 "tags": [TAG.Point, TAG.System, TAG.Shutdown, TAG.Status],
                 "parents": [BRICK.System_Status],
             },
-            "System_Status": {"tags": [TAG.Point, TAG.System, TAG.Status]},
+            "System_Status": {
+                "tags": [TAG.Point, TAG.System, TAG.Status],
+                "subclasses": {
+                    "Emergency_Air_Flow_System_Status": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Emergency,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.System,
+                            TAG.Status,
+                        ],
+                    },
+                },
+            },
             "Speed_Status": {"tags": [TAG.Point, TAG.Speed, TAG.Status]},
         },
     }


### PR DESCRIPTION
Reflects discussion, structures, renaming being done in the definitions spreadsheet (see https://github.com/BrickSchema/Brick/issues/139).

This is a staging area for the removals, renamings and other changes.

### Changes

- `Lockout` "sensors" are actually parameters and have been moved to that hierarchy
- all air humidity sensors have been clarified as measuring *relative humidity*
- rename emergency power off, emergency air flow statuses to reflect the fact that they are statuses of systems
- moved the emergency power off, emergency air flow system status points under the `System Status` class
- reorganize start/stop and on/off status points to reflect the definitions that start/stop is for control loops and on/off can be used for equipment
- Frost sensor is also a temperature sensor