### PR TITLE
Fix ontology IRI of SHACL

### DIFF
--- a/bricksrc/ontology.py
+++ b/bricksrc/ontology.py
@@ -42,7 +42,7 @@ ontology_imports = {
     "currency": "http://qudt.org/2.1/vocab/currency",
     "quantitykind": "http://qudt.org/2.1/vocab/quantitykind",
     "dimensionvector": "http://qudt.org/2.1/vocab/dimensionvector",
-    "shacl": "http://www.w3.org/ns/shacl",
+    "shacl": "http://www.w3.org/ns/shacl#",
     "bacnet": "http://data.ashrae.org/bacnet/2020",
 }
 


### PR DESCRIPTION
Because of `<https://brickschema.org/schema/1.3/Brick> owl:imports <http://www.w3.org/ns/shacl>` and `owl:imports rdfs:range owl:Ontology`, it is inferred that `<http://www.w3.org/ns/shacl> a owl:Ontology`. However, the SHACL Ontology states that `<http://www.w3.org/ns/shacl#> a owl:Ontology`. This PR updates the Brick import to match that. (According to [RFC 7230, Section 5.1](https://www.rfc-editor.org/rfc/rfc7230#section-5.1), the fragment component is excluded when making an HTTP request, so the import functionality should be unchanged.)

```diff
 <https://brickschema.org/schema/1.3/Brick> a owl:Ontology ;
     ...
     owl:imports <http://data.ashrae.org/bacnet/2020>,
         ...
-        <http://www.w3.org/ns/shacl> ;
+        <http://www.w3.org/ns/shacl#> ;
     ...
```
