### PR TITLE
add miscellaneous alarms

### DIFF
--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -18,6 +18,11 @@ alarm_definitions = {
                             },
                             "Low_Air_Flow_Alarm": {
                                 "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Low],
+                                "subclasses": {
+                                    "Low_Discharge_Air_Flow_Alarm": {
+                                        "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Low, TAG.Discharge],
+                                    }
+                                }
                             }
                         }
                     }

--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -7,8 +7,19 @@ alarm_definitions = {
             "Air_Alarm": {
                 "tags": [TAG.Point, TAG.Air, TAG.Alarm],
                 "subclasses": {
-                    "Air_Flow_Loss_Alarm": {
-                        "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Loss],
+                    "Air_Flow_Alarm": {
+                        "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow],
+                        "subclasses": {
+                            "Air_Flow_Loss_Alarm": {
+                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Loss],
+                            },
+                            "High_Air_Flow_Alarm": {
+                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.High],
+                            },
+                            "Low_Air_Flow_Alarm": {
+                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Low],
+                            }
+                        }
                     }
                 },
             },
@@ -19,6 +30,17 @@ alarm_definitions = {
                         "tags": [TAG.Point, TAG.High, TAG.CO2, TAG.Alarm],
                     },
                 },
+            },
+            "Voltage_Alarm": {
+                "tags": [TAG.Point, TAG.Voltage, TAG.Alarm],
+                "subclasses": {
+                    "Low_Voltage_Alarm": {
+                        "tags": [TAG.Point, TAG.Low, TAG.Voltage, TAG.Alarm],
+                    },
+                },
+            },
+            "Valve_Position_Alarm": {
+                "tags": [TAG.Point, TAG.Valve, TAG.Position, TAG.Alarm],
             },
             "Change_Filter_Alarm": {
                 "tags": [TAG.Point, TAG.Change, TAG.Filter, TAG.Alarm],
@@ -47,6 +69,9 @@ alarm_definitions = {
                 "subclasses": {
                     "Unit_Failure_Alarm": {
                         "tags": [TAG.Point, TAG.Unit, TAG.Failure, TAG.Alarm],
+                    },
+                    "Sensor_Failure_Alarm": {
+                        "tags": [TAG.Point, TAG.Sensor, TAG.Failure, TAG.Alarm],
                     },
                 },
             },
@@ -167,6 +192,17 @@ alarm_definitions = {
                                             TAG.Alarm,
                                         ],
                                         "parents": [BRICK.High_Temperature_Alarm],
+                                    },
+                                    "Low_Discharge_Air_Temperature_Alarm": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Low,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Alarm,
+                                        ],
+                                        "parents": [BRICK.Low_Temperature_Alarm],
                                     },
                                 },
                             },

--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -14,6 +14,7 @@ https://brickschema.org/schema/Brick#Air_Differential_Pressure_Sensor,Measures t
 https://brickschema.org/schema/Brick#Air_Differential_Pressure_Setpoint,Sets the target air differential pressure between an upstream and downstream point in a air duct or conduit,
 https://brickschema.org/schema/Brick#Air_Diffuser,A device that is a component of the air distribution system that controls the delivery of conditioned and/or ventilating air into a room,
 https://brickschema.org/schema/Brick#Air_Enthalpy_Sensor,Measures the total heat content of air,
+https://brickschema.org/schema/Brick#Air_Flow_Alarm,An alarm related to air flow.,
 https://brickschema.org/schema/Brick#Air_Flow_Deadband_Setpoint,Sets the size of a deadband of air flow,
 https://brickschema.org/schema/Brick#Air_Flow_Demand_Setpoint,Sets the rate of air flow required for a process,
 https://brickschema.org/schema/Brick#Air_Flow_Loss_Alarm,An alarm that indicates loss in air flow.,
@@ -461,6 +462,7 @@ https://brickschema.org/schema/Brick#Heating_Temperature_Setpoint,Sets temperatu
 https://brickschema.org/schema/Brick#Heating_Thermal_Power_Sensor,,
 https://brickschema.org/schema/Brick#Heating_Valve,A valve that controls air temperature by modulating the amount of hot water flowing through a heating coil,
 https://brickschema.org/schema/Brick#Heating_Ventilation_Air_Conditioning_System,"The equipment, distribution systems and terminals that provide, either collectively or individually, the processes of heating, ventilating or air conditioning to a building or portion of a building",
+https://brickschema.org/schema/Brick#High_Air_Flow_Alarm,An alarm that indicates that the air flow is higher than normal.,
 https://brickschema.org/schema/Brick#High_CO2_Alarm,A device that indicates high concentration of carbon dioxide.,
 https://brickschema.org/schema/Brick#High_Discharge_Air_Temperature_Alarm,An alarm that indicates that discharge air temperature is too high,
 https://brickschema.org/schema/Brick#High_Head_Pressure_Alarm,An alarm that indicates a high pressure generated on the output side of a gas compressor in a refrigeration or air conditioning system.,
