### PR TITLE
Add Ammonia sensor to brick ontology

### DIFF
--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -36,6 +36,17 @@ Each is a qudt:QuantityKind
 quantity_definitions = {
     "Air_Quality": {
         SKOS.narrower: {
+            "Ammonia_Concentration": {
+                QUDT.applicableUnit: [UNIT.PPM, UNIT.PPB],
+                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],
+                SKOS.definition: Literal(
+                    "The concentration of Ammonia in a medium"
+                ),
+                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+                RDFS.label: Literal("AmmoniaConcentration"),
+                SKOS.broader: QUDTQK.DimensionlessRatio,
+
+            },
             "CO_Concentration": {
                 QUDT.applicableUnit: [UNIT.PPM, UNIT.PPB],
                 QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H0T0D1"],

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -330,13 +330,13 @@ sensor_definitions = {
                 "subclasses": {
                     "Ammonia_Sensor": {
                         "tags": [
-                            TAG.Outside,
+                            
                             TAG.Air,
                             TAG.Sensor,
                         ],
                     },
                 },
-                "tags": [TAG.Outside, TAG.Air, TAG.Sensor],
+                "tags": [ TAG.Air, TAG.Sensor],
             },
             "Angle_Sensor": {
                 "substances": [[BRICK.measures, BRICK.Angle]],

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -19,6 +19,13 @@ sensor_definitions = {
             "Air_Quality_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Air, TAG.Quality],
                 "subclasses": {
+                    "Ammonia_Sensor": {
+                        "tags": [TAG.Point, TAG.Ammonia, TAG.Sensor],
+                        "substances": [
+                            [BRICK.measures, BRICK.Air],
+                            [BRICK.measures, BRICK.Ammonia_Concentration],
+                        ],
+                    },
                     "CO_Sensor": {
                         "tags": [TAG.Point, TAG.Sensor, TAG.CO],
                         "substances": [
@@ -325,19 +332,7 @@ sensor_definitions = {
                     },
                 },
             },
-            "NH3_Sensor": {
-                "substances": [[BRICK.measures, BRICK.Air]],
-                "subclasses": {
-                    "Ammonia_Sensor": {
-                        "tags": [
-                            
-                            TAG.Air,
-                            TAG.Sensor,
-                        ],
-                    },
-                },
-                "tags": [ TAG.Air, TAG.Sensor],
-            },
+            
             "Angle_Sensor": {
                 "substances": [[BRICK.measures, BRICK.Angle]],
                 "subclasses": {


### PR DESCRIPTION
As discussed with team, we have added ammonia sensor in the sensor.py files and have generated the generate_brick.py file. Please let us know if the changes can be accepted.