### PR TITLE
Update nightly-builds.yml

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.5
+          python-version: 3.8.13
           architecture: x64
       - name: Set up AllegroGraph (Docker)
         run: |


### PR DESCRIPTION
Nightly builds started failing a couple of days ago because our python build is out of date. We use 3.8.13 on the build script, it looks like 3.8.16 is the newest point release, but I am just matching what we use in our other tests.