### PR TITLE
Fix bad merge: remove exhaust air system

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -353,7 +353,6 @@ https://brickschema.org/schema/Brick#Exhaust_Air_Stack_Flow_Setpoint,Sets exhaus
 https://brickschema.org/schema/Brick#Exhaust_Air_Static_Pressure_Proportional_Band_Parameter,,
 https://brickschema.org/schema/Brick#Exhaust_Air_Static_Pressure_Sensor,The static pressure of air within exhaust regions of an HVAC system,
 https://brickschema.org/schema/Brick#Exhaust_Air_Static_Pressure_Setpoint,Sets static pressure of exhaust air,
-https://brickschema.org/schema/Brick#Exhaust_Air_System,"The equipment, devices, and conduits that handle the exhaust of air from the building",,
 https://brickschema.org/schema/Brick#Exhaust_Air_Temperature_Sensor,Measures the temperature of exhaust air,
 https://brickschema.org/schema/Brick#Exhaust_Air_Velocity_Pressure_Sensor,,
 https://brickschema.org/schema/Brick#Exhaust_Damper,A damper that modulates the flow of exhaust air,

--- a/bricksrc/system.py
+++ b/bricksrc/system.py
@@ -22,31 +22,9 @@ system_subclasses = {
                             TAG.System,
                         ]
                     },
-                    "Exhaust_Air_System": {
-                        "tags": [
-                            TAG.Exhaust,
-                            TAG.Air,
-                            TAG.System,
-                        ]
-                    },
                 },
             },
             "Steam_System": {"tags": [TAG.Steam, TAG.System]},
-            "Air_System": {
-                "tags": [
-                    TAG.Air,
-                    TAG.System,
-                ],
-                "subclasses": {
-                    "Ventilation_Air_System": {
-                        "tags": [
-                            TAG.Ventilation,
-                            TAG.Air,
-                            TAG.System,
-                        ],
-                    },
-                },
-            },
             "Water_System": {
                 "tags": [TAG.Water, TAG.System],
                 "subclasses": {


### PR DESCRIPTION
Fixing my poor handling of #278  which did not include Exhaust Air System; however, the definition was still retained and there was a duplicate dictionary entry which is now removed.