### PR TITLE
Fix inverse property inference rule to use owl, not 223p annotation

### DIFF
--- a/bricksrc/rules.ttl
+++ b/bricksrc/rules.ttl
@@ -12,18 +12,35 @@
 # include this to inform reasoning
 skos:narrower owl:inverseOf skos:broader .
 
-bsh:InferInverseProperties
+bsh:InferInverseProperties1
   a sh:NodeShape ;
   sh:rule [
       a sh:SPARQLRule ;
       sh:construct """
-CONSTRUCT {
+            CONSTRUCT {
 ?o ?invP $this .
-$this ?p ?o .
 }
 WHERE {
-  { $this ?p ?o } UNION { ?o ?invP $this } .
-  ?p owl:inverseOf ?invP .
+$this ?p ?o .
+?p owl:inverseOf ?invP .
+}
+			""" ;
+      sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;
+    ] ;
+  sh:targetClass brick:Entity ;
+.
+
+bsh:InferInverseProperties2
+  a sh:NodeShape ;
+  sh:rule [
+      a sh:SPARQLRule ;
+      sh:construct """
+            CONSTRUCT {
+?o ?p $this .
+}
+WHERE {
+$this ?invP ?o .
+?p owl:inverseOf ?invP .
 }
 			""" ;
       sh:prefixes <https://brickschema.org/schema/1.3/Brick> ;


### PR DESCRIPTION
Previous rule has `s223:inverseOf` instead of `owl:inverseOf`