### PR TITLE
Move Booster fan to be sibling of Supply fan rather than child

### DIFF
--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -256,14 +256,10 @@ hvac_subclasses = {
             },
             "Exhaust_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Exhaust]},
             "Return_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Return]},
+            "Booster_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Booster]},
             "Standby_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Standby]},
             "Discharge_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Discharge]},
-            "Supply_Fan": {
-                "tags": [TAG.Equipment, TAG.Fan, TAG.Supply],
-                "subclasses": {
-                    "Booster_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Booster]},
-                },
-            },
+            "Supply_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Supply]},
         },
     },
     "Economizer": {"tags": [TAG.Equipment, TAG.Economizer]},

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -1,4 +1,3 @@
-from rdflib import Literal
 from .namespaces import TAG, OWL, BRICK
 
 """
@@ -259,7 +258,10 @@ hvac_subclasses = {
             "Booster_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Booster]},
             "Standby_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Standby]},
             "Discharge_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Discharge]},
-            "Supply_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Supply]},
+            "Supply_Fan": {
+                "tags": [TAG.Equipment, TAG.Fan, TAG.Supply],
+                OWL.equivalentClass: BRICK["Discharge_Fan"],
+            },
         },
     },
     "Economizer": {"tags": [TAG.Equipment, TAG.Economizer]},


### PR DESCRIPTION
May also handle supply/discharge fan classes, depending on how we want to handle that.