### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,6 @@ python:
   - "3.6"
   - "3.7"
 
-addons:
-  apt:
-    packages:
-      - docker-ce
-
-env:
-  - DOCKER_API_VERSION=1.38
-
 services:
   - docker
 
@@ -23,6 +15,7 @@ install:
 
 script:
   - pip freeze
+  - python test_docker.py
   # generate new Brick ontology (in case this hasn't been run)
   - python generate_brick.py
   # regenerate SHACL shapes

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
     packages:
       - docker-ce
 
+env:
+  - DOCKER_API_VERSION=1.38
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ install:
 
 script:
   - pip freeze
-  - python test_docker.py
   # generate new Brick ontology (in case this hasn't been run)
   - python generate_brick.py
   # regenerate SHACL shapes

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
   - "3.6"
   - "3.7"
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
   - docker
 
 before_install:
+  - docker version
   - docker pull franzinc/agraph:v7.0.0
 
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ six==1.12.0
 pytest
 tqdm
 pyshacl
-docker
+docker>=4.3.0
 brickschema>=0.1.5
 black
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest
 tqdm
 pyshacl
 docker>=4.3.0
-brickschema>=0.1.5
+brickschema>=0.1.8a5
 black
 pre-commit
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ rdflib-jsonld==0.4.0
 six==1.12.0
 pytest
 tqdm
-pyshacl
+pyshacl>=0.12.0
 docker>=4.3.0
-brickschema>=0.1.8a5
+brickschema>=0.1.8
 black
 pre-commit
 flake8

--- a/test_docker.py
+++ b/test_docker.py
@@ -1,5 +1,5 @@
 import docker
 
-client = docker.from_env()
+client = docker.from_env(version="1.38")
 
 print(client.version())

--- a/test_docker.py
+++ b/test_docker.py
@@ -1,0 +1,5 @@
+import docker
+
+client = docker.from_env()
+
+print(client.version())

--- a/test_docker.py
+++ b/test_docker.py
@@ -1,5 +1,0 @@
-import docker
-
-client = docker.from_env(version="auto")
-
-print(client.version())

--- a/test_docker.py
+++ b/test_docker.py
@@ -1,5 +1,5 @@
 import docker
 
-client = docker.from_env(version="1.38")
+client = docker.from_env(version="auto")
 
 print(client.version())


### PR DESCRIPTION
Travis builds were breaking as a result of the Python client inside `brickschema` choosing the wrong API version. I have no idea why this suddenly started happening, but it happily goes away when the Python client is explicitly told to choose the version "automatically" (https://github.com/BrickSchema/py-brickschema/commit/bd3bfc5aeb30dd778ce71c56b2117a7838250c42)