### PR TITLE
Update ref-schema to latest version and check for any issues

### DIFF
--- a/support/ref-schema.ttl
+++ b/support/ref-schema.ttl
@@ -4,6 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix ref: <https://brickschema.org/schema/Brick/ref#> .
+@prefix s223: <http://data.ashrae.org/standard223#> .
 @prefix sdo: <http://schema.org/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -13,7 +14,17 @@
     dcterms:creator ( [ a sdo:Person ;
                 sdo:email "gtfierro@mines.edu" ;
                 sdo:name "Gabe Fierro" ] ) ;
-    dcterms:title "Ref Schema" .
+    dcterms:title "Ref Schema" ;
+    sh:declare [ sh:namespace "http://www.w3.org/2000/01/rdf-schema#"^^xsd:anyURI ;
+            sh:prefix "rdfs" ],
+        [ sh:namespace "https://brickschema.org/schema/Brick/ref#"^^xsd:anyURI ;
+            sh:prefix "ref" ],
+        [ sh:namespace "http://www.w3.org/ns/shacl#"^^xsd:anyURI ;
+            sh:prefix "sh" ],
+        [ sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+            sh:prefix "rdf" ],
+        [ sh:namespace "http://www.w3.org/2002/07/owl#"^^xsd:anyURI ;
+            sh:prefix "owl" ] .
 
 ref:BACnetReferenceShape a sh:NodeShape ;
     skos:definition "Infers a BACnetReference instance from the object of an hasExternalReference." ;
@@ -24,6 +35,21 @@ ref:BACnetReferenceShape a sh:NodeShape ;
             sh:subject sh:this ] ;
     sh:targetObjectsOf ref:hasExternalReference .
 
+ref:ExternalReferenceShape a sh:NodeShape ;
+    sh:property [ sh:message "All ExternalReference must have an rdfs:label" ;
+            sh:minCount 1 ;
+            sh:path rdfs:label ],
+        [ sh:message "All ExternalReference must have an skos:definition" ;
+            sh:minCount 1 ;
+            sh:path skos:definition ] ;
+    sh:target [ a sh:SPARQLTarget ;
+            sh:prefixes ref: ;
+            sh:select """
+    SELECT ?this WHERE {
+     ?this rdfs:subClassOf+ ref:ExternalReference .
+    }
+    """ ] .
+
 ref:IFCReferenceShape a sh:NodeShape ;
     skos:definition "Infers a IFCReference instance from the object of an hasExternalReference." ;
     sh:rule [ a sh:TripleRule ;
@@ -32,6 +58,16 @@ ref:IFCReferenceShape a sh:NodeShape ;
             sh:predicate rdf:type ;
             sh:subject sh:this ] ;
     sh:targetObjectsOf ref:hasExternalReference .
+
+ref:PreferredShape a sh:NodeShape ;
+    sh:property [ sh:message "An entity can only have one 'preferred' External Reference" ;
+            sh:path ref:hasExternalReference ;
+            sh:qualifiedMaxCount 1 ;
+            sh:qualifiedValueShape [ sh:class ref:ExternalReference ;
+                    sh:property [ sh:datatype xsd:boolean ;
+                            sh:hasValue true ;
+                            sh:path ref:preferred ] ] ] ;
+    sh:targetSubjectsOf ref:hasExternalReference .
 
 ref:TimeseriesReferenceShape a sh:NodeShape ;
     skos:definition "Infers a TimeseriesReference instance from the object of an hasExternalReference." ;
@@ -48,9 +84,9 @@ ref:bacnet-read-property a owl:DatatypeProperty ;
 
 ref:hasTimeseriesReference a owl:ObjectProperty ;
     rdfs:label "hasTimeseriesReference" ;
+    rdfs:range ref:TimeseriesReference ;
     rdfs:subPropertyOf ref:hasExternalReference ;
-    skos:definition "Metadata for accessing related timeseries data: Relates a Brick point to the TimeseriesReference that indicates where and how the data for this point is stored"@en ;
-    sh:class ref:TimeseriesReference .
+    skos:definition "Metadata for accessing related timeseries data: Relates a data source (such as a Brick Point or 223 Property) to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
 
 bacnet:description a bacnet:StandardProperty,
         owl:DatatypeProperty ;
@@ -105,7 +141,6 @@ ref:hasIfcProjectReference a owl:ObjectProperty ;
 
 ref:hasTimeseriesId a owl:DatatypeProperty ;
     rdfs:label "hasTimeseriesId" ;
-    rdfs:range xsd:string ;
     skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
 
 ref:ifcFileLocation a owl:DatatypeProperty ;
