### PR TITLE
adjust the hierarchy for differential setpoints

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -124,7 +124,6 @@ https://brickschema.org/schema/Brick#Chilled_Water_Flow_Setpoint,Sets the target
 https://brickschema.org/schema/Brick#Chilled_Water_Loop,A collection of equipment that transport and regulate chilled water among each other,
 https://brickschema.org/schema/Brick#Chilled_Water_Meter,A meter that measures the usage or consumption of chilled water,
 https://brickschema.org/schema/Brick#Chilled_Water_Pump,A pump that performs work on chilled water; typically part of a chilled water system,
-https://brickschema.org/schema/Brick#Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint,Sets the size of a deadband of differential pressure of chilled water in a chilled water pump,
 https://brickschema.org/schema/Brick#Chilled_Water_Return_Flow_Sensor,Measures the rate of flow of chilled return water,
 https://brickschema.org/schema/Brick#Chilled_Water_Return_Temperature_Sensor,Measures the temperature of chilled water that is returned to a cooling tower,
 https://brickschema.org/schema/Brick#Chilled_Water_Static_Pressure_Setpoint,Sets static pressure of chilled water,

--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -876,6 +876,8 @@ https://brickschema.org/schema/Brick#Sensor,A Sensor is an input point that repr
 https://brickschema.org/schema/Brick#Server_Room,,
 https://brickschema.org/schema/Brick#Service_Room,"A class of spaces related to the operations of building subsystems, e.g. HVAC, electrical, IT, plumbing, etc",
 https://brickschema.org/schema/Brick#Setpoint,A Setpoint is an input value at which the desired property is set,https://xp20.ashrae.org/terminology/index.php?term=setpoint
+https://brickschema.org/schema/Brick#Differential_Setpoint,A type of Setpoints that is related to the difference between two measurements,https://xp20.ashrae.org/terminology/index.php?term=setpoint
+https://brickschema.org/schema/Brick#Differential_Temperature_Setpoint,A type of Setpoints that is related to the difference between two temperature measurements,https://xp20.ashrae.org/terminology/index.php?term=setpoint
 https://brickschema.org/schema/Brick#Shade,A screen on a window.,
 https://brickschema.org/schema/Brick#Shade_Array,An array of Shade commonly attached to a single controller.,
 https://brickschema.org/schema/Brick#Shading_System,Devices that can control daylighting through various means,

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -78,94 +78,6 @@ setpoint_definitions = {
             "Deadband_Setpoint": {
                 "tags": [TAG.Point, TAG.Deadband, TAG.Setpoint],
                 "subclasses": {
-                    "Differential_Pressure_Deadband_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Differential,
-                            TAG.Pressure,
-                            TAG.Deadband,
-                            TAG.Setpoint,
-                        ],
-                        "parents": [BRICK.Differential_Pressure_Setpoint],
-                        "subclasses": {
-                            "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [
-                                    BRICK.Hot_Water_Differential_Pressure_Setpoint
-                                ],
-                            },
-                            "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Chilled,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [
-                                    BRICK.Chilled_Water_Differential_Pressure_Setpoint
-                                ],
-                                "subclasses": {
-                                    "Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Pump,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Deadband,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Discharge_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Discharge,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Supply_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                OWL.equivalentClass: BRICK[
-                                    "Discharge_Water_Differential_Pressure_Deadband_Setpoint"
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
                     "Temperature_Deadband_Setpoint": {
                         BRICK.hasQuantity: BRICK.Temperature,
                         "subclasses": {
@@ -902,20 +814,6 @@ setpoint_definitions = {
                     "Load_Shed_Setpoint": {
                         "tags": [TAG.Point, TAG.Shed, TAG.Load, TAG.Setpoint],
                         "subclasses": {
-                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
                             "Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
                                     TAG.Point,
@@ -942,145 +840,6 @@ setpoint_definitions = {
             "Pressure_Setpoint": {
                 BRICK.hasQuantity: BRICK.Pressure,
                 "subclasses": {
-                    "Differential_Pressure_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                        "subclasses": {
-                            "Air_Differential_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Air,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Air,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Exhaust_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Exhaust,
-                                            TAG.Air,
-                                            TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
-                                        ],
-                                    },
-                                    "Return_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
-                                        ],
-                                    },
-                                    "Supply_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Air,
-                                            TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Water_Differential_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Chilled_Water_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Chilled_Water,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Hot_Water_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Hot_Water,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                            "Load_Shed_Differential_Pressure_Setpoint": {
-                                "parents": [BRICK.Load_Shed_Setpoint],
-                                "subclasses": {
-                                    "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Load,
-                                            TAG.Shed,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Chilled_Water_Differential_Pressure_Setpoint
-                                        ],
-                                    },
-                                },
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Load,
-                                    TAG.Shed,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                        "tags": [
-                            TAG.Point,
-                            TAG.Differential,
-                            TAG.Pressure,
-                            TAG.Setpoint,
-                        ],
-                    },
                     "Static_Pressure_Setpoint": {
                         BRICK.hasQuantity: BRICK.Static_Pressure,
                         "subclasses": {
@@ -1213,71 +972,6 @@ setpoint_definitions = {
                                     TAG.Reset,
                                     TAG.Setpoint,
                                     TAG.Low,
-                                ],
-                            },
-                        },
-                    },
-                    "Temperature_Differential_Reset_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Temperature,
-                            TAG.Differential,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Discharge_Air_Temperature_Reset_Differential_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Discharge_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Discharge_Air_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.High,
-                                        ],
-                                    },
-                                    "Discharge_Air_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.Low,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Supply_Air_Temperature_Reset_Differential_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Supply_Air,
-                                OWL.equivalentClass: BRICK[
-                                    "Discharge_Air_Temperature_Reset_Differential_Setpoint"
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
                                 ],
                             },
                         },
