### PR TITLE
Reduce automated test time

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run the tests
       # -s flag: do not capture output (avoids killing test after 10 min)
       run: |
-        pytest -s -vvvv
+        pytest -s -vvvv -m 'not slow' --durations=0 -n auto tests
     - name: Do integration tests
       run: |
         cd tests/integration

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ format:
 	black tools/
 
 test: Brick.ttl shacl/BrickShape.ttl
-	pytest -s -vvvv -m 'not slow' --durations=0 tests 
+	pytest -s -vvvv -m 'not slow' --durations=0 -n auto tests
 	cd tests/integration && bash run_integration_tests.sh
 
 quantity-test: Brick.ttl

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest>=5.4.3
 tqdm>=4.46.1
 pyshacl>=0.16.1.post1
 docker>=4.3.0
-brickschema>=0.5.1a1
+brickschema>=0.5.1a4
 black==21.5b2
 pre-commit>=2.13.0
 flake8==3.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ black==21.5b2
 pre-commit>=2.13.0
 flake8==3.9.2
 semver>=2.10.1
+pytest-xdist[psutil]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytest>=5.4.3
 tqdm>=4.46.1
 pyshacl>=0.16.1.post1
 docker>=4.3.0
-brickschema>=0.5.1a4
+brickschema>=0.5.1a5
 black==21.5b2
 pre-commit>=2.13.0
 flake8==3.9.2

--- a/tests/test_hierarchy_inference.py
+++ b/tests/test_hierarchy_inference.py
@@ -1,3 +1,4 @@
+import pytest
 import json
 from collections import defaultdict
 import time
@@ -29,6 +30,7 @@ inference_file = "tests/test_hierarchy_inference.ttl"
 entity_postfix = "_0"
 
 
+@pytest.mark.slow
 def test_hierarchyinference():
     # Load the schema
     g = brickschema.Graph()


### PR DESCRIPTION
Remove hierarchy inference test from usual suite of tests to reduce feedback time on automated tests