### PR TITLE
VBIS Shapes Without Redundancy

### DIFF
--- a/alignments/vbis/Brick-VBIS-alignment.ttl
+++ b/alignments/vbis/Brick-VBIS-alignment.ttl
@@ -83,12 +83,6 @@ vbisalign:BoilerShape a sh:NodeShape ;
             sh:pattern "^ME-Bo.*$" ] ;
     sh:targetClass brick:Boiler .
 
-vbisalign:Booster_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Booster_Fan .
-
 vbisalign:Breaker_PanelShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
@@ -225,18 +219,6 @@ vbisalign:Chilled_Water_MeterShape a sh:NodeShape ;
                 sh:pattern "^BMC-Me-En.*$" ] ) ;
     sh:targetClass brick:Chilled_Water_Meter .
 
-vbisalign:Chilled_Water_PumpShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Pu.*$" ] ;
-    sh:targetClass brick:Chilled_Water_Pump .
-
-vbisalign:Chilled_Water_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Chilled_Water_Valve .
-
 vbisalign:ChillerShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
@@ -267,35 +249,11 @@ vbisalign:CondenserShape a sh:NodeShape ;
             sh:pattern "^ME-ACC.*$" ] ;
     sh:targetClass brick:Condenser .
 
-vbisalign:Condenser_Heat_ExchangerShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-HE.*$" ] ;
-    sh:targetClass brick:Condenser_Heat_Exchanger .
-
-vbisalign:Condenser_Water_PumpShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Pu.*$" ] ;
-    sh:targetClass brick:Condenser_Water_Pump .
-
-vbisalign:Cooling_CoilShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Co.*$" ] ;
-    sh:targetClass brick:Cooling_Coil .
-
 vbisalign:Cooling_Tower_FanShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^ME-Fa-CT.*$" ] ;
     sh:targetClass brick:Cooling_Tower_Fan .
-
-vbisalign:Cooling_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Cooling_Valve .
 
 vbisalign:DamperShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -315,23 +273,11 @@ vbisalign:DimmerShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ] ;
     sh:targetClass brick:Dimmer .
 
-vbisalign:Discharge_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Discharge_Fan .
-
 vbisalign:Disconnect_SwitchShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^EP-SG.*$" ] ;
     sh:targetClass brick:Disconnect_Switch .
-
-vbisalign:Domestic_Hot_Water_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Domestic_Hot_Water_Valve .
 
 vbisalign:Door_ControllerShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -350,12 +296,6 @@ vbisalign:EconomizerShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^ME-Da.*$" ] ;
     sh:targetClass brick:Economizer .
-
-vbisalign:Economizer_DamperShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Da.*$" ] ;
-    sh:targetClass brick:Economizer_Damper .
 
 vbisalign:Electrical_EquipmentShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -420,24 +360,6 @@ vbisalign:Energy_StorageShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^EP-BS.*$" ] ;
     sh:targetClass brick:Energy_Storage .
-
-vbisalign:Evaporative_Heat_ExchngerShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-HE.*$" ] ;
-    sh:targetClass brick:Evaporative_Heat_Exchnger .
-
-vbisalign:Exhaust_DamperShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Da.*$" ] ;
-    sh:targetClass brick:Exhaust_Damper .
-
-vbisalign:Exhaust_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Exhaust_Fan .
 
 vbisalign:Eye_Wash_StationShape a sh:NodeShape ;
     sh:or ( [ a sh:PropertyShape ;
@@ -533,12 +455,6 @@ vbisalign:Gas_MeterShape a sh:NodeShape ;
                 sh:pattern "^BMC-FM.*$" ] ) ;
     sh:targetClass brick:Gas_Meter .
 
-vbisalign:Gas_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Gas_Valve .
-
 vbisalign:HVACShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
@@ -585,18 +501,6 @@ vbisalign:Heat_Wheel_VFDShape a sh:NodeShape ;
             sh:pattern "^ME-EMS-VSD.*$" ] ;
     sh:targetClass brick:Heat_Wheel_VFD .
 
-vbisalign:Heating_CoilShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Co.*$" ] ;
-    sh:targetClass brick:Heating_Coil .
-
-vbisalign:Heating_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Heating_Valve .
-
 vbisalign:Hot_Water_MeterShape a sh:NodeShape ;
     sh:or ( [ a sh:PropertyShape ;
                 sh:path vbisalign:hasVBISTag ;
@@ -608,12 +512,6 @@ vbisalign:Hot_Water_MeterShape a sh:NodeShape ;
                 sh:path vbisalign:hasVBISTag ;
                 sh:pattern "^BMC-Me-En.*$" ] ) ;
     sh:targetClass brick:Hot_Water_Meter .
-
-vbisalign:Hot_Water_PumpShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Pu.*$" ] ;
-    sh:targetClass brick:Hot_Water_Pump .
 
 vbisalign:Intercom_EquipmentShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -680,12 +578,6 @@ vbisalign:InverterShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^EP-SPS-In.*$" ] ;
     sh:targetClass brick:Inverter .
