### PR TITLE
Handle extensions separately

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -25,6 +25,11 @@ jobs:
         run: |
           pip install -r requirements.txt
           python generate_brick.py
+          python handle_extensions.py
+      - name: zip imports and extensions
+        run: |
+          zip -r imports.zip imports
+          zip -r extensions.zip extensions
       - uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,4 +39,5 @@ jobs:
           files: |
             Brick.ttl
             Brick+extensions.ttl
-            imports
+            imports.zip
+            extensions.zip

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,14 @@ Brick.ttl: bricksrc/*.py bricksrc/*.ttl bricksrc/definitions.csv generate_brick.
 	mkdir -p extensions
 	python tools/sort_definitions.py bricksrc/definitions.csv
 	python generate_brick.py
+	python handle_extensions.py
 
 clean:
 	rm Brick.ttl Brick+extensions.ttl
 
 format:
 	black generate_brick.py
+	black handle_extensions.py
 	black bricksrc/
 	black tests/
 	black tools/

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -1010,25 +1010,14 @@ for name, graph in extension_graphs.items():
         fp.write(graph.serialize(format="turtle").rstrip())
         fp.write("\n")
 
-# add SHACL shapes to graph
-# G.parse("shacl/BrickEntityShapeBase.ttl", format="ttl")
-
 # serialize Brick to output
 with open("Brick.ttl", "w", encoding="utf-8") as fp:
     fp.write(G.serialize(format="turtle").rstrip())
     fp.write("\n")
 
-# serialize Brick + extensions
-for graph in extension_graphs.values():
-    G += graph
-
-# fetch other ontologies
+# remove extensions file before computing imports
 if os.path.exists("Brick+extensions.ttl"):
-    os.remove("Brick+extensions.ttl")  # remove extensions file before computing imports
-
-with open("Brick+extensions.ttl", "w", encoding="utf-8") as fp:
-    fp.write(G.serialize(format="turtle").rstrip())
-    fp.write("\n")
+    os.remove("Brick+extensions.ttl")
 
 # create new directory for storing imports
 os.makedirs("imports", exist_ok=True)

--- a/handle_extensions.py
+++ b/handle_extensions.py
@@ -1,0 +1,16 @@
+import glob
+import rdflib
+
+# read the base Brick ontology
+brick_graph = rdflib.Graph()
+brick_graph.parse("Brick.ttl", format="ttl")
+
+# add extension files to Brick graph
+extension_files = glob.glob("extensions/*.ttl")
+for filename in extension_files:
+    brick_graph.parse(filename)
+
+# serialize Brick with all extensions added
+with open("Brick+extensions.ttl", "w", encoding="utf-8") as fp:
+    fp.write(brick_graph.serialize(format="turtle").rstrip())
+    fp.write("\n")


### PR DESCRIPTION
- Now reads extensions out of extensions/ folder instead of assuming they will be generated in generate_brick.py
- puts imports and extensions into dedicated .zip files for easier downloading
- separately generates Brick+extensions.ttl