### PR TITLE
Remove empty integration test harness

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -42,7 +42,3 @@ jobs:
       # -s flag: do not capture output (avoids killing test after 10 min)
       run: |
         pytest -s -vvvv --durations=0 -n auto tests
-    - name: Do integration tests
-      run: |
-        cd tests/integration
-        bash run_integration_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ format:
 
 test: Brick.ttl
 	pytest -s -vvvv  -n auto tests
-	cd tests/integration && bash run_integration_tests.sh
 
 quantity-test: Brick.ttl
 	pytest -s -vvvv tests/test_quantities.py

--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -ex
-
-for i in `ls *_test.sh`; do
-    bash $i
-done


### PR DESCRIPTION
The only integration test we had was the Brick version translation script (which is unused now). After we deprecated Brick 1.1, we've moved all migration mechanisms into SHACL, so that ended up removing our last integration test. In some shell environments the `run_integration_tests.sh` script can fail and cause the whole Makefile process to error out. Until we have more integration tests (that are best expressed as shell scripts), let's remove the shell script