### PR TITLE
Unify EntityProperty property shapes that reference brick:value

### DIFF
--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -7,9 +7,9 @@
 site:panel_efficiency  a brick:EfficiencyShape ;
     brick:hasUnit unit:PERCENT ;
     brick:ambientTemperatureOfMeasurement [
-        brick:value "25"^^xsd::double ;
+        brick:value "25"^^xsd:double ;
         brick:hasUnit unit:DEG_C ] ;
-    brick:value 26.0 .
+    brick:value "26.0"^^xsd:double .
 
 site:panel11 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;

--- a/examples/solar_array/solar_array.ttl
+++ b/examples/solar_array/solar_array.ttl
@@ -7,93 +7,93 @@
 site:panel_efficiency  a brick:EfficiencyShape ;
     brick:hasUnit unit:PERCENT ;
     brick:ambientTemperatureOfMeasurement [
-        brick:value "25"^^xsd:double ;
+        brick:value "25"^^xsd:decimal ;
         brick:hasUnit unit:DEG_C ] ;
-    brick:value "26.0"^^xsd:double .
+    brick:value "26.0"^^xsd:decimal .
 
 site:panel11 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:panel12 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double ;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal ;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:panel13 a brick:PV_Panel ;
     brick:isPartOf site:array1 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double ;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal ;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:panel21 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double ;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal ;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:panel22 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double ;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal ;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:panel23 a brick:PV_Panel ;
     brick:isPartOf site:array2 ;
     brick:coordinates [
-        brick:latitude "37.8719"^^xsd:double ;
-        brick:longitude "-122.2585"^^xsd:double ;
+        brick:latitude "37.8719"^^xsd:decimal ;
+        brick:longitude "-122.2585"^^xsd:decimal ;
     ] ;
     brick:ratedModuleConversionEfficiency site:panel_efficiency ;
     brick:measuredPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "240"^^xsd:double ] ;
+            brick:value "240"^^xsd:decimal ] ;
     brick:ratedPowerOutput [ brick:hasUnit unit:W ;
-            brick:value "250"^^xsd:double ];
+            brick:value "250"^^xsd:decimal ];
     brick:panelArea [ brick:hasUnit unit:M2 ;
-            brick:value "5"^^xsd:double ] .
+            brick:value "5"^^xsd:decimal ] .
 
 site:pv_generation_system a brick:PV_Generation_System ;
     brick:hasPart site:array1, site:array2 ;
@@ -123,14 +123,14 @@ site:array1 a brick:PV_Array ;
     brick:azimuth [ brick:hasUnit unit:DEG ;
             brick:rotationalDirection "clockwise" ;
             brick:referenceDirection "North" ;
-            brick:value "200"^^xsd:double ] ;
+            brick:value "200"^^xsd:decimal ] ;
     brick:tilt [ brick:hasUnit unit:DEG ;
-            brick:value "20"^^xsd:double ] .
+            brick:value "20"^^xsd:decimal ] .
 
 site:array2 a brick:PV_Array ;
     brick:azimuth [ brick:hasUnit unit:DEG ;
             brick:rotationalDirection "clockwise" ;
             brick:referenceDirection "North" ;
-            brick:value "180"^^xsd:double ] ;
+            brick:value "180"^^xsd:decimal ] ;
     brick:tilt [ brick:hasUnit unit:DEG ;
-            brick:value "23"^^xsd:double ] .
+            brick:value "23"^^xsd:decimal ] .

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -540,7 +540,7 @@ def define_shape_properties(definitions):
                         "maxInclusive",
                     ]:
                         raise Exception(f"brick:value property {prop_name} not valid")
-                    G.add((v, SH[prop_name], Literal(prop_value)))
+                    G.add((brick_value_shape, SH[prop_name], Literal(prop_value)))
 
 
 def define_properties(definitions, superprop=None):

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -527,9 +527,9 @@ def define_shape_properties(definitions):
             G.add((brick_value_shape, SH.path, BRICK.value))
             dtype = defn.pop("datatype")
             if dtype == BSH.NumericValue:
-                G.add((v, SH["or"], BSH.NumericValue))
+                G.add((brick_value_shape, SH["or"], BSH.NumericValue))
             else:
