### PR TITLE
Move fume hood under exhaust fan class

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -484,7 +484,7 @@ https://brickschema.org/schema/Brick#Frequency_Setpoint,Sets frequency,
 https://brickschema.org/schema/Brick#Frost,"frost formed on the cold surface (tubes, plates) of a cooling coil.",
 https://brickschema.org/schema/Brick#Frost_Sensor,Senses the presence of frost or conditions that may cause frost,
 https://brickschema.org/schema/Brick#Fuel_Oil,Petroleum based oil burned for energy,
-https://brickschema.org/schema/Brick#Fume_Hood,"A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed.",
+https://brickschema.org/schema/Brick#Fume_Hood,"A fume hood is a type of local exhaust ventilation device designed to protect users from exposure to hazardous fumes, vapors, and dust. It is typically mounted over a workspace, table, or shelf to capture and conduct unwanted gases away from the enclosed area.",
 https://brickschema.org/schema/Brick#Fume_Hood_Air_Flow_Sensor,Measures the rate of flow of air in a fume hood,
 https://brickschema.org/schema/Brick#Furniture,"Movable objects intended to support various human activities such as seating, eating and sleeping",https://en.wikipedia.org/wiki/Furniture
 https://brickschema.org/schema/Brick#Gain_Parameter,,

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -17,7 +17,7 @@ equipment_subclasses = {
                     },
                     "Server": {
                         "tags": [TAG.Equipment, TAG.ICT, TAG.Hardware, TAG.Server]
-                    },  
+                    },
                 },
             },
             "ICT_Rack": {
@@ -39,7 +39,13 @@ equipment_subclasses = {
                         "tags": [TAG.Occupancy, TAG.Sensor, TAG.Equipment, TAG.ICT],
                     },
                     "People_Count_Sensor_Equipment": {
-                        "tags": [TAG.People, TAG.Count, TAG.Sensor, TAG.Equipment, TAG.ICT],
+                        "tags": [
+                            TAG.People,
+                            TAG.Count,
+                            TAG.Sensor,
+                            TAG.Equipment,
+                            TAG.ICT,
+                        ],
                     },
                     "Thermostat_Equipment": {
                         "tags": [TAG.Thermostat, TAG.Equipment, TAG.ICT],
@@ -960,7 +966,6 @@ hvac_subclasses = {
             },
         },
     },
-    "Fume_Hood": {"tags": [TAG.Equipment, TAG.Fume, TAG.Hood]},
     "Filter": {
         "tags": [TAG.Equipment, TAG.Filter],
         "subclasses": {
@@ -986,7 +991,12 @@ hvac_subclasses = {
             "Cooling_Tower_Fan": {
                 "tags": [TAG.Cool, TAG.Tower, TAG.Equipment, TAG.Fan],
             },
-            "Exhaust_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Exhaust]},
+            "Exhaust_Fan": {
+                "tags": [TAG.Equipment, TAG.Fan, TAG.Exhaust],
+                "subclasses": {
+                    "Fume_Hood": {"tags": [TAG.Equipment, TAG.Fume, TAG.Hood]},
+                },
+            },
             "Return_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Return]},
             "Booster_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Booster]},
             "Standby_Fan": {"tags": [TAG.Equipment, TAG.Fan, TAG.Standby]},


### PR DESCRIPTION
Proposing to classify `brick:Fume_Hood` as a type of `brick:Exhaust_Fan`. 

A fume hood is a type of local exhaust ventilation device designed to protect users from exposure to hazardous fumes, vapors, and dust. It is typically mounted over a workspace, table, or shelf to capture and conduct unwanted gases away from the enclosed area.