### PR TITLE
disable nightly build on forks?

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: Nightly Build
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'BrickSchema/Brick') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v2
       - name: Get current date


### PR DESCRIPTION
I updated my fork, and the nightly builds are running (and failing, but that's separate)

I'm not sure most folks want their forks to run a nightly build? I'm not heart-set on turning this off by default, but it does seem like a lot of compute that most folks don't want. 

( instructions from here: https://github.community/t/do-not-run-cron-workflows-in-forks/17636 ) - not sure I got it right though

 