-                G.add((v, SH.datatype, dtype))
+                G.add((brick_value_shape, SH.datatype, dtype))
             G.add((v, SH.minCount, Literal(1)))
             if "range" in defn:
                 for prop_name, prop_value in defn.pop("range").items():

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -462,24 +462,23 @@ def define_shape_properties(definitions):
         G.add((shape_name, RDFS.subClassOf, BSH.ValueShape))
 
         needs_value_properties = ["values", "units", "unitsFromQuantity", "datatype"]
+        brick_value_shape = BNode()
         if any(k in defn for k in needs_value_properties):
-            ps = BNode()
-            G.add((shape_name, SH.property, ps))
-            G.add((ps, A, SH.PropertyShape))
-            G.add((ps, SH.path, BRICK.value))
-            G.add((ps, SH.minCount, Literal(1)))
-            G.add((ps, SH.maxCount, Literal(1)))
+            G.add((shape_name, SH.property, brick_value_shape))
+            G.add((brick_value_shape, A, SH.PropertyShape))
+            G.add((brick_value_shape, SH.path, BRICK.value))
+            G.add((brick_value_shape, SH.minCount, Literal(1)))
+            G.add((brick_value_shape, SH.maxCount, Literal(1)))
 
         v = BNode()
         # prop:value PropertyShape
         if "values" in defn:
-            ps = BNode()
             enumeration = BNode()
-            G.add((shape_name, SH.property, ps))
-            G.add((ps, A, SH.PropertyShape))
-            G.add((ps, SH.path, BRICK.value))
-            G.add((ps, SH["in"], enumeration))
-            G.add((ps, SH.minCount, Literal(1)))
+            G.add((shape_name, SH.property, brick_value_shape))
+            G.add((brick_value_shape, A, SH.PropertyShape))
+            G.add((brick_value_shape, SH.path, BRICK.value))
+            G.add((brick_value_shape, SH["in"], enumeration))
+            G.add((brick_value_shape, SH.minCount, Literal(1)))
             vals = defn.pop("values")
             if isinstance(vals[0], str):
                 Collection(
@@ -500,22 +499,22 @@ def define_shape_properties(definitions):
             else:
                 Collection(G, enumeration, map(Literal, vals))
         if "units" in defn:
-            ps = BNode()
+            v = BNode()
             enumeration = BNode()
-            G.add((shape_name, SH.property, ps))
-            G.add((ps, A, SH.PropertyShape))
-            G.add((ps, SH.path, BRICK.hasUnit))
-            G.add((ps, SH["in"], enumeration))
-            G.add((ps, SH.minCount, Literal(1)))
+            G.add((shape_name, SH.property, v))
+            G.add((v, A, SH.PropertyShape))
+            G.add((v, SH.path, BRICK.hasUnit))
+            G.add((v, SH["in"], enumeration))
+            G.add((v, SH.minCount, Literal(1)))
             Collection(G, enumeration, defn.pop("units"))
         if "unitsFromQuantity" in defn:
-            ps = BNode()
+            v = BNode()
             enumeration = BNode()
-            G.add((shape_name, SH.property, ps))
-            G.add((ps, A, SH.PropertyShape))
-            G.add((ps, SH.path, BRICK.hasUnit))
-            G.add((ps, SH["in"], enumeration))
-            G.add((ps, SH.minCount, Literal(1)))
+            G.add((shape_name, SH.property, v))
+            G.add((v, A, SH.PropertyShape))
+            G.add((v, SH.path, BRICK.hasUnit))
+            G.add((v, SH["in"], enumeration))
+            G.add((v, SH.minCount, Literal(1)))
             units = units_for_quantity(defn.pop("unitsFromQuantity"))
             assert len(units) > 0, f"Quantity shape {shape_name} has no units"
             Collection(G, enumeration, units)
@@ -523,9 +522,9 @@ def define_shape_properties(definitions):
             prop_defns = defn.pop("properties")
             define_shape_property_property(shape_name, prop_defns)
         elif "datatype" in defn:
-            G.add((shape_name, SH.property, v))
-            G.add((v, A, SH.PropertyShape))
-            G.add((v, SH.path, BRICK.value))
+            G.add((shape_name, SH.property, brick_value_shape))
+            G.add((brick_value_shape, A, SH.PropertyShape))
+            G.add((brick_value_shape, SH.path, BRICK.value))
             dtype = defn.pop("datatype")
             if dtype == BSH.NumericValue:
                 G.add((v, SH["or"], BSH.NumericValue))


### PR DESCRIPTION
Fixes issue #422 by ensuring that adding property shapes to EntityProperty definitions does not create different property shapes for `brick:value`