-
-vbisalign:Isolation_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Isolation_Valve .
 
 vbisalign:JetShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -767,12 +659,6 @@ vbisalign:Network_Video_RecorderShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ] ;
     sh:targetClass brick:Network_Video_Recorder .
 
-vbisalign:Outside_DamperShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Da.*$" ] ;
-    sh:targetClass brick:Outside_Damper .
-
 vbisalign:Packaged_Air_CooledShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
@@ -784,18 +670,6 @@ vbisalign:PlugStripShape a sh:NodeShape ;
             sh:in ( "EP-GPO-SP-Mu" "EP-GPO-SPUSB-Mu" ) ;
             sh:path vbisalign:hasVBISTag ] ;
     sh:targetClass brick:PlugStrip .
-
-vbisalign:Preheat_Hot_Water_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Preheat_Hot_Water_Valve .
-
-vbisalign:Prehet_Hot_Water_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Prehet_Hot_Water_Valve .
 
 vbisalign:PumpShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -820,30 +694,6 @@ vbisalign:ReciprocatingShape a sh:NodeShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^ME-Chr.*-Re$" ] ;
     sh:targetClass brick:Reciprocating .
-
-vbisalign:Reheat_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Reheat_Valve .
-
-vbisalign:Return_DamperShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Da.*$" ] ;
-    sh:targetClass brick:Return_Damper .
-
-vbisalign:Return_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Return_Fan .
-
-vbisalign:Return_Heating_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Return_Heating_Valve .
 
 vbisalign:Rooftop_UnitShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -917,29 +767,11 @@ vbisalign:Standby_CRACShape a sh:NodeShape ;
             sh:pattern "^ME-PAC.*$" ] ;
     sh:targetClass brick:Standby_CRAC .
 
-vbisalign:Standby_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Standby_Fan .
-
 vbisalign:Steam_DistributionShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
             sh:path vbisalign:hasVBISTag ;
             sh:pattern "^ME-Bo-St.*$" ] ;
     sh:targetClass brick:Steam_Distribution .
-
-vbisalign:Steam_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Steam_Valve .
-
-vbisalign:Supply_FanShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Fa.*$" ] ;
-    sh:targetClass brick:Supply_Fan .
 
 vbisalign:Surveillance_CameraShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;
@@ -1048,24 +880,6 @@ vbisalign:Water_MeterShape a sh:NodeShape ;
                 sh:path vbisalign:hasVBISTag ;
                 sh:pattern "^BMC-FM.*$" ] ) ;
     sh:targetClass brick:Water_Meter .
