### PR TITLE
Fix: deterministic serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 Brick.ttl: bricksrc/*.py bricksrc/*.ttl bricksrc/definitions.csv generate_brick.py
 	mkdir -p extensions
 	python generate_brick.py
-	cd shacl && python generate_shacl.py
+	cd shacl && python -c 'import sys; sys.path.append("../bricksrc")' generate_shacl.py
 
 shacl/BrickShape.ttl: bricksrc/*.py generate_brick.py shacl/generate_shacl.py
-	cd shacl && python generate_shacl.py
+	cd shacl && python -c 'import sys; sys.path.append("../bricksrc")' generate_shacl.py
 
 clean:
 	rm Brick.ttl Brick+extensions.ttl

--- a/bricksrc/blanknode.py
+++ b/bricksrc/blanknode.py
@@ -1,0 +1,10 @@
+from rdflib import BNode
+
+
+class BlankNode:
+    counter = -1
+
+    @staticmethod
+    def new():
+        BlankNode.counter += 1
+        return BNode("N" + str(BlankNode.counter))

--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from rdflib import Literal, BNode, URIRef
 from rdflib.collection import Collection
 
+from bricksrc.blanknode import BlankNode
+
 from .namespaces import DCTERMS, SDO, RDFS, RDF, OWL, BRICK, TAG, BSH
 from .version import BRICK_VERSION, BRICK_FULL_VERSION
 
@@ -40,15 +42,15 @@ def define_ontology(G):
 
     # add creators from ontology markup above
     creators = []
-    creator_list = BNode()
+    creator_list = BlankNode.new()
     for creator in ontology.pop(DCTERMS.creator):
-        creator1 = BNode()
+        creator1 = BlankNode.new()
         creators.append(creator1)
         for k, v in creator.items():
             G.add((creator1, k, v))
 
     # add publisher info
-    publisher = BNode()
+    publisher = BlankNode.new()
     G.add((brick_iri_version, DCTERMS.publisher, publisher))
     for k, v in ontology.pop(DCTERMS.publisher).items():
         G.add((publisher, k, v))

--- a/bricksrc/timeseries.py
+++ b/bricksrc/timeseries.py
@@ -2,6 +2,7 @@
 
 from .namespaces import BRICK, A, OWL, SKOS, SH, XSD
 from rdflib import Literal, BNode
+from bricksrc.blanknode import BlankNode
 
 
 def define_timeseries_model(G):
@@ -39,14 +40,14 @@ def define_timeseries_model(G):
         )
     )
 
-    idprop = BNode()
+    idprop = BlankNode.new()
     G.add((idprop, A, SH.PropertyShape))
     G.add((idprop, SH.path, BRICK.hasTimeseriesId))
     G.add((idprop, SH.minCount, Literal(1)))
     G.add((idprop, SH.maxCount, Literal(1)))
     G.add((idprop, SH.datatype, XSD.string))
 
-    storedprop = BNode()
+    storedprop = BlankNode.new()
     G.add((storedprop, A, SH.PropertyShape))
     G.add((storedprop, SH.path, BRICK.storedAt))
     G.add((storedprop, SH["class"], BRICK.Database))

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -46,6 +46,7 @@ from bricksrc.quantities import quantity_definitions, get_units
 from bricksrc.properties import properties
 from bricksrc.entity_properties import shape_properties, entity_properties
 from bricksrc.timeseries import define_timeseries_model
+from bricksrc.blanknode import BlankNode
 
 logging.basicConfig(
     format="%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
@@ -101,10 +102,10 @@ def add_restriction(klass, definition):
     if len(definition) == 0:
         return
     elements = []
-    equivalent_class = BNode()
-    list_name = BNode()
+    equivalent_class = BlankNode.new()
+    list_name = BlankNode.new()
     for idnum, item in enumerate(definition):
-        restriction = BNode()
+        restriction = BlankNode.new()
         elements.append(restriction)
         G.add((restriction, A, OWL.Restriction))
         G.add((restriction, OWL.onProperty, item[0]))
@@ -145,8 +146,8 @@ def add_tags(klass, definition):
         )  # make sure the tag is declared as such
 
     all_restrictions = []
-    equivalent_class = BNode()
-    list_name = BNode()
+    equivalent_class = BlankNode.new()
+    list_name = BlankNode.new()
 
     # add SHACL shape
     sc = BSH[klass.split("#")[-1] + "_TagShape"]
@@ -174,7 +175,7 @@ def add_tags(klass, definition):
         if tag not in shacl_tag_property_shapes:
             cond = BNode(f"has_{tag.split('#')[-1]}_condition")
             prop = BNode(f"has_{tag.split('#')[-1]}_tag")
-            tagshape = BNode()
+            tagshape = BlankNode.new()
             shaclGraph.add((rule, SH.condition, cond))
             shaclGraph.add((cond, SH.property, prop))
             shaclGraph.add((prop, SH.path, BRICK.hasTag))
@@ -370,8 +371,8 @@ def define_constraints(constraints, classname):
     that apply to the nodeshape.
     """
     for property_name, property_values in constraints.items():
-        pnode = BNode()
-        onode = BNode()
+        pnode = BlankNode.new()
+        onode = BlankNode.new()
         G.add((classname, A, SH.NodeShape))
         G.add((classname, SH.property, pnode))
         G.add((pnode, SH["path"], property_name))
@@ -382,7 +383,7 @@ def define_constraints(constraints, classname):
             G.add((pnode, SH["or"], onode))
             possible_values = []
             for pv in property_values:
-                pvnode = BNode()
+                pvnode = BlankNode.new()
                 G.add((pvnode, SH["class"], pv))
                 possible_values.append(pvnode)
             Collection(G, onode, possible_values)
@@ -413,7 +414,7 @@ def define_entity_properties(definitions, superprop=None):
 
 def define_shape_property_property(shape_name, definitions):
     for prop_name, prop_defn in definitions.items():
-        ps = BNode()
+        ps = BlankNode.new()
         G.add((shape_name, SH.property, ps))
         G.add((ps, A, SH.PropertyShape))
         G.add((ps, SH.path, prop_name))
@@ -430,7 +431,7 @@ def define_shape_property_property(shape_name, definitions):
             else:
                 G.add((ps, SH.datatype, dtype))
         elif "values" in prop_defn:
-            enumeration = BNode()
+            enumeration = BlankNode.new()
             G.add((ps, SH["in"], enumeration))
             G.add((ps, SH.minCount, Literal(1)))
             Collection(G, enumeration, map(Literal, prop_defn.pop("values")))
@@ -459,11 +460,11 @@ def define_shape_properties(definitions):
         G.add((shape_name, A, SH.NodeShape))
         G.add((shape_name, A, OWL.Class))
 
-        v = BNode()
+        v = BlankNode.new()
         # prop:value PropertyShape
         if "values" in defn:
-            ps = BNode()
-            enumeration = BNode()
+            ps = BlankNode.new()
+            enumeration = BlankNode.new()
             G.add((shape_name, SH.property, ps))
             G.add((ps, A, SH.PropertyShape))
             G.add((ps, SH.path, BRICK.value))
@@ -489,8 +490,8 @@ def define_shape_properties(definitions):
             else:
                 Collection(G, enumeration, map(Literal, vals))
         if "units" in defn:
-            ps = BNode()
-            enumeration = BNode()
+            ps = BlankNode.new()
+            enumeration = BlankNode.new()
             G.add((shape_name, SH.property, ps))
             G.add((ps, A, SH.PropertyShape))
             G.add((ps, SH.path, BRICK.hasUnit))
@@ -498,8 +499,8 @@ def define_shape_properties(definitions):
             G.add((ps, SH.minCount, Literal(1)))
             Collection(G, enumeration, defn.pop("units"))
         if "unitsFromQuantity" in defn:
-            ps = BNode()
-            enumeration = BNode()
+            ps = BlankNode.new()
+            enumeration = BlankNode.new()
             G.add((shape_name, SH.property, ps))
             G.add((ps, A, SH.PropertyShape))
             G.add((ps, SH.path, BRICK.hasUnit))

--- a/shacl/generate_shacl.py
+++ b/shacl/generate_shacl.py
@@ -1,8 +1,6 @@
 from rdflib import Graph, Literal, BNode
 import sys
 from bricksrc.blanknode import BlankNode
-
-sys.path.append("..")
 from bricksrc.namespaces import RDF, RDFS, BRICK, BSH, SH, SKOS  # noqa: E402
 from bricksrc.namespaces import bind_prefixes  # noqa: E402
 from bricksrc.properties import properties as property_definitions  # noqa: E402

--- a/shacl/generate_shacl.py
+++ b/shacl/generate_shacl.py
@@ -1,5 +1,6 @@
 from rdflib import Graph, Literal, BNode
 import sys
+from bricksrc.blanknode import BlankNode
 
 sys.path.append("..")
 from bricksrc.namespaces import RDF, RDFS, BRICK, BSH, SH, SKOS  # noqa: E402
@@ -37,7 +38,7 @@ def addDomainShape(propertyName, expectedType):
 # Make shape for expectedRange property
 def addRangeShape(propertyName, expectedType):
     rangeShapeDict[propertyName] = expectedType
-    sh_prop = BNode()
+    sh_prop = BlankNode.new()
     shapename = f"{propertyName}RangeShape"
     G.add((BSH[shapename], SH["property"], sh_prop))
     G.add((BSH[shapename], A, SH.NodeShape))


### PR DESCRIPTION
Avoid randomness by using explicit enumeration of blank node identities.

Another attempt to fix #324 