### PR TITLE
Add reheat and ability to represent dehumidification process

### DIFF
--- a/bricksrc/command.py
+++ b/bricksrc/command.py
@@ -21,6 +21,7 @@ command_definitions = {
             "Cooling_Command": {"tags": [TAG.Point, TAG.Cool, TAG.Command]},
             "Heating_Command": {"tags": [TAG.Point, TAG.Heat, TAG.Command]},
             "Preheat_Command": {"tags": [TAG.Point, TAG.Preheat, TAG.Command]},
+            "Reheat_Command": {"tags": [TAG.Point, TAG.Reheat, TAG.Command]},
             "Luminance_Command": {"tags": [TAG.Point, TAG.Luminance, TAG.Command]},
             "Bypass_Command": {"tags": [TAG.Point, TAG.Bypass, TAG.Command]},
             "Damper_Command": {
@@ -35,6 +36,10 @@ command_definitions = {
             },
             "Humidify_Command": {
                 "tags": [TAG.Point, TAG.Humidify, TAG.Command],
+                BRICK.hasQuantity: BRICK.Humidity,
+            },
+            "Dehumidification_Command": {
+                "tags": [TAG.Point, TAG.Dehumidification, TAG.Command],
                 BRICK.hasQuantity: BRICK.Humidity,
             },
             "Position_Command": {

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -728,6 +728,16 @@ valve_subclasses = {
                                     TAG.Equipment,
                                 ]
                             },
+                            "Reheat_Hot_Water_Valve": {
+                                "tags": [
+                                    TAG.Reheat,
+                                    TAG.Water,
+                                    TAG.Hot,
+                                    TAG.Valve,
+                                    TAG.Heat,
+                                    TAG.Equipment,
+                                ]
+                            },
                         },
                     },
                     "Makeup_Water_Valve": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1514,6 +1514,18 @@ sensor_definitions = {
                                             TAG.Temperature,
                                             TAG.Sensor,
                                         ],
+                                    },
+                                    "Reheat_Supply_Air_Temperature_Sensor": {
+                                        "aliases": [BRICK["Reheat_Discharge_Air_Temperature_Sensor"]],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Reheat,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Sensor,
+                                        ],
                                     }
                                 },
                             },


### PR DESCRIPTION
Proposing to add commands, sensor, and equipment classes to support the dehumidification process in the Brick ontology. Specifically, we are introducing the following:

- Reheat Command (`Reheat_Command`)
- Reheat Supply Air Temperature (SAT) Sensor (`Reheat_SAT_Sensor`)
- Reheat Hot Water Valve (`Reheat_Hot_Water_Valve`)
- Dehumidification Command (`Dehumidification_Command`)

## Why These Additions are Necessary

### Reheat Command (`Reheat_Command`)
The reheat command is needed for distinguishing the heating command needed to reheat the supply air post-dehumidification. Without a dedicated reheat command, it isn't possible to decouple the reheat operation from other heating operations within an HVAC system.

### Reheat Hot Water Valve (`Reheat_Hot_Water_Valve`)
The Reheat Hot Water Valve controls the flow of hot water to the heating elements used in the reheat process. This tag allows for control and monitoring of the hot water valve.

### Reheat SAT Sensor (`Reheat_SAT_Sensor`)
The Reheat SAT Sensor will be responsible for monitoring the temperature of the supply air post-reheat. This sensor is necessary for implementing feedback loops that can adjust the reheat command or reheat hot water valve.

### Dehumidification Command (`Dehumidification_Command`)
Dehumidification Command is used to initiate the control sequence using the introduced concepts listed above.