-
-vbisalign:Water_PumpShape a sh:NodeShape ;
-    sh:or ( [ a sh:PropertyShape ;
-                sh:path vbisalign:hasVBISTag ;
-                sh:pattern "^ME-Pu.*$" ] [ a sh:PropertyShape ;
-                sh:path vbisalign:hasVBISTag ;
-                sh:pattern "^HY-Pu.*$" ] [ a sh:PropertyShape ;
-                sh:path vbisalign:hasVBISTag ;
-                sh:pattern "^FS-Pu.*$" ] [ a sh:PropertyShape ;
-                sh:path vbisalign:hasVBISTag ;
-                sh:pattern "^LS-Pu.*$" ] ) ;
-    sh:targetClass brick:Water_Pump .
-
-vbisalign:Water_ValveShape a sh:NodeShape ;
-    sh:property [ a sh:PropertyShape ;
-            sh:path vbisalign:hasVBISTag ;
-            sh:pattern "^ME-Va.*$" ] ;
-    sh:targetClass brick:Water_Valve .
 
 vbisalign:Weather_StationShape a sh:NodeShape ;
     sh:property [ a sh:PropertyShape ;

--- a/alignments/vbis/generate.py
+++ b/alignments/vbis/generate.py
@@ -59,7 +59,7 @@ def get_vbis_tags(d):
 
 # use a set to eliminate duplicate rows in the CSV file
 finished_brick_classes = set()
-with open("vbis-brick-v4.csv") as f:
+with open("vbis-brick-v5.csv") as f:
     r = csv.reader(f)
     header = next(r)
     for row in r:

--- a/alignments/vbis/vbis-brick-v5.csv
+++ b/alignments/vbis/vbis-brick-v5.csv
@@ -52,21 +52,11 @@
 ,"Computer Room Air Conditioning",,,,"ME-PAC*",,,,,,,
 ,"Condenser",,,,"ME-ACC*",,,,,,,
 ,"Damper",,,,"ME-Da*",,,,,,,
-,,"Economizer Damper",,,"ME-Da*",,,,,,,"As VBIS is structured by types of dampers as opposed to use of dampers the same VBIS pattern applies to all dampers."
-,,"Exhaust Damper",,,"ME-Da*",,,,,,,
-,,"Outside Damper",,,"ME-Da*",,,,,,,
-,,"Return Damper",,,"ME-Da*",,,,,,,
 ,,"Fire Damper",,,"ME-Da-FD*",1,"Damper",,,,,
 ,,"Smoke Damper",,,"ME-Da-MFSD*",1,"Damper",,,,,
 ,"Economizer",,,,"ME-Da*",,,,,,,"VBIS classification identifies the equipment type, rather than use hence Economiser configuration would still be a Damper code as Economizer is a combination of outside and return dampers."
 ,"Fan",,,,"ME-Fa*",,,,,,,
 ,,"Cooling Tower Fan",,,"ME-Fa-CT*",,,,,,,
-,,"Discharge Fan",,,"ME-Fa*",,,,,,,
-,,"Exhaust Fan",,,"ME-Fa*",,,,,,,
-,,"Return Fan",,,"ME-Fa*",,,,,,,
-,,"Standby Fan",,,"ME-Fa*",,,,,,,
-,,"Supply Fan",,,"ME-Fa*",,,,,,,
-,,,"Booster Fan",,"ME-Fa*",,,,,,,
 ,,"Jet",,,"ME-Fa-Je",1,"Fan",,,,,
 ,,"Carpark Jet ",,,"ME-Fa-CJ",1,"Fan",,,,,
 ,,"Smoke Extraction",,,"ME-Fa-SE",1,"Fan",,,,,
@@ -76,16 +66,8 @@
 ,"HX",,,,"ME-HE*",,,,"SP-HE*",,,"Note: VBIS also has Heat Exchangers specific to Spas and Pools discipline [SP-HE*]"
 ,"Heat Exchanger",,,,"ME-HE*",,,,"SP-HE*",,,"Note: VBIS also has Heat Exchangers specific to Spas and Pools discipline [SP-HE*]"
 ,,"Coil",,,"ME-Co*",,,,,,,"VBIS has Coils structured as its own product"
-,,,"Cooling Coil",,"ME-Co*",,,,,,,
-,,,"Heating Coil",,"ME-Co*",,,,,,,
-,,"Condenser Heat Exchanger",,,"ME-HE*",,,,,,,
-,,"Evaporative Heat Exchnger",,,"ME-HE*",,,,,,,
 ,,"Heat Wheel",,,"ME-HE-ATA-AW",,,,,,,
 ,"Pump",,,,"ME-Pu*",,,,,,,
-,,"Water Pump",,,"ME-Pu*",,,,"HY-Pu*","FS-Pu*","LS-Pu*","Note: VBIS also has pumps in Hydraulics [HY-Pu*], Fire [FS-Pu*] and Landscape [LS-Pu*]"
-,,,"Chilled Water Pump",,"ME-Pu*",,,,,,,
-,,,"Condenser Water Pump",,"ME-Pu*",,,,,,,
-,,,"Hot Water Pump",,"ME-Pu*",,,,,,,
 ,"Space Heater",,,,"FFE-He*",,,,,,,
 ,"Terminal Unit",,,,"ME-ATU*",,,,,,,
 ,,"FCU",,,"ME-FCU*",,,,,,,
@@ -102,19 +84,6 @@
 ,"VFD",,,,"ME-EMS-VSD*",,,,,,,
 ,,"Heat Wheel VFD",,,"ME-EMS-VSD*",,,,,,,"VFD associated with a specific use, in VBIS as VFDs are classfied by types it can have the same selection of VFD products be applicable."
 ,"Valve",,,,"ME-Va*",,,,,,,
-,,"Cooling Valve",,,"ME-Va*",,,,,,,
-,,"Gas Valve",,,"ME-Va*",,,,,,,
-,,"Heating Valve",,,"ME-Va*",,,,,,,
-,,,"Domestic Hot Water Valve",,"ME-Va*",,,,,,,
-,,,"Prehet Hot Water Valve",,"ME-Va*",,,,,,,
-,,,"Reheat Valve",,"ME-Va*",,,,,,,
-,,,"Return Heating Valve",,"ME-Va*",,,,,,,
-,,,"Isolation Valve",,"ME-Va*",,,,,,,
-,,,"Steam Valve",,"ME-Va*",,,,,,,
-,,,"Water Valve",,"ME-Va*",,,,,,,
-,,,,"Chilled Water Valve","ME-Va*",,,,,,,
-,,,,"Domestic Hot Water Valve","ME-Va*",,,,,,,
-,,,,"Preheat Hot Water Valve","ME-Va*",,,,,,,
 ,"Variable Frequency Drive",,,,"ME-EMS-VSD*",,,,,,,
 "Lighting Equipment",,,,,"EL-*",,,,,,,"This is an entire discipline in VBIS"
 ,"Interface",,,,"EL-Li-Con*",,,,,,,


### PR DESCRIPTION
The current mapping has the same VBIS tag or tag prefix applied to a class and its subclasses (e.g. `ME-Fa`, the Fan prefix, for `brick:Fan`, `brick:Discharge_Fan`, etc). When we do VBIS -> Brick inference, having the subclasses associated with the VBIS tag means that it is ambiguous which one should be used. By removing the redundant mappings from the alignment, the inference properly uses the generic class, and does not presume to use a more specific class.