### PR TITLE
Moving Entity Properties to Brick namespace

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -363,7 +363,7 @@ https://brickschema.org/schema/1.2/Brick#hasOutputSubstance,The subject produces
 https://brickschema.org/schema/1.2/Brick#hasPart,The subject is composed in part of the entity given by the object,
 https://brickschema.org/schema/1.2/Brick#hasPoint,The subject has a digital/analog input/output point given by the object,
 https://brickschema.org/schema/1.2/Brick#hasTag,The subject has the given tag,
-https://brickschema.org/schema/1.2/Brick#hasUnit,The QUDT unit associated with this Point,
+https://brickschema.org/schema/1.2/Brick#hasUnit,The QUDT unit associated with this Brick entity (usually a Brick Point instance or Entity Property),
 https://brickschema.org/schema/1.2/Brick#Heat_Exchanger,A heat exchanger is a piece of equipment built for efficient heat transfer from one medium to another. The media may be separated by a solid wall to prevent mixing or they may be in direct contact,BEDES
 https://brickschema.org/schema/1.2/Brick#Heat_Exchanger_Supply_Water_Temperature_Sensor,Measures the temperature of water supplied by a heat exchanger,
 https://brickschema.org/schema/1.2/Brick#Heat_Exchanger_System_Enable_Status,Indicates if the heat exchanger system has been enabled,

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -1,4 +1,4 @@
-from .namespaces import BRICK, TAG, OWL, RDFS, SKOS, UNIT, PROP, XSD
+from .namespaces import BRICK, TAG, OWL, RDFS, SKOS, UNIT, XSD
 from rdflib import Namespace, Literal
 
 # these are the "relationship"/predicates/OWL properties that
