### PR TITLE
Fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Brick Development Team
+Copyright (c) 2016-2023, Brick Consortium, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,12 +28,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-About the Copyright Holders
-===========================
-Brick Development Team was initiated to produce a unified metadata
-schema for resources in buildings in early 2016. The team consists
-of members from IBM; Carnegie Mellon University; University of
-California, Berkeley; University of California, Los Angeles;
-University of California, San Diego; University of Virginia and
-University of Southern Denmark.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ It will produce three files inside `history/{old_version}-{new_version}`.
 - `added_classes.txt`: A list of new classes introduced in the current version compared to the previous version.
 - `removed_classes.txt`: A list of old classes removed in the current version compared to the previous version.
 - `possible_mapping.json`: A map of candidate classes that can replace removed classes. Keys are removed classes and the values are candidate correspondants in the new vesion.
+
+
+---
+
+*The Brick Development Team was initiated to produce a unified metadata schema for resources in buildings in early 2016. The team consists of members from IBM; Carnegie Mellon University; University of California, Berkeley; University of California, Los Angeles; University of California, San Diego; University of Virginia and University of Southern Denmark.*


### PR DESCRIPTION
 - change copyright holder to Brick Consortium, Inc
 - move acknowledgements of creators to README rather than at bottom of LICENSE file. This will assist with automatic detection of the bsd 3 clause license
 - update copyright year to include 2023