### PR TITLE
Minor Ontology Fixes (Tag typo and AllDifferent usage)

### DIFF
--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -736,7 +736,7 @@ sensor_definitions = {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Occupancy],
                 "substances": [[BRICK.measures, BRICK.Occupancy]],
                 "subclasses": {
-                    "PIR_Sensor": {"tags": [TAG.Point, TAG.Pir, TAG.Sensor]}
+                    "PIR_Sensor": {"tags": [TAG.Point, TAG.PIR, TAG.Sensor]}
                 },
             },
             "Piezoelectric_Sensor": {

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -455,19 +455,6 @@ for r in res:
         G.add((r[0], QUDT.applicableUnit, unit))
         G.add((unit, QUDT.symbol, symb))
 
-logging.info("Finishing Tag definitions")
-# declares that all tags are pairwise different; i.e. no two tags refer
-# to the same tag
-different_tag_list = []
-tags = G.query("""SELECT ?tag WHERE { ?tag a brick:Tag }""")
-for tag in tags:
-    different_tag_list.append(TAG[tag])
-    G.add((TAG[tag], A, BRICK.Tag))
-different_tag = BNode("tags_are_different")
-G.add((BRICK.Tag, A, OWL.AllDifferent))
-G.add((BRICK.Tag, OWL.distinctMembers, different_tag))
-Collection(G, different_tag, different_tag_list)
-
 logging.info("Adding class definitions")
 add_definitions()
 


### PR DESCRIPTION
Ran into these when doing some Brick development, which caused some issues with some existing tools.

- `Pir` -> `PIR`: standardizing the tag spelling
- Removing the use of `AllDifferent` for the tags. This is a carry-over from an older development effort to approximate some closed-world stylings on inferring Brick classes from sets of tags

Neither of these changes should affect broad Brick usage