### PR TITLE
Fix namespace in example1 graph

### DIFF
--- a/examples/example1/generate.py
+++ b/examples/example1/generate.py
@@ -38,7 +38,7 @@ things don't conflict with names in other Brick models (more on that later).
 
 Namespaces are URLs; they do not have to actually point to a real web resource,
 but it is of course helpful if they point to some documentation (try going to
-https://brickschema.org/schema/1.1.0/Brick#Air_Handler_Unit as an example).
+https://brickschema.org/schema/1.1/Brick#Air_Handler_Unit as an example).
 
 We will choose an arbitrary URL for our namespace and refer to it by the
 nickname "bldg" for convenience. "bldg" is also called a "prefix".
@@ -56,7 +56,7 @@ simply allows us to refer to classes and relationships that are defined in the
 Brick schema.
 
 """
-BRICK = Namespace("https://brickschema.org/schema/1.1.0/Brick#")
+BRICK = Namespace("https://brickschema.org/schema/1.1/Brick#")
 g.bind("brick", BRICK)
 
 

--- a/examples/example1/sample_graph.ttl
+++ b/examples/example1/sample_graph.ttl
@@ -1,5 +1,5 @@
 @prefix bldg: <http://example.com/mybuilding#> .
-@prefix brick: <https://brickschema.org/schema/1.1.0/Brick#> .
+@prefix brick: <https://brickschema.org/schema/1.1/Brick#> .
 
 bldg:AHU1A a brick:Air_Handler_Unit ;
     brick:feeds bldg:VAV2-4,


### PR DESCRIPTION
This was using the old `1.1.0` version in the namespace, which made it difficult to use with other tools. This PR changes the namespace in the graph to use the expected `1.1` version (major + minor only)