### PR TITLE
Rename `Solar Radiance Sensor` to `Solar Irradiance Sensor` for Accuracy

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -934,7 +934,7 @@ https://brickschema.org/schema/Brick#Soil_Temperature_Sensor,Measures the temper
 https://brickschema.org/schema/Brick#Solar_Azimuth_Angle_Sensor,Measures the azimuth angle of the sun,
 https://brickschema.org/schema/Brick#Solar_Irradiance,The power per unit area of solar electromagnetic radiation incident on a surface,
 https://brickschema.org/schema/Brick#Solar_Radiance,The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction,
-https://brickschema.org/schema/Brick#Solar_Radiance_Sensor,The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction,
+https://brickschema.org/schema/Brick#Solar_Irradiance_Sensor,The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction,
 https://brickschema.org/schema/Brick#Solar_Thermal_Collector,A type of solar panels that converts solar radiation into thermal energy.,
 https://brickschema.org/schema/Brick#Solar_Zenith_Angle_Sensor,Measures the zenith angle of the sun,
 https://brickschema.org/schema/Brick#Solid,"one of the three states or phases of matter characterized by stability of dimensions, relative incompressibility, and molecular motion held to limited oscillation.",

--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -934,7 +934,7 @@ https://brickschema.org/schema/Brick#Soil_Temperature_Sensor,Measures the temper
 https://brickschema.org/schema/Brick#Solar_Azimuth_Angle_Sensor,Measures the azimuth angle of the sun,
 https://brickschema.org/schema/Brick#Solar_Irradiance,The power per unit area of solar electromagnetic radiation incident on a surface,
 https://brickschema.org/schema/Brick#Solar_Radiance,The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction,
-https://brickschema.org/schema/Brick#Solar_Irradiance_Sensor,The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction,
+https://brickschema.org/schema/Brick#Solar_Irradiance_Sensor,Measures solar irradiance levels for photovoltaic systems,
 https://brickschema.org/schema/Brick#Solar_Thermal_Collector,A type of solar panels that converts solar radiation into thermal energy.,
 https://brickschema.org/schema/Brick#Solar_Zenith_Angle_Sensor,Measures the zenith angle of the sun,
 https://brickschema.org/schema/Brick#Solid,"one of the three states or phases of matter characterized by stability of dimensions, relative incompressibility, and molecular motion held to limited oscillation.",

--- a/bricksrc/deprecations.py
+++ b/bricksrc/deprecations.py
@@ -1,30 +1,35 @@
 from .namespaces import BRICK, RDFS, SKOS, A
 
 deprecations = {
+    BRICK.Solar_Radiance_Sensor: {
+        "version": "1.3.0",
+        "mitigation_messsage": "The class 'Solar_Radiance_Sensor' is deprecated in favor of 'Solar_Irradiance_Sensor'. The new name better reflects the standard unit of measurement, watts per square meter (W/m²), and aligns with the terminology commonly used in solar applications.",
+        RDFS.subClassOf: BRICK.Sensor,
+    },
     BRICK.Occupied_Air_Temperature_Cooling_Setpoint: {
             "version": "1.3.0",
             "mitigation_message": "'Occupied_Air_Temperature_Cooling_Setpoint' is deprecated in favor of further specifying that it is a zone air setpoint.",
             "replace_with": BRICK.Occupied_Cooling_Zone_Air_Temperature_Setpoint,
             RDFS.subClassOf: BRICK.Occupied_Air_Temperature_Setpoint,
-        },
+    },
     BRICK.Occupied_Air_Temperature_Heating_Setpoint: {
             "version": "1.3.0",
             "mitigation_message": "'Occupied_Air_Temperature_Heating_Setpoint' is deprecated in favor of further specifying that it is a zone air setpoint.",
             "replace_with": BRICK.Occupied_Heating_Zone_Air_Temperature_Setpoint,
             RDFS.subClassOf: BRICK.Occupied_Air_Temperature_Setpoint,
-        },
+    },
     BRICK.Unoccupied_Air_Temperature_Cooling_Setpoint: {
             "version": "1.3.0",
             "mitigation_message": "'Unoccupied_Air_Temperature_Cooling_Setpoint' is deprecated in favor of further specifying that it is a zone air setpoint.",
             "replace_with": BRICK.Unoccupied_Cooling_Zone_Air_Temperature_Setpoint,
             RDFS.subClassOf: BRICK.Unoccupied_Air_Temperature_Setpoint,
-        },
+    },
     BRICK.Unoccupied_Air_Temperature_Heating_Setpoint: {
             "version": "1.3.0",
             "mitigation_message": "'Unoccupied_Air_Temperature_Heating_Setpoint' is deprecated in favor of further specifying that it is a zone air setpoint.",
             "replace_with": BRICK.Unoccupied_Heating_Zone_Air_Temperature_Setpoint,
             RDFS.subClassOf: BRICK.Unoccupied_Air_Temperature_Setpoint,
-        },
+    },
     BRICK.Effective_Air_Temperature_Cooling_Setpoint: {
         "version": "1.3.0",
         "mitigation_message": "The class 'Effective_Air_Temperature_Cooling_Setpoint' is deprecated in favor of further specifying that it is a zone air setpoint.",

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1322,9 +1322,9 @@ sensor_definitions = {
                 BRICK.hasSubstance: BRICK.Refrigerant,
                 "tags": [TAG.Point, TAG.Sensor, TAG.Refrigerant, TAG.Level],
             },
-            "Solar_Radiance_Sensor": {
-                "tags": [TAG.Point, TAG.Sensor, TAG.Radiance, TAG.Solar],
-                BRICK.hasQuantity: BRICK.Solar_Radiance,
+            "Solar_Irradiance_Sensor": {
+                "tags": [TAG.Point, TAG.Sensor, TAG.Irradiance, TAG.Solar],
+                BRICK.hasQuantity: BRICK.Solar_Irradiance,
             },
             "Speed_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Speed],


### PR DESCRIPTION
Upon reviewing our current `Solar_Radiance_Sensor`, renaming to`Solar_Irradiance_Sensor` might be the most appropriate class name for our context. Here's why:

Solar Irradiance represents the power per unit area received from the Sun. Solar applications are most interested in the total amount of solar power received on a surface area. The unit of measurement is often given in watts per square meter (W/m²).

Considering the above distinctions and the prevalent use of W/m² as a measurement unit, I believe that Solar Irradiance Sensor would be a more accurate and suitable class name.

Thank you



