### PR TITLE
Weather -> Weather_Station with associated definition

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -789,7 +789,7 @@ https://brickschema.org/schema/1.1/Brick#Water_Temperature_Sensor,Measures the t
 https://brickschema.org/schema/1.1/Brick#Water_Temperature_Setpoint,Sets temperature of water,
 https://brickschema.org/schema/1.1/Brick#Water_Usage_Sensor,"Measures the amount of water that is consumed, over some period of time",
 https://brickschema.org/schema/1.1/Brick#Water_Valve,A valve that modulates the flow of water,
-https://brickschema.org/schema/1.1/Brick#Weather,,
+https://brickschema.org/schema/1.1/Brick#Weather_Station,A dedicated weather measurement station,https://bedes.lbl.gov/bedes-online/weather-station
 https://brickschema.org/schema/1.1/Brick#Weather_Condition,,
 https://brickschema.org/schema/1.1/Brick#Wet_Bulb_Temperature,"The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)",
 https://brickschema.org/schema/1.1/Brick#Wind_Direction,Direction of wind relative to North,

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -5,10 +5,8 @@ from .namespaces import TAG, OWL, BRICK
 Set up subclasses of the equipment superclass
 """
 equipment_subclasses = {
-    "HVAC": {
-        "tags": [TAG.HVAC]
-    },
-    "Weather": {"tags": [TAG.Weather]},
+    "HVAC": {"tags": [TAG.HVAC]},
+    "Weather_Station": {"tags": [TAG.Weather, TAG.Station]},
     "Electrical_Equipment": {
         "tags": [TAG.Electrical, TAG.Equipment],
         "subclasses": {
@@ -22,29 +20,15 @@ equipment_subclasses = {
             },
             "Inverter": {"tags": [TAG.Inverter, TAG.Equipment]},
             "PlugStrip": {"tags": [TAG.PlugStrip, TAG.Equipment]},
-            "Disconnect_Switch": {
-                "tags": [TAG.Disconnect, TAG.Switch, TAG.Equipment],
-            },
-            "Switchgear": {
-                "tags": [TAG.Switchgear, TAG.Equipment],
-            },
-            "Bus_Riser": {
-                "tags": [TAG.Riser, TAG.Equipment],
-            },
-            "Transformer": {
-                "tags": [TAG.Transformer, TAG.Equipment],
-            },
-            "Motor_Control_Center": {
-                "tags": [TAG.Motor, TAG.Equipment],
-            },
-            "Breaker_Panel": {
-                "tags": [TAG.Breaker, TAG.Equipment],
-            },
+            "Disconnect_Switch": {"tags": [TAG.Disconnect, TAG.Switch, TAG.Equipment]},
+            "Switchgear": {"tags": [TAG.Switchgear, TAG.Equipment]},
+            "Bus_Riser": {"tags": [TAG.Riser, TAG.Equipment]},
+            "Transformer": {"tags": [TAG.Transformer, TAG.Equipment]},
+            "Motor_Control_Center": {"tags": [TAG.Motor, TAG.Equipment]},
+            "Breaker_Panel": {"tags": [TAG.Breaker, TAG.Equipment]},
         },
     },
-    "Gas_Distribution": {
-        "tags": [TAG.Gas, TAG.Distribution, TAG.Equipment],
-    },
+    "Gas_Distribution": {"tags": [TAG.Gas, TAG.Distribution, TAG.Equipment]},
     "Meter": {
         "tags": [TAG.Meter, TAG.Equipment],
         "subclasses": {
@@ -113,12 +97,8 @@ equipment_subclasses = {
             "Building_Meter": {"tags": [TAG.Meter, TAG.Equipment, TAG.Building]},
         },
     },
-    "Water_Distribution": {
-        "tags": [TAG.Water, TAG.Distribution, TAG.Equipment],
-    },
-    "Steam_Distribution": {
-        "tags": [TAG.Steam, TAG.Distribution, TAG.Equipment],
-    },
+    "Water_Distribution": {"tags": [TAG.Water, TAG.Distribution, TAG.Equipment]},
+    "Steam_Distribution": {"tags": [TAG.Steam, TAG.Distribution, TAG.Equipment]},
     "Solar_Panel": {"tags": [TAG.Solar, TAG.Equipment]},
     "Louver": {"tags": [TAG.Shade, TAG.Equipment, TAG.Louver]},
     "Lighting_Equipment": {
@@ -385,13 +365,9 @@ valve_subclasses = {
             },
         },
     },
-    "Gas_Valve": {
-        "tags": [TAG.Gas, TAG.Valve, TAG.Equipment],
-    },
+    "Gas_Valve": {"tags": [TAG.Gas, TAG.Valve, TAG.Equipment]},
     "Isolation_Valve": {"tags": [TAG.Isolation, TAG.Valve, TAG.Equipment]},
-    "Steam_Valve": {
-        "tags": [TAG.Steam, TAG.Valve, TAG.Equipment],
-    },
+    "Steam_Valve": {"tags": [TAG.Steam, TAG.Valve, TAG.Equipment]},
 }
 
 security_subclasses = {


### PR DESCRIPTION
Weather Station makes more sense as an Equipment than old "Weather" did, which was inherited from Brick v1.0.3. Using `A dedicated weather measurement station` as the definition for now, but open to other more descriptive definitions