@@ -1487,9 +1181,6 @@ setpoint_definitions = {
                     "Rated_Speed_Setpoint": {
                         "tags": [TAG.Point, TAG.Rated, TAG.Speed, TAG.Setpoint],
                     },
-                    "Differential_Speed_Setpoint": {
-                        "tags": [TAG.Point, TAG.Differential, TAG.Speed, TAG.Setpoint],
-                    },
                 },
             },
             "Temperature_Setpoint": {
@@ -1501,17 +1192,6 @@ setpoint_definitions = {
                         BRICK.hasSubstance: BRICK.Air,
                         "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Setpoint],
                         "subclasses": {
-                            "Differential_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                BRICK.hasSubstance: BRICK.Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Differential,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
                             "Discharge_Air_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 BRICK.hasSubstance: BRICK.Discharge_Air,
@@ -2131,17 +1811,6 @@ setpoint_definitions = {
                                     }
                                 },
                             },
-                            "Water_Differential_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                BRICK.hasSubstance: BRICK.Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
                             "Chilled_Water_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 BRICK.hasSubstance: BRICK.Chilled_Water,
@@ -2355,6 +2024,325 @@ setpoint_definitions = {
                     },
                 },
             },
+            "Differential_Setpoint":{
+                "tags": [TAG.Point, TAG.Differential, TAG.Setpoint],
+                "subclasses": {
+                    "Differential_Temperature_Setpoint": {
+                        "subclasses": {
+                            "Water_Differential_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                BRICK.hasSubstance: BRICK.Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Differential_Air_Temperature_Setpoint": { #TODO: The name of this should be aligned with Water_Differential_Temperature_Setpoint.
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                BRICK.hasSubstance: BRICK.Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Differential,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        }
+                    },
+                    "Differential_Speed_Setpoint": {
+                        "tags": [TAG.Point, TAG.Differential, TAG.Speed, TAG.Setpoint],
+                    },
+                    "Temperature_Differential_Reset_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Reset,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Discharge_Air_Temperature_Reset_Differential_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Discharge_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Discharge_Air_Temperature_High_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.High,
+                                        ],
+                                    },
+                                    "Discharge_Air_Temperature_Low_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.Low,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Supply_Air_Temperature_Reset_Differential_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Air_Temperature_Reset_Differential_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                    },
+                    "Differential_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "subclasses": {
+                            "Air_Differential_Pressure_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Air,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Air,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Exhaust_Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Exhaust,
+                                            TAG.Air,
+                                            TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
+                                        ],
+                                    },
+                                    "Return_Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
+                                        ],
+                                    },
+                                    "Supply_Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Air,
+                                            TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Water_Differential_Pressure_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Water,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Chilled_Water_Differential_Pressure_Setpoint": {
+                                        BRICK.hasSubstance: BRICK.Chilled_Water,
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Differential,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Hot_Water_Differential_Pressure_Setpoint": {
+                                        BRICK.hasSubstance: BRICK.Hot_Water,
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Differential,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Differential,
+                                                    TAG.Pressure,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            "Load_Shed_Differential_Pressure_Setpoint": {
+                                "parents": [BRICK.Load_Shed_Setpoint],
+                                "subclasses": {
+                                    "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Differential,
+                                            TAG.Pressure,
+                                            TAG.Load,
+                                            TAG.Shed,
+                                            TAG.Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Chilled_Water_Differential_Pressure_Setpoint
+                                        ],
+                                    },
+                                },
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Load,
+                                    TAG.Shed,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                        "tags": [
+                            TAG.Point,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Differential_Pressure_Deadband_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Deadband,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Hot_Water,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Chilled_Water,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Chilled,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Discharge_Water_Differential_Pressure_Deadband_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Discharge_Water,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Discharge,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Supply_Water_Differential_Pressure_Deadband_Setpoint": {
+                                BRICK.hasSubstance: BRICK.Supply_Water,
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                OWL.equivalentClass: BRICK[
+                                    "Discharge_Water_Differential_Pressure_Deadband_Setpoint"
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Deadband,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                    },
+                }
+            }
         },
     }
 }


### PR DESCRIPTION
Addressing https://github.com/BrickSchema/Brick/issues/330

- Added `Differential_Setpoint` for grouping all the difference related setpoints. Not super necessary, I figured it's useful to group detailed setpoints this way. Open to removing it.
- Introduced Differential_Temperature_Setpoint for grouping Water_Differential_Temperature_Setpoint and Differential_Air_Temperature_Setpoint.
  - Those two are another example of inconsistent naming but I left them as they are for now as I'm unsure if we can introduce breaking changes in the upcoming release. I do love to modify this sooner than later.
- Removed `Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint` as it's against our base principle on not having detailed equipment flavored points