### PR TITLE
Complete labels and annotations

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -229,7 +229,8 @@ def define_concept_hierarchy(definitions, typeclasses, broader=None, related=Non
             G.add((concept, SKOS.related, related))
         # add label
         class_label = concept.split("#")[-1].replace("_", " ")
-        G.add((concept, RDFS.label, Literal(class_label)))
+        if not G.objects(concept, RDFS.label):
+            G.add((concept, RDFS.label, Literal(class_label)))
 
         # define mapping to substances + quantities if it exists
         # "substances" property is a list of (predicate, object) pairs
@@ -285,7 +286,9 @@ def define_classes(definitions, parent, pun_classes=False):
         G.add((classname, RDFS.subClassOf, parent))
         # add label
         class_label = classname.split("#")[-1].replace("_", " ")
-        G.add((classname, RDFS.label, Literal(class_label)))
+
+        if not G.objects(classname, RDFS.label):
+            G.add((classname, RDFS.label, Literal(class_label)))
         if pun_classes:
             G.add((classname, A, classname))
 
@@ -700,7 +703,7 @@ for r in res:
         G.add((unit, A, UNIT.Unit))
         if symb is not None:
             G.add((unit, QUDT.symbol, symb))
-        if label is not None:
+        if label is not None and not G.objects(unit, RDFS.label):
             G.add((unit, RDFS.label, label))
 
 logging.info("Adding class definitions")

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -4,6 +4,7 @@ import sys
 import rdflib
 import brickschema
 from warnings import warn
+from collections import Counter
 from rdflib import RDF, RDFS, Namespace, BNode
 
 sys.path.append("..")
@@ -109,3 +110,10 @@ def test_valid_definition_encoding():
             or isinstance(seealso, rdflib.URIRef)
             or isinstance(seealso, rdflib.Literal)
         ), ("SeeAlso %s should be a URI or Literal or None" % seealso)
+
+
+def test_rdfs_labels():
+    labels = g.subjects(predicate=RDFS.label)
+    c = Counter(labels)
+    for entity, count in c.items():
+        assert count == 1, f"Entity {entity} has {count} labels, which is more than 1"


### PR DESCRIPTION
Addresses https://github.com/BrickSchema/Brick/issues/304. 

- [X] Ensures that `rdfs:label` annotations are not added if they already exist. 
- [X] Adds a test to verify that there are no double `rdfs:label` annotations on classes.
- [x] `skos:definition` should have an `@en` language label
- [x] `rdfs:label` should have an `@en` language label (where appropriate, i.e. not tags)
- [x] properties should have `rdfs:label`