### PR TITLE
Deprecate Speed Status

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -1005,11 +1005,10 @@ https://brickschema.org/schema/Brick#Space,"A part of the physical world or a vi
 https://brickschema.org/schema/Brick#Space_Heater,"A heater used to warm the air in an enclosed area, such as a room or office",
 https://brickschema.org/schema/Brick#Speed,,
 https://brickschema.org/schema/Brick#Speed_Command,A command to set speed to a certain degree.,
-https://brickschema.org/schema/Brick#Speed_Mode_Status,Status indicating the speed mode,
+https://brickschema.org/schema/Brick#Speed_Mode_Status,"Indicates the speed mode of a motor with various categorical settings, such as a multi-state value including low, medium, and high."
 https://brickschema.org/schema/Brick#Speed_Reset_Command,,
 https://brickschema.org/schema/Brick#Speed_Sensor,Measures the magnitude of velocity of some form of movement,
 https://brickschema.org/schema/Brick#Speed_Setpoint,Sets speed,
-https://brickschema.org/schema/Brick#Speed_Status,"Indicates the operating speed of a device or equipment, e.g. fan",
 https://brickschema.org/schema/Brick#Sports_Service_Room,A class of spaces used in the support of sports,
 https://brickschema.org/schema/Brick#Stage_Enable_Command,A point representing a discrete stage which the equipment should be operating at. The desired stage number should be identified by an entity property,
 https://brickschema.org/schema/Brick#Stage_Riser,A low platform in a space or on a stage,

--- a/bricksrc/deprecations.py
+++ b/bricksrc/deprecations.py
@@ -1,6 +1,11 @@
 from .namespaces import BRICK, RDFS, SKOS, A, REC
 
 deprecations = {
+    BRICK.Speed_Status: {
+        "version": "1.4.0",
+        "mitigation_message": "Speed Status is no longer necessary. Use Speed Mode Status for motors with various categorical speed settings, such as low, medium, and high. To further clarify, points representing the current speed of a variable speed fan as an analog value or input, use Speed Sensor.",
+        "replace_with": BRICK.Speed_Mode_Status,
+    },
     BRICK.Condenser: {
         "version": "1.3.0",
         "mitigation_message": "'Condenser' and 'Condensing Unit' are interchangable terms. Renaming class to 'Condensing_Unit' to further aligns with ASHRAE's terminology.",

--- a/bricksrc/status.py
+++ b/bricksrc/status.py
@@ -17,7 +17,6 @@ status_definitions = {
             "Damper_Position_Status": {
                 "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Status],
                 BRICK.hasQuantity: BRICK.Position,
-                "tags": [TAG.Damper, TAG.Position, TAG.Status, TAG.Point],
             },
             "Direction_Status": {
                 BRICK.hasQuantity: BRICK.Direction,
@@ -246,6 +245,9 @@ status_definitions = {
             },
             "Mode_Status": {
                 "subclasses": {
+                    "Speed_Mode_Status": {
+                        "tags": [TAG.Point, TAG.Speed, TAG.Status, TAG.Mode],
+                    },
                     "Zone_Air_Conditioning_Mode_Status": {
                         "tags": [
                             TAG.Point,
@@ -540,15 +542,6 @@ status_definitions = {
                             },
                         },
                     },
-                },
-            },
-            "Speed_Status": {
-                "tags": [TAG.Point, TAG.Speed, TAG.Status],
-                "subclasses": {
-                    "Speed_Mode_Status": {
-                        "tags": [TAG.Point, TAG.Speed, TAG.Status, TAG.Mode],
-                        "parents": [BRICK.Mode_Status],
-                    }
                 },
             },
         },


### PR DESCRIPTION
Speed Status is no longer necessary. Recommend using Speed Mode Status for motors with various categorical speed settings, such as an Multi-state value containing low, medium, and high. 

For points representing the current speed of a variable speed motor such as an analog value or input, Speed Sensor would be most appropriate.