### PR TITLE
Make minor changes to Brick/223 mapping

### DIFF
--- a/extensions/brick_extension_mappings_223.ttl
+++ b/extensions/brick_extension_mappings_223.ttl
@@ -10,9 +10,6 @@
 @prefix s223tobrick: <https://brickschema.org/extension/brick_extension_interpret_223#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-s223:AbstractSensor
-  s223tobrick:translatesTo brick:Sensor ;
-.
 s223:ActuatableProperty
   s223tobrick:translatesTo brick:Command ;
 .
@@ -61,8 +58,14 @@ s223:Medium-NaturalGas
 s223:Medium-Refrigerant
   s223tobrick:translatesTo brick:Refrigerant ;
 .
+s223:ObservableProperty
+  s223tobrick:translatesTo brick:Sensor ;
+.
 s223:PhysicalSpace
   s223tobrick:translatesTo brick:Location ;
+.
+s223:Property
+  s223tobrick:translatesTo brick:Point ;
 .
 s223:Pump
   s223tobrick:translatesTo brick:Pump ;


### PR DESCRIPTION
- Brick Point should be a 223 Property, not a AbstractSensor
- 223 ObservableProperty is a Brick Sensor
- Abstract Sensor has no equivalent in Brick. it is the "thing" that produces the observation, not the box hosting it (which would be Brick Sensor_Equipment)