@@ -574,6 +576,8 @@ https://brickschema.org/schema/Brick#Lockout_Status,"Indicates if a piece of equ
 https://brickschema.org/schema/Brick#Loop,A collection of connected equipment; part of a System,
 https://brickschema.org/schema/Brick#Lounge,A room for lesiure activities or relaxing,
 https://brickschema.org/schema/Brick#Louver,"Device consisting of an assembly of parallel sloping vanes, intended to permit the passage of air while providing a measure of protection against environmental influences",
+https://brickschema.org/schema/Brick#Low_Air_Flow_Alarm,An alarm that indicates that the air flow is lower than normal.,
+https://brickschema.org/schema/Brick#Low_Discharge_Air_Flow_Alarm,An alarm that indicates that the discharge air flow is lower than normal.,
 https://brickschema.org/schema/Brick#Low_Freeze_Protect_Temperature_Parameter,,
 https://brickschema.org/schema/Brick#Low_Humidity_Alarm,An alarm that indicates low concentration of water vapor in the air.,
 https://brickschema.org/schema/Brick#Low_Humidity_Alarm_Parameter,A parameter determining the humidity level at which to trigger a low humidity alarm,
@@ -584,6 +588,7 @@ https://brickschema.org/schema/Brick#Low_Return_Air_Temperature_Alarm,An alarm t
 https://brickschema.org/schema/Brick#Low_Suction_Pressure_Alarm,An alarm that indicates a low suction pressure in the compressor in a refrigeration or air conditioning system.,
 https://brickschema.org/schema/Brick#Low_Temperature_Alarm,An alarm that indicates low temperature.,
 https://brickschema.org/schema/Brick#Low_Temperature_Alarm_Parameter,A parameter determining the temperature level at which to trigger a low temperature alarm,
+https://brickschema.org/schema/Brick#Low_Voltage_Alarm,An alarm that indicates the voltage is lower than its normal state.,
 https://brickschema.org/schema/Brick#Lowest_Exhaust_Air_Static_Pressure_Sensor,The lowest observed static pressure of air in exhaust regions of an HVAC system over some period of time,
 https://brickschema.org/schema/Brick#Luminaire,"A complete lighting unit consisting of a lamp or lamps and ballast(s) (when applicable) together with the parts designed to distribute the light, to position and protect the lamps, and to connect the lamps to the power supply.",
 https://brickschema.org/schema/Brick#Luminaire_Driver,A power source for a luminaire,
@@ -1013,6 +1018,7 @@ https://brickschema.org/schema/Brick#VFD_Enable_Command,Enables operation of a v
 https://brickschema.org/schema/Brick#Valve,"A device that regulates, directs or controls the flow of a fluid by opening, closing or partially obstructing various passageways",https://en.wikipedia.org/wiki/Valve
 https://brickschema.org/schema/Brick#Valve_Command,Controls or reports the openness of a valve (typically as a proportion of its full range of motion),
 https://brickschema.org/schema/Brick#Valve_Position_Sensor,Measures the current position of a valve in terms of the percent of fully open,
+https://brickschema.org/schema/Brick#Valve_Position_Alarm,An alarm that indicates that the valve position is not in a normal state.,
 https://brickschema.org/schema/Brick#Variable_Air_Volume_Box,A device that regulates the volume and temperature of air delivered to a zone by opening or closing a damper,https://en.wikipedia.org/wiki/Variable_air_volume
 https://brickschema.org/schema/Brick#Variable_Air_Volume_Box_With_Reheat,A VAV box with a reheat coil mounted on the discharge end of the unit that can heat the air delivered to a zone,
 https://brickschema.org/schema/Brick#Variable_Frequency_Drive,"Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure.",https://xp20.ashrae.org/terminology/index.php?term=vfd&submit=Search
@@ -1026,6 +1032,7 @@ https://brickschema.org/schema/Brick#Vertical_Space,A class of spaces used to co
 https://brickschema.org/schema/Brick#Visitor_Lobby,A lobby for visitors to the building. Sometimes used to distinguish from an employee entrance looby,
 https://brickschema.org/schema/Brick#Voltage,"Voltage, also referred to as Electric Tension, is the difference between electrical potentials of two points. For an electric field within a medium, (U_{ab} = - \int_{r_a}^{r_b} E . {dr}), where (E) is electric field strength. For an irrotational electric field, the voltage is independent of the path between the two points (a) and (b).",
 https://brickschema.org/schema/Brick#Voltage_Angle,Angle of voltage phasor,
+https://brickschema.org/schema/Brick#Voltage_Alarm,An alarm that indicates the voltage is not in a normal state.,
 https://brickschema.org/schema/Brick#Voltage_Imbalance,The percent deviation from average voltage,
 https://brickschema.org/schema/Brick#Voltage_Imbalance_Sensor,"A sensor which measures the voltage difference (imbalance) between phases of an electrical system",
 https://brickschema.org/schema/Brick#Voltage_Sensor,Measures the voltage of an electrical device or object,


### PR DESCRIPTION
Adding misc alarms.

@gtfierro I'm adding `Sensor_Failure_Alarm` indicating whether a specific sensing module is failing or not. For doing so, I should be able to add tags `Sensor` and `Alarm`, which will classify this as a `Sensor` as well. We had similar issues in different places, but I can't recall how we resolved it. Do you have any idea?