@@ -6,94 +6,94 @@ from rdflib import Namespace, Literal
 # These are all instances of Brick.EntityProperty, which is
 # a subclass of OWL.ObjectProperty
 entity_properties = {
-    PROP.hasArea: {
+    BRICK.hasArea: {
         SKOS.definition: Literal("Entity has 2-dimensional area"),
         RDFS.domain: BRICK.Location,
-        RDFS.range: PROP.AreaShape,
+        RDFS.range: BRICK.AreaShape,
         "subproperties": {
-            PROP.hasGrossArea: {
+            BRICK.hasGrossArea: {
                 SKOS.definition: Literal("Entity has gross 2-dimensional area"),
                 RDFS.domain: BRICK.Location,
-                RDFS.range: PROP.AreaShape,
+                RDFS.range: BRICK.AreaShape,
             },
-            PROP.hasNetArea: {
+            BRICK.hasNetArea: {
                 SKOS.definition: Literal("Entity has net 2-dimensional area"),
                 RDFS.domain: BRICK.Location,
-                RDFS.range: PROP.AreaShape,
+                RDFS.range: BRICK.AreaShape,
             },
         },
     },
-    PROP.hasVolume: {
+    BRICK.hasVolume: {
         SKOS.definition: Literal("Entity has 3-dimensional volume"),
         RDFS.domain: BRICK.Location,
-        RDFS.range: PROP.VolumeShape,
+        RDFS.range: BRICK.VolumeShape,
     },
     # electrical properties
-    PROP.hasComplexity: {
+    BRICK.hasComplexity: {
         SKOS.definition: Literal("Entity has this power complexity"),
-        RDFS.range: PROP.PowerComplexityShape,
+        RDFS.range: BRICK.PowerComplexityShape,
     },
-    PROP.hasPowerFlow: {
+    BRICK.hasPowerFlow: {
         SKOS.definition: Literal(
             "Entity has this power flow relative to the building'"
         ),
-        RDFS.range: PROP.PowerFlowShape,
+        RDFS.range: BRICK.PowerFlowShape,
     },
-    PROP.hasPhases: {
+    BRICK.hasPhases: {
         SKOS.definition: Literal("Entity has these electrical AC phases"),
-        RDFS.range: PROP.PhasesShape,
+        RDFS.range: BRICK.PhasesShape,
     },
-    PROP.hasPhaseCount: {
+    BRICK.hasPhaseCount: {
         SKOS.definition: Literal("Entity has these phases"),
-        RDFS.range: PROP.PhaseCountShape,
+        RDFS.range: BRICK.PhaseCountShape,
     },
-    PROP.hasCurrentFlowType: {
+    BRICK.hasCurrentFlowType: {
         SKOS.definition: Literal("The current flow type of the entity"),
-        RDFS.range: PROP.CurrentFlowTypeShape,
+        RDFS.range: BRICK.CurrentFlowTypeShape,
     },
     # equipment operation properties
-    PROP.hasStage: {
+    BRICK.hasStage: {
         SKOS.definition: Literal("The associated operational stage"),
-        RDFS.range: PROP.StageShape,
+        RDFS.range: BRICK.StageShape,
     },
-    PROP.hasStageCount: {
+    BRICK.hasStageCount: {
         SKOS.definition: Literal(
             "The number of operational stages supported by this eqiupment"
         ),
         RDFS.domain: BRICK.Equipment,
-        RDFS.range: PROP.StageShape,
+        RDFS.range: BRICK.StageShape,
     },
-    PROP.hasBuildingPrimaryFunction: {
+    BRICK.hasBuildingPrimaryFunction: {
         SKOS.definition: Literal(
             "Enumerated string applied to a site record to indicate the building's primary function. The list of primary functions is derived from the US Energy Star program (adopted from Project Haystack)"
         ),
         RDFS.seeAlso: Literal("https://project-haystack.org/tag/primaryFunction"),
         RDFS.domain: BRICK.Building,
-        RDFS.range: PROP.BuildingPrimaryFunctionShape,
+        RDFS.range: BRICK.BuildingPrimaryFunctionShape,
     },
-    PROP.hasCoolingCapacity: {
+    BRICK.hasCoolingCapacity: {
         SKOS.definition: Literal(
             "Measurement of a chiller ability to remove heat (adopted from Project Haystack)"
         ),
         RDFS.domain: BRICK.Chiller,
-        RDFS.range: PROP.CoolingCapacityShape,
+        RDFS.range: BRICK.CoolingCapacityShape,
         RDFS.seeAlso: Literal("https://project-haystack.org/tag/coolingCapacity"),
     },
-    PROP.hasYearBuilt: {
+    BRICK.hasYearBuilt: {
         SKOS.definition: Literal(
             "Four digit year that a building was first built. (adopted from Project Haystack)"
         ),
         RDFS.domain: BRICK.Building,
-        RDFS.range: PROP.YearBuiltShape,
+        RDFS.range: BRICK.YearBuiltShape,
         RDFS.seeAlso: Literal("https://project-haystack.org/tag/yearBuilt"),
     },
     # special stuff
-    PROP.aggregate: {
+    BRICK.aggregate: {
         SKOS.definition: Literal(
             "Description of how the dta for this point is aggregated"
         ),
         RDFS.domain: BRICK.Point,
-        RDFS.range: PROP.AggregationShape,
+        RDFS.range: BRICK.AggregationShape,
     },
 }
 
@@ -188,26 +188,26 @@ building_primary_function_values = [
 
 # These are the shapes that govern what values of Entity Properties should look like
 shape_properties = {
-    PROP.AreaShape: {"units": [UNIT.FT2, UNIT.M2], "datatype": XSD.float},
-    PROP.VolumeShape: {"units": [UNIT.FT3, UNIT.M3], "datatype": XSD.float},
-    PROP.PowerComplexityShape: {"values": ["real", "reactive", "apparent"]},
-    PROP.PowerFlowShape: {"values": ["import", "export", "net", "absolute"]},
-    PROP.PhasesShape: {"values": ["A", "B", "C", "AB", "BC", "AC", "ABC"]},
-    PROP.PhaseCountShape: {"values": ["1", "2", "3", "Total"]},
-    PROP.CurrentFlowTypeShape: {"values": ["AC", "DC"]},
-    PROP.StageShape: {"values": [1, 2, 3, 4]},
-    PROP.BuildingPrimaryFunctionShape: {"values": building_primary_function_values},
-    PROP.YearBuiltShape: {"datatype": XSD.integer},
-    PROP.CoolingCapacityShape: {
+    BRICK.AreaShape: {"units": [UNIT.FT2, UNIT.M2], "datatype": XSD.float},
+    BRICK.VolumeShape: {"units": [UNIT.FT3, UNIT.M3], "datatype": XSD.float},
+    BRICK.PowerComplexityShape: {"values": ["real", "reactive", "apparent"]},
+    BRICK.PowerFlowShape: {"values": ["import", "export", "net", "absolute"]},
+    BRICK.PhasesShape: {"values": ["A", "B", "C", "AB", "BC", "AC", "ABC"]},
+    BRICK.PhaseCountShape: {"values": ["1", "2", "3", "Total"]},
+    BRICK.CurrentFlowTypeShape: {"values": ["AC", "DC"]},
+    BRICK.StageShape: {"values": [1, 2, 3, 4]},
+    BRICK.BuildingPrimaryFunctionShape: {"values": building_primary_function_values},
+    BRICK.YearBuiltShape: {"datatype": XSD.integer},
+    BRICK.CoolingCapacityShape: {
         "datatype": XSD.float,
         "units": [UNIT.TON_FG, UNIT["BTU_IT-PER-HR"], UNIT["BTU_TH-PER-HR"], UNIT.W],
     },
-    PROP.AggregationShape: {
+    BRICK.AggregationShape: {
         "properties": {
-            PROP.aggregationFunction: {
+            BRICK.aggregationFunction: {
                 "values": ["max", "min", "count", "mean", "sum", "median", "mode"]
             },
-            PROP.aggregationInterval: {
+            BRICK.aggregationInterval: {
                 SKOS.definition: Literal(
                     "Interval expressed in an ISO 8601 Duration string, e.g. RP1D"
                 ),

--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -4,9 +4,6 @@ from .version import BRICK_VERSION
 BRICK = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/Brick#")
 TAG = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/BrickTag#")
 BSH = Namespace(f"https://brickschema.org/schema/{BRICK_VERSION}/BrickShape#")
-PROP = Namespace(
-    f"https://brickschema.org/schema/{BRICK_VERSION}/BrickEntityProperties#"
-)
 SH = Namespace("http://www.w3.org/ns/shacl#")
 XSD = Namespace("http://www.w3.org/2001/XMLSchema#")
 OWL = Namespace("http://www.w3.org/2002/07/owl#")
@@ -38,7 +35,6 @@ def bind_prefixes(g):
     g.bind("sh", SH)
     g.bind("brick", BRICK)
     g.bind("tag", TAG)
-    g.bind("prop", PROP)
     g.bind("vcard", VCARD)
     g.bind("bsh", BSH)
     g.bind("qudtqk", QUDTQK)

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -1,10 +1,10 @@
-from .namespaces import A, OWL, RDFS, BRICK, VCARD, UNIT, PROP, QUDT
+from .namespaces import A, OWL, RDFS, BRICK, VCARD, UNIT, QUDT
 
 """
 Defining properties
 """
 properties = {
-    PROP.value: {RDFS.subPropertyOf: QUDT.value},
+    BRICK.value: {RDFS.subPropertyOf: QUDT.value},
     "isLocationOf": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         OWL.inverseOf: BRICK["hasLocation"],

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -108,8 +108,6 @@ properties = {
     },
     "hasUnit": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
-        # TODO: do we use a new hasUnit for properties? the domain isn't a point
-        RDFS.domain: BRICK.Point,
         RDFS.range: UNIT.Unit,
     },
 }

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -18,7 +18,6 @@ from bricksrc.namespaces import (
     QUDT,
     QUDTQK,
     SH,
-    PROP,
 )
 from bricksrc.namespaces import bind_prefixes
 
@@ -278,7 +277,7 @@ def define_entity_properties(definitions, superprop=None):
     properties to the EntityProperty instances (like SKOS.definition)
     """
     for entprop, defn in definitions.items():
-        G.add((entprop, A, PROP.EntityProperty))
+        G.add((entprop, A, BRICK.EntityProperty))
         if "subproperties" in defn:
             subproperties = defn.pop("subproperties")
             define_entity_properties(subproperties, entprop)
@@ -316,7 +315,7 @@ def define_shape_properties(definitions):
             enumeration = BNode()
             G.add((shape_name, SH.property, ps))
             G.add((ps, A, SH.PropertyShape))
-            G.add((ps, SH.path, PROP.value))
+            G.add((ps, SH.path, BRICK.value))
             G.add((ps, SH["in"], enumeration))
             G.add((ps, SH.minCount, Literal(1)))
             Collection(G, enumeration, map(Literal, defn.pop("values")))
@@ -347,7 +346,7 @@ def define_shape_properties(definitions):
         elif "datatype" in defn:
             G.add((shape_name, SH.property, v))
             G.add((v, A, SH.PropertyShape))
-            G.add((v, SH.path, PROP.value))
+            G.add((v, SH.path, BRICK.value))
             G.add((v, SH.datatype, defn.pop("datatype")))
             G.add((v, SH.minCount, Literal(1)))
 
@@ -527,10 +526,10 @@ G.add((BRICK.Substance, RDFS.subClassOf, BRICK.Measurable))
 G.add((BRICK.Substance, A, OWL.Class))
 
 # entity property definitions
-G.add((PROP.value, A, OWL.DatatypeProperty))
-G.add((PROP.value, SKOS.definition, Literal("The basic value of an entity property")))
-G.add((PROP.EntityProperty, RDFS.subClassOf, OWL.ObjectProperty))
-G.add((PROP.EntityProperty, A, OWL.Class))
+G.add((BRICK.value, A, OWL.DatatypeProperty))
+G.add((BRICK.value, SKOS.definition, Literal("The basic value of an entity property")))
+G.add((BRICK.EntityProperty, RDFS.subClassOf, OWL.ObjectProperty))
+G.add((BRICK.EntityProperty, A, OWL.Class))
 define_shape_properties(shape_properties)
 define_entity_properties(entity_properties)
 

--- a/shacl/BrickShape.ttl
+++ b/shacl/BrickShape.ttl
@@ -57,11 +57,6 @@ bsh:hasTagRangeShape a sh:NodeShape ;
             sh:path brick:hasTag ] ;
     sh:targetSubjectsOf brick:hasTag .
 
-bsh:hasUnitDomainShape a sh:NodeShape ;
-    sh:class brick:Point ;
-    sh:message "Property hasUnit has subject with incorrect type" ;
-    sh:targetSubjectsOf brick:hasUnit .
-
 bsh:hasUnitRangeShape a sh:NodeShape ;
     sh:property [ sh:class unit:Unit ;
             sh:message "Property hasUnit has object with incorrect type" ;


### PR DESCRIPTION
As per the Friday discussion, it was decided that the entity properties are better served as part of the Brick namespace, to reduce confusion.

This PR fixes that definition and also edits the `hasUnit` property definition so that the domain is not mandated to be a Point