@@ -114,12 +149,10 @@ ref:ifcFileLocation a owl:DatatypeProperty ;
 
 ref:ifcGlobalID a owl:DatatypeProperty ;
     rdfs:label "ifcGlobalID" ;
-    rdfs:range xsd:string ;
     skos:definition "The IFC Global ID of the entity" .
 
 ref:ifcName a owl:DatatypeProperty ;
     rdfs:label "ifcName" ;
-    rdfs:range xsd:string ;
     skos:definition "The name of the IFC entity" .
 
 ref:ifcProject a owl:Class,
@@ -136,23 +169,21 @@ ref:ifcProject a owl:Class,
 
 ref:ifcProjectID a owl:DatatypeProperty ;
     rdfs:label "ifcProjectID" ;
-    rdfs:range xsd:string ;
     skos:definition "The IFC ID of the containing project" .
+
+ref:preferred a owl:DatatypeProperty ;
+    skos:definition "An entity can have one 'preferred' External Reference. Consumers of the model should prioritize any external reference with the 'preferred' property" .
 
 ref:storedAt a owl:DatatypeProperty ;
     rdfs:label "storedAt" ;
-    rdfs:range xsd:anyURI ;
     skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
 
 ref:BACnetReference a owl:Class,
         sh:NodeShape ;
+    rdfs:label "BACnet Reference" ;
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to the BACnet object represented by this entity." ;
     sh:or ( [ sh:property [ a sh:PropertyShape ;
-                        sh:datatype bacnet:Property ;
-                        sh:defaultValue bacnet:Present_Value ;
-                        sh:path ref:bacnet-read-property ],
-                    [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
                         sh:path bacnet:object-type ],
                     [ a sh:PropertyShape ;
@@ -170,7 +201,11 @@ ref:BACnetReference a owl:Class,
                     [ a sh:PropertyShape ;
                         sh:datatype xsd:string ;
                         sh:minCount 1 ;
-                        sh:path bacnet:object-identifier ] ] [ sh:property [ a sh:PropertyShape ;
+                        sh:path bacnet:object-identifier ],
+                    [ a sh:PropertyShape ;
+                        sh:datatype bacnet:Property ;
+                        sh:defaultValue bacnet:Present_Value ;
+                        sh:path ref:read-property ] ] [ sh:property [ a sh:PropertyShape ;
                         skos:definition "Clause Q.8 BACnet URI scheme: bacnet:// <device> / <object> [ / <property> [ / <index> ]]" ;
                         sh:datatype xsd:string ;
                         sh:path ref:BACnetURI ] ] ) ;
@@ -181,6 +216,7 @@ ref:BACnetReference a owl:Class,
 
 ref:IFCReference a owl:Class,
         sh:NodeShape ;
+    rdfs:label "Industry Foundation Classes Reference" ;
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to an entity in an IFC project which may contain additional metadata about this entity." ;
     sh:property [ a sh:PropertyShape ;
@@ -198,13 +234,9 @@ ref:IFCReference a owl:Class,
             sh:minCount 1 ;
             sh:path ref:hasIfcProjectReference ] .
 
-ref:ExternalReference a owl:Class,
-        sh:NodeShape ;
-    rdfs:label "External reference" ;
-    skos:definition "The parent class of all external reference types" .
-
 ref:TimeseriesReference a owl:Class,
         sh:NodeShape ;
+    rdfs:label "Timeseries Reference" ;
     rdfs:subClassOf ref:ExternalReference ;
     skos:definition "A reference to a stream of timeseries data in a database. Contains the data for this entity" ;
     sh:property [ a sh:PropertyShape ;
@@ -214,9 +246,17 @@ ref:TimeseriesReference a owl:Class,
             sh:path ref:hasTimeseriesId ],
         [ a sh:PropertyShape ;
             skos:definition "Refers to a database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment" ;
-            sh:datatype xsd:string ;
+            sh:nodeKind sh:IRIOrLiteral ;
             sh:path ref:storedAt ] .
+
+ref:ExternalReference a owl:Class,
+        sh:NodeShape ;
+    rdfs:label "External reference" ;
+    rdfs:subClassOf s223:ExternalReference ;
+    skos:definition "The parent class of all external reference types" .
 
 ref:hasExternalReference a owl:ObjectProperty ;
     rdfs:label "hasExternalReference" ;
+    rdfs:subPropertyOf s223:hasExternalReference ;
     skos:definition "Points to the external reference for this entity, which contains additional metadata/data not included in this graph." .
+


### PR DESCRIPTION
`ref:ExternalReference` now subclasses from `s223:ExternalReference` and `ref:hasExternalReference` is now a subproperty of `s223:hasExternalReference`. Also includes small miscellaneous changes from earlier ref-schema work