### PR TITLE
Fix sh:prefixes usage

### DIFF
--- a/bricksrc/deprecations.ttl
+++ b/bricksrc/deprecations.ttl
@@ -29,7 +29,7 @@ brick:Fresh_Air_Fan brick:deprecation [
             } WHERE {
               $this rdf:type brick:Fresh_Air_Fan .
             }""" ;
-            sh:prefixes rdf:, brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         ] ;
         sh:targetClass brick:Fresh_Air_Fan ;
     ] ;
@@ -50,7 +50,7 @@ brick:Exhaust_Fan_Disable_Command brick:deprecation [
             } WHERE {
               $this rdf:type brick:Exhaust_Fan_Disable_Command .
             }""" ;
-            sh:prefixes rdf:, brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         ] ;
         sh:targetClass brick:Exhaust_Fan_Disable_Command ;
     ] ;
@@ -69,7 +69,7 @@ brick:Exhaust_Fan_Enable_Command brick:deprecation [
             } WHERE {
               $this rdf:type brick:Exhaust_Fan_Enable_Command .
             }""" ;
-            sh:prefixes rdf:, brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         ] ;
         sh:targetClass brick:Exhaust_Fan_Enable_Command ;
     ] ;
@@ -88,7 +88,7 @@ brick:Rain_Sensor brick:deprecation [
             } WHERE {
               $this rdf:type brick:Rain_Sensor.
             }""" ;
-            sh:prefixes rdf:, brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         ] ;
         sh:targetClass brick:Rain_Sensor ;
     ] ;

--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from rdflib import Literal, BNode, URIRef
 from rdflib.collection import Collection
 
-from .namespaces import DCTERMS, SDO, RDFS, RDF, OWL, BRICK, TAG, BSH
+from .namespaces import DCTERMS, SDO, RDFS, RDF, OWL, BRICK, TAG, BSH, SH
 from .version import BRICK_VERSION, BRICK_FULL_VERSION
 
 # defines metadata about the Brick ontology
@@ -32,6 +32,21 @@ ontology = {
     RDFS.seeAlso: URIRef("https://brickschema.org"),
 }
 
+shacl_namespace_declarations = [
+    {
+        SH.namespace: Literal(str(RDF)),
+        SH.prefix: Literal("rdf"),
+    },
+    {
+        SH.namespace: Literal(str(RDFS)),
+        SH.prefix: Literal("rdfs"),
+    },
+    {
+        SH.namespace: Literal(str(BRICK)),
+        SH.prefix: Literal("brick"),
+    },
+]
+
 
 def define_ontology(G):
     brick_iri_version = URIRef(f"https://brickschema.org/schema/{BRICK_VERSION}/Brick")
@@ -58,3 +73,10 @@ def define_ontology(G):
     # add other simple attributes
     for k, v in ontology.items():
         G.add((brick_iri_version, k, v))
+
+    # add SHACL namespace/prefix declarations for SHACL rules
+    for declaration in shacl_namespace_declarations:
+        decl = BNode()
+        G.add((brick_iri_version, SH.declare, decl))
+        for k, v in declaration.items():
+            G.add((decl, k, v))

--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from rdflib import Literal, BNode, URIRef
 from rdflib.collection import Collection
 
-from .namespaces import DCTERMS, SDO, RDFS, RDF, OWL, BRICK, TAG, BSH, SH
+from .namespaces import DCTERMS, SDO, RDFS, RDF, OWL, BRICK, TAG, BSH, SH, XSD
 from .version import BRICK_VERSION, BRICK_FULL_VERSION
 
 # defines metadata about the Brick ontology
