### PR TITLE
Change nightly build action so that only a single tag is generated

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -26,10 +26,11 @@ jobs:
       - uses: meeDamian/github-release@2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          name: Nightly Build
-          tag: nightly-${{ steps.date.outputs.date }}
+          name: Nightly Build ${{ steps.date.outputs.date }}
+          tag: nightly
           body: >
             This is an automatically generated release
           files: >
             Brick.ttl
           gzip: false
+          allow_override: true


### PR DESCRIPTION
An unintended consequence of the GH action added in #170 was a bunch of nightly releases getting generated with different tags (https://github.com/BrickSchema/Brick/releases). It would probably be more helpful if there was a single nightly release that was constantly overridden rather than a new release every single day. Thoughts?