### PR TITLE
Fix typo and some missing tags (#434) reported by mcc513.

### DIFF
--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -312,14 +312,14 @@ command_definitions = {
                 },
             },
             "Frequency_Command": {
-                "tags": [TAG.Point, TAG.Fequency, TAG.Command],
+                "tags": [TAG.Point, TAG.Frequency, TAG.Command],
                 BRICK.hasQuantity: BRICK.Frequency,
                 "subclasses": {
                     "Max_Frequency_Command": {
-                        "tags": [TAG.Point, TAG.Max, TAG.Fequency, TAG.Command],
+                        "tags": [TAG.Point, TAG.Max, TAG.Frequency, TAG.Command],
                     },
                     "Min_Frequency_Command": {
-                        "tags": [TAG.Point, TAG.Min, TAG.Fequency, TAG.Command],
+                        "tags": [TAG.Point, TAG.Min, TAG.Frequency, TAG.Command],
                     },
                 },
             },

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1255,6 +1255,7 @@ sensor_definitions = {
                             },
                             "Underfloor_Air_Plenum_Static_Pressure_Sensor": {
                                 "tags": [
+                                    TAG.Point,
                                     TAG.Underfloor,
                                     TAG.Air,
                                     TAG.Plenum,
@@ -1401,6 +1402,7 @@ sensor_definitions = {
                 },
             },
             "Refrigerant_Level_Sensor": {
+                "tags": [TAG.Point, TAG.Refrigerant, TAG.Level, TAG.Sensor],
                 BRICK.hasQuantity: BRICK.Level,
                 BRICK.hasSubstance: BRICK.Refrigerant,
             },

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -1050,6 +1050,7 @@ setpoint_definitions = {
                             },
                             "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {
                                 "tags": [
+                                    TAG.Point,
                                     TAG.Underfloor,
                                     TAG.Air,
                                     TAG.Plenum,
@@ -2284,6 +2285,7 @@ setpoint_definitions = {
                 "tags": [TAG.Point, TAG.Differential, TAG.Setpoint],
                 "subclasses": {
                     "Differential_Temperature_Setpoint": {
+                        "tags": [TAG.Point, TAG.Differential, TAG.Temperature, TAG.Setpoint],
                         "subclasses": {
                             "Water_Differential_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Differential_Temperature,

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -15,6 +15,7 @@ status_definitions = {
             },
             "Tint_Status": {"tags": [TAG.Tint, TAG.Status, TAG.Point]},
             "Damper_Position_Status": {
+                "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Status],
                 BRICK.hasQuantity: BRICK.Position,
             },
             "Direction_Status": {


### PR DESCRIPTION
 * Fix 'Fequency' typo.
 * Add Point tag to Underfloor_Air_Plenum_Static_Pressure_Sensor and Underfloor_Air_Plenum_Static_Pressure_Setpoint.
 * Add associated tags to Damper_Position_Status, Differential_Temperature_Setpoint and Refrigerant_Level_Sensor.

This doesn't address point 4 on issue #434.