### PR TITLE
update to new pybrickschema API

### DIFF
--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -1,5 +1,4 @@
 from brickschema.graph import Graph
-from brickschema.inference import BrickInferenceSession
 from rdflib import Literal, URIRef
 from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDTDV, QUDT, UNIT
 
@@ -7,10 +6,9 @@ from .namespaces import SKOS, OWL, RDFS, BRICK, QUDTQK, QUDTDV, QUDT, UNIT
 g = Graph()
 g.load_file("support/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl")
 g.load_file("support/VOCAB_QUDT-UNITS-ALL-v2.1.ttl")
-g.g.bind("qudt", QUDT)
-g.g.bind("qudtqk", QUDTQK)
-sess = BrickInferenceSession()
-g = sess.expand(g)
+g.bind("qudt", QUDT)
+g.bind("qudtqk", QUDTQK)
+g.expand(profile="shacl+tag+owlrl")
 
 
 def get_units(brick_quantity):


### PR DESCRIPTION
Saw in the new docs that you can spec multiple profiles, so this fixes #209 - not sure that we need all 3, but the output of Brick.ttl is the same as the the Brick.ttl we were getting a few days ago in the nightly build. 