### PR TITLE
Update Ontology Metadata

### DIFF
--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -20,7 +20,7 @@ ontology = {
         },
     ],
     DCTERMS.license: URIRef("https://github.com/BrickSchema/brick/blob/master/LICENSE"),
-    DCTERMS.issued: Literal("2016-11"),
+    DCTERMS.issued: Literal("2016-11-16"),
     DCTERMS.modified: Literal(datetime.now().strftime("%Y-%m-%d")),
     DCTERMS.publisher: {
         RDF.type: SDO.Consortium,

--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -38,18 +38,23 @@ def define_ontology(G):
     G.add((brick_iri_version, RDF.type, OWL.Ontology))
     G.add((brick_iri_version, RDFS.isDefinedBy, brick_iri_version))
 
+    # add creators from ontology markup above
     creators = []
     creator_list = BNode()
-
     for creator in ontology.pop(DCTERMS.creator):
         creator1 = BNode()
         creators.append(creator1)
         for k, v in creator.items():
             G.add((creator1, k, v))
+
+    # add publisher info
+    publisher = BNode()
+    G.add((brick_iri_version, DCTERMS.publisher, publisher))
     for k, v in ontology.pop(DCTERMS.publisher).items():
-        G.add((brick_iri_version, k, v))
+        G.add((publisher, k, v))
     Collection(G, creator_list, creators)
     G.add((brick_iri_version, DCTERMS.creator, creator_list))
 
+    # add other simple attributes
     for k, v in ontology.items():
         G.add((brick_iri_version, k, v))

--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from rdflib import Literal, BNode, URIRef
 from rdflib.collection import Collection
 
@@ -8,13 +9,25 @@ from .version import BRICK_VERSION, BRICK_FULL_VERSION
 ontology = {
     DCTERMS.creator: [
         {
+            RDF.type: SDO.Person,
             SDO.email: Literal("gtfierro@cs.berkeley.edu"),
             SDO.name: Literal("Gabe Fierro"),
         },
-        {SDO.email: Literal("jbkoh@eng.ucsd.edu"), SDO.name: Literal("Jason Koh")},
+        {
+            RDF.type: SDO.Person,
+            SDO.email: Literal("jbkoh@eng.ucsd.edu"),
+            SDO.name: Literal("Jason Koh"),
+        },
     ],
     DCTERMS.license: URIRef("https://github.com/BrickSchema/brick/blob/master/LICENSE"),
-    DCTERMS.version: Literal(BRICK_FULL_VERSION),
+    DCTERMS.issued: Literal("2016-11"),
+    DCTERMS.modified: Literal(datetime.now().strftime("%Y-%m-%d")),
+    DCTERMS.publisher: {
+        RDF.type: SDO.Consortium,
+        SDO.legalName: Literal("Brick Consortium, Inc"),
+        SDO.sameAs: URIRef("https://brickschema.org/consortium/"),
+    },
+    OWL.versionInfo: Literal(BRICK_FULL_VERSION),
     RDFS.label: Literal("Brick"),
     RDFS.seeAlso: URIRef("https://brickschema.org"),
 }
@@ -31,9 +44,10 @@ def define_ontology(G):
     for creator in ontology.pop(DCTERMS.creator):
         creator1 = BNode()
         creators.append(creator1)
-        G.add((creator1, RDF.type, SDO.Person))
         for k, v in creator.items():
             G.add((creator1, k, v))
+    for k, v in ontology.pop(DCTERMS.publisher).items():
+        G.add((brick_iri_version, k, v))
     Collection(G, creator_list, creators)
     G.add((brick_iri_version, DCTERMS.creator, creator_list))
 


### PR DESCRIPTION
- dcterms:publisher
- dcterms:issued
- dcterms:modified (will be updated whenever Brick is built)
- owl:versionInfo instead of dcterms:version

Should address the feedback in #242 and #243 