### PR TITLE
Merge domain and range shapes

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -572,7 +572,7 @@ def define_properties(definitions, superprop=None):
         # define range/domain using SHACL shapes
         if "range" in propdefn:
             defn = propdefn.pop("range")
-            range_shape = BSH[f"range_shape_{prop.split('#')[-1]}"]
+            range_shape = BSH[f"shape_{prop.split('#')[-1]}"]
             G.add((range_shape, A, SH.NodeShape))
             G.add((range_shape, SH.targetSubjectsOf, prop))
             constraint = BNode()
@@ -592,7 +592,7 @@ def define_properties(definitions, superprop=None):
                 G.add((constraint, SH["class"], defn))
         if "domain" in propdefn:
             defn = propdefn.pop("domain")
-            domain_shape = BSH[f"domain_shape_{prop.split('#')[-1]}"]
+            domain_shape = BSH[f"shape_{prop.split('#')[-1]}"]
             G.add((domain_shape, A, SH.NodeShape))
             G.add((domain_shape, SH.targetSubjectsOf, prop))
             if isinstance(defn, (tuple, list)):

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -578,7 +578,7 @@ def define_properties(definitions, superprop=None):
             constraint = BNode()
             G.add((range_shape, SH.property, constraint))
             G.add((constraint, SH.path, prop))
-            G.add((constraint, SH.minCount, Literal(1)))
+            G.add((constraint, SH.minCount, Literal(0)))
             if isinstance(defn, (tuple, list)):
                 enumeration = BNode()
                 G.add((constraint, SH["or"], enumeration))


### PR DESCRIPTION
Proposing to merge the `bsh:domain_shape_...` and `bsh:range_shape_...` shapes, e.g.:

```ttl
bsh:domain_shape_isMeteredBy a sh:NodeShape ;
    sh:or ( [ sh:class brick:Equipment ] [ sh:class brick:Location ] [ sh:class brick:Collection ] ) ;
    sh:targetSubjectsOf brick:isMeteredBy .

bsh:range_shape_isMeteredBy a sh:NodeShape ;
    sh:property [ sh:class brick:Meter ;
            sh:minCount 1 ;
            sh:path brick:isMeteredBy ] ;
    sh:targetSubjectsOf brick:isMeteredBy .
```

&rarr;

```ttl
bsh:shape_isMeteredBy a sh:NodeShape ;
    sh:or ( [ sh:class brick:Equipment ] [ sh:class brick:Location ] [ sh:class brick:Collection ] ) ;
    sh:property [ sh:class brick:Meter ;
            sh:minCount 1 ;
            sh:path brick:isMeteredBy ] ;
    sh:targetSubjectsOf brick:isMeteredBy .
```

As I understand it, there should be no difference between the two ways from the point of view of SHACL. However, the latter is much easier to de-compile for documentation generation purposes.[^1]

[^1]: See, for example, how `brick:isMeteredBy` is currently missing from the [REC documentation of `brick:Equipment`](https://dev.realestatecore.io/ontology/Asset/Equipment/Equipment).

/cc @gtfierro @epaulson @hammar 