### PR TITLE
PV Systems and Entity Properties

### DIFF
--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -8,25 +8,43 @@ from rdflib import Namespace, Literal
 entity_properties = {
     BRICK.area: {
         SKOS.definition: Literal("Entity has 2-dimensional area"),
-        RDFS.domain: BRICK.Location,
         RDFS.range: BRICK.AreaShape,
         "subproperties": {
             BRICK.grossArea: {
                 SKOS.definition: Literal("Entity has gross 2-dimensional area"),
-                RDFS.domain: BRICK.Location,
                 RDFS.range: BRICK.AreaShape,
             },
             BRICK.netArea: {
                 SKOS.definition: Literal("Entity has net 2-dimensional area"),
-                RDFS.domain: BRICK.Location,
+                RDFS.range: BRICK.AreaShape,
+            },
+            BRICK.panelArea: {
+                SKOS.definition: Literal("Surface area of a panel, such as a PV panel"),
+                # TODO: needs to go on equipment; do we remove "domain" from the above?
                 RDFS.range: BRICK.AreaShape,
             },
         },
     },
     BRICK.volume: {
         SKOS.definition: Literal("Entity has 3-dimensional volume"),
-        RDFS.domain: BRICK.Location,
         RDFS.range: BRICK.VolumeShape,
+    },
+    BRICK.orientation: {
+        SKOS.definition: Literal(
+            "The direction an entity is facing, relative to some reference point (usually a 'compass' direction)"
+        ),
+        # TODO: for points + equipment? or just equipment?
+        RDFS.range: BRICK.OrientationShape,
+    },
+    BRICK.tilt: {
+        SKOS.definition: Literal(
+            "The direction an entity is facing in degrees above the horizon"
+        ),
+        RDFS.range: BRICK.TiltShape,
+    },
+    BRICK.coordinates: {
+        SKOS.definition: Literal("The location of an entity in latitude/longitude"),
+        RDFS.range: BRICK.CoordinateShape,
     },
     # electrical properties
     BRICK.powerComplexity: {
@@ -219,6 +237,20 @@ shape_properties = {
     BRICK.CurrentFlowTypeShape: {"values": ["AC", "DC"]},
     BRICK.StageShape: {"values": [1, 2, 3, 4]},
     BRICK.BuildingPrimaryFunctionShape: {"values": building_primary_function_values},
+    BRICK.CoordinateShape: {
+        "properties": {
+            BRICK.latitude: {"datatype": XSD.float},
+            BRICK.longitude: {"datatype": XSD.float},
+        },
+    },
+    BRICK.TiltShape: {"units": [UNIT.DEG], "datatype": XSD.float},
+    BRICK.OrientationShape: {
+        "units": [UNIT.DEG],
+        "datatype": XSD.float,
+        "properties": {
+            BRICK.orientationRelativeTo: {"values": ["North", "South", "East", "West"]}
+        },
+    },
     BRICK.YearBuiltShape: {"datatype": XSD.integer},
     BRICK.ThermalTransmittenceShape: {
         "datatype": XSD.float,

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -78,6 +78,12 @@ entity_properties = {
         SKOS.definition: Literal("The nominal measured power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
     },
+    BRICK.temperatureCoefficientofPmax: {
+        SKOS.definition: Literal(
+            "The % change in power output for every degree celsius that the entity is hotter than 25 degrees celsius"
+        ),
+        RDFS.range: BRICK.TemperatureCoefficientPerDegreeCelsiusShape,
+    },
     BRICK.conversionEfficiency: {
         SKOS.definition: Literal(
             "The percent efficiency of the conversion process (usually to power or energy) carried out by the entity"
@@ -296,11 +302,11 @@ shape_properties = {
         "datatype": XSD.float,
         "units": [UNIT.KiloW, UNIT.W, UNIT.MegaW],
         "properties": {
-            BRICK.temperatureCoefficientofPmax: {
+            BRICK.ambientTemperatureOfMeasurement: {
                 SKOS.definition: Literal(
-                    "The % change in power output for every degree celsius that the entity is hotter than 25 degrees celsius"
+                    "The ambient temperature at which the power output was measured"
                 ),
-                RDFS.range: BRICK.TemperatureCoefficientPerDegreeCelsiusShape,
+                RDFS.range: BRICK.TemperatureShape,
             },
         },
     },

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -275,6 +275,11 @@ shape_properties = {
         },
     },
     BRICK.TiltShape: {"units": [UNIT.DEG], "datatype": XSD.float},
+    BRICK.TemperatureShape: {"units": [UNIT.DEG_C, UNIT.DEG_F], "datatype": XSD.float},
+    BRICK.TemperatureCoefficientPerDegreeCelsiusShape: {
+        "units": [UNIT.PERCENT],
+        "datatype": XSD.float,
+    },
     BRICK.AzimuthShape: {
         "units": [UNIT.DEG],
         "datatype": XSD.float,
@@ -290,6 +295,14 @@ shape_properties = {
     BRICK.PowerOutputShape: {
         "datatype": XSD.float,
         "units": [UNIT.KiloW, UNIT.W, UNIT.MegaW],
+        "properties": {
+            BRICK.temperatureCoefficientofPmax: {
+                SKOS.definition: Literal(
+                    "The % change in power output for every degree celsius that the entity is hotter than 25 degrees celsius"
+                ),
+                RDFS.range: BRICK.TemperatureCoefficientPerDegreeCelsiusShape,
+            },
+        },
     },
     BRICK.EfficiencyShape: {
         "datatype": XSD.float,
@@ -303,7 +316,10 @@ shape_properties = {
     BRICK.AggregationShape: {
         "properties": {
             BRICK.aggregationFunction: {
-                "values": ["max", "min", "count", "mean", "sum", "median", "mode"]
+                SKOS.definition: Literal(
+                    "The aggregation function applied to data in the interval which produces the value"
+                ),
+                "values": ["max", "min", "count", "mean", "sum", "median", "mode"],
             },
             BRICK.aggregationInterval: {
                 SKOS.definition: Literal(

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -76,11 +76,27 @@ entity_properties = {
         SKOS.definition: Literal("The maximum measured power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
     },
-    BRICK.moduleEfficiency: {
+    BRICK.conversionEfficiency: {
         SKOS.definition: Literal(
-            "The percentage of sunlight that is converted into usable power, as measured using Standard Test Conditions (STC): 1000 W/sqm irradiance, 25 degC panel temperature, no wind"
+            "The percent efficiency of the conversion process (usually to power or energy) carried out by the entity"
         ),
-        RDFS.range: BRICK.ModuleEfficiencyShape,
+        RDFS.range: BRICK.EfficiencyShape,
+        "subproperties": {
+            BRICK.ratedModuleConversionEfficiency: {
+                SKOS.definition: Literal(
+                    "The *rated* percentage of sunlight that is converted into usable power, as measured using Standard Test Conditions (STC): 1000 W/sqm irradiance, 25 degC panel temperature, no wind"
+                ),
+                RDFS.domain: BRICK.PV_Panel,
+                RDFS.range: BRICK.EfficiencyShape,
+            },
+            BRICK.measuredModuleConversionEfficiency: {
+                SKOS.definition: Literal(
+                    "The measured percentage of sunlight that is converted into usable power"
+                ),
+                RDFS.domain: BRICK.PV_Panel,
+                RDFS.range: BRICK.EfficiencyShape,
+            },
+        },
     },
     # equipment operation properties
     BRICK.operationalStage: {
@@ -273,10 +289,10 @@ shape_properties = {
         "datatype": XSD.float,
         "units": [UNIT.KiloW, UNIT.W, UNIT.MegaW],
     },
-    BRICK.ModuleEfficiencyShape: {
+    BRICK.EfficiencyShape: {
         "datatype": XSD.float,
         "units": [UNIT.PERCENT],
-        "range": {"minInclusive": 0, "maxInclusive": 100},
+        "range": {"minInclusive": 0},
     },
     BRICK.CoolingCapacityShape: {
         "datatype": XSD.float,

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -71,11 +71,11 @@ entity_properties = {
         RDFS.range: BRICK.CurrentFlowTypeShape,
     },
     BRICK.ratedPowerOutput: {
-        SKOS.definition: Literal("The maximum rated power output of the entity"),
+        SKOS.definition: Literal("The nominal rated power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
     },
     BRICK.measuredPowerOutput: {
-        SKOS.definition: Literal("The maximum measured power output of the entity"),
+        SKOS.definition: Literal("The nominal measured power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
     },
     BRICK.conversionEfficiency: {

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -29,12 +29,11 @@ entity_properties = {
         SKOS.definition: Literal("Entity has 3-dimensional volume"),
         RDFS.range: BRICK.VolumeShape,
     },
-    BRICK.orientation: {
+    BRICK.azimuth: {
         SKOS.definition: Literal(
-            "The direction an entity is facing, relative to some reference point (usually a 'compass' direction)"
+            "(Horizontal) angle between a projected vector and a reference vector (typically a compass bearing). The projected vector usually indicates the direction of a face or plane."
         ),
-        # TODO: for points + equipment? or just equipment?
-        RDFS.range: BRICK.OrientationShape,
+        RDFS.range: BRICK.AzimuthShape,
     },
     BRICK.tilt: {
         SKOS.definition: Literal(
@@ -244,12 +243,11 @@ shape_properties = {
         },
     },
     BRICK.TiltShape: {"units": [UNIT.DEG], "datatype": XSD.float},
-    BRICK.OrientationShape: {
+    BRICK.AzimuthShape: {
         "units": [UNIT.DEG],
         "datatype": XSD.float,
-        "properties": {
-            BRICK.orientationRelativeTo: {"values": ["North", "South", "East", "West"]}
-        },
+        "rotationalDirection": {"values": ["clockwise", "counterclockwise"]},
+        "referenceDirection": {"values": ["North", "South", "East", "West"]},
     },
     BRICK.YearBuiltShape: {"datatype": XSD.integer},
     BRICK.ThermalTransmittenceShape: {

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -248,6 +248,7 @@ shape_properties = {
         "datatype": XSD.float,
         "rotationalDirection": {"values": ["clockwise", "counterclockwise"]},
         "referenceDirection": {"values": ["North", "South", "East", "West"]},
+        "range": {"minInclusive": 0, "maxInclusive": 360},
     },
     BRICK.YearBuiltShape: {"datatype": XSD.integer},
     BRICK.ThermalTransmittenceShape: {

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -68,6 +68,14 @@ entity_properties = {
         SKOS.definition: Literal("The current flow type of the entity"),
         RDFS.range: BRICK.CurrentFlowTypeShape,
     },
+    BRICK.ratedPowerOutput: {
+        SKOS.definition: Literal("The rated power output of the entity"),
+        RDFS.range: BRICK.PowerOutputShape,
+    },
+    BRICK.measuredPowerOutput: {
+        SKOS.definition: Literal("The measured power output of the entity"),
+        RDFS.range: BRICK.PowerOutputShape,
+    },
     # equipment operation properties
     BRICK.operationalStage: {
         SKOS.definition: Literal("The associated operational stage"),
@@ -254,6 +262,10 @@ shape_properties = {
     BRICK.ThermalTransmittenceShape: {
         "datatype": XSD.float,
         "units": [UNIT.BTU_IT, UNIT["W-PER-M2-K"]],
+    },
+    BRICK.PowerOutputShape: {
+        "datatype": XSD.float,
+        "units": [UNIT.KiloW, UNIT.W, UNIT.MegaW],
     },
     BRICK.CoolingCapacityShape: {
         "datatype": XSD.float,

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -1,5 +1,8 @@
-from .namespaces import BRICK, TAG, OWL, RDFS, SKOS, UNIT, XSD
-from rdflib import Namespace, Literal
+"""
+Entity property definitions
+"""
+from rdflib import Literal
+from .namespaces import BRICK, RDFS, SKOS, UNIT, XSD
 
 # these are the "relationship"/predicates/OWL properties that
 # relate a Brick entity to a structured value.

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -20,7 +20,6 @@ entity_properties = {
             },
             BRICK.panelArea: {
                 SKOS.definition: Literal("Surface area of a panel, such as a PV panel"),
-                # TODO: needs to go on equipment; do we remove "domain" from the above?
                 RDFS.range: BRICK.AreaShape,
             },
         },

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -69,12 +69,18 @@ entity_properties = {
         RDFS.range: BRICK.CurrentFlowTypeShape,
     },
     BRICK.ratedPowerOutput: {
-        SKOS.definition: Literal("The rated power output of the entity"),
+        SKOS.definition: Literal("The maximum rated power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
     },
     BRICK.measuredPowerOutput: {
-        SKOS.definition: Literal("The measured power output of the entity"),
+        SKOS.definition: Literal("The maximum measured power output of the entity"),
         RDFS.range: BRICK.PowerOutputShape,
+    },
+    BRICK.moduleEfficiency: {
+        SKOS.definition: Literal(
+            "The percentage of sunlight that is converted into usable power, as measured using Standard Test Conditions (STC): 1000 W/sqm irradiance, 25 degC panel temperature, no wind"
+        ),
+        RDFS.range: BRICK.ModuleEfficiencyShape,
     },
     # equipment operation properties
     BRICK.operationalStage: {
@@ -266,6 +272,11 @@ shape_properties = {
     BRICK.PowerOutputShape: {
         "datatype": XSD.float,
         "units": [UNIT.KiloW, UNIT.W, UNIT.MegaW],
+    },
+    BRICK.ModuleEfficiencyShape: {
+        "datatype": XSD.float,
+        "units": [UNIT.PERCENT],
+        "range": {"minInclusive": 0, "maxInclusive": 100},
     },
     BRICK.CoolingCapacityShape: {
         "datatype": XSD.float,

--- a/bricksrc/properties.py
+++ b/bricksrc/properties.py
@@ -1,10 +1,12 @@
-from .namespaces import A, OWL, RDFS, BRICK, VCARD, UNIT, QUDT, XSD
+from .namespaces import A, OWL, RDFS, BRICK, VCARD, UNIT, QUDT, XSD, SDO
 
 """
 Defining properties
 """
 properties = {
     "value": {RDFS.subPropertyOf: QUDT.value},
+    "latitutde": {RDFS.subPropertyOf: SDO.latitude},
+    "longitude": {RDFS.subPropertyOf: SDO.longitude},
     "hasQUDTReference": {A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty]},
     "isLocationOf": {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -1,0 +1,52 @@
+@prefix bldg: <urn:example#> .
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+bldg:panel11 a brick:PV_Panel ;
+    brick:isPartOf bldg:array1 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:panel12 a brick:PV_Panel ;
+    brick:isPartOf bldg:array1 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:panel13 a brick:PV_Panel ;
+    brick:isPartOf bldg:array1 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:panel21 a brick:PV_Panel ;
+    brick:isPartOf bldg:array2 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:panel22 a brick:PV_Panel ;
+    brick:isPartOf bldg:array2 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:panel23 a brick:PV_Panel ;
+    brick:isPartOf bldg:array2 ;
+    brick:panelArea [ brick:hasUnit unit:M2 ;
+            brick:value 5 ] .
+
+bldg:pv_generation_system a brick:PV_Generation_System ;
+    brick:hasPart bldg:array1,
+        bldg:array2 .
+
+bldg:array1 a brick:Photovoltaic_Array ;
+    brick:orientation [ brick:hasUnit unit:DEG ;
+            brick:orientationRelativeTo "South" ;
+            brick:value 0 ] ;
+    brick:tilt [ brick:hasUnit unit:DEG ;
+            brick:value 20 ] .
+
+bldg:array2 a brick:Photovoltaic_Array ;
+    brick:orientation [ brick:hasUnit unit:DEG ;
+            brick:orientationRelativeTo "South" ;
+            brick:value 2 ] ;
+    brick:tilt [ brick:hasUnit unit:DEG ;
+            brick:value 23 ] .

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -11,6 +11,7 @@ site:panel11 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
@@ -28,6 +29,7 @@ site:panel12 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
@@ -45,6 +47,7 @@ site:panel13 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
@@ -62,6 +65,7 @@ site:panel21 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
@@ -79,6 +83,7 @@ site:panel22 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
@@ -96,6 +101,7 @@ site:panel23 a brick:PV_Panel ;
     ] ;
     brick:ratedModuleConversionEfficiency [
         brick:hasUnit unit:PERCENT ;
+        brick:ambientTemperatureOfMeasurement [ brick:value 25 ; brick:hasUnit unit:DEG_C ] ;
         brick:value 26 ;
     ] ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -5,31 +5,43 @@
 
 site:panel11 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel12 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel13 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel21 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel22 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel23 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
+    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+            brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -5,42 +5,102 @@
 
 site:panel11 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel12 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel13 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel21 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel22 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
 site:panel23 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
-    brick:ratedPowerOutput: [ brick:hasUnit unit:W ;
+    brick:coordinates [
+        brick:latitude 37.8719 ;
+        brick:longitude -122.2585 ;
+    ] ;
+    brick:ratedModuleConversionEfficiency [
+        brick:hasUnit unit:PERCENT ;
+        brick:value 26 ;
+    ] ;
+    brick:measuredPowerOutput [ brick:hasUnit unit:W ;
+            brick:value 240 ] ;
+    brick:ratedPowerOutput [ brick:hasUnit unit:W ;
             brick:value 250 ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -54,13 +54,16 @@ site:pv_meter   a   brick:Electrical_Meter ;
                     site:pv_daily_peak_power .
 
 site:pv_power   a   brick:Electrical_Power_Sensor ;
+    brick:powerFlow [ brick:value "export" ] ;
     brick:hasUnit   unit:KiloW .
 
 site:pv_energy   a   brick:Energy_Sensor ;
+    brick:powerFlow [ brick:value "export" ] ;
     brick:hasUnit   unit:KiloW-HR .
 
 site:pv_daily_peak_power   a   brick:Power_Sensor ;
     brick:hasUnit   unit:KiloW ;
+    brick:powerFlow [ brick:value "export" ] ;
     brick:aggregate [
         brick:aggregationFunction    "max" ;
         brick:aggregationInterval    "RP1D" ;

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -38,15 +38,17 @@ bldg:pv_generation_system a brick:PV_Generation_System ;
         bldg:array2 .
 
 bldg:array1 a brick:Photovoltaic_Array ;
-    brick:orientation [ brick:hasUnit unit:DEG ;
-            brick:orientationRelativeTo "South" ;
-            brick:value 0 ] ;
+    brick:azimuth [ brick:hasUnit unit:DEG ;
+            brick:rotationalDirection "clockwise" ;
+            brick:referenceDirection "North" ;
+            brick:value 200 ] ;
     brick:tilt [ brick:hasUnit unit:DEG ;
             brick:value 20 ] .
 
 bldg:array2 a brick:Photovoltaic_Array ;
-    brick:orientation [ brick:hasUnit unit:DEG ;
-            brick:orientationRelativeTo "South" ;
-            brick:value 2 ] ;
+    brick:azimuth [ brick:hasUnit unit:DEG ;
+            brick:rotationalDirection "clockwise" ;
+            brick:referenceDirection "North" ;
+            brick:value 180 ] ;
     brick:tilt [ brick:hasUnit unit:DEG ;
             brick:value 23 ] .

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -1,43 +1,60 @@
-@prefix bldg: <urn:example#> .
+@prefix site: <urn:example#> .
 @prefix brick: <https://brickschema.org/schema/Brick#> .
 @prefix unit: <http://qudt.org/vocab/unit/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-bldg:panel11 a brick:PV_Panel ;
-    brick:isPartOf bldg:array1 ;
+site:panel11 a brick:PV_Panel ;
+    brick:isPartOf site:array1 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:panel12 a brick:PV_Panel ;
-    brick:isPartOf bldg:array1 ;
+site:panel12 a brick:PV_Panel ;
+    brick:isPartOf site:array1 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:panel13 a brick:PV_Panel ;
-    brick:isPartOf bldg:array1 ;
+site:panel13 a brick:PV_Panel ;
+    brick:isPartOf site:array1 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:panel21 a brick:PV_Panel ;
-    brick:isPartOf bldg:array2 ;
+site:panel21 a brick:PV_Panel ;
+    brick:isPartOf site:array2 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:panel22 a brick:PV_Panel ;
-    brick:isPartOf bldg:array2 ;
+site:panel22 a brick:PV_Panel ;
+    brick:isPartOf site:array2 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:panel23 a brick:PV_Panel ;
-    brick:isPartOf bldg:array2 ;
+site:panel23 a brick:PV_Panel ;
+    brick:isPartOf site:array2 ;
     brick:panelArea [ brick:hasUnit unit:M2 ;
             brick:value 5 ] .
 
-bldg:pv_generation_system a brick:PV_Generation_System ;
-    brick:hasPart bldg:array1,
-        bldg:array2 .
+site:pv_generation_system a brick:PV_Generation_System ;
+    brick:hasPart site:array1, site:array2 ;
+    brick:feeds site:pv_meter .
 
-bldg:array1 a brick:Photovoltaic_Array ;
+site:pv_meter   a   brick:Electrical_Meter ;
+    brick:hasPoint  site:pv_power, site:pv_energy,
+                    site:pv_daily_peak_power .
+
+site:pv_power   a   brick:Electrical_Power_Sensor ;
+    brick:hasUnit   unit:KiloW .
+
+site:pv_energy   a   brick:Energy_Sensor ;
+    brick:hasUnit   unit:KiloW-HR .
+
+site:pv_daily_peak_power   a   brick:Power_Sensor ;
+    brick:hasUnit   unit:KiloW ;
+    brick:aggregate [
+        brick:aggregationFunction    "max" ;
+        brick:aggregationInterval    "RP1D" ;
+    ] .
+
+site:array1 a brick:Photovoltaic_Array ;
     brick:azimuth [ brick:hasUnit unit:DEG ;
             brick:rotationalDirection "clockwise" ;
             brick:referenceDirection "North" ;
@@ -45,7 +62,7 @@ bldg:array1 a brick:Photovoltaic_Array ;
     brick:tilt [ brick:hasUnit unit:DEG ;
             brick:value 20 ] .
 
-bldg:array2 a brick:Photovoltaic_Array ;
+site:array2 a brick:Photovoltaic_Array ;
     brick:azimuth [ brick:hasUnit unit:DEG ;
             brick:rotationalDirection "clockwise" ;
             brick:referenceDirection "North" ;

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -409,6 +409,16 @@ def define_shape_properties(definitions):
             G.add((v, SH.path, BRICK.value))
             G.add((v, SH.datatype, defn.pop("datatype")))
             G.add((v, SH.minCount, Literal(1)))
+            if "range" in defn:
+                for prop_name, prop_value in defn.pop("range").items():
+                    if prop_name not in [
+                        "minExclusive",
+                        "minInclusive",
+                        "maxExclusive",
+                        "maxInclusive",
+                    ]:
+                        raise Exception(f"brick:value property {prop_name} not valid")
+                    G.add((v, SH[prop_name], Literal(prop_value)))
 
 
 def define_properties(definitions, superprop=None):


### PR DESCRIPTION
Adds entity properties and examples for PV systems. Online discussions have suggested the following properties:
* [X] panelArea
* [X] ~~orientation~~ azimuth
* [X] tilt
* [x] geocoordinates:
   * some w3c ontology?
   * schema.org (https://schema.org/GeoCoordinates) 
   * embed GeoJSON as a literal?
   * pluscodes or ubid?
* [x] add points to the example
* [x] add rated/measured capacity as an entity property (kw / sqm)
* [x] conversion efficiency (rated vs actual) --- relative to temperature? Need to look up how this is captured normally

Ongoing discussions on how to handle the geolocation of panels and how to express these entity property values in different ways.