### PR TITLE
Change QUDT.hasQuality to QUDT.hasQuantity in BRICK.Pressure_Status

### DIFF
--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -464,7 +464,7 @@ status_definitions = {
                 "tags": [TAG.Point, TAG.Overridden, TAG.Status],
             },
             "Pressure_Status": {
-                QUDT.hasQuality: BRICK.Pressure,
+                QUDT.hasQuantity: BRICK.Pressure,
                 "subclasses": {
                     "Discharge_Air_Duct_Pressure_Status": {
                         "tags": [


### PR DESCRIPTION
There is no `qudt:hasQuality`. I assume that `qudt:hasQuantity` is meant.