### PR TITLE
Fix decoding errors (for Windows 10)

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -303,7 +303,7 @@ def add_definitions():
     adds it to the graph. If available, adds the source information of
     through RDFS.seeAlso.
     """
-    with open("./bricksrc/definitions.csv") as dictionary_file:
+    with open("./bricksrc/definitions.csv", encoding="utf-8") as dictionary_file:
         dictionary = csv.reader(dictionary_file)
 
         # skip the header


### PR DESCRIPTION
Building BRICK on **Windows 10** gives me the following error:
```
Traceback (most recent call last):
  File "generate_brick.py", line 472, in <module>
    add_definitions()
  File "generate_brick.py", line 313, in add_definitions
    for definition in dictionary:
  File "c:\users\shrey\anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 6449: character maps to <undefined>
```
Specifying the encoding (for definitions.csv) seems to fix this.