### PR TITLE
Replacing sh:and/sh:not with just sh:not

### DIFF
--- a/bricksrc/root_class_shapes.ttl
+++ b/bricksrc/root_class_shapes.ttl
@@ -9,16 +9,11 @@
 
 
 brick:Location a sh:NodeShape ;
-    sh:node [
-        sh:message "Location is an exclusive top class." ;
-        sh:and (
-            [sh:not [ sh:class brick:Point ] ; sh:message "Location is an exclusive top class." ]
-            [sh:not [ sh:class brick:Equipment ] ; sh:message "Location is an exclusive top class." ]
-            [sh:not [ sh:class brick:Substance ] ; sh:message "Location is an exclusive top class." ]
-            [sh:not [ sh:class brick:Quantity ] ; sh:message "Location is an exclusive top class." ]
-            [sh:not [ sh:class brick:Collection ] ; sh:message "Location is an exclusive top class." ]
-        );
-    ] ;
+    sh:node [sh:not [ sh:class brick:Point ] ; sh:message "Location is an exclusive top class."],
+            [sh:not [ sh:class brick:Equipment ] ; sh:message "Location is an exclusive top class." ],
+            [sh:not [ sh:class brick:Substance ] ; sh:message "Location is an exclusive top class." ],
+            [sh:not [ sh:class brick:Quantity ] ; sh:message "Location is an exclusive top class." ],
+            [sh:not [ sh:class brick:Collection ] ; sh:message "Location is an exclusive top class." ] ;
     sh:property [
         sh:path brick:hasPart;
         sh:class brick:Location;
@@ -37,16 +32,11 @@ brick:Location a sh:NodeShape ;
     .
 
 brick:Equipment a sh:NodeShape ;
-    sh:node [
-        sh:message "Equipment is an exclusive top class." ;
-        sh:and (
-            [sh:not [ sh:class brick:Point ] ; sh:message "Equipment is an exclusive top class." ]
-            [sh:not [ sh:class brick:Location ] ; sh:message "Equipment is an exclusive top class." ]
-            [sh:not [ sh:class brick:Substance ] ; sh:message "Equipment is an exclusive top class." ]
-            [sh:not [ sh:class brick:Quantity ] ; sh:message "Equipment is an exclusive top class." ]
-            [sh:not [ sh:class brick:Collection ] ; sh:message "Equipment is an exclusive top class." ]
-        );
-    ] ;
+    sh:node    [sh:not [ sh:class brick:Point ] ; sh:message "Equipment is an exclusive top class." ],
+               [sh:not [ sh:class brick:Location ] ; sh:message "Equipment is an exclusive top class." ],
+               [sh:not [ sh:class brick:Substance ] ; sh:message "Equipment is an exclusive top class." ],
+               [sh:not [ sh:class brick:Quantity ] ; sh:message "Equipment is an exclusive top class." ],
+               [sh:not [ sh:class brick:Collection ] ; sh:message "Equipment is an exclusive top class." ] ;
     sh:property [
         sh:path brick:hasPart;
         sh:class brick:Equipment;
@@ -77,16 +67,11 @@ brick:Equipment a sh:NodeShape ;
     .
 
 brick:Point a sh:NodeShape;
-    sh:node [
-        sh:and (
-            [sh:not [ sh:class brick:Equipment ] ; sh:message "Point is an exclusive top class." ]
-            [sh:not [ sh:class brick:Location ] ; sh:message "Point is an exclusive top class." ]
-            [sh:not [ sh:class brick:Substance ] ; sh:message "Point is an exclusive top class." ]
-            [sh:not [ sh:class brick:Quantity ] ; sh:message "Point is an exclusive top class." ]
-            [sh:not [ sh:class brick:Collection ] ; sh:message "Point is an exclusive top class." ]
-        );
-        sh:message "Point is an exclusive top class." ;
-    ] ;
+    sh:node [sh:not [ sh:class brick:Equipment ] ; sh:message "Point is an exclusive top class." ],
+            [sh:not [ sh:class brick:Location ] ; sh:message "Point is an exclusive top class." ],
+            [sh:not [ sh:class brick:Substance ] ; sh:message "Point is an exclusive top class." ],
+            [sh:not [ sh:class brick:Quantity ] ; sh:message "Point is an exclusive top class." ],
+            [sh:not [ sh:class brick:Collection ] ; sh:message "Point is an exclusive top class." ] ;
     sh:property [
         sh:path brick:hasLocation ;
         sh:maxCount 0 ;
@@ -95,16 +80,11 @@ brick:Point a sh:NodeShape;
     .
 
 brick:Collection a sh:NodeShape;
-    sh:node [
-        sh:and (
-            [sh:not [ sh:class brick:Equipment ] ; sh:message "Collection is an exclusive top class." ]
-            [sh:not [ sh:class brick:Location ] ; sh:message "Collection is an exclusive top class." ]
-            [sh:not [ sh:class brick:Substance ] ; sh:message "Collection is an exclusive top class." ]
-            [sh:not [ sh:class brick:Quantity ] ; sh:message "Collection is an exclusive top class." ]
-            [sh:not [ sh:class brick:Point ] ; sh:message "Collection is an exclusive top class." ]
-        );
-        sh:message "Collection is an exclusive top class." ;
-    ] ;
+    sh:node [sh:not [ sh:class brick:Equipment ] ; sh:message "Collection is an exclusive top class." ],
+            [sh:not [ sh:class brick:Location ] ; sh:message "Collection is an exclusive top class." ],
+            [sh:not [ sh:class brick:Substance ] ; sh:message "Collection is an exclusive top class." ],
+            [sh:not [ sh:class brick:Quantity ] ; sh:message "Collection is an exclusive top class." ],
+            [sh:not [ sh:class brick:Point ] ; sh:message "Collection is an exclusive top class." ] ;
     sh:property [
         sh:path brick:hasPart;
         sh:or (


### PR DESCRIPTION
PySHACL complains because we have multiple sh:not negation clauses inside a single shape (the object of sh:node). This alternate form should be equivalent while avoiding the issues for PySHACL. PySHACL is *technically* correct in rejecting multiple `sh:not` clauses in the same shape, but other SHACL processors don't mind this. 