### PR TITLE
Remove duplicate shackles for brick:Location

### DIFF
--- a/shacl/BrickEntityShapeBase.ttl
+++ b/shacl/BrickEntityShapeBase.ttl
@@ -9,6 +9,7 @@
 
 
 brick:Location a sh:NodeShape ;
+    sh:message "Location is an exclusive top class." ;
     sh:and (
         [sh:not [ sh:class brick:Point ] ; sh:message "Location is an exclusive top class." ]
         [sh:not [ sh:class brick:Equipment ] ; sh:message "Location is an exclusive top class." ]

--- a/shacl/BrickEntityShapeBase.ttl
+++ b/shacl/BrickEntityShapeBase.ttl
@@ -149,26 +149,6 @@ brick:Collection a sh:NodeShape;
     );
     .
 
-brick:Location a sh:NodeShape ;
-    sh:and ( [ sh:message "Location is an exclusive top class." ;
-                sh:not [ sh:class brick:Point ] ] [ sh:message "Location is an exclusive top class." ;
-                sh:not [ sh:class brick:Equipment ] ] [ sh:message "Location is an exclusive top class." ;
-                sh:not [ sh:class brick:Substance ] ] [ sh:message "Location is an exclusive top class." ;
-                sh:not [ sh:class brick:Quantity ] ] [ sh:message "Location is an exclusive top class." ;
-                sh:not [ sh:class brick:Collection ] ] ) ;
-    sh:property [ sh:class brick:Location ;
-            sh:message "A Location's parts should be always Locations." ;
-            sh:path brick:hasPart ],
-        [ sh:class brick:Location ;
-            sh:message "A Location's parts should be always Locations." ;
-            sh:path brick:isPartOf ],
-        [ sh:class brick:Equipment ;
-            sh:message "Locations can be fed only by other Equipment." ;
-            sh:path brick:isFedBy ],
-        [ sh:class brick:Point ;
-            sh:message "A Location may have associated Points" ;
-            sh:path brick:hasPoint ] .
-
 bsh:hasLocationShape a sh:Nodeshape;
     sh:targetSubjectsOf brick:hasLocation;
     sh:not [

--- a/shacl/BrickEntityShapeBase.ttl
+++ b/shacl/BrickEntityShapeBase.ttl
@@ -150,7 +150,7 @@ brick:Collection a sh:NodeShape;
     );
     .
 
-bsh:hasLocationShape a sh:Nodeshape;
+bsh:hasLocationShape a sh:NodeShape;
     sh:targetSubjectsOf brick:hasLocation;
     sh:not [
         sh:class brick:Point;


### PR DESCRIPTION
[BrickEntityShapeBase.ttl](../blob/master/shacl/BrickEntityShapeBase.ttl) currently seems to have duplicate information about `brick:Location`:

https://github.com/BrickSchema/Brick/blob/c15ba7fa4a7690b8f1c35dead065c9d1c3d5f733/shacl/BrickEntityShapeBase.ttl#L11-L39

https://github.com/BrickSchema/Brick/blob/c15ba7fa4a7690b8f1c35dead065c9d1c3d5f733/shacl/BrickEntityShapeBase.ttl#L152-L170

This PR removes the latter.

(Should one of them have been about `brick:Measurable`?)