### PR TITLE
Use "/" suffix for sosa namespace

### DIFF
--- a/bricksrc/namespaces.py
+++ b/bricksrc/namespaces.py
@@ -12,7 +12,7 @@ RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
 SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 DCTERMS = Namespace("http://purl.org/dc/terms#")
 SDO = Namespace("http://schema.org/")
-SOSA = Namespace("http://www.w3.org/ns/sosa#")
+SOSA = Namespace("http://www.w3.org/ns/sosa/")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
 
 # QUDT namespaces


### PR DESCRIPTION
Somehow this slipped through; this small PR brings Brick's reference of SOSA in line with the official [documentation](https://www.w3.org/TR/vocab-ssn/)