@@ -34,16 +34,20 @@ ontology = {
 
 shacl_namespace_declarations = [
     {
-        SH.namespace: Literal(str(RDF)),
+        SH.namespace: Literal(str(RDF), datatype=XSD.anyURI),
         SH.prefix: Literal("rdf"),
     },
     {
-        SH.namespace: Literal(str(RDFS)),
+        SH.namespace: Literal(str(RDFS), datatype=XSD.anyURI),
         SH.prefix: Literal("rdfs"),
     },
     {
-        SH.namespace: Literal(str(BRICK)),
+        SH.namespace: Literal(str(BRICK), datatype=XSD.anyURI),
         SH.prefix: Literal("brick"),
+    },
+    {
+        SH.namespace: Literal(str(OWL), datatype=XSD.anyURI),
+        SH.prefix: Literal("owl"),
     },
 ]
 

--- a/bricksrc/rules.ttl
+++ b/bricksrc/rules.ttl
@@ -26,7 +26,7 @@ WHERE {
   ?p owl:inverseOf ?invP .
 }
 			""" ;
-      sh:prefixes owl: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
   sh:targetClass brick:Entity ;
 .
@@ -45,8 +45,7 @@ WHERE {
   ?prop a owl:SymmetricProperty .
 }
 			""" ;
-        sh:prefixes owl: ;
-        sh:prefixes rdf: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
   sh:targetClass brick:Entity ;
 .
@@ -62,8 +61,7 @@ $this brick:hasTag ?tag .
     $this rdf:type/rdfs:subClassOf* ?class .
     ?class brick:hasAssociatedTag ?tag .
 }""" ;
-    sh:prefixes rdf: ;
-    sh:prefixes brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:targetClass brick:Entity ;
 .
@@ -80,9 +78,7 @@ CONSTRUCT {
     ?shape a sh:NodeShape .
     ?ent $this ?val .
 }""" ;
-    sh:prefixes rdfs: ;
-    sh:prefixes rdf: ;
-    sh:prefixes sh: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:targetSubjectsOf rdfs:range ;
 .
@@ -98,7 +94,7 @@ CONSTRUCT {
     $this rdfs:subPropertyOf ?super .
     ?s $this ?o .
 }""" ;
-    sh:prefixes rdfs: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:targetSubjectsOf rdfs:subPropertyOf ;
 .
@@ -117,8 +113,7 @@ bsh:DeprecationRule
         CONSTRUCT { $this owl:deprecated true }
         WHERE { $this brick:deprecation ?dep }
         """ ;
-        sh:prefixes owl: ;
-        sh:prefixes brick: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:property [
         sh:path brick:deprecatedInVersion ;
@@ -145,7 +140,7 @@ bsh:DeprecationRuleForInstances
     sh:sparql [
       a sh:SPARQLConstraint ;
       sh:message "Entity has type which is deprecated" ;
-      sh:prefixes brick:, rdf: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
       sh:select """SELECT $this WHERE { $this rdf:type/owl:deprecated true }""" ;
     ] ;
 .
@@ -193,7 +188,7 @@ CONSTRUCT {
     UNION
     { $this owl:equivalentClass ?t2 }
 }""" ;
-    sh:prefixes owl: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:targetSubjectsOf owl:equivalentClass ;
 .
@@ -211,7 +206,7 @@ CONSTRUCT {
     UNION
     { $this owl:equivalentClass ?t2 }
 }""" ;
-    sh:prefixes owl: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
     ] ;
     sh:targetObjectsOf owl:equivalentClass ;
 .
@@ -256,7 +251,7 @@ bsh:VirtualMeterRule a sh:NodeShape ;
     sh:sparql [
         a sh:SPARQLConstraint ;
         sh:message "Only meters can have the isVirtualMeter property be true" ;
-        sh:prefixes brick:, rdf:, rdfs: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         sh:select """
             SELECT $this WHERE {
                 $this brick:isVirtualMeter/brick:value true .
@@ -279,7 +274,7 @@ bsh:TimeseriesReferenceOnPointsConstraint a sh:NodeShape ;
     sh:sparql [
         a sh:SPARQLConstraint ;
         sh:message "Only Brick Points can have external timeseries references" ;
-        sh:prefixes ref:, rdf:, rdfs: ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
         sh:select """
             SELECT $this
             WHERE {

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -8,7 +8,7 @@ from rdflib import Graph, Literal, BNode, URIRef
 from rdflib.namespace import XSD
 from rdflib.collection import Collection
 
-from bricksrc.ontology import define_ontology
+from bricksrc.ontology import define_ontology, BRICK_VERSION
 
 from bricksrc.namespaces import (
     BRICK,
@@ -739,8 +739,7 @@ def handle_deprecations():
                     ),
                 )
             )
-            G.add((rule, SH.prefixes, URIRef(RDF)))
-            G.add((rule, SH.prefixes, URIRef(BRICK)))
+            G.add((rule, SH.prefixes, URIRef(f"https://brickschema.org/schema/{BRICK_VERSION}/Brick")))
 
 
 logging.info("Beginning BRICK Ontology compilation")


### PR DESCRIPTION
Fixing a misunderstanding of the SHACL standard's `sh:prefixes` annotation