### PR TITLE
Fix sh:or/sh:property

### DIFF
--- a/shacl/BrickEntityShapeBase.ttl
+++ b/shacl/BrickEntityShapeBase.ttl
@@ -52,40 +52,28 @@ brick:Equipment a sh:NodeShape ;
         sh:class brick:Equipment;
         sh:message "A piece of Equipment's parts should be always other Equipment."
     ];
-    sh:or (
-        sh:property [
-            sh:path brick:isPartOf;
-            sh:class brick:System;
-            sh:message "Equipment can be part of a Collection, System or other Equipment"
-        ]
-        sh:property [
-            sh:path brick:isPartOf;
-            sh:class brick:Equipment;
-            sh:message "Equipment can be part of a Collection, System or other Equipment"
-        ]
-        sh:property [
-            sh:path brick:isPartOf;
-            sh:class brick:Collection;
-            sh:message "Equipment can be part of a Collection, System or other Equipment"
-        ]
-    ) ;
+    sh:property [
+        sh:path brick:isPartOf;
+        sh:or (
+            [ sh:class brick:System ]
+            [ sh:class brick:Equipment ]
+            [ sh:class brick:Collection ]
+        );
+        sh:message "Equipment can be part of a Collection, System or other Equipment."
+    ];
     sh:property [
         sh:path brick:hasLocation;
         sh:class brick:Location;
         sh:message "A piece of Equipment can be located only at a Location"
     ];
-    sh:or (
-        sh:property [
-            sh:path brick:feeds;
-            sh:class brick:Equipment ;
-            sh:message "A piece of Equipment can feed a Equipment" ;
-        ]
-        sh:property [
-            sh:path brick:feeds;
-            sh:class brick:Location ;
-            sh:message "A piece of Equipment can feed a Location" ;
-        ]
-    ) ;
+    sh:property [
+        sh:path brick:feeds;
+        sh:or (
+            [ sh:class brick:Equipment ]
+            [ sh:class brick:Location ]
+        );
+        sh:message "A piece of Equipment can feed a Equipment or Location."
+    ];
     sh:property [
         sh:path brick:hasPoint;
         sh:class brick:Point;
@@ -102,18 +90,14 @@ brick:Point a sh:NodeShape;
         [sh:not [ sh:class brick:Collection ] ; sh:message "Point is an exclusive top class." ]
     );
     sh:message "Point is an exclusive top class." ;
-    sh:or (
-        sh:property [
-            sh:path brick:isPointOf;
-            sh:class brick:Location ;
-            sh:message "A point can be associated with Locations or Equipment" ;
-        ]
-        sh:property [
-            sh:path brick:isPointOf;
-            sh:class brick:Equipment ;
-            sh:message "A point can be associated with Locations or Equipment" ;
-        ]
-    ) ;
+    sh:property [
+        sh:path brick:isPointOf;
+        sh:or (
+            [ sh:class brick:Location ]
+            [ sh:class brick:Equipment ]
+        );
+        sh:message "A point can be associated with Locations or Equipment."
+    ];
     .
 
 brick:Collection a sh:NodeShape;
@@ -125,28 +109,16 @@ brick:Collection a sh:NodeShape;
         [sh:not [ sh:class brick:Point ] ; sh:message "Collection is an exclusive top class." ]
     );
     sh:message "Collection is an exclusive top class." ;
-    sh:or (
-        sh:property [
-            sh:path brick:hasPart;
-            sh:class brick:Equipment;
-            sh:message "A Collection can be associated with Equipments, Locations, Points, and other Collections."
-        ]
-        sh:property [
-            sh:path brick:hasPart;
-            sh:class brick:Location;
-            sh:message "A Collection can be associated with Equipments, Locations, Points, and other Collections."
-        ]
-        sh:property [
-            sh:path brick:hasPart;
-            sh:class brick:Point;
-            sh:message "A Collection can be associated with Equipments, Locations, Points, and other Collections."
-        ]
-        sh:property [
-            sh:path brick:hasPart;
-            sh:class brick:Collection;
-            sh:message "A Collection can be associated with Equipments, Locations, Points, and other Collections."
-        ]
-    );
+    sh:property [
+        sh:path brick:hasPart;
+        sh:or (
+            [ sh:class brick:Equipment ]
+            [ sh:class brick:Location ]
+            [ sh:class brick:Point ]
+            [ sh:class brick:Collection ]
+        );
+        sh:message "A Collection can be associated with Equipments, Locations, Points, and other Collections."
+    ];
     .
 
 brick:Location a sh:NodeShape ;


### PR DESCRIPTION
#299 fixed some properties in [BrickEntityShapeBase.ttl](../blob/master/shacl/BrickEntityShapeBase.ttl) to look like this:

https://github.com/BrickSchema/Brick/blob/c15ba7fa4a7690b8f1c35dead065c9d1c3d5f733/shacl/BrickEntityShapeBase.ttl#L55-L71

It seems the intention here was to create a choice between 3 properties. However, if you look closely at it, the list actually contains 6 elements (the first/third/fifth element being `sh:property` and the second/fourth/sixth element being the blank nodes), so this seems to be invalid SHACL.

I think the actual intention is to have 1 property with a choice between 3 classes. There is [an example](https://www.w3.org/TR/shacl/#OrConstraintComponent) in the SHACL spec for this case that looks like this:

```
ex:PersonAddressShape
	a sh:NodeShape ;
	sh:targetClass ex:Person ;
	sh:property [
		sh:path ex:address ;
		sh:or (
			[
				sh:datatype xsd:string ;
			]
			[
				sh:class ex:Address ;
			]
		)
	] .
```

So this PR fixes the "fix" in #299 by reverting it 😄 