### PR TITLE
Discharge supply match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 Brick.ttl: bricksrc/*.py bricksrc/*.ttl bricksrc/definitions.csv generate_brick.py
 	mkdir -p extensions
-	python generate_brick.py
-	cd shacl && python generate_shacl.py
+	python3.10 generate_brick.py
+	cd shacl && python3.10 generate_shacl.py
 
 shacl/BrickShape.ttl: bricksrc/*.py generate_brick.py shacl/generate_shacl.py
 	cd shacl && python generate_shacl.py

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 Brick.ttl: bricksrc/*.py bricksrc/*.ttl bricksrc/definitions.csv generate_brick.py
 	mkdir -p extensions
-	python3.10 generate_brick.py
-	cd shacl && python3.10 generate_shacl.py
+	python generate_brick.py
+	cd shacl && python generate_shacl.py
 
 shacl/BrickShape.ttl: bricksrc/*.py generate_brick.py shacl/generate_shacl.py
 	cd shacl && python generate_shacl.py
@@ -34,3 +34,6 @@ hierarchy-test: Brick.ttl
 
 measures-test: Brick.ttl
 	pytest -s -vvvv tests/test_measures_inference.py
+
+matches-test: Brick.ttl
+	pytest -s -vvvv tests/test_matching_classes.py

--- a/bricksrc/alarm.py
+++ b/bricksrc/alarm.py
@@ -11,20 +11,58 @@ alarm_definitions = {
                         "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow],
                         "subclasses": {
                             "Air_Flow_Loss_Alarm": {
-                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Loss],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Air,
+                                    TAG.Alarm,
+                                    TAG.Flow,
+                                    TAG.Loss,
+                                ],
                             },
                             "High_Air_Flow_Alarm": {
-                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.High],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Air,
+                                    TAG.Alarm,
+                                    TAG.Flow,
+                                    TAG.High,
+                                ],
                             },
                             "Low_Air_Flow_Alarm": {
-                                "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Low],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Air,
+                                    TAG.Alarm,
+                                    TAG.Flow,
+                                    TAG.Low,
+                                ],
                                 "subclasses": {
                                     "Low_Discharge_Air_Flow_Alarm": {
-                                        "tags": [TAG.Point, TAG.Air, TAG.Alarm, TAG.Flow, TAG.Low, TAG.Discharge],
-                                    }
-                                }
-                            }
-                        }
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Air,
+                                            TAG.Alarm,
+                                            TAG.Flow,
+                                            TAG.Low,
+                                            TAG.Discharge,
+                                        ],
+                                    },
+                                    "Low_Supply_Air_Flow_Alarm": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Low_Discharge_Air_Flow_Alarm"
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Air,
+                                            TAG.Alarm,
+                                            TAG.Flow,
+                                            TAG.Low,
+                                            TAG.Supply,
+                                        ],
+                                    },
+                                },
+                            },
+                        },
                     }
                 },
             },
@@ -222,6 +260,36 @@ alarm_definitions = {
                                     TAG.Temperature,
                                     TAG.Alarm,
                                 ],
+                                "subclasses": {
+                                    "High_Supply_Air_Temperature_Alarm": {
+                                        OWL.equivalentClass: BRICK[
+                                            "High_Discharge_Air_Temperature_Alarm"
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.High,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Alarm,
+                                        ],
+                                        "parents": [BRICK.High_Temperature_Alarm],
+                                    },
+                                    "Low_Supply_Air_Temperature_Alarm": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Low_Discharge_Air_Temperature_Alarm"
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Low,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Alarm,
+                                        ],
+                                        "parents": [BRICK.Low_Temperature_Alarm],
+                                    },
+                                },
                             },
                             "Return_Air_Temperature_Alarm": {
                                 "tags": [
@@ -266,6 +334,20 @@ alarm_definitions = {
                     "Smoke_Detection_Alarm": {
                         "tags": [TAG.Point, TAG.Smoke, TAG.Detection, TAG.Alarm],
                         "subclasses": {
+                            "Supply_Air_Smoke_Detection_Alarm": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Smoke_Detection_Alarm"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Air,
+                                    TAG.Smoke,
+                                    TAG.Detection,
+                                    TAG.Alarm,
+                                ],
+                                "parents": [BRICK.Air_Alarm],
+                            },
                             "Discharge_Air_Smoke_Detection_Alarm": {
                                 "tags": [
                                     TAG.Point,

--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -242,6 +242,27 @@ command_definitions = {
                             },
                         },
                     },
+                    "Occupied_Load_Shed_Command": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Occupied,
+                            TAG.Load,
+                            TAG.Shed,
+                            TAG.Command,
+                        ],
+                        "subclasses": {
+                            "Zone_Occupied_Load_Shed_Command": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Zone,
+                                    TAG.Occupied,
+                                    TAG.Load,
+                                    TAG.Shed,
+                                    TAG.Command,
+                                ],
+                            },
+                        },
+                    },
                 },
             },
             "Mode_Command": {
@@ -263,6 +284,9 @@ command_definitions = {
                 "subclasses": {
                     "Max_Frequency_Command": {
                         "tags": [TAG.Point, TAG.Max, TAG.Fequency, TAG.Command],
+                    },
+                    "Min_Frequency_Command": {
+                        "tags": [TAG.Point, TAG.Min, TAG.Fequency, TAG.Command],
                     },
                 },
             },

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -654,6 +654,7 @@ hvac_subclasses = {
                 "tags": [TAG.Equipment, TAG.Return, TAG.Air, TAG.Plenum]
             },
             "Supply_Air_Plenum": {
+                OWL.equivalentClass: BRICK["Discharge_Air_Plenum"],
                 "tags": [TAG.Equipment, TAG.Supply, TAG.Air, TAG.Plenum],
                 "subclasses": {
                     "Underfloor_Air_Plenum": {
@@ -665,6 +666,9 @@ hvac_subclasses = {
                         ]
                     },
                 },
+            },
+            "Discharge_Air_Plenum": {
+                "tags": [TAG.Equipment, TAG.Discharge, TAG.Air, TAG.Plenum],
             },
         },
     },
@@ -678,7 +682,13 @@ valve_subclasses = {
                 "tags": [TAG.Valve, TAG.Water, TAG.Equipment],
                 "subclasses": {
                     "Thermostatic_Mixing_Valve": {
-                        "tags": [TAG.Mixed, TAG.Valve, TAG.Water, TAG.Thermal, TAG.Equipment],
+                        "tags": [
+                            TAG.Mixed,
+                            TAG.Valve,
+                            TAG.Water,
+                            TAG.Thermal,
+                            TAG.Equipment,
+                        ],
                     },
                     "Chilled_Water_Valve": {
                         "tags": [TAG.Chilled, TAG.Valve, TAG.Water, TAG.Equipment],
@@ -728,7 +738,7 @@ valve_subclasses = {
                 },
             },
             "Gas_Valve": {"tags": [TAG.Gas, TAG.Valve, TAG.Equipment]},
-        }
+        },
     }
 }
 

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -48,6 +48,15 @@ parameter_definitions = {
                             TAG.Setpoint,
                         ],
                     },
+                    "Min_Load_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Min,
+                            TAG.Load,
+                            TAG.Parameter,
+                            TAG.Setpoint,
+                        ],
+                    },
                 },
             },
             "Temperature_Parameter": {
@@ -433,6 +442,9 @@ parameter_definitions = {
                                                 ],
                                             },
                                             "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                                OWL.equivalentClass: BRICK[
+                                                    "Discharge_Water_Differential_Pressure_Integral_Time_Parameter"
+                                                ],
                                                 "tags": [
                                                     TAG.Point,
                                                     TAG.Supply,
@@ -616,6 +628,9 @@ parameter_definitions = {
                                         ],
                                     },
                                     "Supply_Water_Differential_Pressure_Proportional_Band_Parameter": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Water_Differential_Pressure_Proportional_Band_Parameter"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -804,6 +819,9 @@ parameter_definitions = {
                                 ],
                             },
                             "Supply_Water_Temperature_Proportional_Band_Parameter": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Water_Temperature_Proportional_Band_Parameter"
+                                ],
                                 "parents": [BRICK.Temperature_Parameter],
                                 "tags": [
                                     TAG.Point,
@@ -1128,6 +1146,17 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Min_Limit],
                             },
+                            "Max_Fresh_Air_Setpoint_Limit": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Max,
+                                    TAG.Fresh,
+                                    TAG.Air,
+                                    TAG.Limit,
+                                    TAG.Setpoint,
+                                ],
+                                "parents": [BRICK.Max_Limit],
+                            },
                         },
                     },
                     "Ventilation_Air_Flow_Ratio_Limit": {
@@ -1315,6 +1344,18 @@ parameter_definitions = {
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
+                                    "Max_Outside_Air_Flow_Setpoint_Limit": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Max,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Limit,
+                                            TAG.Parameter,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
                                     "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
                                         OWL.equivalentClass: BRICK[
                                             "Max_Cooling_Discharge_Air_Flow_Setpoint_Limit"

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -156,6 +156,9 @@ parameter_definitions = {
                                 ],
                                 "subclasses": {
                                     "Supply_Air_Integral_Gain_Parameter": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Integral_Gain_Parameter"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -165,7 +168,18 @@ parameter_definitions = {
                                             TAG.Parameter,
                                             TAG.PID,
                                         ],
-                                    }
+                                    },
+                                    "Discharge_Air_Integral_Gain_Parameter": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Integral,
+                                            TAG.Gain,
+                                            TAG.Parameter,
+                                            TAG.PID,
+                                        ],
+                                    },
                                 },
                             },
                             "Proportional_Gain_Parameter": {
@@ -178,6 +192,9 @@ parameter_definitions = {
                                 ],
                                 "subclasses": {
                                     "Supply_Air_Proportional_Gain_Parameter": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Proportional_Gain_Parameter"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Parameter,
@@ -185,6 +202,17 @@ parameter_definitions = {
                                             TAG.Gain,
                                             TAG.Proportional,
                                             TAG.Supply,
+                                            TAG.Air,
+                                        ],
+                                    },
+                                    "Discharge_Air_Proportional_Gain_Parameter": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Parameter,
+                                            TAG.PID,
+                                            TAG.Gain,
+                                            TAG.Proportional,
+                                            TAG.Discharge,
                                             TAG.Air,
                                         ],
                                     },
@@ -238,6 +266,20 @@ parameter_definitions = {
                                             TAG.Parameter,
                                         ],
                                         "subclasses": {
+                                            "Supply_Air_Static_Pressure_Step_Parameter": {
+                                                OWL.equivalentClass: BRICK[
+                                                    "Discharge_Air_Static_Pressure_Step_Parameter"
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Air,
+                                                    TAG.Static,
+                                                    TAG.Pressure,
+                                                    TAG.Step,
+                                                    TAG.Parameter,
+                                                ],
+                                            },
                                             "Discharge_Air_Static_Pressure_Step_Parameter": {
                                                 "tags": [
                                                     TAG.Point,
@@ -528,24 +570,27 @@ parameter_definitions = {
                                             },
                                         },
                                     },
-                                    "Supply_Water_Differential_Pressure_Integral_Time_Parameter": {
+                                    "Supply_Water_Temperature_Integral_Time_Parameter": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Water_Temperature_Integral_Time_Parameter"
+                                        ],
+                                        "parents": [BRICK.Temperature_Parameter],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
                                             TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
+                                            TAG.Temperature,
                                             TAG.Integral,
                                             TAG.Time,
                                             TAG.Parameter,
                                             TAG.PID,
                                         ],
                                     },
-                                    "Supply_Water_Temperature_Integral_Time_Parameter": {
+                                    "Discharge_Water_Temperature_Integral_Time_Parameter": {
                                         "parents": [BRICK.Temperature_Parameter],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Supply,
+                                            TAG.Discharge,
                                             TAG.Water,
                                             TAG.Temperature,
                                             TAG.Integral,
@@ -570,8 +615,6 @@ parameter_definitions = {
                     "Proportional_Band_Parameter": {
                         "tags": [
                             TAG.Point,
-                            TAG.Parameter,
-                            TAG.PID,
                             TAG.Proportional,
                             TAG.Band,
                             TAG.Parameter,
@@ -919,6 +962,9 @@ parameter_definitions = {
                         "parents": [BRICK.Temperature_Parameter],
                         "subclasses": {
                             "Supply_Air_Temperature_Setpoint_Limit": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Temperature_Setpoint_Limit"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Supply,
@@ -929,6 +975,9 @@ parameter_definitions = {
                                 ],
                                 "subclasses": {
                                     "Max_Supply_Air_Temperature_Setpoint_Limit": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Max_Discharge_Air_Temperature_Setpoint_Limit"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Max,
@@ -943,6 +992,9 @@ parameter_definitions = {
                                         ],
                                     },
                                     "Min_Supply_Air_Temperature_Setpoint_Limit": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Min_Discharge_Air_Temperature_Setpoint_Limit"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Min,

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -503,6 +503,20 @@ sensor_definitions = {
                             [BRICK.measures, BRICK.Exhaust_Air],
                         ],
                     },
+                    "Supply_Air_Dewpoint_Sensor": {
+                        OWL.equivalentClass: BRICK["Discharge_Air_Dewpoint_Sensor"],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Sensor,
+                            TAG.Dewpoint,
+                            TAG.Air,
+                            TAG.Supply,
+                        ],
+                        "substances": [
+                            [BRICK.measures, BRICK.Dewpoint],
+                            [BRICK.measures, BRICK.Supply_Air],
+                        ],
+                    },
                     "Discharge_Air_Dewpoint_Sensor": {
                         "tags": [
                             TAG.Point,
@@ -872,6 +886,9 @@ sensor_definitions = {
                                         "parents": [BRICK.Hot_Water_Flow_Sensor],
                                     },
                                     "Supply_Condenser_Water_Flow_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Condenser_Water_Flow_Sensor"
+                                        ],
                                         "substances": [
                                             [BRICK.measures, BRICK.Flow],
                                             [
@@ -935,6 +952,23 @@ sensor_definitions = {
                                                 BRICK.measures,
                                                 BRICK.Discharge_Hot_Water,
                                             ],
+                                        ],
+                                    },
+                                    "Discharge_Condenser_Water_Flow_Sensor": {
+                                        "substances": [
+                                            [BRICK.measures, BRICK.Flow],
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Discharge_Condenser_Water,
+                                            ],
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Sensor,
+                                            TAG.Flow,
+                                            TAG.Water,
+                                            TAG.Discharge,
+                                            TAG.Condenser,
                                         ],
                                     },
                                 },
@@ -1265,6 +1299,9 @@ sensor_definitions = {
                                         ],
                                     },
                                     "Supply_Air_Differential_Pressure_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Differential_Pressure_Sensor"
+                                        ],
                                         "substances": [
                                             [
                                                 BRICK.measures,
@@ -1275,6 +1312,23 @@ sensor_definitions = {
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Sensor,
+                                            TAG.Pressure,
+                                            TAG.Differential,
+                                        ],
+                                    },
+                                    "Discharge_Air_Differential_Pressure_Sensor": {
+                                        "substances": [
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Differential_Pressure,
+                                            ],
+                                            [BRICK.measures, BRICK.Discharge_Air],
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
                                             TAG.Air,
                                             TAG.Sensor,
                                             TAG.Pressure,
@@ -1969,7 +2023,37 @@ sensor_definitions = {
                                     [BRICK.measures, BRICK.Water],
                                 ],
                             },
+                            "Supply_Water_Temperature_Sensor": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Water_Temperature_Sensor"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Sensor,
+                                    TAG.Temperature,
+                                    TAG.Water,
+                                    TAG.Supply,
+                                ],
+                                "substances": [
+                                    [BRICK.measures, BRICK.Temperature],
+                                    [BRICK.measures, BRICK.Supply_Water],
+                                ],
+                            },
+                            "Heat_Exchanger_Discharge_Water_Temperature_Sensor": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Heat,
+                                    TAG.Exchanger,
+                                    TAG.Discharge,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Sensor,
+                                ],
+                            },
                             "Heat_Exchanger_Supply_Water_Temperature_Sensor": {
+                                OWL.equivalentClass: BRICK[
+                                    "Heat_Exchanger_Discharge_Water_Temperature_Sensor"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Heat,
@@ -1980,7 +2064,61 @@ sensor_definitions = {
                                     TAG.Sensor,
                                 ],
                             },
+                            "Hot_Water_Discharge_Temperature_Sensor": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Sensor,
+                                    TAG.Temperature,
+                                    TAG.Water,
+                                    TAG.Hot,
+                                    TAG.Discharge,
+                                ],
+                                "substances": [
+                                    [BRICK.measures, BRICK.Temperature],
+                                    [BRICK.measures, BRICK.Discharge_Hot_Water],
+                                ],
+                                "subclasses": {
+                                    "Domestic_Hot_Water_Discharge_Temperature_Sensor": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Discharge,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                        ],
+                                    },
+                                    "High_Temperature_Hot_Water_Discharge_Temperature_Sensor": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.High,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Discharge,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                        ],
+                                    },
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_Sensor": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Discharge,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                        ],
+                                    },
+                                },
+                            },
                             "Hot_Water_Supply_Temperature_Sensor": {
+                                OWL.equivalentClass: BRICK[
+                                    "Hot_Water_Discharge_Temperature_Sensor"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Sensor,
@@ -2004,10 +2142,14 @@ sensor_definitions = {
                                             TAG.Sensor,
                                         ],
                                         "parents": [
-                                            BRICK.Water_Differential_Temperature_Sensor
+                                            BRICK.Water_Differential_Temperature_Sensor,
+                                            BRICK.Hot_Water_Discharge_Temperature_Sensor,
                                         ],
                                     },
                                     "Domestic_Hot_Water_Supply_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Domestic_Hot_Water_Discharge_Temperature_Sensor"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Domestic,
@@ -2019,6 +2161,9 @@ sensor_definitions = {
                                         ],
                                     },
                                     "High_Temperature_Hot_Water_Supply_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "High_Temperature_Hot_Water_Discharge_Temperature_Sensor"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.High,
@@ -2031,6 +2176,9 @@ sensor_definitions = {
                                         ],
                                     },
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Medium_Temperature_Hot_Water_Discharge_Temperature_Sensor"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Medium,
@@ -2078,6 +2226,9 @@ sensor_definitions = {
                                         ],
                                     },
                                     "Chilled_Water_Supply_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Chilled_Water_Discharge_Temperature_Sensor"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Sensor,
@@ -2091,6 +2242,23 @@ sensor_definitions = {
                                             [
                                                 BRICK.measures,
                                                 BRICK.Supply_Chilled_Water,
+                                            ],
+                                        ],
+                                    },
+                                    "Chilled_Water_Discharge_Temperature_Sensor": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Sensor,
+                                            TAG.Temperature,
+                                            TAG.Water,
+                                            TAG.Chilled,
+                                            TAG.Discharge,
+                                        ],
+                                        "substances": [
+                                            [BRICK.measures, BRICK.Temperature],
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Discharge_Chilled_Water,
                                             ],
                                         ],
                                     },
@@ -2209,6 +2377,9 @@ sensor_definitions = {
                                         ],
                                     },
                                     "Differential_Supply_Return_Water_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Differential_Discharge_Return_Water_Temperature_Sensor"
+                                        ],
                                         "substances": [
                                             [
                                                 BRICK.measures,
@@ -2232,7 +2403,36 @@ sensor_definitions = {
                                             TAG.Sensor,
                                         ],
                                         "parents": [
-                                            BRICK.Water_Differential_Temperature_Sensor
+                                            BRICK.Water_Differential_Temperature_Sensor,
+                                            BRICK.Supply_Water_Temperature_Sensor,
+                                        ],
+                                    },
+                                    "Differential_Discharge_Return_Water_Temperature_Sensor": {
+                                        "substances": [
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Differential_Temperature,
+                                            ],
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Discharge_Water,
+                                            ],
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Return_Water,
+                                            ],
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Differential,
+                                            TAG.Discharge,
+                                            TAG.Return,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                        ],
+                                        "parents": [
+                                            BRICK.Water_Differential_Temperature_Sensor,
+                                            BRICK.Discharge_Water_Temperature_Sensor,
                                         ],
                                     },
                                 },
@@ -2265,6 +2465,9 @@ sensor_definitions = {
                                 ],
                                 "subclasses": {
                                     "Supply_Condenser_Water_Temperature_Sensor": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Condenser_Water_Temperature_Sensor"
+                                        ],
                                         "substances": [
                                             [BRICK.measures, BRICK.Temperature],
                                             [
@@ -2274,6 +2477,23 @@ sensor_definitions = {
                                         ],
                                         "tags": [
                                             TAG.Supply,
+                                            TAG.Condenser,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                            TAG.Point,
+                                        ],
+                                    },
+                                    "Discharge_Condenser_Water_Temperature_Sensor": {
+                                        "substances": [
+                                            [BRICK.measures, BRICK.Temperature],
+                                            [
+                                                BRICK.measures,
+                                                BRICK.Discharge_Condenser_Water,
+                                            ],
+                                        ],
+                                        "tags": [
+                                            TAG.Discharge,
                                             TAG.Condenser,
                                             TAG.Water,
                                             TAG.Temperature,

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -167,6 +167,28 @@ setpoint_definitions = {
                                 ],
                                 "parents": [BRICK.Heating_Temperature_Setpoint],
                             },
+                            "Unoccupied_Cooling_Temperature_Deadband_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Unoccupied,
+                                    TAG.Cool,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                                "parents": [BRICK.Cooling_Temperature_Setpoint],
+                            },
+                            "Unoccupied_Heating_Temperature_Deadband_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Unoccupied,
+                                    TAG.Heat,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                                "parents": [BRICK.Heating_Temperature_Setpoint],
+                            },
                             "Discharge_Air_Temperature_Deadband_Setpoint": {
                                 "subclasses": {
                                     "Heating_Discharge_Air_Temperature_Deadband_Setpoint": {
@@ -368,39 +390,6 @@ setpoint_definitions = {
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Cooling_Discharge_Air_Flow_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Cool,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Cool,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Heating_Discharge_Air_Flow_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Heat,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
                                     "Occupied_Discharge_Air_Flow_Setpoint": {
                                         "subclasses": {
                                             "Occupied_Cooling_Discharge_Air_Flow_Setpoint": {
@@ -435,6 +424,66 @@ setpoint_definitions = {
                                         "tags": [
                                             TAG.Point,
                                             TAG.Occupied,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Unoccupied_Discharge_Air_Flow_Setpoint": {
+                                        "subclasses": {
+                                            "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint
+                                                ],
+                                            },
+                                            "Unoccupied_Heating_Discharge_Air_Flow_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint
+                                                ],
+                                            },
+                                        },
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Cooling_Discharge_Air_Flow_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Cool,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Heating_Discharge_Air_Flow_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Heat,
                                             TAG.Discharge,
                                             TAG.Air,
                                             TAG.Flow,
@@ -541,6 +590,55 @@ setpoint_definitions = {
                                         "tags": [
                                             TAG.Point,
                                             TAG.Occupied,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Unoccupied_Supply_Air_Flow_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Unoccupied_Discharge_Air_Flow_Setpoint"
+                                        ],
+                                        "subclasses": {
+                                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                OWL.equivalentClass: BRICK[
+                                                    "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint"
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint
+                                                ],
+                                            },
+                                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                OWL.equivalentClass: BRICK[
+                                                    "Unoccupied_Heating_Discharge_Air_Flow_Setpoint"
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Supply_Air_Flow_Setpoint
+                                                ],
+                                            },
+                                        },
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
                                             TAG.Supply,
                                             TAG.Air,
                                             TAG.Flow,
@@ -798,6 +896,7 @@ setpoint_definitions = {
                         ],
                     },
                     "Supply_Air_Humidity_Setpoint": {
+                        OWL.equivalentClass: BRICK["Discharge_Air_Humidity_Setpoint"],
                         "tags": [
                             TAG.Point,
                             TAG.Humidity,
@@ -1192,6 +1291,9 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Medium,
@@ -1281,6 +1383,9 @@ setpoint_definitions = {
                                 ],
                                 "subclasses": {
                                     "Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Medium,
@@ -1484,6 +1589,30 @@ setpoint_definitions = {
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
+                                "subclasses": {
+                                    "Occupied_Air_Temperature_Cooling_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Cool,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "parents": [BRICK.Cooling_Temperature_Setpoint],
+                                    },
+                                    "Occupied_Air_Temperature_Heating_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Heat,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "parents": [BRICK.Heating_Temperature_Setpoint],
+                                    },
+                                },
                             },
                             "Return_Air_Temperature_Setpoint": {
                                 "tags": [
@@ -1771,6 +1900,9 @@ setpoint_definitions = {
                                 },
                             },
                             "Supply_Air_Temperature_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Temperature_Setpoint"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Supply,
@@ -1780,6 +1912,9 @@ setpoint_definitions = {
                                 ],
                                 "subclasses": {
                                     "Effective_Supply_Air_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Effective_Discharge_Air_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -1794,6 +1929,9 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Occupied_Supply_Air_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Occupied_Discharge_Air_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -1808,6 +1946,9 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Unoccupied_Supply_Air_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Unoccupied_Discharge_Air_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -1847,17 +1988,29 @@ setpoint_definitions = {
                         "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Cool],
                         "subclasses": {
                             "Occupied_Cooling_Temperature_Setpoint": {
-                                "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Cool, TAG.Occupied],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Cool,
+                                    TAG.Occupied,
+                                ],
                             }
-                        }
+                        },
                     },
                     "Heating_Temperature_Setpoint": {
                         "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Heat],
                         "subclasses": {
                             "Occupied_Heating_Temperature_Setpoint": {
-                                "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Heat, TAG.Occupied],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Heat,
+                                    TAG.Occupied,
+                                ],
                             }
-                        }
+                        },
                     },
                     "Schedule_Temperature_Setpoint": {
                         "tags": [
@@ -2019,6 +2172,9 @@ setpoint_definitions = {
                                 ],
                             },
                             "Supply_Water_Temperature_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Water_Temperature_Setpoint"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Supply,

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -277,9 +277,23 @@ setpoint_definitions = {
                                 "parents": [BRICK.Air_Temperature_Setpoint],
                             },
                             "Supply_Water_Temperature_Deadband_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Water_Temperature_Deadband_Setpoint"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Supply,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                                "parents": [BRICK.Supply_Water_Temperature_Setpoint],
+                            },
+                            "Discharge_Water_Temperature_Deadband_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Discharge,
                                     TAG.Water,
                                     TAG.Temperature,
                                     TAG.Deadband,
@@ -927,6 +941,23 @@ setpoint_definitions = {
                                 ],
                             },
                             "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_Load_Shed_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Supply,
+                                    TAG.Pressure,
+                                    TAG.Shed,
+                                    TAG.Load,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Medium_Temperature_Hot_Water_Discharge_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Medium,
@@ -941,7 +972,7 @@ setpoint_definitions = {
                                 ],
                             },
                         },
-                    }
+                    },
                 },
                 "tags": [TAG.Point, TAG.Load, TAG.Setpoint],
             },
@@ -980,9 +1011,22 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Supply_Air_Differential_Pressure_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Differential_Pressure_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
+                                        ],
+                                    },
+                                    "Discharge_Air_Differential_Pressure_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
                                             TAG.Air,
                                             TAG.Setpoint,
                                             TAG.Pressure,
@@ -1159,6 +1203,47 @@ setpoint_definitions = {
             "Reset_Setpoint": {
                 "tags": [TAG.Point, TAG.Reset, TAG.Setpoint],
                 "subclasses": {
+                    "Supply_Air_Flow_Reset_Setpoint": {
+                        OWL.equivalentClass: BRICK["Discharge_Air_Flow_Reset_Setpoint"],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Supply_Air_Flow_High_Reset_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Flow_High_Reset_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.High,
+                                ],
+                            },
+                            "Supply_Air_Flow_Low_Reset_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Flow_Low_Reset_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.Low,
+                                ],
+                            },
+                        },
+                    },
                     "Discharge_Air_Flow_Reset_Setpoint": {
                         "tags": [
                             TAG.Point,
@@ -1265,6 +1350,40 @@ setpoint_definitions = {
                         ],
                         "subclasses": {
                             "Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Hot_Water_Discharge_Temperature_High_Reset_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Supply,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint"
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Supply,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Hot_Water_Discharge_Temperature_High_Reset_Setpoint": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Hot,
@@ -1284,23 +1403,6 @@ setpoint_definitions = {
                                             TAG.Hot,
                                             TAG.Water,
                                             TAG.Discharge,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint": {
-                                        OWL.equivalentClass: BRICK[
-                                            "Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint"
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Supply,
                                             TAG.Temperature,
                                             TAG.High,
                                             TAG.Reset,
@@ -1371,6 +1473,9 @@ setpoint_definitions = {
                                 ],
                             },
                             "Hot_Water_Supply_Temperature_Low_Reset_Setpoint": {
+                                OWL.equivalentClass: BRICK[
+                                    "Hot_Water_Discharge_Temperature_Low_Reset_Setpoint"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Hot,
@@ -1399,6 +1504,20 @@ setpoint_definitions = {
                                             TAG.Setpoint,
                                         ],
                                     },
+                                },
+                            },
+                            "Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Discharge,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
                                     "Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint": {
                                         "tags": [
                                             TAG.Point,
@@ -1962,6 +2081,34 @@ setpoint_definitions = {
                                             BRICK.Unoccupied_Air_Temperature_Setpoint
                                         ],
                                     },
+                                    "Supply_Air_Temperature_Heating_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Temperature_Heating_Setpoint"
+                                        ],
+                                        "parents": [BRICK.Heating_Temperature_Setpoint],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_Cooling_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Air_Temperature_Cooling_Setpoint"
+                                        ],
+                                        "parents": [BRICK.Cooling_Temperature_Setpoint],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Cool,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
                                 },
                             },
                             "Min_Air_Temperature_Setpoint": {
@@ -1995,7 +2142,16 @@ setpoint_definitions = {
                                     TAG.Cool,
                                     TAG.Occupied,
                                 ],
-                            }
+                            },
+                            "Unoccupied_Cooling_Temperature_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Cool,
+                                    TAG.Unoccupied,
+                                ],
+                            },
                         },
                     },
                     "Heating_Temperature_Setpoint": {
@@ -2009,7 +2165,16 @@ setpoint_definitions = {
                                     TAG.Heat,
                                     TAG.Occupied,
                                 ],
-                            }
+                            },
+                            "Unoccupied_Heating_Temperature_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Heat,
+                                    TAG.Unoccupied,
+                                ],
+                            },
                         },
                     },
                     "Schedule_Temperature_Setpoint": {
@@ -2083,6 +2248,9 @@ setpoint_definitions = {
                                 "parents": [BRICK.Hot_Water_Temperature_Setpoint],
                                 "subclasses": {
                                     "Domestic_Hot_Water_Supply_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Domestic_Hot_Water_Discharge_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Domestic,
@@ -2095,7 +2263,21 @@ setpoint_definitions = {
                                         "parents": [
                                             BRICK.Supply_Water_Temperature_Setpoint
                                         ],
-                                    }
+                                    },
+                                    "Domestic_Hot_Water_Discharge_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Discharge,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Discharge_Water_Temperature_Setpoint
+                                        ],
+                                    },
                                 },
                             },
                             "Water_Differential_Temperature_Setpoint": {
@@ -2170,6 +2352,44 @@ setpoint_definitions = {
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
+                                "subclasses": {
+                                    "Discharge_Hot_Water_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Hot,
+                                        ],
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint
+                                        ],
+                                    },
+                                    "Discharge_Chilled_Water_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Chilled,
+                                        ],
+                                        "parents": [
+                                            BRICK.Chilled_Water_Temperature_Setpoint
+                                        ],
+                                    },
+                                    "Discharge_Condenser_Water_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Condenser,
+                                        ],
+                                    },
+                                },
                             },
                             "Supply_Water_Temperature_Setpoint": {
                                 OWL.equivalentClass: BRICK[
@@ -2184,6 +2404,9 @@ setpoint_definitions = {
                                 ],
                                 "subclasses": {
                                     "Supply_Hot_Water_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Hot_Water_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -2197,6 +2420,9 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Supply_Chilled_Water_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Chilled_Water_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -2210,6 +2436,9 @@ setpoint_definitions = {
                                         ],
                                     },
                                     "Supply_Condenser_Water_Temperature_Setpoint": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Condenser_Water_Temperature_Setpoint"
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
@@ -2227,6 +2456,9 @@ setpoint_definitions = {
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                             TAG.Condenser,
+                                        ],
+                                        "parents": [
+                                            BRICK.Discharge_Water_Temperature_Setpoint
                                         ],
                                     },
                                 },

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -79,6 +79,9 @@ status_definitions = {
                         ],
                     },
                     "Hot_Water_Supply_Temperature_Load_Shed_Status": {
+                        OWL.equivalentClass: BRICK[
+                            "Hot_Water_Discharge_Temperature_Load_Shed_Status"
+                        ],
                         "tags": [
                             TAG.Point,
                             TAG.Hot,
@@ -216,6 +219,9 @@ status_definitions = {
                 "subclasses": {
                     "Occupied_Mode_Status": {
                         "tags": [TAG.Point, TAG.Occupied, TAG.Mode, TAG.Status],
+                    },
+                    "Unoccupied_Mode_Status": {
+                        "tags": [TAG.Point, TAG.Unoccupied, TAG.Mode, TAG.Status],
                     },
                     "Operating_Mode_Status": {
                         "subclasses": {

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -77,6 +77,22 @@ status_definitions = {
                             TAG.Shed,
                             TAG.Status,
                         ],
+                        "subclasses": {
+                            "Medium_Temperature_Hot_Water_Discharge_Temperature_Load_Shed_Status": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Discharge,
+                                    TAG.Temperature,
+                                    TAG.Load,
+                                    TAG.Shed,
+                                    TAG.Status,
+                                ],
+                            },
+                        },
                     },
                     "Hot_Water_Supply_Temperature_Load_Shed_Status": {
                         OWL.equivalentClass: BRICK[
@@ -94,6 +110,9 @@ status_definitions = {
                         ],
                         "subclasses": {
                             "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status": {
+                                OWL.equivalentClass: BRICK[
+                                    "Medium_Temperature_Hot_Water_Discharge_Temperature_Load_Shed_Status"
+                                ],
                                 "tags": [
                                     TAG.Point,
                                     TAG.Medium,

--- a/bricksrc/substances.py
+++ b/bricksrc/substances.py
@@ -129,12 +129,24 @@ substances = {
                                 ],
                                 "subclasses": {
                                     "Supply_Condenser_Water": {
+                                        OWL.equivalentClass: BRICK[
+                                            "Discharge_Condenser_Water"
+                                        ],
                                         "tags": [
                                             TAG.Fluid,
                                             TAG.Liquid,
                                             TAG.Water,
                                             TAG.Condenser,
                                             TAG.Supply,
+                                        ],
+                                    },
+                                    "Discharge_Condenser_Water": {
+                                        "tags": [
+                                            TAG.Fluid,
+                                            TAG.Liquid,
+                                            TAG.Water,
+                                            TAG.Condenser,
+                                            TAG.Discharge,
                                         ],
                                     },
                                     "Return_Condenser_Water": {

--- a/tests/test_matching_classes.py
+++ b/tests/test_matching_classes.py
@@ -1,0 +1,216 @@
+import pytest
+import rdflib
+from rdflib.namespace import OWL, RDF, RDFS
+from rdflib import Graph, URIRef
+import json
+import brickschema
+import sys
+
+sys.path.append("..")
+
+from bricksrc.version import BRICK_VERSION  # noqa: E402
+from bricksrc.namespaces import BRICK  # noqa: E402
+
+
+def getDict(g, q):
+    dict = {}
+
+    res = g.query(q)
+
+    for row in res:
+        c1 = row.c.toPython().replace("https://brickschema.org/schema/Brick#", "")
+        if row.p:
+            c2 = row.p.toPython().replace("https://brickschema.org/schema/Brick#", "")
+            if c1 in dict:
+                dict[c1].append(c2)
+            else:
+                dict[c1] = [c2]
+
+    return dict
+
+
+def matchMinMax(d):
+    ds = {}
+    ds["MissingMatchingMin"] = []
+    ds["MissingMatchingMax"] = []
+    ds["AllGood"] = []
+    dislist = []
+    countmatch = 0
+    countobutnotu = 0
+    countubutnoto = 0
+    for c in d:
+        if "Min" in c:
+            s = c.replace("Min", "Max")
+            if s in d:
+                # print('debug:',s,e[s])
+                ds["AllGood"].append((s, c))
+                countmatch += 1
+                dislist.append(c)
+            else:
+                ds["MissingMatchingMax"].append(c)
+                dislist.append(c)
+                countobutnotu += 1
+    for c in d:
+        if "Max" in c:
+            dis = c.replace("Max", "Min")
+            if dis in dislist:
+                pass
+            else:
+                ds["MissingMatchingMin"].append(c)
+                countubutnoto += 1
+    # print(json.dumps(ds,indent=4),file=open('tests/mm.json','w'))
+    assert not ds[
+        "MissingMatchingMin"
+    ], "There are {0} classes that have Max but not Min".format(
+        len(ds["MissingMatchingMin"])
+    )
+    assert not ds[
+        "MissingMatchingMax"
+    ], "There are {0} classes that have Min but not Max".format(
+        len(ds["MissingMatchingMax"])
+    )
+
+
+def matchOccupiedUnoccupied(d):
+    ds = {}
+    ds["MissingMatchingOccupied"] = []
+    ds["MissingMatchingUnoccupied"] = []
+    ds["AllGood"] = []
+    dislist = []
+    countmatch = 0
+    countobutnotu = 0
+    countubutnoto = 0
+    for c in d:
+        if "Occupied" in c:
+            s = c.replace("Occupied", "Unoccupied")
+            if s in d:
+                # print('debug:',s,e[s])
+                ds["AllGood"].append((s, c))
+                countmatch += 1
+                dislist.append(c)
+            else:
+                ds["MissingMatchingUnoccupied"].append(c)
+                dislist.append(c)
+                countobutnotu += 1
+    for c in d:
+        if "Unoccupied" in c:
+            dis = c.replace("Unoccupied", "Occupied")
+            if dis in dislist:
+                pass
+            else:
+                ds["MissingMatchingOccupied"].append(c)
+                countubutnoto += 1
+
+    # print(json.dumps(ds,indent=4),file=open('tests/uo.json','w'))
+    assert not ds[
+        "MissingMatchingOccupied"
+    ], "There are {0} classes that have Unoccupied but not Occupied".format(
+        len(ds["MissingMatchingOccupied"])
+    )
+    assert not ds[
+        "MissingMatchingUnoccupied"
+    ], "There are {0} classes that have Occupied but not Unoccupied".format(
+        len(ds["MissingMatchingUnoccupied"])
+    )
+
+
+def matchSupplyDischarge(d, e):
+    ds = {}
+    ds["MissingMatchingDischarge"] = []
+    ds["MissingMatchingSupply"] = []
+    ds["NoEquivalenceDefined"] = {}
+    ds["AllGood"] = {}
+    dislist = []
+    countmatch = 0
+    countdbutnots = 0
+    countsbutnotd = 0
+    for c in d:
+        if "Discharge" in c:
+            s = c.replace("Discharge", "Supply")
+            if s in d:
+                if s in e:
+                    # print('debug:',s,e[s])
+                    if c in e[s]:
+                        pass
+                    else:
+                        print("*ERROR* ", s, e[s])
+                    ds["AllGood"][c] = s
+                elif c in e:
+                    if s in e[c]:
+                        pass
+                    else:
+                        print("*ERROR* ", c, e[c])
+                    ds["AllGood"][c] = s
+                else:
+                    ds["NoEquivalenceDefined"][c] = s
+                countmatch += 1
+                dislist.append(c)
+            else:
+                ds["MissingMatchingSupply"].append(c)
+                dislist.append(c)
+                countdbutnots += 1
+    for c in d:
+        if "Supply" in c:
+            dis = c.replace("Supply", "Discharge")
+            if dis in dislist:
+                pass
+            else:
+                ds["MissingMatchingDischarge"].append(c)
+                countsbutnotd += 1
+
+    # print(json.dumps(ds,indent=4),file=open('tests/ds.json','w'))
+    assert not ds[
+        "MissingMatchingSupply"
+    ], "There are {0} classes that have Discharge but not Supply".format(
+        len(ds["MissingMatchingSupply"])
+    )
+    assert not ds[
+        "MissingMatchingDischarge"
+    ], "There are {0} classes that have Supply but not Discharge".format(
+        len(ds["MissingMatchingDischarge"])
+    )
+    assert not ds[
+        "NoEquivalenceDefined"
+    ], "There are {0} classes that don't have Supply = Discharge defined".format(
+        len(ds["NoEquivalenceDefined"])
+    )
+
+
+# maincode
+def test_matching_classes():
+    g = Graph()
+
+    g.parse("Brick.ttl", format="turtle")
+    # DeductiveClosure(OWLRL_Semantics).expand(g)
+
+    d = getDict(
+        g,
+        """
+       SELECT DISTINCT ?c ?p
+       WHERE {
+           ?c rdfs:subClassOf* brick:Class .
+           ?c rdfs:subClassOf ?p .
+           ?p rdfs:subClassOf* brick:Class .
+       }
+       """,
+    )
+
+    print("verifying min max classes...")
+    matchMinMax(d)
+    print("verifying occupied unoccupied classes...")
+    matchOccupiedUnoccupied(d)
+
+    deq = getDict(
+        g,
+        """
+       SELECT DISTINCT ?c ?p
+       WHERE {
+           ?c rdfs:subClassOf* brick:Class .
+           OPTIONAL {
+           ?c owl:equivalentClass ?p .
+           }
+       }
+       """,
+    )
+    print("verifying supply discharge classes...")
+    matchSupplyDischarge(d, deq)

--- a/tests/test_matching_classes.py
+++ b/tests/test_matching_classes.py
@@ -5,6 +5,7 @@ from rdflib import Graph, URIRef
 import json
 import brickschema
 import sys
+from collections import defaultdict
 
 sys.path.append("..")
 
@@ -13,7 +14,8 @@ from bricksrc.namespaces import BRICK  # noqa: E402
 
 
 def getDict(g, q):
-    dict = {}
+
+    d = defaultdict(list)
 
     res = g.query(q)
 
@@ -21,12 +23,9 @@ def getDict(g, q):
         c1 = row.c.toPython().replace("https://brickschema.org/schema/Brick#", "")
         if row.p:
             c2 = row.p.toPython().replace("https://brickschema.org/schema/Brick#", "")
-            if c1 in dict:
-                dict[c1].append(c2)
-            else:
-                dict[c1] = [c2]
+            d[c1].append(c2)
 
-    return dict
+    return d
 
 
 def matchMinMax(d):


### PR DESCRIPTION
The changes here remove inconsistencies between Point subclasses.

All min_ classes are matched with max_ classes
All supply_ classes are matched with discharge_ classes and declared equivalent
All occupied_ classes are matched with unoccupied_ classes

A new test is introduced for verifying the matches in future updates