### PR TITLE
Reclassify Freezer as Equipment

### DIFF
--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -17,7 +17,7 @@ equipment_subclasses = {
                     },
                     "Server": {
                         "tags": [TAG.Equipment, TAG.ICT, TAG.Hardware, TAG.Server]
-                    },  
+                    },
                 },
             },
             "ICT_Rack": {
@@ -39,7 +39,13 @@ equipment_subclasses = {
                         "tags": [TAG.Occupancy, TAG.Sensor, TAG.Equipment, TAG.ICT],
                     },
                     "People_Count_Sensor_Equipment": {
-                        "tags": [TAG.People, TAG.Count, TAG.Sensor, TAG.Equipment, TAG.ICT],
+                        "tags": [
+                            TAG.People,
+                            TAG.Count,
+                            TAG.Sensor,
+                            TAG.Equipment,
+                            TAG.ICT,
+                        ],
                     },
                     "Thermostat_Equipment": {
                         "tags": [TAG.Thermostat, TAG.Equipment, TAG.ICT],
@@ -959,6 +965,9 @@ hvac_subclasses = {
                 ],
             },
         },
+    },
+    "Freezer": {
+        "tags": [TAG.Freezer, TAG.Equipment],
     },
     "Fume_Hood": {"tags": [TAG.Equipment, TAG.Fume, TAG.Hood]},
     "Filter": {

--- a/bricksrc/location.py
+++ b/bricksrc/location.py
@@ -192,14 +192,6 @@ location_subclasses = {
                     "Laboratory": {
                         "tags": [TAG.Laboratory, TAG.Room, TAG.Location],
                         "subclasses": {
-                            "Freezer": {
-                                "tags": [
-                                    TAG.Freezer,
-                                    TAG.Laboratory,
-                                    TAG.Room,
-                                    TAG.Location,
-                                ],
-                            },
                             "Cold_Box": {
                                 "tags": [
                                     TAG.Cold,


### PR DESCRIPTION
A freezer's composition typically includes a compressor, metering device, condenser coil, evaporator coil, and defrost system, all of which serve a compartment of varying sizes depending on its application. It is designed to maintain this compartment at sub-freezing temperatures. While I understand the perspective of classifying the compartment as a brick:Space, this disregards the core components of a freezer that perform the work of maintaining the desired temperature.

Since a freezer's primary function is to maintain the necessary sub-freezing environment. Classifying it as brick:Equipment is most appropriate to distinguish it from "passive" spaces. Therefore, I propose reclassifying brick:Freezer as brick:Equipment rather than brick:Room.

Additionally, I see the perspective of classifying a Walk-in Freezer/Cooler as both brick:Equipment and brick:Space. However, since these also perform active work to maintain specific temperatures, I would prefer to classify them as brick:Equipment. With that being said, perhaps there's room to consider a class, such as Walk-in Freezer, which is both type equipment and space.