### PR TITLE
open() calls explicitly set UTF-8 encoding

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -894,7 +894,7 @@ extension_graphs = {"shacl_tag_inference": shaclGraph}
 
 # serialize extensions to output
 for name, graph in extension_graphs.items():
-    with open(f"extensions/brick_extension_{name}.ttl", "w") as fp:
+    with open(f"extensions/brick_extension_{name}.ttl", "w", encoding="utf-8") as fp:
         # need to write this manually; turtle serializer doesn't always add
         fp.write("@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n")
         fp.write(graph.serialize(format="turtle").rstrip())
@@ -911,13 +911,13 @@ if not valid:
 
 
 # serialize Brick to output
-with open("Brick.ttl", "w") as fp:
+with open("Brick.ttl", "w", encoding="utf-8") as fp:
     fp.write(G.serialize(format="turtle").rstrip())
     fp.write("\n")
 
 # serialize Brick + extensions
 for graph in extension_graphs.values():
     G += graph
-with open("Brick+extensions.ttl", "w") as fp:
+with open("Brick+extensions.ttl", "w", encoding="utf-8") as fp:
     fp.write(G.serialize(format="turtle").rstrip())
     fp.write("\n")


### PR DESCRIPTION
This allows Brick to build properly on Windows machines where the default open() encoding returned by locale.getpreferredencoding is something other than UTF-8