### PR TITLE
Swapping out brick quantitykinds for QUDT QKs when Brick adds nothing

### DIFF
--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -3,7 +3,7 @@ Entity property definitions
 """
 from collections import defaultdict
 from rdflib import Literal
-from .namespaces import BRICK, RDFS, SKOS, UNIT, XSD, SH, BSH, REF
+from .namespaces import BRICK, RDFS, SKOS, UNIT, XSD, SH, BSH, REF, QUDTQK
 
 # these are the "relationship"/predicates/OWL properties that
 # relate a Brick entity to a structured value.
@@ -461,7 +461,7 @@ shape_properties = {
             BRICK.longitude: {"datatype": BSH.NumericValue},
         },
     },
-    BSH.TiltShape: {"unitsFromQuantity": BRICK.Angle, "datatype": BSH.NumericValue},
+    BSH.TiltShape: {"unitsFromQuantity": QUDTQK.Angle, "datatype": BSH.NumericValue},
     BSH.TemperatureShape: {
         "unitsFromQuantity": BRICK.Temperature,
         "datatype": BSH.NumericValue,
@@ -471,7 +471,7 @@ shape_properties = {
         "datatype": BSH.NumericValue,
     },
     BSH.AzimuthShape: {
-        "unitsFromQuantity": BRICK.Angle,
+        "unitsFromQuantity": QUDTQK.Angle,
         "datatype": BSH.NumericValue,
         "rotationalDirection": {"values": ["clockwise", "counterclockwise"]},
         "referenceDirection": {"values": ["North", "South", "East", "West"]},

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -174,29 +174,15 @@ quantity_definitions = {
             },
         },
     },
-    "Angle": {BRICK.hasQUDTReference: QUDTQK["Angle"]},
-    "Conductivity": {BRICK.hasQUDTReference: QUDTQK["Conductivity"]},
-    "Capacity": {BRICK.hasQUDTReference: QUDTQK["Capacity"]},
-    "Enthalpy": {
+    "GrainsOfMoisture": {
+        QUDT.applicableUnit: UNIT.GRAIN,
+        QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
+        RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
+        RDFS.label: Literal("GrainsOfMoisture"),
         SKOS.definition: Literal(
-            "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"
+            "Mass of moisture per pround of air, measured in grains of water"
         ),
-        BRICK.hasQUDTReference: QUDTQK["Enthalpy"],
-    },
-    "Mass": {
-        BRICK.hasQUDTReference: QUDTQK["Mass"],
-        SKOS.narrower: {
-            "GrainsOfMoisture": {
-                QUDT.applicableUnit: UNIT.GRAIN,
-                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M1H0T0D0"],
-                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
-                RDFS.label: Literal("GrainsOfMoisture"),
-                SKOS.definition: Literal(
-                    "Mass of moisture per pround of air, measured in grains of water"
-                ),
-                SKOS.broader: QUDTQK.Mass,
-            }
-        },
+        SKOS.broader: QUDTQK.Mass,
     },
     "Phasor": {
         SKOS.related: {
@@ -244,22 +230,6 @@ quantity_definitions = {
     "Power": {
         BRICK.hasQUDTReference: QUDTQK["Power"],
         SKOS.narrower: {
-            "Electric_Power": {
-                BRICK.hasQUDTReference: QUDTQK["ElectricPower"],
-                SKOS.narrower: {
-                    "Apparent_Power": {BRICK.hasQUDTReference: QUDTQK["ApparentPower"]},
-                    "Active_Power": {
-                        OWL.sameAs: BRICK["Real_Power"],
-                        BRICK.hasQUDTReference: QUDTQK["ActivePower"],
-                    },
-                    "Real_Power": {
-                        OWL.sameAs: BRICK["Active_Power"],
-                        BRICK.hasQUDTReference: QUDTQK["ActivePower"],
-                    },
-                    "Reactive_Power": {BRICK.hasQUDTReference: QUDTQK["ReactivePower"]},
-                    "Complex_Power": {BRICK.hasQUDTReference: QUDTQK["ComplexPower"]},
-                },
-            },
             "Peak_Power": {
                 SKOS.broader: QUDTQK.Power,
                 QUDT.applicableUnit: [UNIT.KiloW, UNIT.MegaW, UNIT.MilliW, UNIT.W],
@@ -768,7 +738,6 @@ quantity_definitions = {
         # TODO: what are these?
         SKOS.narrower: {"Acceleration_Time": {}, "Deceleration_Time": {}},
     },
-    "Torque": {BRICK.hasQUDTReference: QUDTQK["Torque"]},
     # TODO: https://ci.mines-stetienne.fr/seas/WeatherOntology-0.9#AirTemperature ?
     "Volume": {
         BRICK.hasQUDTReference: QUDTQK["Volume"],

--- a/bricksrc/relationships.py
+++ b/bricksrc/relationships.py
@@ -21,7 +21,7 @@ relationships = {
         A: [OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         RDFS.label: Literal("Has Quantity"),
         RDFS.subPropertyOf: QUDT.hasQuantityKind,
-        "range": BRICK.Quantity,
+        "range": [BRICK.Quantity, QUDT.QuantityKind],
         "domain": BRICK.Point,
     },
     "value": {

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import BRICK, TAG, OWL, RDFS, QUDT
+from .namespaces import BRICK, TAG, OWL, RDFS, QUDT, QUDTQK
 
 sensor_definitions = {
     "Sensor": {
@@ -300,7 +300,7 @@ sensor_definitions = {
                 },
             },
             "Angle_Sensor": {
-                BRICK.hasQuantity: BRICK.Angle,
+                BRICK.hasQuantity: QUDTQK.Angle,
                 "subclasses": {
                     "Solar_Azimuth_Angle_Sensor": {
                         "tags": [
@@ -325,7 +325,7 @@ sensor_definitions = {
             },
             "Capacity_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Capacity],
-                BRICK.hasQuantity: BRICK.Capacity,
+                BRICK.hasQuantity: QUDTQK.Capacity,
             },
             "Contact_Sensor": {"tags": [TAG.Point, TAG.Sensor, TAG.Contact]},
             "Conductivity_Sensor": {
@@ -333,7 +333,7 @@ sensor_definitions = {
                 # TODO: pull from
                 # https://technical.buildingsmart.org/standards/ifc/ifc-schema-specifications/
                 "tags": [TAG.Point, TAG.Sensor, TAG.Conductivity],
-                BRICK.hasQuantity: BRICK.Conductivity,
+                BRICK.hasQuantity: QUDTQK.Conductivity,
                 "subclasses": {
                     "Deionised_Water_Conductivity_Sensor": {
                         "tags": [
@@ -343,14 +343,14 @@ sensor_definitions = {
                             TAG.Water,
                             TAG.Deionised,
                         ],
-                        BRICK.hasQuantity: BRICK.Conductivity,
+                        BRICK.hasQuantity: QUDTQK.Conductivity,
                         BRICK.hasSubstance: BRICK.Deionized_Water,
                     }
                 },
             },
             "Current_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Current],
-                BRICK.hasQuantity: BRICK.Electric_Current,
+                BRICK.hasQuantity: QUDTQK.ElectricCurrent,
                 "subclasses": {
                     "Load_Current_Sensor": {
                         "tags": [TAG.Point, TAG.Load, TAG.Current, TAG.Sensor],
@@ -539,10 +539,10 @@ sensor_definitions = {
             },
             "Enthalpy_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Enthalpy],
-                BRICK.hasQuantity: BRICK.Enthalpy,
+                BRICK.hasQuantity: QUDTQK.Enthalpy,
                 "subclasses": {
                     "Air_Enthalpy_Sensor": {
-                        BRICK.hasQuantity: BRICK.Enthalpy,
+                        BRICK.hasQuantity: QUDTQK.Enthalpy,
                         BRICK.hasSubstance: BRICK.Air,
                         "subclasses": {
                             "Outside_Air_Enthalpy_Sensor": {
@@ -553,7 +553,7 @@ sensor_definitions = {
                                     TAG.Enthalpy,
                                     TAG.Sensor,
                                 ],
-                                BRICK.hasQuantity: BRICK.Enthalpy,
+                                BRICK.hasQuantity: QUDTQK.Enthalpy,
                                 BRICK.hasSubstance: BRICK.Outside_Air,
                             },
                             "Return_Air_Enthalpy_Sensor": {
@@ -564,7 +564,7 @@ sensor_definitions = {
                                     TAG.Enthalpy,
                                     TAG.Sensor,
                                 ],
-                                BRICK.hasQuantity: BRICK.Enthalpy,
+                                BRICK.hasQuantity: QUDTQK.Enthalpy,
                                 BRICK.hasSubstance: BRICK.Return_Air,
                             },
                         },
@@ -1273,7 +1273,7 @@ sensor_definitions = {
                     },
                     "Electric_Power_Sensor": {
                         "tags": [TAG.Point, TAG.Sensor, TAG.Power, TAG.Electric],
-                        BRICK.hasQuantity: BRICK.Electric_Power,
+                        BRICK.hasQuantity: QUDTQK.ElectricPower,
                         "subclasses": {
                             "Reactive_Power_Sensor": {
                                 "tags": [
@@ -1283,7 +1283,7 @@ sensor_definitions = {
                                     TAG.Reactive,
                                     TAG.Electric,
                                 ],
-                                BRICK.hasQuantity: BRICK.Reactive_Power,
+                                BRICK.hasQuantity: QUDTQK.ReactivePower,
                             },
                             "Active_Power_Sensor": {
                                 "tags": [
@@ -1293,7 +1293,7 @@ sensor_definitions = {
                                     TAG.Real,
                                     TAG.Electric,
                                 ],
-                                BRICK.hasQuantity: BRICK.Active_Power,
+                                BRICK.hasQuantity: QUDTQK.ActivePower,
                             },
                         },
                     },
@@ -1344,7 +1344,7 @@ sensor_definitions = {
             },
             "Torque_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Torque],
-                BRICK.hasQuantity: BRICK.Torque,
+                BRICK.hasQuantity: QUDTQK.Torque,
                 "subclasses": {
                     "Motor_Torque_Sensor": {
                         "tags": [TAG.Point, TAG.Motor, TAG.Torque, TAG.Sensor],
@@ -1353,7 +1353,7 @@ sensor_definitions = {
             },
             "Voltage_Sensor": {
                 "tags": [TAG.Point, TAG.Sensor, TAG.Voltage],
-                BRICK.hasQuantity: BRICK.Voltage,
+                BRICK.hasQuantity: QUDTQK.Voltage,
                 "subclasses": {
                     "Battery_Voltage_Sensor": {
                         "tags": [TAG.Point, TAG.Sensor, TAG.Voltage, TAG.Battery],

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -1,4 +1,4 @@
-from .namespaces import TAG, BRICK, RDFS, OWL, QUDT
+from .namespaces import TAG, BRICK, RDFS, OWL, QUDT, QUDTQK
 from rdflib import Literal
 
 setpoint_definitions = {
@@ -22,7 +22,7 @@ setpoint_definitions = {
                 "tags": [TAG.Point, TAG.Setpoint, TAG.Illuminance]
             },
             "Enthalpy_Setpoint": {
-                BRICK.hasQuantity: BRICK.Enthalpy,
+                BRICK.hasQuantity: QUDTQK.Enthalpy,
                 "tags": [TAG.Point, TAG.Setpoint, TAG.Enthalpy],
             },
             "Dewpoint_Setpoint": {


### PR DESCRIPTION
In some cases, Brick augments QUDT's quantity kinds (e.g. by adding new units, refining the existing units, or altering the definition to be more specific to the building/HVAC context).

<details>
<summary>Temperature is a good example of this. `Temperature` in Brick is `ThermodynamicTemperature` in QUDT, but Brick also adds some special subtypes </summary>

```python
    "Temperature": {
        BRICK.hasQUDTReference: QUDTQK["Temperature"],
        SKOS.narrower: {
            "Differential_Temperature": {
                BRICK.hasQUDTReference: QUDTQK["Temperature"],
                QUDT.isDeltaQuantity: Literal(True),
            },
            "Operative_Temperature": {
                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
                SKOS.definition: Literal(
                    "The uniform temperature of an imaginary black enclosure in which an occupant would exchange the same amount of heat by radiation plus convection as in the actual nonuniform environment (https://en.wikipedia.org/wiki/Operative_temperature)"
                ),
                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                RDFS.label: Literal("Operative_Temperature"),
                SKOS.broader: QUDTQK.Temperature,
            },
            "Radiant_Temperature": {
                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
                SKOS.definition: Literal(
                    "the uniform temperature of an imaginary enclosure in which the radiant heat transfer from the human body is equal to the radiant heat transfer in the actual non-uniform enclosure. (https://en.wikipedia.org/wiki/Mean_radiant_temperature)"
                ),
                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                RDFS.label: Literal("Radiant_Temperature"),
                SKOS.broader: QUDTQK.Temperature,
            },
            "Dry_Bulb_Temperature": {
                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
                SKOS.definition: Literal(
                    "The temperature of air measured by a thermometer freely exposed to the air, but shielded from radiation and moisture. (https://en.wikipedia.org/wiki/Dry-bulb_temperature)"
                ),
                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                RDFS.label: Literal("Dry_Bulb_Temperature"),
                SKOS.broader: QUDTQK.Temperature,
                SKOS.narrower: {
                    "Differential_Dry_Bulb_Temperature": {
                        QUDT.isDeltaQuantity: Literal(True),
                    },
                },
            },
            "Wet_Bulb_Temperature": {
                QUDT.applicableUnit: [UNIT["DEG_F"], UNIT["DEG_C"], UNIT["K"]],
                SKOS.definition: Literal(
                    "The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)"
                ),
                QUDT.hasDimensionVector: QUDTDV["A0E0L0I0M0H1T0D0"],
                RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                RDFS.label: Literal("Wet_Bulb_Temperature"),
                SKOS.broader: QUDTQK.Temperature,
            },
        },
```
</details>


In others, Brick simply copies all of the properties from the existing QUDT quantity kind. This PR removes redundant QKs from Brick and expands the `hasQuantity` relationship to accept QUDT QKs in addition to Brick's own.

Addresses an initial thought in https://github.com/BrickSchema/Brick/issues/450