### PR TITLE
Setpoint Restructure

### DIFF
--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -1,5 +1,5 @@
 from rdflib import Literal
-from .namespaces import BRICK, TAG, OWL
+from .namespaces import BRICK, TAG, OWL, QUDTQK
 
 parameter_definitions = {
     "Parameter": {
@@ -10,6 +10,20 @@ parameter_definitions = {
                 "subclasses": {
                     "Alarm_Delay_Parameter": {
                         "tags": [TAG.Point, TAG.Alarm, TAG.Delay, TAG.Parameter],
+                    },
+                },
+            },
+            "Time_Parameter": {
+                BRICK.hasQuantity: BRICK.Time,
+                "tags": [TAG.Point, TAG.Time, TAG.Parameter],
+                "subclasses": {
+                    "Deceleration_Time_Parameter": {
+                        BRICK.hasQuantity: BRICK.Time,
+                        "tags": [TAG.Point, TAG.Time, TAG.Parameter, TAG.Deceleration],
+                    },
+                    "Acceleration_Time_Parameter": {
+                        BRICK.hasQuantity: BRICK.Time,
+                        "tags": [TAG.Point, TAG.Time, TAG.Parameter, TAG.Acceleration],
                     },
                 },
             },
@@ -68,7 +82,6 @@ parameter_definitions = {
                             TAG.Max,
                             TAG.Load,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
                     },
                     "Min_Load_Setpoint": {
@@ -77,8 +90,247 @@ parameter_definitions = {
                             TAG.Min,
                             TAG.Load,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
+                    },
+                },
+            },
+            "Deadband_Parameter": {
+                "tags": [TAG.Point, TAG.Deadband, TAG.Parameter],
+                BRICK.hasQuantity: QUDTQK.Dimensionless,
+                "subclasses": {
+                    "Humidity_Deadband_Parameter": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        "tags": [TAG.Point, TAG.Deadband, TAG.Parameter, TAG.Humidity],
+                    },
+                    "Temperature_Deadband_Parameter": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "subclasses": {
+                            "Occupied_Cooling_Temperature_Deadband_Parameter": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Occupied,
+                                    TAG.Cool,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Cooling_Temperature_Setpoint],
+                            },
+                            "Occupied_Heating_Temperature_Deadband_Parameter": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Occupied,
+                                    TAG.Heat,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Heating_Temperature_Setpoint],
+                            },
+                            "Unoccupied_Cooling_Temperature_Deadband_Parameter": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Unoccupied,
+                                    TAG.Cool,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Cooling_Temperature_Setpoint],
+                            },
+                            "Unoccupied_Heating_Temperature_Deadband_Parameter": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Unoccupied,
+                                    TAG.Heat,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Heating_Temperature_Setpoint],
+                            },
+                            "Supply_Air_Temperature_Deadband_Parameter": {
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "aliases": [
+                                    BRICK[
+                                        "Discharge_Air_Temperature_Deadband_Parameter"
+                                    ]
+                                ],
+                                "subclasses": {
+                                    "Heating_Supply_Air_Temperature_Deadband_Parameter": {
+                                        "aliases": [
+                                            BRICK[
+                                                "Heating_Discharge_Air_Temperature_Deadband_Parameter"
+                                            ]
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Heat,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Deadband,
+                                            TAG.Parameter,
+                                        ],
+                                        "parents": [
+                                            BRICK.Discharge_Air_Temperature_Heating_Setpoint,
+                                            BRICK.Heating_Temperature_Setpoint,
+                                        ],
+                                    },
+                                    "Cooling_Supply_Air_Temperature_Deadband_Parameter": {
+                                        "aliases": [
+                                            BRICK[
+                                                "Cooling_Discharge_Air_Temperature_Deadband_Parameter"
+                                            ]
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Cool,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Deadband,
+                                            TAG.Parameter,
+                                        ],
+                                        "parents": [
+                                            BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
+                                            BRICK.Cooling_Temperature_Setpoint,
+                                        ],
+                                    },
+                                },
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [
+                                    BRICK.Discharge_Air_Temperature_Setpoint,
+                                    BRICK.Air_Temperature_Setpoint,
+                                ],
+                            },
+                            "Entering_Water_Temperature_Deadband_Parameter": {
+                                BRICK.hasSubstance: BRICK.Entering_Water,
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Entering,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Entering_Water_Temperature_Setpoint],
+                            },
+                            "Leaving_Water_Temperature_Deadband_Parameter": {
+                                BRICK.hasSubstance: BRICK.Leaving_Water,
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Leaving,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Leaving_Water_Temperature_Setpoint],
+                            },
+                        },
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Deadband,
+                            TAG.Parameter,
+                        ],
+                        "parents": [BRICK.Temperature_Setpoint],
+                    },
+                    "Air_Flow_Deadband_Parameter": {
+                        BRICK.hasSubstance: BRICK.Air,
+                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        "subclasses": {
+                            "Exhaust_Air_Stack_Flow_Deadband_Parameter": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Exhaust,
+                                    TAG.Air,
+                                    TAG.Stack,
+                                    TAG.Flow,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [BRICK.Exhaust_Air_Stack_Flow_Setpoint],
+                            }
+                        },
+                        "tags": [
+                            TAG.Point,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Deadband,
+                            TAG.Parameter,
+                        ],
+                        "parents": [BRICK.Air_Flow_Setpoint],
+                    },
+                    "Static_Pressure_Deadband_Parameter": {
+                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Static,
+                            TAG.Pressure,
+                            TAG.Deadband,
+                            TAG.Parameter,
+                        ],
+                        "parents": [BRICK.Static_Pressure_Setpoint],
+                        "subclasses": {
+                            "Supply_Air_Static_Pressure_Deadband_Parameter": {
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                "aliases": [
+                                    BRICK[
+                                        "Discharge_Air_Static_Pressure_Deadband_Parameter"
+                                    ]
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Deadband,
+                                    TAG.Parameter,
+                                ],
+                                "parents": [
+                                    BRICK.Discharge_Air_Static_Pressure_Setpoint,
+                                    BRICK.Supply_Air_Static_Pressure_Setpoint,
+                                ],
+                            },
+                        },
                     },
                 },
             },
@@ -832,7 +1084,6 @@ parameter_definitions = {
                             TAG.Speed,
                             TAG.Limit,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
                         "subclasses": {
                             "Max_Speed_Setpoint_Limit": {
@@ -842,7 +1093,6 @@ parameter_definitions = {
                                     TAG.Speed,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "parents": [BRICK.Max_Limit],
                             },
@@ -853,7 +1103,6 @@ parameter_definitions = {
                                     TAG.Speed,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "parents": [BRICK.Min_Limit],
                             },
@@ -865,7 +1114,7 @@ parameter_definitions = {
                             TAG.Air,
                             TAG.Temperature,
                             TAG.Limit,
-                            TAG.Setpoint,
+                            TAG.Parameter,
                         ],
                         "parents": [BRICK.Temperature_Parameter],
                         "subclasses": {
@@ -880,7 +1129,7 @@ parameter_definitions = {
                                     TAG.Air,
                                     TAG.Temperature,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "subclasses": {
                                     "Max_Supply_Air_Temperature_Setpoint_Limit": {
@@ -897,7 +1146,7 @@ parameter_definitions = {
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Limit,
-                                            TAG.Setpoint,
+                                            TAG.Parameter,
                                         ],
                                         "parents": [
                                             BRICK.Max_Temperature_Setpoint_Limit
@@ -917,7 +1166,7 @@ parameter_definitions = {
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Limit,
-                                            TAG.Setpoint,
+                                            TAG.Parameter,
                                         ],
                                         "parents": [
                                             BRICK.Min_Temperature_Setpoint_Limit
@@ -934,7 +1183,6 @@ parameter_definitions = {
                             TAG.Flow,
                             TAG.Limit,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
                         "subclasses": {
                             "Max_Air_Flow_Setpoint_Limit": {
@@ -945,7 +1193,6 @@ parameter_definitions = {
                                     TAG.Flow,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Air_Flow_Setpoint_Limit": {
@@ -956,7 +1203,6 @@ parameter_definitions = {
                                     TAG.Flow,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                         },
@@ -973,7 +1219,7 @@ parameter_definitions = {
                                     TAG.Max,
                                     TAG.Position,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Max_Limit],
                             },
@@ -983,7 +1229,7 @@ parameter_definitions = {
                                     TAG.Min,
                                     TAG.Position,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Min_Limit],
                             },
@@ -996,7 +1242,6 @@ parameter_definitions = {
                             TAG.Pressure,
                             TAG.Limit,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
                         "subclasses": {
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1009,7 +1254,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1022,7 +1266,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1035,7 +1278,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1048,7 +1290,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                         },
@@ -1059,7 +1300,7 @@ parameter_definitions = {
                             TAG.Fresh,
                             TAG.Air,
                             TAG.Limit,
-                            TAG.Setpoint,
+                            TAG.Parameter,
                         ],
                         "subclasses": {
                             "Min_Fresh_Air_Setpoint_Limit": {
@@ -1069,7 +1310,7 @@ parameter_definitions = {
                                     TAG.Fresh,
                                     TAG.Air,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Min_Limit],
                             },
@@ -1080,7 +1321,7 @@ parameter_definitions = {
                                     TAG.Fresh,
                                     TAG.Air,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Max_Limit],
                             },
@@ -1102,7 +1343,6 @@ parameter_definitions = {
                             TAG.Pressure,
                             TAG.Limit,
                             TAG.Parameter,
-                            TAG.Setpoint,
                         ],
                         "subclasses": {
                             "Min_Static_Pressure_Setpoint_Limit": {
@@ -1113,7 +1353,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
@@ -1124,7 +1363,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "High_Static_Pressure_Cutout_Setpoint_Limit": {
@@ -1135,7 +1373,7 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Cutout,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                             },
                         },
@@ -1150,7 +1388,6 @@ parameter_definitions = {
                                     TAG.Speed,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
@@ -1169,7 +1406,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1182,7 +1418,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Hot_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1195,7 +1430,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Max_Static_Pressure_Setpoint_Limit": {
@@ -1206,7 +1440,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "subclasses": {
                                     "Max_Supply_Air_Static_Pressure_Setpoint_Limit": {
@@ -1225,7 +1458,6 @@ parameter_definitions = {
                                             TAG.Pressure,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                     },
                                 },
@@ -1236,7 +1468,7 @@ parameter_definitions = {
                                     TAG.Max,
                                     TAG.Temperature,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Temperature_Parameter],
                             },
@@ -1248,7 +1480,6 @@ parameter_definitions = {
                                     TAG.Flow,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "subclasses": {
                                     "Max_Outside_Air_Flow_Setpoint_Limit": {
@@ -1260,7 +1491,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                     },
                                     "Max_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1279,7 +1509,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                         "subclasses": {
                                             "Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1299,7 +1528,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                             "Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1319,7 +1547,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                         },
@@ -1340,7 +1567,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                         "subclasses": {
                                             "Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
@@ -1360,7 +1586,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                             "Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
@@ -1380,7 +1605,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                         },
@@ -1399,7 +1623,6 @@ parameter_definitions = {
                                     TAG.Speed,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Hot_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1412,7 +1635,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Chilled_Water_Differential_Pressure_Setpoint_Limit": {
@@ -1425,7 +1647,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
@@ -1444,7 +1665,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                             },
                             "Min_Temperature_Setpoint_Limit": {
@@ -1453,7 +1673,7 @@ parameter_definitions = {
                                     TAG.Min,
                                     TAG.Temperature,
                                     TAG.Limit,
-                                    TAG.Setpoint,
+                                    TAG.Parameter,
                                 ],
                                 "parents": [BRICK.Temperature_Parameter],
                             },
@@ -1465,7 +1685,6 @@ parameter_definitions = {
                                     TAG.Pressure,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "subclasses": {
                                     "Min_Supply_Air_Static_Pressure_Setpoint_Limit": {
@@ -1484,7 +1703,6 @@ parameter_definitions = {
                                             TAG.Pressure,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                     },
                                 },
@@ -1497,7 +1715,6 @@ parameter_definitions = {
                                     TAG.Flow,
                                     TAG.Limit,
                                     TAG.Parameter,
-                                    TAG.Setpoint,
                                 ],
                                 "subclasses": {
                                     "Min_Outside_Air_Flow_Setpoint_Limit": {
@@ -1509,7 +1726,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                     },
                                     "Min_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1528,7 +1744,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                         "subclasses": {
                                             "Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1548,7 +1763,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                             "Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit": {
@@ -1568,7 +1782,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                         },
@@ -1589,7 +1802,6 @@ parameter_definitions = {
                                             TAG.Flow,
                                             TAG.Limit,
                                             TAG.Parameter,
-                                            TAG.Setpoint,
                                         ],
                                         "subclasses": {
                                             "Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
@@ -1609,7 +1821,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                             "Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit": {
@@ -1629,7 +1840,6 @@ parameter_definitions = {
                                                     TAG.Flow,
                                                     TAG.Limit,
                                                     TAG.Parameter,
-                                                    TAG.Setpoint,
                                                 ],
                                             },
                                         },

--- a/bricksrc/parameter.py
+++ b/bricksrc/parameter.py
@@ -94,18 +94,18 @@ parameter_definitions = {
                     },
                 },
             },
-            "Deadband_Parameter": {
+            "Deadband": {
                 "tags": [TAG.Point, TAG.Deadband, TAG.Parameter],
                 BRICK.hasQuantity: QUDTQK.Dimensionless,
                 "subclasses": {
-                    "Humidity_Deadband_Parameter": {
+                    "Humidity_Deadband": {
                         BRICK.hasQuantity: QUDTQK.RelativeHumidity,
                         "tags": [TAG.Point, TAG.Deadband, TAG.Parameter, TAG.Humidity],
                     },
-                    "Temperature_Deadband_Parameter": {
+                    "Temperature_Deadband": {
                         BRICK.hasQuantity: BRICK.Temperature,
                         "subclasses": {
-                            "Occupied_Cooling_Temperature_Deadband_Parameter": {
+                            "Occupied_Cooling_Temperature_Deadband": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
                                     TAG.Point,
@@ -117,7 +117,7 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Cooling_Temperature_Setpoint],
                             },
-                            "Occupied_Heating_Temperature_Deadband_Parameter": {
+                            "Occupied_Heating_Temperature_Deadband": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
                                     TAG.Point,
@@ -129,7 +129,7 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Heating_Temperature_Setpoint],
                             },
-                            "Unoccupied_Cooling_Temperature_Deadband_Parameter": {
+                            "Unoccupied_Cooling_Temperature_Deadband": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Unoccupied,
@@ -140,7 +140,7 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Cooling_Temperature_Setpoint],
                             },
-                            "Unoccupied_Heating_Temperature_Deadband_Parameter": {
+                            "Unoccupied_Heating_Temperature_Deadband": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Unoccupied,
@@ -151,7 +151,7 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Heating_Temperature_Setpoint],
                             },
-                            "Supply_Air_Temperature_Deadband_Parameter": {
+                            "Supply_Air_Temperature_Deadband": {
                                 BRICK.hasSubstance: [
                                     BRICK.Supply_Air,
                                     BRICK.Discharge_Air,
@@ -162,15 +162,13 @@ parameter_definitions = {
                                 ],
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "aliases": [
-                                    BRICK[
-                                        "Discharge_Air_Temperature_Deadband_Parameter"
-                                    ]
+                                    BRICK["Discharge_Air_Temperature_Deadband"]
                                 ],
                                 "subclasses": {
-                                    "Heating_Supply_Air_Temperature_Deadband_Parameter": {
+                                    "Heating_Supply_Air_Temperature_Deadband": {
                                         "aliases": [
                                             BRICK[
-                                                "Heating_Discharge_Air_Temperature_Deadband_Parameter"
+                                                "Heating_Discharge_Air_Temperature_Deadband"
                                             ]
                                         ],
                                         BRICK.hasQuantity: BRICK.Temperature,
@@ -190,10 +188,10 @@ parameter_definitions = {
                                             BRICK.Heating_Temperature_Setpoint,
                                         ],
                                     },
-                                    "Cooling_Supply_Air_Temperature_Deadband_Parameter": {
+                                    "Cooling_Supply_Air_Temperature_Deadband": {
                                         "aliases": [
                                             BRICK[
-                                                "Cooling_Discharge_Air_Temperature_Deadband_Parameter"
+                                                "Cooling_Discharge_Air_Temperature_Deadband"
                                             ]
                                         ],
                                         BRICK.hasQuantity: BRICK.Temperature,
@@ -228,7 +226,7 @@ parameter_definitions = {
                                     BRICK.Air_Temperature_Setpoint,
                                 ],
                             },
-                            "Entering_Water_Temperature_Deadband_Parameter": {
+                            "Entering_Water_Temperature_Deadband": {
                                 BRICK.hasSubstance: BRICK.Entering_Water,
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
@@ -241,7 +239,7 @@ parameter_definitions = {
                                 ],
                                 "parents": [BRICK.Entering_Water_Temperature_Setpoint],
                             },
-                            "Leaving_Water_Temperature_Deadband_Parameter": {
+                            "Leaving_Water_Temperature_Deadband": {
                                 BRICK.hasSubstance: BRICK.Leaving_Water,
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
@@ -263,11 +261,11 @@ parameter_definitions = {
                         ],
                         "parents": [BRICK.Temperature_Setpoint],
                     },
-                    "Air_Flow_Deadband_Parameter": {
+                    "Air_Flow_Deadband": {
                         BRICK.hasSubstance: BRICK.Air,
                         BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
                         "subclasses": {
-                            "Exhaust_Air_Stack_Flow_Deadband_Parameter": {
+                            "Exhaust_Air_Stack_Flow_Deadband": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Exhaust,
@@ -289,7 +287,7 @@ parameter_definitions = {
                         ],
                         "parents": [BRICK.Air_Flow_Setpoint],
                     },
-                    "Static_Pressure_Deadband_Parameter": {
+                    "Static_Pressure_Deadband": {
                         BRICK.hasQuantity: BRICK.Static_Pressure,
                         "tags": [
                             TAG.Point,
@@ -300,7 +298,7 @@ parameter_definitions = {
                         ],
                         "parents": [BRICK.Static_Pressure_Setpoint],
                         "subclasses": {
-                            "Supply_Air_Static_Pressure_Deadband_Parameter": {
+                            "Supply_Air_Static_Pressure_Deadband": {
                                 BRICK.hasSubstance: [
                                     BRICK.Supply_Air,
                                     BRICK.Discharge_Air,
@@ -311,9 +309,7 @@ parameter_definitions = {
                                 ],
                                 BRICK.hasQuantity: BRICK.Static_Pressure,
                                 "aliases": [
-                                    BRICK[
-                                        "Discharge_Air_Static_Pressure_Deadband_Parameter"
-                                    ]
+                                    BRICK["Discharge_Air_Static_Pressure_Deadband"]
                                 ],
                                 "tags": [
                                     TAG.Point,

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -1206,14 +1206,13 @@ setpoint_definitions = {
                                             TAG.Effective,
                                         ],
                                     },
-                                    "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Effective_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Effective_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Effective,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
@@ -1290,14 +1289,13 @@ setpoint_definitions = {
                                             TAG.Occupied,
                                         ],
                                     },
-                                    "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Occupied_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Occupied_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Occupied,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
@@ -1524,65 +1522,60 @@ setpoint_definitions = {
                                     },
                                 },
                             },
-                            "Target_Zone_Air_Temperature_Setpoint": {
+                            "Zone_Air_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 BRICK.hasSubstance: BRICK.Zone_Air,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Target,
                                     TAG.Zone,
                                     TAG.Air,
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Effective_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Effective_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Effective,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Occupied_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Occupied_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Occupied,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Standby_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Standby_Zone_Air_Temperature_Setpoint": {
                                         "tags": [
                                             TAG.Point,
                                             TAG.Standby,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Unoccupied_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Unoccupied_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Unoccupied,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
@@ -1646,14 +1639,13 @@ setpoint_definitions = {
                                             TAG.Unoccupied,
                                         ],
                                     },
-                                    "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                    "Unoccupied_Zone_Air_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Unoccupied_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Unoccupied,
-                                            TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -1,807 +1,895 @@
-from .namespaces import TAG, BRICK, RDFS, QUDTQK
+from namespaces import TAG, BRICK, RDFS, QUDTQK
 from rdflib import Literal
 
 setpoint_definitions = {
     "Setpoint": {
-        RDFS.seeAlso: Literal(
-            "https://xp20.ashrae.org/terminology/index.php?term=setpoint"
-        ),
-        "tags": [TAG.Point, TAG.Setpoint],
+        RDFS.seeAlso: "https://xp20.ashrae.org/terminology/index.php?term=setpoint",
+        "tags": [
+            TAG.Point,
+            TAG.Setpoint,
+        ],
         "subclasses": {
-            "Current_Ratio_Setpoint": {
-                BRICK.hasQuantity: BRICK.Electric_Current,
-                "tags": [TAG.Point, TAG.Setpoint, TAG.Current, TAG.Electric, TAG.Ratio],
-            },
-            "Voltage_Ratio_Setpoint": {
-                BRICK.hasQuantity: BRICK.Voltage,
-                "tags": [TAG.Point, TAG.Setpoint, TAG.Voltage, TAG.Electric, TAG.Ratio],
-            },
-            "Frequency_Setpoint": {
-                "tags": [TAG.Point, TAG.Setpoint, TAG.Frequency],
-                BRICK.hasQuantity: BRICK.Frequency,
-            },
-            "Illuminance_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.Illuminance,
-                "tags": [TAG.Point, TAG.Setpoint, TAG.Illuminance],
-            },
-            "Enthalpy_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.Enthalpy,
-                "tags": [TAG.Point, TAG.Setpoint, TAG.Enthalpy],
-            },
-            "Dewpoint_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.DewPointTemperature,
-                "tags": [TAG.Point, TAG.Dewpoint, TAG.Setpoint],
-            },
-            "Demand_Setpoint": {
-                "tags": [TAG.Point, TAG.Demand, TAG.Setpoint],
-                BRICK.hasQuantity: QUDTQK.Power,
+            "Target_Setpoint": {
                 "subclasses": {
-                    "Cooling_Demand_Setpoint": {
-                        "tags": [TAG.Point, TAG.Cool, TAG.Demand, TAG.Setpoint],
-                    },
-                    "Heating_Demand_Setpoint": {
-                        "tags": [TAG.Point, TAG.Heat, TAG.Demand, TAG.Setpoint],
-                    },
-                    "Preheat_Demand_Setpoint": {
-                        "tags": [TAG.Point, TAG.Preheat, TAG.Demand, TAG.Setpoint],
-                    },
-                    "Air_Flow_Demand_Setpoint": {
-                        BRICK.hasSubstance: BRICK.Air,
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                    "Dewpoint_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.DewPointTemperature,
                         "tags": [
                             TAG.Point,
-                            TAG.Air,
-                            TAG.Flow,
-                            TAG.Demand,
+                            TAG.Dewpoint,
                             TAG.Setpoint,
                         ],
-                        "subclasses": {
-                            "Supply_Air_Flow_Demand_Setpoint": {
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                "aliases": [
-                                    BRICK["Discharge_Air_Flow_Demand_Setpoint"]
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Demand,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
                     },
-                },
-            },
-            "Damper_Position_Setpoint": {
-                BRICK.hasQuantity: BRICK.Position,
-                "tags": [TAG.Point, TAG.Damper, TAG.Position, TAG.Setpoint],
-            },
-            "Deadband_Setpoint": {
-                "tags": [TAG.Point, TAG.Deadband, TAG.Setpoint],
-                BRICK.hasQuantity: QUDTQK.Dimensionless,
-                "subclasses": {
-                    "Humidity_Deadband_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        "tags": [TAG.Point, TAG.Deadband, TAG.Setpoint, TAG.Humidity],
-                    },
-                    "Temperature_Deadband_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
+                    "Differential_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Dimensionless,
                         "subclasses": {
-                            "Occupied_Cooling_Temperature_Deadband_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
+                            "Differential_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Occupied,
-                                    TAG.Cool,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
+                                    TAG.Differential,
+                                    TAG.Pressure,
                                     TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Cooling_Temperature_Setpoint],
-                            },
-                            "Occupied_Heating_Temperature_Deadband_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Occupied,
-                                    TAG.Heat,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Heating_Temperature_Setpoint],
-                            },
-                            "Unoccupied_Cooling_Temperature_Deadband_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Unoccupied,
-                                    TAG.Cool,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Cooling_Temperature_Setpoint],
-                            },
-                            "Unoccupied_Heating_Temperature_Deadband_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Unoccupied,
-                                    TAG.Heat,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Heating_Temperature_Setpoint],
-                            },
-                            "Supply_Air_Temperature_Deadband_Setpoint": {
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "aliases": [
-                                    BRICK["Discharge_Air_Temperature_Deadband_Setpoint"]
                                 ],
                                 "subclasses": {
-                                    "Heating_Supply_Air_Temperature_Deadband_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Heating_Discharge_Air_Temperature_Deadband_Setpoint"
-                                            ]
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                                    "Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        BRICK.hasSubstance: BRICK.Air,
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Heat,
-                                            TAG.Supply,
-                                            TAG.Discharge,
                                             TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Deadband,
+                                            TAG.Differential,
+                                            TAG.Pressure,
                                             TAG.Setpoint,
                                         ],
-                                        "parents": [
-                                            BRICK.Discharge_Air_Temperature_Heating_Setpoint,
-                                            BRICK.Heating_Temperature_Setpoint,
+                                        "subclasses": {
+                                            "Exhaust_Air_Differential_Pressure_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                BRICK.hasSubstance: BRICK.Exhaust_Air,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Exhaust,
+                                                    TAG.Air,
+                                                    TAG.Setpoint,
+                                                    TAG.Pressure,
+                                                    TAG.Differential,
+                                                ],
+                                            },
+                                            "Return_Air_Differential_Pressure_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                BRICK.hasSubstance: BRICK.Return_Air,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Setpoint,
+                                                    TAG.Pressure,
+                                                    TAG.Differential,
+                                                ],
+                                            },
+                                            "Supply_Air_Differential_Pressure_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Discharge_Air_Differential_Pressure_Setpoint,
+                                                ],
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Setpoint,
+                                                    TAG.Pressure,
+                                                    TAG.Differential,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Water_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        BRICK.hasSubstance: BRICK.Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Water,
+                                            TAG.Differential,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Chilled_Water_Differential_Pressure_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                BRICK.hasSubstance: BRICK.Chilled_Water,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Chilled,
+                                                    TAG.Water,
+                                                    TAG.Differential,
+                                                    TAG.Pressure,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Hot_Water_Differential_Pressure_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                BRICK.hasSubstance: BRICK.Hot_Water,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Differential,
+                                                    TAG.Pressure,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Domestic_Hot_Water_Differential_Pressure_Setpoint": {
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Domestic,
+                                                            TAG.Temperature,
+                                                            TAG.Hot,
+                                                            TAG.Water,
+                                                            TAG.Differential,
+                                                            TAG.Pressure,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
+                                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Medium,
+                                                            TAG.Temperature,
+                                                            TAG.Hot,
+                                                            TAG.Water,
+                                                            TAG.Differential,
+                                                            TAG.Pressure,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            "Differential_Speed_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Speed,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Differential,
+                                    TAG.Speed,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Differential_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Differential,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Differential_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Differential,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
                                         ],
                                     },
-                                    "Cooling_Supply_Air_Temperature_Deadband_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Cooling_Discharge_Air_Temperature_Deadband_Setpoint"
-                                            ]
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                                    "Water_Differential_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                        BRICK.hasSubstance: BRICK.Water,
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Cool,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
+                                            TAG.Water,
+                                            TAG.Differential,
                                             TAG.Temperature,
-                                            TAG.Deadband,
                                             TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
-                                            BRICK.Cooling_Temperature_Setpoint,
                                         ],
                                     },
                                 },
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
+                            },
+                            "Load_Shed_Differential_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
                                 "parents": [
-                                    BRICK.Discharge_Air_Temperature_Setpoint,
-                                    BRICK.Air_Temperature_Setpoint,
-                                ],
-                            },
-                            "Entering_Water_Temperature_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Entering_Water,
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Entering,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Entering_Water_Temperature_Setpoint],
-                            },
-                            "Leaving_Water_Temperature_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Leaving_Water,
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Leaving,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Leaving_Water_Temperature_Setpoint],
-                            },
-                        },
-                        "tags": [
-                            TAG.Point,
-                            TAG.Temperature,
-                            TAG.Deadband,
-                            TAG.Setpoint,
-                        ],
-                        "parents": [BRICK.Temperature_Setpoint],
-                    },
-                    "Air_Flow_Deadband_Setpoint": {
-                        BRICK.hasSubstance: BRICK.Air,
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        "subclasses": {
-                            "Exhaust_Air_Stack_Flow_Deadband_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Exhaust,
-                                    TAG.Air,
-                                    TAG.Stack,
-                                    TAG.Flow,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Exhaust_Air_Stack_Flow_Setpoint],
-                            }
-                        },
-                        "tags": [
-                            TAG.Point,
-                            TAG.Air,
-                            TAG.Flow,
-                            TAG.Deadband,
-                            TAG.Setpoint,
-                        ],
-                        "parents": [BRICK.Air_Flow_Setpoint],
-                    },
-                    "Static_Pressure_Deadband_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Static,
-                            TAG.Pressure,
-                            TAG.Deadband,
-                            TAG.Setpoint,
-                        ],
-                        "parents": [BRICK.Static_Pressure_Setpoint],
-                        "subclasses": {
-                            "Supply_Air_Static_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "aliases": [
-                                    BRICK[
-                                        "Discharge_Air_Static_Pressure_Deadband_Setpoint"
-                                    ]
+                                    BRICK.Load_Shed_Setpoint,
                                 ],
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Static,
+                                    TAG.Load,
+                                    TAG.Shed,
+                                    TAG.Differential,
                                     TAG.Pressure,
-                                    TAG.Deadband,
                                     TAG.Setpoint,
                                 ],
-                                "parents": [
-                                    BRICK.Discharge_Air_Static_Pressure_Setpoint,
-                                    BRICK.Supply_Air_Static_Pressure_Setpoint,
+                            },
+                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Shed,
+                                    TAG.Load,
+                                    TAG.Setpoint,
                                 ],
                             },
                         },
                     },
-                },
-            },
-            "Flow_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                "tags": [TAG.Point, TAG.Flow, TAG.Setpoint],
-                "subclasses": {
-                    "Air_Flow_Setpoint": {
+                    "Enthalpy_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Enthalpy,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Setpoint,
+                            TAG.Enthalpy,
+                        ],
+                    },
+                    "Flow_Setpoint": {
                         BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        BRICK.hasSubstance: BRICK.Air,
-                        "tags": [TAG.Point, TAG.Air, TAG.Flow, TAG.Setpoint],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Flow,
+                            TAG.Setpoint,
+                        ],
                         "subclasses": {
-                            "Air_Flow_Demand_Setpoint": {
+                            "Air_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Air,
                                 "tags": [
                                     TAG.Point,
                                     TAG.Air,
                                     TAG.Flow,
-                                    TAG.Demand,
                                     TAG.Setpoint,
                                 ],
-                            },
-                            "Exhaust_Air_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Exhaust_Air,
                                 "subclasses": {
-                                    "Exhaust_Air_Stack_Flow_Setpoint": {
+                                    "Exhaust_Air_Flow_Setpoint": {
                                         BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Exhaust,
                                             TAG.Air,
-                                            TAG.Stack,
                                             TAG.Flow,
                                             TAG.Setpoint,
                                         ],
-                                    }
+                                        "subclasses": {
+                                            "Exhaust_Air_Stack_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Exhaust,
+                                                    TAG.Air,
+                                                    TAG.Stack,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Outside_Air_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Flow_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Flow_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: [
+                                            BRICK.Supply_Air,
+                                            BRICK.Discharge_Air,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Cooling_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Occupied,
+                                                            TAG.Cool,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Unoccupied,
+                                                            TAG.Cool,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                            "Heating_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Occupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Occupied,
+                                                            TAG.Heat,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Unoccupied,
+                                                            TAG.Heat,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                            "Occupied_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Occupied,
+                                                            TAG.Cool,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Occupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Occupied,
+                                                            TAG.Heat,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                            "Unoccupied_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Unoccupied,
+                                                            TAG.Cool,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                        "aliases": [
+                                                            BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                        ],
+                                                        "parents": [
+                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Unoccupied,
+                                                            TAG.Heat,
+                                                            TAG.Supply,
+                                                            TAG.Discharge,
+                                                            TAG.Air,
+                                                            TAG.Flow,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
                                 },
+                            },
+                            "Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Water,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Exhaust,
-                                    TAG.Air,
+                                    TAG.Water,
                                     TAG.Flow,
                                     TAG.Setpoint,
                                 ],
+                                "subclasses": {
+                                    "Bypass_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Bypass_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Bypass,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Chilled_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Chilled_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Chilled_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Chilled,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Leaving_Chilled_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Chilled,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Condenser_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Condenser_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Condenser,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Entering_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Entering_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Chilled_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Chilled,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Entering_Hot_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Hot_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Hot_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Leaving_Hot_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Leaving_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Leaving_Chilled_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Chilled,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Leaving_Hot_Water_Flow_Setpoint": {
+                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
                             },
-                            "Outside_Air_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        },
+                    },
+                    "Frequency_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Frequency,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Setpoint,
+                            TAG.Frequency,
+                        ],
+                    },
+                    "Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.PressureRatio,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Building_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Building_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Building,
+                                ],
+                            },
+                            "Bypass_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Bypass_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Bypass,
+                                ],
+                            },
+                            "Exhaust_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Exhaust_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Exhaust,
+                                ],
+                            },
+                            "Mixed_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Mixed_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Mixed,
+                                ],
+                            },
+                            "Occupied_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Occupied,
+                                ],
+                            },
+                            "Outside_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
                                 BRICK.hasSubstance: BRICK.Outside_Air,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Flow,
+                                    TAG.Humidity,
                                     TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Outside,
                                 ],
                             },
-                            "Supply_Air_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                            "Return_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Return,
+                                ],
+                            },
+                            "Supply_Air_Humidity_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Humidity_Setpoint,
+                                ],
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
                                 BRICK.hasSubstance: [
                                     BRICK.Supply_Air,
                                     BRICK.Discharge_Air,
                                 ],
-                                "aliases": [BRICK["Discharge_Air_Flow_Setpoint"]],
-                                "subclasses": {
-                                    "Supply_Air_Flow_Demand_Setpoint": {
-                                        "aliases": [
-                                            BRICK["Discharge_Air_Flow_Demand_Setpoint"]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Demand,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Occupied_Supply_Air_Flow_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Occupied_Discharge_Air_Flow_Setpoint"
-                                            ]
-                                        ],
-                                        "subclasses": {
-                                            "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK[
-                                                        "Occupied_Cooling_Discharge_Air_Flow_Setpoint"
-                                                    ]
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Cool,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                ],
-                                            },
-                                            "Occupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK[
-                                                        "Occupied_Heating_Discharge_Air_Flow_Setpoint"
-                                                    ]
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Heat,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                ],
-                                            },
-                                        },
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Occupied,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Unoccupied_Supply_Air_Flow_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Unoccupied_Discharge_Air_Flow_Setpoint"
-                                            ]
-                                        ],
-                                        "subclasses": {
-                                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK[
-                                                        "Unoccupied_Cooling_Discharge_Air_Flow_Setpoint"
-                                                    ]
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Cool,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                ],
-                                            },
-                                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK[
-                                                        "Unoccupied_Heating_Discharge_Air_Flow_Setpoint"
-                                                    ]
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Heat,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                ],
-                                            },
-                                        },
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Unoccupied,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Cooling_Supply_Air_Flow_Setpoint": {
-                                        "aliases": [
-                                            BRICK["Cooling_Discharge_Air_Flow_Setpoint"]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Cool,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Heating_Supply_Air_Flow_Setpoint": {
-                                        "aliases": [
-                                            BRICK["Heating_Discharge_Air_Flow_Setpoint"]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Heat,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
                                     TAG.Supply,
                                     TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
+                                ],
+                            },
+                            "Unoccupied_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
                                     TAG.Setpoint,
+                                    TAG.Unoccupied,
+                                ],
+                            },
+                            "Zone_Air_Humidity_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasSubstance: BRICK.Zone_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Humidity,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                    TAG.Zone,
                                 ],
                             },
                         },
                     },
-                    "Water_Flow_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        BRICK.hasSubstance: BRICK.Water,
+                    "Illuminance_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Illuminance,
                         "tags": [
                             TAG.Point,
-                            TAG.Water,
-                            TAG.Flow,
+                            TAG.Setpoint,
+                            TAG.Illuminance,
+                        ],
+                    },
+                    "Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Shed,
+                            TAG.Load,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
-                            "Condenser_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Condenser_Water,
+                            "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Condenser,
-                                    TAG.Water,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Entering_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Entering_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Entering,
-                                    TAG.Water,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Chilled_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [BRICK.Chilled_Water_Flow_Setpoint],
-                                    },
-                                    "Entering_Hot_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [BRICK.Hot_Water_Flow_Setpoint],
-                                    },
-                                },
-                            },
-                            "Leaving_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Leaving_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Leaving,
-                                    TAG.Water,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Leaving_Chilled_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [BRICK.Chilled_Water_Flow_Setpoint],
-                                    },
-                                    "Leaving_Hot_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [BRICK.Hot_Water_Flow_Setpoint],
-                                    },
-                                },
-                            },
-                            "Hot_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                "tags": [
-                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
                                     TAG.Hot,
                                     TAG.Water,
-                                    TAG.Flow,
+                                    TAG.Entering,
+                                    TAG.Pressure,
+                                    TAG.Shed,
+                                    TAG.Load,
                                     TAG.Setpoint,
                                 ],
                             },
-                            "Chilled_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Chilled,
-                                    TAG.Water,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Bypass_Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Bypass_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Bypass,
-                                    TAG.Water,
-                                    TAG.Flow,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                },
-            },
-            "Humidity_Setpoint": {
-                "tags": [TAG.Point, TAG.Humidity, TAG.Setpoint],
-                BRICK.hasQuantity: QUDTQK.PressureRatio,
-                "subclasses": {
-                    "Unoccupied_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        "tags": [TAG.Point, TAG.Humidity, TAG.Setpoint, TAG.Unoccupied],
-                    },
-                    "Occupied_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        "tags": [TAG.Point, TAG.Humidity, TAG.Setpoint, TAG.Occupied],
-                    },
-                    "Bypass_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Bypass_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Bypass,
-                        ],
-                    },
-                    "Outside_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Outside_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Outside,
-                        ],
-                    },
-                    "Zone_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Zone_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Zone,
-                        ],
-                    },
-                    "Building_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Building_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Building,
-                        ],
-                    },
-                    "Mixed_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Mixed_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Mixed,
-                        ],
-                    },
-                    "Return_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Return_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Return,
-                        ],
-                    },
-                    "Exhaust_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: BRICK.Exhaust_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Exhaust,
-                        ],
-                    },
-                    "Supply_Air_Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                        BRICK.hasSubstance: [BRICK.Supply_Air, BRICK.Discharge_Air],
-                        "aliases": [BRICK["Discharge_Air_Humidity_Setpoint"]],
-                        "tags": [
-                            TAG.Point,
-                            TAG.Humidity,
-                            TAG.Setpoint,
-                            TAG.Air,
-                            TAG.Supply,
-                            TAG.Discharge,
-                        ],
-                    },
-                },
-            },
-            "Load_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.Power,
-                "subclasses": {
-                    "Load_Shed_Setpoint": {
-                        "tags": [TAG.Point, TAG.Shed, TAG.Load, TAG.Setpoint],
-                        "subclasses": {
                             "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
                                     TAG.Point,
@@ -815,6 +903,768 @@ setpoint_definitions = {
                                     TAG.Load,
                                     TAG.Setpoint,
                                 ],
+                            },
+                            "Load_Shed_Differential_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "parents": [
+                                    BRICK.Load_Shed_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Load,
+                                    TAG.Shed,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Pressure,
+                                    TAG.Shed,
+                                    TAG.Load,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                    },
+                    "Luminance_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Luminance,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Luminance,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Position_Setpoint": {
+                        "subclasses": {
+                            "Damper_Position_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Position,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Damper,
+                                    TAG.Position,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Valve_Position_Setpoint": {},
+                        },
+                    },
+                    "Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Pressure,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Air_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Pressure,
+                                "tags": [
+                                    TAG.Setpoint,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                    TAG.Air,
+                                ],
+                                "subclasses": {
+                                    "Building_Air_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Building_Air,
+                                        "parents": [
+                                            BRICK.Air_Pressure_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Building,
+                                            TAG.Air,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Building_Air_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Building_Air,
+                                        "parents": [
+                                            BRICK.Air_Pressure_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Building,
+                                            TAG.Air,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Chilled_Water_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Chilled_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Duct_Air_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Duct,
+                                            TAG.Air,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Exhaust_Air_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Exhaust,
+                                            TAG.Air,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Hot_Water_Static_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: BRICK.Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Static_Pressure_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Static_Pressure_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Static_Pressure,
+                                        BRICK.hasSubstance: [
+                                            BRICK.Supply_Air,
+                                            BRICK.Discharge_Air,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Underfloor,
+                                            TAG.Air,
+                                            TAG.Plenum,
+                                            TAG.Static,
+                                            TAG.Pressure,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Velocity_Pressure_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Velocity,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Water_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Pressure,
+                                "tags": [
+                                    TAG.Setpoint,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                    TAG.Water,
+                                ],
+                            },
+                        },
+                    },
+                    "Speed_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Speed,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Speed,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Rated_Speed_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Speed,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Rated,
+                                    TAG.Speed,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                    },
+                    "Temperature_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Effective_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Effective,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Effective_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Effective_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Effective_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Effective,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Mixed_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Mixed_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Mixed,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Occupied_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Occupied_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Occupied_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Occupied_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Return_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Occupied_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Unoccupied_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Room_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Occupied_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Unoccupied_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: [
+                                            BRICK.Supply_Air,
+                                            BRICK.Discharge_Air,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Effective_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Effective,
+                                                ],
+                                            },
+                                            "Occupied_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Occupied,
+                                                ],
+                                            },
+                                            "Supply_Air_Temperature_Cooling_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Cool,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Supply_Air_Temperature_Heating_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Discharge_Air_Temperature_Heating_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Target_Zone_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Zone_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Effective,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Standby_Target_Zone_Air_Temperature_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Standby,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Unoccupied_Air_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Unoccupied_Return_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Return,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                            "Unoccupied_Room_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Room,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                            "Unoccupied_Supply_Air_Temperature_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Heat,
+                                                    TAG.Setpoint,
+                                                    TAG.Unoccupied,
+                                                ],
+                                            },
+                                            "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Target,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
                             },
                             "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
@@ -830,318 +1680,442 @@ setpoint_definitions = {
                                     TAG.Setpoint,
                                 ],
                             },
-                        },
-                    },
-                },
-                "tags": [TAG.Point, TAG.Load, TAG.Setpoint],
-            },
-            "Luminance_Setpoint": {
-                "tags": [TAG.Point, TAG.Luminance, TAG.Setpoint],
-                BRICK.hasQuantity: QUDTQK.Luminance,
-            },
-            "Pressure_Setpoint": {
-                BRICK.hasQuantity: BRICK.Pressure,
-                "subclasses": {
-                    "Air_Pressure_Setpoint": {
-                        "tags": [TAG.Setpoint, TAG.Pressure, TAG.Setpoint, TAG.Air],
-                        BRICK.hasQuantity: BRICK.Pressure,
-                    },
-                    "Water_Pressure_Setpoint": {
-                        "tags": [TAG.Setpoint, TAG.Pressure, TAG.Setpoint, TAG.Water],
-                        BRICK.hasQuantity: BRICK.Pressure,
-                    },
-                    "Static_Pressure_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                        "subclasses": {
-                            "Building_Air_Static_Pressure_Setpoint": {
-                                "parents": [BRICK["Air_Pressure_Setpoint"]],
-                                BRICK.hasSubstance: BRICK.Building_Air,
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Building,
-                                    TAG.Air,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Chilled_Water_Static_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Chilled,
-                                    TAG.Water,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Duct_Air_Static_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Air,
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Duct,
-                                    TAG.Air,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Exhaust_Air_Static_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Exhaust_Air,
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Exhaust,
-                                    TAG.Air,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Hot_Water_Static_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Air_Static_Pressure_Setpoint": {
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
-                                "aliases": [
-                                    BRICK["Discharge_Air_Static_Pressure_Setpoint"]
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Underfloor,
-                                    TAG.Air,
-                                    TAG.Plenum,
-                                    TAG.Static,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ]
-                            },
-                        },
-                        "tags": [TAG.Point, TAG.Static, TAG.Pressure, TAG.Setpoint],
-                    },
-                    "Velocity_Pressure_Setpoint": {
-                        "tags": [TAG.Point, TAG.Velocity, TAG.Pressure, TAG.Setpoint],
-                    },
-                },
-                "tags": [TAG.Point, TAG.Pressure, TAG.Setpoint],
-            },
-            "Reset_Setpoint": {
-                "tags": [TAG.Point, TAG.Reset, TAG.Setpoint],
-                BRICK.hasQuantity: QUDTQK.Dimensionless,
-                "subclasses": {
-                    "Supply_Air_Flow_Reset_Setpoint": {
-                        "aliases": [BRICK["Discharge_Air_Flow_Reset_Setpoint"]],
-                        BRICK.hasSubstance: BRICK.Discharge_Air,
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Supply,
-                            TAG.Discharge,
-                            TAG.Air,
-                            TAG.Flow,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Supply_Air_Flow_High_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK["Discharge_Air_Flow_High_Reset_Setpoint"]
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.High,
-                                ],
-                            },
-                            "Supply_Air_Flow_Low_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK["Discharge_Air_Flow_Low_Reset_Setpoint"]
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.Low,
-                                ],
-                            },
-                        },
-                    },
-                    "Temperature_High_Reset_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Temperature,
-                            TAG.High,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
                                     TAG.Hot,
                                     TAG.Water,
                                     TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
+                                    TAG.Pressure,
+                                    TAG.Shed,
+                                    TAG.Load,
                                     TAG.Setpoint,
                                 ],
-                                "subclasses": {
-                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
                             },
-                            "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Outside_Air_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Outside_Air,
+                            "Radiant_Panel_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Radiant,
+                                    TAG.Panel,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Embedded_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Embedded,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Core_Temperature_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Core,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Inside_Face_Surface_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Inside,
+                                            TAG.Face,
+                                            TAG.Surface,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Outside_Face_Surface_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Face,
+                                            TAG.Surface,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Schedule_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Schedule,
+                                ],
+                            },
+                            "Water_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Chilled_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Chilled_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Chilled_Water_Temperature_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Chilled,
+                                                ],
+                                            },
+                                            "Leaving_Chilled_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Chilled,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Domestic_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Entering_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Hot,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Leaving_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Hot,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Entering_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Entering_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Chilled_Water_Temperature_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Chilled,
+                                                ],
+                                            },
+                                            "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Entering_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Hot,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Entering_Hot_Water_Temperature_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Hot,
+                                                ],
+                                            },
+                                            "Entering_Water_Temperature_Deadband_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Water,
+                                                "parents": [
+                                                    BRICK.Entering_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Deadband,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Hot_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Domestic_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                                "subclasses": {
+                                                    "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                        "parents": [
+                                                            BRICK.Entering_Water_Temperature_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Domestic,
+                                                            TAG.Hot,
+                                                            TAG.Entering,
+                                                            TAG.Water,
+                                                            TAG.Temperature,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                    "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                        "parents": [
+                                                            BRICK.Leaving_Water_Temperature_Setpoint,
+                                                        ],
+                                                        "tags": [
+                                                            TAG.Point,
+                                                            TAG.Domestic,
+                                                            TAG.Hot,
+                                                            TAG.Leaving,
+                                                            TAG.Water,
+                                                            TAG.Temperature,
+                                                            TAG.Setpoint,
+                                                        ],
+                                                    },
+                                                },
+                                            },
+                                            "Entering_Hot_Water_Temperature_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                                "parents": [
+                                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Hot,
+                                                ],
+                                            },
+                                            "Leaving_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Hot,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Leaving_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Condenser_Water_Temperature_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Entering_Condenser_Water,
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Entering,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Condenser,
+                                                ],
+                                            },
+                                            "Leaving_Chilled_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Chilled_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Chilled,
+                                                ],
+                                            },
+                                            "Leaving_Condenser_Water_Temperature_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Condenser,
+                                                ],
+                                            },
+                                            "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Leaving_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Hot,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Leaving_Hot_Water_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                    TAG.Hot,
+                                                ],
+                                            },
+                                            "Leaving_Water_Temperature_Deadband_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Temperature,
+                                                BRICK.hasSubstance: BRICK.Leaving_Water,
+                                                "parents": [
+                                                    BRICK.Leaving_Water_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Leaving,
+                                                    TAG.Water,
+                                                    TAG.Temperature,
+                                                    TAG.Deadband,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            "Threshold_Setpoint": {
+                "subclasses": {
+                    "Lockout_Setpoint": {},
+                    "Lower_Threshold_Setpoint": {
+                        "subclasses": {
+                            "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Enable,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.System,
                                     TAG.Outside,
                                     TAG.Air,
                                     TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
                                     TAG.Setpoint,
                                 ],
-                            },
-                            "Return_Air_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Return_Air,
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Return,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                    "Temperature_Low_Reset_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Temperature,
-                            TAG.Low,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
                             },
                             "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
                                 "tags": [
@@ -1171,9 +2145,222 @@ setpoint_definitions = {
                                     },
                                 },
                             },
-                            "Outside_Air_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Outside_Air,
+                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Heating_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Heat,
+                                ],
+                                "subclasses": {
+                                    "Heating_Zone_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Zone_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Effective,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Occupied_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Standby_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Standby,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Occupied_Heating_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Heat,
+                                            TAG.Occupied,
+                                        ],
+                                        "subclasses": {
+                                            "Occupied_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Heating_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Open,
+                                            TAG.Heat,
+                                            TAG.Valve,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Unoccupied_Heating_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Heat,
+                                            TAG.Unoccupied,
+                                        ],
+                                        "subclasses": {
+                                            "Unoccupied_Heating_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                            "Humidification_Setpoint": {},
+                            "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Low_Outside_Air_Temperature_Enable_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Low,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Enable,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Outside_Air_Temperature_Low_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
                                 "tags": [
                                     TAG.Point,
                                     TAG.Outside,
@@ -1185,8 +2372,8 @@ setpoint_definitions = {
                                 ],
                             },
                             "Return_Air_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Return_Air,
                                 BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
                                 "tags": [
                                     TAG.Point,
                                     TAG.Return,
@@ -1197,463 +2384,29 @@ setpoint_definitions = {
                                     TAG.Setpoint,
                                 ],
                             },
-                        },
-                    },
-                },
-            },
-            "Speed_Setpoint": {
-                BRICK.hasQuantity: BRICK.Speed,
-                "tags": [TAG.Point, TAG.Speed, TAG.Setpoint],
-                "subclasses": {
-                    "Rated_Speed_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Speed,
-                        "tags": [TAG.Point, TAG.Rated, TAG.Speed, TAG.Setpoint],
-                    },
-                },
-            },
-            "Temperature_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.Temperature,
-                "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint],
-                "subclasses": {
-                    "Air_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        BRICK.hasSubstance: BRICK.Air,
-                        "tags": [TAG.Point, TAG.Air, TAG.Temperature, TAG.Setpoint],
-                        "subclasses": {
-                            "Effective_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Effective,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Mixed_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Mixed_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Mixed,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Occupied_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Occupied,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Return_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Return_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Return,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Return_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Effective,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Return_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Occupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Return_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Unoccupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                },
-                            },
-                            "Room_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Room,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Room_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Room,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Effective,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Room_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Room,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Occupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Room_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Room,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Unoccupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                },
-                            },
-                            "Target_Zone_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Zone_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Target,
-                                    TAG.Zone,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Target_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Effective,
-                                            TAG.Target,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Target_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Occupied,
-                                            TAG.Target,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Unoccupied,
-                                            TAG.Target,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Standby_Target_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Standby,
-                                            TAG.Target,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Cooling_Zone_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Zone_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Cool,
-                                    TAG.Zone,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Cooling_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Effective,
-                                            TAG.Cool,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Occupied,
-                                            TAG.Cool,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Unoccupied,
-                                            TAG.Cool,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Standby_Cooling_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Standby,
-                                            TAG.Cool,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Heating_Zone_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Zone_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Heat,
-                                    TAG.Zone,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Heating_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Effective,
-                                            TAG.Heat,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Occupied,
-                                            TAG.Heat,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Unoccupied,
-                                            TAG.Heat,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Standby_Heating_Zone_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Standby,
-                                            TAG.Heat,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Outside_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Outside_Air,
-                                "subclasses": {
-                                    "Low_Outside_Air_Temperature_Enable_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Low,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Enable,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Disable,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.System,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Enable,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.System,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Open,
-                                            TAG.Heat,
-                                            TAG.Valve,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [BRICK.Heating_Temperature_Setpoint],
-                                    },
-                                    "Outside_Air_Lockout_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Lockout,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Unoccupied_Air_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Unoccupied,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
+                            "Supply_Air_Flow_Low_Reset_Setpoint": {
                                 "aliases": [
-                                    BRICK["Discharge_Air_Temperature_Setpoint"]
+                                    BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.Low,
+                                ],
+                            },
+                            "Supply_Air_Temperature_Low_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_Low_Reset_Setpoint,
                                 ],
                                 "tags": [
                                     TAG.Point,
@@ -1661,513 +2414,205 @@ setpoint_definitions = {
                                     TAG.Discharge,
                                     TAG.Air,
                                     TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Effective_Supply_Air_Temperature_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Effective_Discharge_Air_Temperature_Setpoint"
-                                            ]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Effective,
-                                        ],
-                                        "parents": [
-                                            BRICK.Effective_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Occupied_Supply_Air_Temperature_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Occupied_Discharge_Air_Temperature_Setpoint"
-                                            ]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Occupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Occupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Unoccupied_Supply_Air_Temperature_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Unoccupied_Discharge_Air_Temperature_Setpoint"
-                                            ]
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                            TAG.Unoccupied,
-                                        ],
-                                        "parents": [
-                                            BRICK.Unoccupied_Air_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_Heating_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Discharge_Air_Temperature_Heating_Setpoint"
-                                            ]
-                                        ],
-                                        "parents": [BRICK.Heating_Temperature_Setpoint],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Heat,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_Cooling_Setpoint": {
-                                        "aliases": [
-                                            BRICK[
-                                                "Discharge_Air_Temperature_Cooling_Setpoint"
-                                            ]
-                                        ],
-                                        "parents": [BRICK.Cooling_Temperature_Setpoint],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Cool,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Min_Air_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Min,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ]
-                            },
-                            "Max_Air_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Max,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ]
-                            },
-                        },
-                    },
-                    "Cooling_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Cool],
-                        "subclasses": {
-                            "Occupied_Cooling_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Cool,
-                                    TAG.Occupied,
-                                ],
-                            },
-                            "Unoccupied_Cooling_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Cool,
-                                    TAG.Unoccupied,
-                                ],
-                            },
-                        },
-                    },
-                    "Heating_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [TAG.Point, TAG.Temperature, TAG.Setpoint, TAG.Heat],
-                        "subclasses": {
-                            "Occupied_Heating_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Heat,
-                                    TAG.Occupied,
-                                ],
-                            },
-                            "Unoccupied_Heating_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Heat,
-                                    TAG.Unoccupied,
-                                ],
-                            },
-                        },
-                    },
-                    "Schedule_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Temperature,
-                            TAG.Setpoint,
-                            TAG.Schedule,
-                        ],
-                    },
-                    "Radiant_Panel_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Radiant,
-                            TAG.Panel,
-                            TAG.Temperature,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Inside_Face_Surface_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Inside,
-                                    TAG.Face,
-                                    TAG.Surface,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Outside_Face_Surface_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Outside,
-                                    TAG.Face,
-                                    TAG.Surface,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Embedded_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Embedded,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Core_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Core,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "Water_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Temperature,
-                        BRICK.hasSubstance: BRICK.Water,
-                        "subclasses": {
-                            "Domestic_Hot_Water_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Domestic,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "parents": [BRICK.Hot_Water_Temperature_Setpoint],
-                                "subclasses": {
-                                    "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Domestic,
-                                            TAG.Hot,
-                                            TAG.Entering,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Entering_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Domestic,
-                                            TAG.Hot,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Leaving_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                },
-                            },
-                            "Chilled_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Chilled,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Hot_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Leaving_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Leaving_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Leaving,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Leaving_Condenser_Water_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Condenser,
-                                        ],
-                                    },
-                                    "Leaving_Hot_Water_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Hot,
-                                        ],
-                                        "parents": [
-                                            BRICK.Hot_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Leaving_Chilled_Water_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Chilled,
-                                        ],
-                                        "parents": [
-                                            BRICK.Chilled_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Entering_Condenser_Water_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Entering_Condenser_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Entering,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Condenser,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Entering_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Entering_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Entering,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Hot_Water_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Entering,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Hot,
-                                        ],
-                                        "parents": [
-                                            BRICK.Hot_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                    "Entering_Chilled_Water_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Entering,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Chilled,
-                                        ],
-                                        "parents": [
-                                            BRICK.Chilled_Water_Temperature_Setpoint
-                                        ],
-                                    },
-                                },
-                            },
-                            "Min_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Min,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Max_Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Max,
-                                    TAG.Water,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                        "tags": [TAG.Point, TAG.Water, TAG.Temperature, TAG.Setpoint],
-                    },
-                },
-            },
-            "CO2_Setpoint": {
-                BRICK.hasQuantity: BRICK.CO2_Concentration,
-                "subclasses": {
-                    "Return_Air_CO2_Setpoint": {
-                        BRICK.hasQuantity: BRICK.CO2_Concentration,
-                        "tags": [TAG.Point, TAG.Return, TAG.Air, TAG.CO2, TAG.Setpoint],
-                    }
-                },
-                "tags": [TAG.Point, TAG.CO2, TAG.Setpoint],
-            },
-            "Time_Setpoint": {
-                BRICK.hasQuantity: BRICK.Time,
-                "tags": [TAG.Point, TAG.Time, TAG.Setpoint],
-                "subclasses": {
-                    "Deceleration_Time_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Time,
-                        "tags": [TAG.Point, TAG.Time, TAG.Setpoint, TAG.Deceleration],
-                    },
-                    "Acceleration_Time_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Time,
-                        "tags": [TAG.Point, TAG.Time, TAG.Setpoint, TAG.Acceleration],
-                    },
-                },
-            },
-            "Differential_Setpoint": {
-                BRICK.hasQuantity: QUDTQK.Dimensionless,
-                "subclasses": {
-                    "Differential_Temperature_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Temperature,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Differential,
-                            TAG.Temperature,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Water_Differential_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                BRICK.hasSubstance: BRICK.Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Water,
                                     TAG.Differential,
-                                    TAG.Temperature,
+                                    TAG.Reset,
                                     TAG.Setpoint,
+                                    TAG.Low,
                                 ],
                             },
-                            "Differential_Air_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                            "Temperature_Low_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Differential,
-                                    TAG.Air,
                                     TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
                                     TAG.Setpoint,
                                 ],
+                                "subclasses": {
+                                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Temperature,
+                                                    TAG.Low,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Temperature,
+                                                    TAG.Low,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Outside_Air_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Return_Air_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_Low_Reset_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                        "parents": [
+                                            BRICK.Temperature_Low_Reset_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.Low,
+                                        ],
+                                    },
+                                },
                             },
                         },
                     },
-                    "Differential_Speed_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Speed,
-                        "tags": [TAG.Point, TAG.Differential, TAG.Speed, TAG.Setpoint],
-                    },
-                    "Temperature_Differential_Reset_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                    "Outside_Air_Lockout_Temperature_Setpoint": {
                         "tags": [
                             TAG.Point,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Lockout,
                             TAG.Temperature,
-                            TAG.Differential,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Reset_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.Dimensionless,
+                        "tags": [
+                            TAG.Point,
                             TAG.Reset,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
+                            "Supply_Air_Flow_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_Reset_Setpoint,
+                                ],
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Discharge_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Supply_Air_Flow_High_Reset_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.High,
+                                        ],
+                                    },
+                                    "Supply_Air_Flow_Low_Reset_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.Low,
+                                        ],
+                                    },
+                                },
+                            },
                             "Supply_Air_Temperature_Reset_Differential_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Reset_Differential_Setpoint,
+                                ],
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
                                 BRICK.hasSubstance: [
                                     BRICK.Supply_Air,
                                     BRICK.Discharge_Air,
-                                ],
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                "aliases": [
-                                    BRICK[
-                                        "Discharge_Air_Temperature_Reset_Differential_Setpoint"
-                                    ]
                                 ],
                                 "tags": [
                                     TAG.Point,
@@ -2179,14 +2624,119 @@ setpoint_definitions = {
                                     TAG.Reset,
                                     TAG.Setpoint,
                                 ],
+                            },
+                            "Temperature_Differential_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Temperature_High_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
                                 "subclasses": {
-                                    "Supply_Air_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Temperature,
+                                                    TAG.High,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
                                         BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Temperature,
+                                                    TAG.High,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Outside_Air_Temperature_High_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Return_Air_Temperature_High_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_High_Reset_Setpoint": {
                                         "aliases": [
-                                            BRICK[
-                                                "Discharge_Air_Temperature_High_Reset_Setpoint"
-                                            ]
+                                            BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                        "parents": [
+                                            BRICK.Temperature_High_Reset_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
@@ -2199,17 +2749,111 @@ setpoint_definitions = {
                                             TAG.Setpoint,
                                             TAG.High,
                                         ],
-                                        "parents": [
-                                            BRICK["Temperature_High_Reset_Setpoint"]
+                                    },
+                                },
+                            },
+                            "Temperature_Low_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Temperature,
+                                                    TAG.Low,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Temperature,
+                                                    TAG.Low,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Outside_Air_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Return_Air_Temperature_Low_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
                                         ],
                                     },
                                     "Supply_Air_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        BRICK.hasQuantity: BRICK.Temperature,
                                         "aliases": [
-                                            BRICK[
-                                                "Discharge_Air_Temperature_Low_Reset_Setpoint"
-                                            ]
+                                            BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                        "parents": [
+                                            BRICK.Temperature_Low_Reset_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
@@ -2222,129 +2866,219 @@ setpoint_definitions = {
                                             TAG.Setpoint,
                                             TAG.Low,
                                         ],
-                                        "parents": [
-                                            BRICK["Temperature_Low_Reset_Setpoint"]
-                                        ],
                                     },
                                 },
                             },
                         },
                     },
-                    "Differential_Pressure_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                    "Supply_Air_Flow_Reset_Setpoint": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_Reset_Setpoint,
+                        ],
+                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Setpoint,
+                        ],
                         "subclasses": {
-                            "Air_Differential_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Air,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                            "Supply_Air_Flow_High_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
+                                ],
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
                                     TAG.Air,
-                                    TAG.Differential,
-                                    TAG.Pressure,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.High,
+                                ],
+                            },
+                            "Supply_Air_Flow_Low_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.Low,
+                                ],
+                            },
+                        },
+                    },
+                    "Upper_Threshold_Setpoint": {
+                        "subclasses": {
+                            "CO2_Setpoint": {
+                                BRICK.hasQuantity: BRICK.CO2_Concentration,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.CO2,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Exhaust_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Exhaust,
-                                            TAG.Air,
-                                            TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
-                                        ],
-                                    },
-                                    "Return_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                    "Return_Air_CO2_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.CO2_Concentration,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Return,
                                             TAG.Air,
+                                            TAG.CO2,
                                             TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
                                         ],
                                     },
-                                    "Supply_Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                },
+                            },
+                            "Cooling_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                    TAG.Cool,
+                                ],
+                                "subclasses": {
+                                    "Cooling_Zone_Air_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Zone_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Effective_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Effective_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Effective,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Occupied_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Standby_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Standby,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Occupied_Cooling_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Cool,
+                                            TAG.Occupied,
+                                        ],
+                                        "subclasses": {
+                                            "Occupied_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Occupied_Air_Temperature_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
+                                                    TAG.Temperature,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Supply_Air_Temperature_Cooling_Setpoint": {
                                         "aliases": [
-                                            BRICK[
-                                                "Discharge_Air_Differential_Pressure_Setpoint"
-                                            ]
+                                            BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Cooling_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
                                             TAG.Discharge,
                                             TAG.Air,
-                                            TAG.Setpoint,
-                                            TAG.Pressure,
-                                            TAG.Differential,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Water_Differential_Pressure_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Chilled_Water_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Chilled_Water,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
+                                            TAG.Temperature,
+                                            TAG.Cool,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Hot_Water_Differential_Pressure_Setpoint": {
-                                        BRICK.hasSubstance: BRICK.Hot_Water,
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                    "Unoccupied_Cooling_Temperature_Setpoint": {
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
+                                            TAG.Temperature,
                                             TAG.Setpoint,
+                                            TAG.Cool,
+                                            TAG.Unoccupied,
                                         ],
                                         "subclasses": {
-                                            "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Setpoint,
+                                            "Unoccupied_Cooling_Zone_Air_Temperature_Setpoint": {
+                                                "parents": [
+                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
                                                 ],
-                                            },
-                                            "Domestic_Hot_Water_Differential_Pressure_Setpoint": {
                                                 "tags": [
                                                     TAG.Point,
-                                                    TAG.Domestic,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Zone,
+                                                    TAG.Air,
                                                     TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
                                                     TAG.Setpoint,
                                                 ],
                                             },
@@ -2352,125 +3086,289 @@ setpoint_definitions = {
                                     },
                                 },
                             },
-                            "Load_Shed_Differential_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "parents": [BRICK.Load_Shed_Setpoint],
-                                "subclasses": {
-                                    "Chilled_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Chilled,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Load,
-                                            TAG.Shed,
-                                            TAG.Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Chilled_Water_Differential_Pressure_Setpoint
-                                        ],
-                                    },
-                                },
+                            "Dehumidification_Setpoint": {},
+                            "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Load,
-                                    TAG.Shed,
-                                    TAG.Differential,
-                                    TAG.Pressure,
+                                    TAG.Disable,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.System,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
                             },
-                        },
-                        "tags": [
-                            TAG.Point,
-                            TAG.Differential,
-                            TAG.Pressure,
-                            TAG.Setpoint,
-                        ],
-                    },
-                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Medium,
-                            TAG.Temperature,
-                            TAG.Hot,
-                            TAG.Water,
-                            TAG.Differential,
-                            TAG.Pressure,
-                            TAG.Shed,
-                            TAG.Load,
-                            TAG.Setpoint,
-                        ],
-                    },
-                    "Differential_Pressure_Deadband_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Differential,
-                            TAG.Pressure,
-                            TAG.Deadband,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Hot_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
+                            "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
                                 "tags": [
                                     TAG.Point,
                                     TAG.Hot,
                                     TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Chilled_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Chilled,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Leaving_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Leaving_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Leaving,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Entering_Water_Differential_Pressure_Deadband_Setpoint": {
-                                BRICK.hasSubstance: BRICK.Entering_Water,
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
                                     TAG.Entering,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Deadband,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
                                     TAG.Setpoint,
                                 ],
+                                "subclasses": {
+                                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Outside_Air_Temperature_High_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Return_Air_Temperature_High_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Supply_Air_Flow_High_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.High,
+                                ],
+                            },
+                            "Supply_Air_Temperature_High_Reset_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_High_Reset_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                    TAG.High,
+                                ],
+                            },
+                            "Temperature_High_Reset_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Entering,
+                                                    TAG.Temperature,
+                                                    TAG.High,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
+                                                    TAG.Hot,
+                                                    TAG.Water,
+                                                    TAG.Leaving,
+                                                    TAG.Temperature,
+                                                    TAG.High,
+                                                    TAG.Reset,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Outside_Air_Temperature_High_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Outside,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Return_Air_Temperature_High_Reset_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_High_Reset_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
+                                        ],
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
+                                        "parents": [
+                                            BRICK.Temperature_High_Reset_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Differential,
+                                            TAG.Reset,
+                                            TAG.Setpoint,
+                                            TAG.High,
+                                        ],
+                                    },
+                                },
                             },
                         },
                     },
                 },
             },
         },
-    }
+    },
 }

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -1,4 +1,4 @@
-from namespaces import TAG, BRICK, RDFS, QUDTQK
+from .namespaces import TAG, BRICK, RDFS, QUDTQK
 from rdflib import Literal
 
 setpoint_definitions = {

--- a/bricksrc/setpoint.py
+++ b/bricksrc/setpoint.py
@@ -9,717 +9,136 @@ setpoint_definitions = {
             TAG.Setpoint,
         ],
         "subclasses": {
-            "Target_Setpoint": {
+            "Dewpoint_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.DewPointTemperature,
+                "tags": [
+                    TAG.Point,
+                    TAG.Dewpoint,
+                    TAG.Setpoint,
+                ],
+            },
+            "Differential_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.Dimensionless,
                 "subclasses": {
-                    "Dewpoint_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.DewPointTemperature,
+                    "Differential_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
                         "tags": [
                             TAG.Point,
-                            TAG.Dewpoint,
-                            TAG.Setpoint,
-                        ],
-                    },
-                    "Differential_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Dimensionless,
-                        "subclasses": {
-                            "Differential_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Air_Differential_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        BRICK.hasSubstance: BRICK.Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Air,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Exhaust_Air_Differential_Pressure_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                BRICK.hasSubstance: BRICK.Exhaust_Air,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Exhaust,
-                                                    TAG.Air,
-                                                    TAG.Setpoint,
-                                                    TAG.Pressure,
-                                                    TAG.Differential,
-                                                ],
-                                            },
-                                            "Return_Air_Differential_Pressure_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                BRICK.hasSubstance: BRICK.Return_Air,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Setpoint,
-                                                    TAG.Pressure,
-                                                    TAG.Differential,
-                                                ],
-                                            },
-                                            "Supply_Air_Differential_Pressure_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Discharge_Air_Differential_Pressure_Setpoint,
-                                                ],
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                BRICK.hasSubstance: BRICK.Supply_Air,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Setpoint,
-                                                    TAG.Pressure,
-                                                    TAG.Differential,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Water_Differential_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                        BRICK.hasSubstance: BRICK.Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Chilled_Water_Differential_Pressure_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                BRICK.hasSubstance: BRICK.Chilled_Water,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Chilled,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Hot_Water_Differential_Pressure_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                BRICK.hasSubstance: BRICK.Hot_Water,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Differential,
-                                                    TAG.Pressure,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Domestic_Hot_Water_Differential_Pressure_Setpoint": {
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Domestic,
-                                                            TAG.Temperature,
-                                                            TAG.Hot,
-                                                            TAG.Water,
-                                                            TAG.Differential,
-                                                            TAG.Pressure,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
-                                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Medium,
-                                                            TAG.Temperature,
-                                                            TAG.Hot,
-                                                            TAG.Water,
-                                                            TAG.Differential,
-                                                            TAG.Pressure,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                            "Differential_Speed_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Speed,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Differential,
-                                    TAG.Speed,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Differential_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Differential,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Differential_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Differential,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Water_Differential_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                        BRICK.hasSubstance: BRICK.Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Water,
-                                            TAG.Differential,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Load_Shed_Differential_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "parents": [
-                                    BRICK.Load_Shed_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Load,
-                                    TAG.Shed,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                    "Enthalpy_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Enthalpy,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Setpoint,
-                            TAG.Enthalpy,
-                        ],
-                    },
-                    "Flow_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Flow,
+                            TAG.Differential,
+                            TAG.Pressure,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
-                            "Air_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                            "Air_Differential_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
                                 BRICK.hasSubstance: BRICK.Air,
                                 "tags": [
                                     TAG.Point,
                                     TAG.Air,
-                                    TAG.Flow,
+                                    TAG.Differential,
+                                    TAG.Pressure,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Exhaust_Air_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                    "Exhaust_Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
                                         BRICK.hasSubstance: BRICK.Exhaust_Air,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Exhaust,
                                             TAG.Air,
-                                            TAG.Flow,
                                             TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
                                         ],
-                                        "subclasses": {
-                                            "Exhaust_Air_Stack_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Exhaust,
-                                                    TAG.Air,
-                                                    TAG.Stack,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Outside_Air_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Outside_Air,
+                                    "Return_Air_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        BRICK.hasSubstance: BRICK.Return_Air,
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Outside,
+                                            TAG.Return,
                                             TAG.Air,
-                                            TAG.Flow,
                                             TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
                                         ],
                                     },
-                                    "Supply_Air_Flow_Setpoint": {
+                                    "Supply_Air_Differential_Pressure_Setpoint": {
                                         "aliases": [
-                                            BRICK.Discharge_Air_Flow_Setpoint,
+                                            BRICK.Discharge_Air_Differential_Pressure_Setpoint,
                                         ],
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: [
-                                            BRICK.Supply_Air,
-                                            BRICK.Discharge_Air,
-                                        ],
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                                        BRICK.hasSubstance: BRICK.Supply_Air,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Supply,
                                             TAG.Discharge,
                                             TAG.Air,
-                                            TAG.Flow,
                                             TAG.Setpoint,
+                                            TAG.Pressure,
+                                            TAG.Differential,
                                         ],
-                                        "subclasses": {
-                                            "Cooling_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Cool,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Occupied,
-                                                            TAG.Cool,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Unoccupied,
-                                                            TAG.Cool,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                            "Heating_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Heat,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Occupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Occupied,
-                                                            TAG.Heat,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Unoccupied,
-                                                            TAG.Heat,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                            "Occupied_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Occupied_Discharge_Air_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Occupied,
-                                                            TAG.Cool,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Occupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Occupied,
-                                                            TAG.Heat,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                            "Unoccupied_Supply_Air_Flow_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Unoccupied_Discharge_Air_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Cooling_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Unoccupied,
-                                                            TAG.Cool,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
-                                                        "aliases": [
-                                                            BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
-                                                        ],
-                                                        "parents": [
-                                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
-                                                            BRICK.Heating_Supply_Air_Flow_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Unoccupied,
-                                                            TAG.Heat,
-                                                            TAG.Supply,
-                                                            TAG.Discharge,
-                                                            TAG.Air,
-                                                            TAG.Flow,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                        },
                                     },
                                 },
                             },
-                            "Water_Flow_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                            "Water_Differential_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Pressure,
                                 BRICK.hasSubstance: BRICK.Water,
                                 "tags": [
                                     TAG.Point,
                                     TAG.Water,
-                                    TAG.Flow,
+                                    TAG.Differential,
+                                    TAG.Pressure,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Bypass_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Bypass_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Bypass,
-                                            TAG.Water,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Chilled_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                    "Chilled_Water_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
                                         BRICK.hasSubstance: BRICK.Chilled_Water,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Chilled,
                                             TAG.Water,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Chilled_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Chilled,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Leaving_Chilled_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Chilled,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Condenser_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Condenser_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Condenser,
-                                            TAG.Water,
-                                            TAG.Flow,
+                                            TAG.Differential,
+                                            TAG.Pressure,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Entering_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Entering_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Entering,
-                                            TAG.Water,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Chilled_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Chilled,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Entering_Hot_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Hot_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                    "Hot_Water_Differential_Pressure_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Differential_Pressure,
                                         BRICK.hasSubstance: BRICK.Hot_Water,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Hot,
                                             TAG.Water,
-                                            TAG.Flow,
+                                            TAG.Differential,
+                                            TAG.Pressure,
                                             TAG.Setpoint,
                                         ],
                                         "subclasses": {
-                                            "Entering_Hot_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Flow_Setpoint,
-                                                ],
+                                            "Domestic_Hot_Water_Differential_Pressure_Setpoint": {
                                                 "tags": [
                                                     TAG.Point,
+                                                    TAG.Domestic,
+                                                    TAG.Temperature,
                                                     TAG.Hot,
                                                     TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Flow,
+                                                    TAG.Differential,
+                                                    TAG.Pressure,
                                                     TAG.Setpoint,
                                                 ],
                                             },
-                                            "Leaving_Hot_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Flow_Setpoint,
-                                                ],
+                                            "Medium_Temperature_Hot_Water_Differential_Pressure_Setpoint": {
+                                                BRICK.hasQuantity: BRICK.Differential_Pressure,
                                                 "tags": [
                                                     TAG.Point,
+                                                    TAG.Medium,
+                                                    TAG.Temperature,
                                                     TAG.Hot,
                                                     TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Leaving_Water_Flow_Setpoint": {
-                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                        BRICK.hasSubstance: BRICK.Leaving_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Flow,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Leaving_Chilled_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Chilled,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Flow,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Leaving_Hot_Water_Flow_Setpoint": {
-                                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Flow_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Flow,
+                                                    TAG.Differential,
+                                                    TAG.Pressure,
                                                     TAG.Setpoint,
                                                 ],
                                             },
@@ -729,703 +148,1052 @@ setpoint_definitions = {
                             },
                         },
                     },
-                    "Frequency_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Frequency,
+                    "Differential_Speed_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Speed,
                         "tags": [
                             TAG.Point,
+                            TAG.Differential,
+                            TAG.Speed,
                             TAG.Setpoint,
-                            TAG.Frequency,
                         ],
                     },
-                    "Humidity_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.PressureRatio,
+                    "Differential_Temperature_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Temperature,
                         "tags": [
                             TAG.Point,
-                            TAG.Humidity,
+                            TAG.Differential,
+                            TAG.Temperature,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
-                            "Building_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                BRICK.hasSubstance: BRICK.Building_Air,
+                            "Differential_Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
+                                    TAG.Differential,
                                     TAG.Air,
-                                    TAG.Building,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
                                 ],
                             },
-                            "Bypass_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                BRICK.hasSubstance: BRICK.Bypass_Air,
+                            "Water_Differential_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Differential_Temperature,
+                                BRICK.hasSubstance: BRICK.Water,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Humidity,
+                                    TAG.Water,
+                                    TAG.Differential,
+                                    TAG.Temperature,
                                     TAG.Setpoint,
-                                    TAG.Air,
-                                    TAG.Bypass,
                                 ],
                             },
-                            "Exhaust_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        },
+                    },
+                    "Load_Shed_Differential_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "parents": [
+                            BRICK.Load_Shed_Setpoint,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Load,
+                            TAG.Shed,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                },
+            },
+            "Enthalpy_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.Enthalpy,
+                "tags": [
+                    TAG.Point,
+                    TAG.Setpoint,
+                    TAG.Enthalpy,
+                ],
+            },
+            "Flow_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                "tags": [
+                    TAG.Point,
+                    TAG.Flow,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Air_Flow_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        BRICK.hasSubstance: BRICK.Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Exhaust_Air_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
                                 BRICK.hasSubstance: BRICK.Exhaust_Air,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
-                                    TAG.Air,
                                     TAG.Exhaust,
-                                ],
-                            },
-                            "Mixed_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                BRICK.hasSubstance: BRICK.Mixed_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
                                     TAG.Air,
-                                    TAG.Mixed,
-                                ],
-                            },
-                            "Occupied_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Humidity,
+                                    TAG.Flow,
                                     TAG.Setpoint,
-                                    TAG.Occupied,
                                 ],
+                                "subclasses": {
+                                    "Exhaust_Air_Stack_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Exhaust,
+                                            TAG.Air,
+                                            TAG.Stack,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
                             },
-                            "Outside_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                            "Outside_Air_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
                                 BRICK.hasSubstance: BRICK.Outside_Air,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
-                                    TAG.Air,
                                     TAG.Outside,
-                                ],
-                            },
-                            "Return_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                BRICK.hasSubstance: BRICK.Return_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
                                     TAG.Air,
-                                    TAG.Return,
+                                    TAG.Flow,
+                                    TAG.Setpoint,
                                 ],
                             },
-                            "Supply_Air_Humidity_Setpoint": {
+                            "Supply_Air_Flow_Setpoint": {
                                 "aliases": [
-                                    BRICK.Discharge_Air_Humidity_Setpoint,
+                                    BRICK.Discharge_Air_Flow_Setpoint,
                                 ],
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
                                 BRICK.hasSubstance: [
                                     BRICK.Supply_Air,
                                     BRICK.Discharge_Air,
                                 ],
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
-                                    TAG.Air,
                                     TAG.Supply,
                                     TAG.Discharge,
-                                ],
-                            },
-                            "Unoccupied_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
-                                    TAG.Unoccupied,
-                                ],
-                            },
-                            "Zone_Air_Humidity_Setpoint": {
-                                BRICK.hasQuantity: QUDTQK.RelativeHumidity,
-                                BRICK.hasSubstance: BRICK.Zone_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Humidity,
-                                    TAG.Setpoint,
                                     TAG.Air,
-                                    TAG.Zone,
-                                ],
-                            },
-                        },
-                    },
-                    "Illuminance_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Illuminance,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Setpoint,
-                            TAG.Illuminance,
-                        ],
-                    },
-                    "Load_Shed_Setpoint": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Shed,
-                            TAG.Load,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
+                                    TAG.Flow,
                                     TAG.Setpoint,
-                                ],
-                            },
-                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Load_Shed_Differential_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "parents": [
-                                    BRICK.Load_Shed_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Load,
-                                    TAG.Shed,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Pressure,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Differential,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                        },
-                    },
-                    "Luminance_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Luminance,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Luminance,
-                            TAG.Setpoint,
-                        ],
-                    },
-                    "Position_Setpoint": {
-                        "subclasses": {
-                            "Damper_Position_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Position,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Damper,
-                                    TAG.Position,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Valve_Position_Setpoint": {},
-                        },
-                    },
-                    "Pressure_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Pressure,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Pressure,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Air_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Pressure,
-                                "tags": [
-                                    TAG.Setpoint,
-                                    TAG.Pressure,
-                                    TAG.Setpoint,
-                                    TAG.Air,
                                 ],
                                 "subclasses": {
-                                    "Building_Air_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Building_Air,
-                                        "parents": [
-                                            BRICK.Air_Pressure_Setpoint,
+                                    "Cooling_Supply_Air_Flow_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Cooling_Discharge_Air_Flow_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Building,
+                                            TAG.Cool,
+                                            TAG.Supply,
+                                            TAG.Discharge,
                                             TAG.Air,
-                                            TAG.Static,
-                                            TAG.Pressure,
+                                            TAG.Flow,
                                             TAG.Setpoint,
                                         ],
+                                        "subclasses": {
+                                            "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Heating_Supply_Air_Flow_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Heat,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Occupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Occupied_Supply_Air_Flow_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Occupied_Discharge_Air_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Occupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Occupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Occupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Occupied,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    "Unoccupied_Supply_Air_Flow_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Unoccupied_Discharge_Air_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                        "subclasses": {
+                                            "Unoccupied_Cooling_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Cooling_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Cooling_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Cooling_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Cool,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                            "Unoccupied_Heating_Supply_Air_Flow_Setpoint": {
+                                                "aliases": [
+                                                    BRICK.Unoccupied_Heating_Discharge_Air_Flow_Setpoint,
+                                                ],
+                                                "parents": [
+                                                    BRICK.Heating_Discharge_Air_Flow_Setpoint,
+                                                    BRICK.Heating_Supply_Air_Flow_Setpoint,
+                                                ],
+                                                "tags": [
+                                                    TAG.Point,
+                                                    TAG.Unoccupied,
+                                                    TAG.Heat,
+                                                    TAG.Supply,
+                                                    TAG.Discharge,
+                                                    TAG.Air,
+                                                    TAG.Flow,
+                                                    TAG.Setpoint,
+                                                ],
+                                            },
+                                        },
                                     },
                                 },
                             },
-                            "Static_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                        },
+                    },
+                    "Water_Flow_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        BRICK.hasSubstance: BRICK.Water,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Water,
+                            TAG.Flow,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Bypass_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Bypass_Water,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Static,
-                                    TAG.Pressure,
+                                    TAG.Bypass,
+                                    TAG.Water,
+                                    TAG.Flow,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Chilled_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Chilled_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Chilled,
+                                    TAG.Water,
+                                    TAG.Flow,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Building_Air_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Building_Air,
+                                    "Entering_Chilled_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
                                         "parents": [
-                                            BRICK.Air_Pressure_Setpoint,
+                                            BRICK.Chilled_Water_Flow_Setpoint,
                                         ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Building,
-                                            TAG.Air,
-                                            TAG.Static,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Chilled_Water_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Chilled_Water,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Chilled,
                                             TAG.Water,
-                                            TAG.Static,
-                                            TAG.Pressure,
+                                            TAG.Entering,
+                                            TAG.Flow,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Duct_Air_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Duct,
-                                            TAG.Air,
-                                            TAG.Static,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
+                                    "Leaving_Chilled_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
+                                        "parents": [
+                                            BRICK.Chilled_Water_Flow_Setpoint,
                                         ],
-                                    },
-                                    "Exhaust_Air_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Exhaust_Air,
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Exhaust,
-                                            TAG.Air,
-                                            TAG.Static,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Hot_Water_Static_Pressure_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: BRICK.Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
+                                            TAG.Chilled,
                                             TAG.Water,
-                                            TAG.Static,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Static_Pressure_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Static_Pressure_Setpoint,
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Static_Pressure,
-                                        BRICK.hasSubstance: [
-                                            BRICK.Supply_Air,
-                                            BRICK.Discharge_Air,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Static,
-                                            TAG.Pressure,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Underfloor,
-                                            TAG.Air,
-                                            TAG.Plenum,
-                                            TAG.Static,
-                                            TAG.Pressure,
+                                            TAG.Leaving,
+                                            TAG.Flow,
                                             TAG.Setpoint,
                                         ],
                                     },
                                 },
                             },
-                            "Velocity_Pressure_Setpoint": {
+                            "Condenser_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Condenser_Water,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Velocity,
-                                    TAG.Pressure,
+                                    TAG.Condenser,
+                                    TAG.Water,
+                                    TAG.Flow,
                                     TAG.Setpoint,
                                 ],
                             },
-                            "Water_Pressure_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Pressure,
+                            "Entering_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Entering_Water,
                                 "tags": [
+                                    TAG.Point,
+                                    TAG.Entering,
+                                    TAG.Water,
+                                    TAG.Flow,
                                     TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Chilled_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                        "parents": [
+                                            BRICK.Chilled_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Entering_Hot_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Hot_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Flow,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Hot_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Leaving_Hot_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Water_Flow_Setpoint": {
+                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                BRICK.hasSubstance: BRICK.Leaving_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Leaving,
+                                    TAG.Water,
+                                    TAG.Flow,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Chilled_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Leaving_Chilled_Water,
+                                        "parents": [
+                                            BRICK.Chilled_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Chilled,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Leaving_Hot_Water_Flow_Setpoint": {
+                                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Flow_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Flow,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            "Frequency_Setpoint": {
+                BRICK.hasQuantity: BRICK.Frequency,
+                "tags": [
+                    TAG.Point,
+                    TAG.Setpoint,
+                    TAG.Frequency,
+                ],
+            },
+            "Humidity_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.PressureRatio,
+                "tags": [
+                    TAG.Point,
+                    TAG.Humidity,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Building_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Building_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Building,
+                        ],
+                    },
+                    "Bypass_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Bypass_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Bypass,
+                        ],
+                    },
+                    "Exhaust_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Exhaust_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Exhaust,
+                        ],
+                    },
+                    "Mixed_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Mixed_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Mixed,
+                        ],
+                    },
+                    "Occupied_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Occupied,
+                        ],
+                    },
+                    "Outside_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Outside_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Outside,
+                        ],
+                    },
+                    "Return_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Return_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Return,
+                        ],
+                    },
+                    "Supply_Air_Humidity_Setpoint": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Humidity_Setpoint,
+                        ],
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: [
+                            BRICK.Supply_Air,
+                            BRICK.Discharge_Air,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Supply,
+                            TAG.Discharge,
+                        ],
+                    },
+                    "Unoccupied_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Unoccupied,
+                        ],
+                    },
+                    "Zone_Air_Humidity_Setpoint": {
+                        BRICK.hasQuantity: QUDTQK.RelativeHumidity,
+                        BRICK.hasSubstance: BRICK.Zone_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Humidity,
+                            TAG.Setpoint,
+                            TAG.Air,
+                            TAG.Zone,
+                        ],
+                    },
+                },
+            },
+            "Illuminance_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.Illuminance,
+                "tags": [
+                    TAG.Point,
+                    TAG.Setpoint,
+                    TAG.Illuminance,
+                ],
+            },
+            "Load_Shed_Setpoint": {
+                "tags": [
+                    TAG.Point,
+                    TAG.Shed,
+                    TAG.Load,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Load_Shed_Differential_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "parents": [
+                            BRICK.Load_Shed_Setpoint,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Load,
+                            TAG.Shed,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Differential_Pressure,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Differential,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                },
+            },
+            "Luminance_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.Luminance,
+                "tags": [
+                    TAG.Point,
+                    TAG.Luminance,
+                    TAG.Setpoint,
+                ],
+            },
+            "Position_Setpoint": {
+                "subclasses": {
+                    "Damper_Position_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Position,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Damper,
+                            TAG.Position,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Valve_Position_Setpoint": {},
+                },
+            },
+            "Pressure_Setpoint": {
+                BRICK.hasQuantity: BRICK.Pressure,
+                "tags": [
+                    TAG.Point,
+                    TAG.Pressure,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Air_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Pressure,
+                        "tags": [
+                            TAG.Setpoint,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                            TAG.Air,
+                        ],
+                        "subclasses": {
+                            "Building_Air_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Building_Air,
+                                "parents": [
+                                    BRICK.Air_Pressure_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Building,
+                                    TAG.Air,
+                                    TAG.Static,
                                     TAG.Pressure,
                                     TAG.Setpoint,
-                                    TAG.Water,
                                 ],
                             },
                         },
                     },
-                    "Speed_Setpoint": {
-                        BRICK.hasQuantity: BRICK.Speed,
+                    "Static_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Static_Pressure,
                         "tags": [
                             TAG.Point,
-                            TAG.Speed,
+                            TAG.Static,
+                            TAG.Pressure,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
-                            "Rated_Speed_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Speed,
+                            "Building_Air_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Building_Air,
+                                "parents": [
+                                    BRICK.Air_Pressure_Setpoint,
+                                ],
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Rated,
-                                    TAG.Speed,
+                                    TAG.Building,
+                                    TAG.Air,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Chilled_Water_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Chilled_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Chilled,
+                                    TAG.Water,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Duct_Air_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Duct,
+                                    TAG.Air,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Exhaust_Air_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Exhaust_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Exhaust,
+                                    TAG.Air,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Hot_Water_Static_Pressure_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: BRICK.Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Supply_Air_Static_Pressure_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Static_Pressure_Setpoint,
+                                ],
+                                BRICK.hasQuantity: BRICK.Static_Pressure,
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Static,
+                                    TAG.Pressure,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Underfloor_Air_Plenum_Static_Pressure_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Underfloor,
+                                    TAG.Air,
+                                    TAG.Plenum,
+                                    TAG.Static,
+                                    TAG.Pressure,
                                     TAG.Setpoint,
                                 ],
                             },
                         },
                     },
-                    "Temperature_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Temperature,
+                    "Velocity_Pressure_Setpoint": {
                         "tags": [
                             TAG.Point,
+                            TAG.Velocity,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Water_Pressure_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Pressure,
+                        "tags": [
+                            TAG.Setpoint,
+                            TAG.Pressure,
+                            TAG.Setpoint,
+                            TAG.Water,
+                        ],
+                    },
+                },
+            },
+            "Speed_Setpoint": {
+                BRICK.hasQuantity: BRICK.Speed,
+                "tags": [
+                    TAG.Point,
+                    TAG.Speed,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Rated_Speed_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Speed,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Rated,
+                            TAG.Speed,
+                            TAG.Setpoint,
+                        ],
+                    },
+                },
+            },
+            "Temperature_Setpoint": {
+                BRICK.hasQuantity: QUDTQK.Temperature,
+                "tags": [
+                    TAG.Point,
+                    TAG.Temperature,
+                    TAG.Setpoint,
+                ],
+                "subclasses": {
+                    "Air_Temperature_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Air,
                             TAG.Temperature,
                             TAG.Setpoint,
                         ],
                         "subclasses": {
-                            "Air_Temperature_Setpoint": {
+                            "Effective_Air_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
                                 BRICK.hasSubstance: BRICK.Air,
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Effective,
                                     TAG.Air,
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Effective_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Effective,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
+                                    "Effective_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Effective_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Effective_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Effective_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Effective_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Effective_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Effective,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Mixed_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Mixed_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Mixed,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Occupied_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Occupied,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Occupied_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Occupied_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Occupied_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Occupied_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Return_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Return_Air,
                                         "tags": [
                                             TAG.Point,
                                             TAG.Return,
                                             TAG.Air,
                                             TAG.Temperature,
+                                            TAG.Heat,
                                             TAG.Setpoint,
+                                            TAG.Effective,
                                         ],
-                                        "subclasses": {
-                                            "Effective_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Occupied_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Unoccupied_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Room_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Air,
+                                    "Effective_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Room,
                                             TAG.Air,
                                             TAG.Temperature,
+                                            TAG.Heat,
                                             TAG.Setpoint,
+                                            TAG.Effective,
                                         ],
-                                        "subclasses": {
-                                            "Effective_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Occupied_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Unoccupied_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Supply_Air_Temperature_Setpoint": {
+                                    "Effective_Supply_Air_Temperature_Setpoint": {
                                         "aliases": [
-                                            BRICK.Discharge_Air_Temperature_Setpoint,
+                                            BRICK.Effective_Discharge_Air_Temperature_Setpoint,
                                         ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: [
-                                            BRICK.Supply_Air,
-                                            BRICK.Discharge_Air,
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
@@ -1433,377 +1201,733 @@ setpoint_definitions = {
                                             TAG.Discharge,
                                             TAG.Air,
                                             TAG.Temperature,
+                                            TAG.Heat,
                                             TAG.Setpoint,
+                                            TAG.Effective,
                                         ],
-                                        "subclasses": {
-                                            "Effective_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Effective_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Effective,
-                                                ],
-                                            },
-                                            "Occupied_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Occupied,
-                                                ],
-                                            },
-                                            "Supply_Air_Temperature_Cooling_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Cooling_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Cool,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Supply_Air_Temperature_Heating_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Discharge_Air_Temperature_Heating_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Heating_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Unoccupied_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Target_Zone_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Zone_Air,
+                                    "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
+                                            TAG.Effective,
                                             TAG.Target,
                                             TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Effective_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Effective,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Occupied_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Standby_Target_Zone_Air_Temperature_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Standby,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Unoccupied_Air_Temperature_Setpoint": {
+                                },
+                            },
+                            "Mixed_Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Mixed_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Mixed,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Occupied_Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Occupied,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Occupied_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Unoccupied,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Occupied_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Occupied_Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Target,
+                                            TAG.Zone,
                                             TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Unoccupied_Return_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Return,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                            "Unoccupied_Room_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Room,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                            "Unoccupied_Supply_Air_Temperature_Setpoint": {
-                                                "aliases": [
-                                                    BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
-                                                ],
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Supply,
-                                                    TAG.Discharge,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Heat,
-                                                    TAG.Setpoint,
-                                                    TAG.Unoccupied,
-                                                ],
-                                            },
-                                            "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Target,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
                                     },
                                 },
                             },
-                            "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Pressure,
-                                    TAG.Shed,
-                                    TAG.Load,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Radiant_Panel_Temperature_Setpoint": {
+                            "Return_Air_Temperature_Setpoint": {
                                 BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
                                 "tags": [
                                     TAG.Point,
-                                    TAG.Radiant,
-                                    TAG.Panel,
+                                    TAG.Return,
+                                    TAG.Air,
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Embedded_Temperature_Setpoint": {
+                                    "Effective_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Embedded,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Effective,
+                                        ],
+                                    },
+                                    "Occupied_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Unoccupied_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Room_Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Room,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Effective_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Effective,
+                                        ],
+                                    },
+                                    "Occupied_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Unoccupied_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Supply_Air_Temperature_Setpoint": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Setpoint,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: [
+                                    BRICK.Supply_Air,
+                                    BRICK.Discharge_Air,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Effective_Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Effective_Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Effective,
+                                        ],
+                                    },
+                                    "Occupied_Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Occupied_Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Occupied,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_Cooling_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Cooling_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Cool,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Supply_Air_Temperature_Heating_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Discharge_Air_Temperature_Heating_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Heating_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Unoccupied_Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Target_Zone_Air_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Zone_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Target,
+                                    TAG.Zone,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Effective_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Effective,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Core_Temperature_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Core,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Inside_Face_Surface_Temperature_Setpoint": {
+                                    "Occupied_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Inside,
-                                            TAG.Face,
-                                            TAG.Surface,
+                                            TAG.Occupied,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
                                     },
-                                    "Outside_Face_Surface_Temperature_Setpoint": {
+                                    "Standby_Target_Zone_Air_Temperature_Setpoint": {
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Face,
-                                            TAG.Surface,
+                                            TAG.Standby,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
                                     },
                                 },
                             },
-                            "Schedule_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
+                            "Unoccupied_Air_Temperature_Setpoint": {
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Unoccupied,
+                                    TAG.Air,
                                     TAG.Temperature,
                                     TAG.Setpoint,
-                                    TAG.Schedule,
                                 ],
+                                "subclasses": {
+                                    "Unoccupied_Return_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Return,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                    "Unoccupied_Room_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Room,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                    "Unoccupied_Supply_Air_Temperature_Setpoint": {
+                                        "aliases": [
+                                            BRICK.Unoccupied_Discharge_Air_Temperature_Setpoint,
+                                        ],
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Supply,
+                                            TAG.Discharge,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Heat,
+                                            TAG.Setpoint,
+                                            TAG.Unoccupied,
+                                        ],
+                                    },
+                                    "Unoccupied_Target_Zone_Air_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Target,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
                             },
-                            "Water_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Water,
+                        },
+                    },
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Load_Shed_Setpoint": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Pressure,
+                            TAG.Shed,
+                            TAG.Load,
+                            TAG.Setpoint,
+                        ],
+                    },
+                    "Radiant_Panel_Temperature_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Radiant,
+                            TAG.Panel,
+                            TAG.Temperature,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Embedded_Temperature_Setpoint": {
                                 "tags": [
                                     TAG.Point,
+                                    TAG.Embedded,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Core_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Core,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Inside_Face_Surface_Temperature_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Inside,
+                                    TAG.Face,
+                                    TAG.Surface,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                            "Outside_Face_Surface_Temperature_Setpoint": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Face,
+                                    TAG.Surface,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                            },
+                        },
+                    },
+                    "Schedule_Temperature_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Setpoint,
+                            TAG.Schedule,
+                        ],
+                    },
+                    "Water_Temperature_Setpoint": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Water,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Water,
+                            TAG.Temperature,
+                            TAG.Setpoint,
+                        ],
+                        "subclasses": {
+                            "Chilled_Water_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Chilled_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Chilled,
                                     TAG.Water,
                                     TAG.Temperature,
                                     TAG.Setpoint,
                                 ],
                                 "subclasses": {
-                                    "Chilled_Water_Temperature_Setpoint": {
+                                    "Entering_Chilled_Water_Temperature_Setpoint": {
                                         BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Chilled_Water,
+                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                        "parents": [
+                                            BRICK.Chilled_Water_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
                                             TAG.Chilled,
+                                        ],
+                                    },
+                                    "Leaving_Chilled_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Chilled_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Chilled,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Domestic_Hot_Water_Temperature_Setpoint": {
+                                "parents": [
+                                    BRICK.Hot_Water_Temperature_Setpoint,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Domestic,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Entering_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Entering,
                                             TAG.Water,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Entering_Chilled_Water_Temperature_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Chilled,
-                                                ],
-                                            },
-                                            "Leaving_Chilled_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Chilled,
-                                                ],
-                                            },
-                                        },
                                     },
+                                    "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Leaving_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Entering_Water_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Entering_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Entering,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Chilled_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
+                                        "parents": [
+                                            BRICK.Chilled_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Chilled,
+                                        ],
+                                    },
+                                    "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Entering_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                    "Entering_Hot_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Hot,
+                                        ],
+                                    },
+                                    "Entering_Water_Temperature_Deadband_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Entering_Water,
+                                        "parents": [
+                                            BRICK.Entering_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Deadband,
+                                            TAG.Setpoint,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Hot_Water_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
                                     "Domestic_Hot_Water_Temperature_Setpoint": {
                                         "parents": [
                                             BRICK.Hot_Water_Temperature_Setpoint,
@@ -1847,1520 +1971,122 @@ setpoint_definitions = {
                                             },
                                         },
                                     },
-                                    "Entering_Water_Temperature_Setpoint": {
+                                    "Entering_Hot_Water_Temperature_Setpoint": {
                                         BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Entering_Water,
+                                        BRICK.hasSubstance: BRICK.Entering_Hot_Water,
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
                                             TAG.Entering,
                                             TAG.Water,
                                             TAG.Temperature,
                                             TAG.Setpoint,
+                                            TAG.Hot,
                                         ],
-                                        "subclasses": {
-                                            "Entering_Chilled_Water_Temperature_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Chilled_Water,
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Chilled,
-                                                ],
-                                            },
-                                            "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Entering_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Domestic,
-                                                    TAG.Hot,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Entering_Hot_Water_Temperature_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Hot,
-                                                ],
-                                            },
-                                            "Entering_Water_Temperature_Deadband_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Water,
-                                                "parents": [
-                                                    BRICK.Entering_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Deadband,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Hot_Water_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Hot_Water,
+                                    "Leaving_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint,
+                                        ],
                                         "tags": [
                                             TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
                                             TAG.Hot,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Water_Temperature_Setpoint": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Leaving,
+                                    TAG.Water,
+                                    TAG.Temperature,
+                                    TAG.Setpoint,
+                                ],
+                                "subclasses": {
+                                    "Entering_Condenser_Water_Temperature_Setpoint": {
+                                        BRICK.hasQuantity: BRICK.Temperature,
+                                        BRICK.hasSubstance: BRICK.Entering_Condenser_Water,
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Entering,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Condenser,
+                                        ],
+                                    },
+                                    "Leaving_Chilled_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Chilled_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Chilled,
+                                        ],
+                                    },
+                                    "Leaving_Condenser_Water_Temperature_Setpoint": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Condenser,
+                                        ],
+                                    },
+                                    "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Leaving_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Domestic,
+                                            TAG.Hot,
+                                            TAG.Leaving,
                                             TAG.Water,
                                             TAG.Temperature,
                                             TAG.Setpoint,
                                         ],
-                                        "subclasses": {
-                                            "Domestic_Hot_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Hot_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Domestic,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                                "subclasses": {
-                                                    "Entering_Domestic_Hot_Water_Temperature_Setpoint": {
-                                                        "parents": [
-                                                            BRICK.Entering_Water_Temperature_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Domestic,
-                                                            TAG.Hot,
-                                                            TAG.Entering,
-                                                            TAG.Water,
-                                                            TAG.Temperature,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                    "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
-                                                        "parents": [
-                                                            BRICK.Leaving_Water_Temperature_Setpoint,
-                                                        ],
-                                                        "tags": [
-                                                            TAG.Point,
-                                                            TAG.Domestic,
-                                                            TAG.Hot,
-                                                            TAG.Leaving,
-                                                            TAG.Water,
-                                                            TAG.Temperature,
-                                                            TAG.Setpoint,
-                                                        ],
-                                                    },
-                                                },
-                                            },
-                                            "Entering_Hot_Water_Temperature_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Hot_Water,
-                                                "parents": [
-                                                    BRICK.Hot_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Hot,
-                                                ],
-                                            },
-                                            "Leaving_Hot_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Hot_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Hot,
-                                                ],
-                                            },
-                                        },
                                     },
-                                    "Leaving_Water_Temperature_Setpoint": {
+                                    "Leaving_Hot_Water_Temperature_Setpoint": {
+                                        "parents": [
+                                            BRICK.Hot_Water_Temperature_Setpoint,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Leaving,
+                                            TAG.Water,
+                                            TAG.Temperature,
+                                            TAG.Setpoint,
+                                            TAG.Hot,
+                                        ],
+                                    },
+                                    "Leaving_Water_Temperature_Deadband_Setpoint": {
                                         BRICK.hasQuantity: BRICK.Temperature,
                                         BRICK.hasSubstance: BRICK.Leaving_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Leaving,
-                                            TAG.Water,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Condenser_Water_Temperature_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Entering_Condenser_Water,
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Entering,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Condenser,
-                                                ],
-                                            },
-                                            "Leaving_Chilled_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Chilled_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Chilled,
-                                                ],
-                                            },
-                                            "Leaving_Condenser_Water_Temperature_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Condenser,
-                                                ],
-                                            },
-                                            "Leaving_Domestic_Hot_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Leaving_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Domestic,
-                                                    TAG.Hot,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Leaving_Hot_Water_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Hot_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                    TAG.Hot,
-                                                ],
-                                            },
-                                            "Leaving_Water_Temperature_Deadband_Setpoint": {
-                                                BRICK.hasQuantity: BRICK.Temperature,
-                                                BRICK.hasSubstance: BRICK.Leaving_Water,
-                                                "parents": [
-                                                    BRICK.Leaving_Water_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Leaving,
-                                                    TAG.Water,
-                                                    TAG.Temperature,
-                                                    TAG.Deadband,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            "Threshold_Setpoint": {
-                "subclasses": {
-                    "Lockout_Setpoint": {},
-                    "Lower_Threshold_Setpoint": {
-                        "subclasses": {
-                            "Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Enable,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.System,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Heating_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Heat,
-                                ],
-                                "subclasses": {
-                                    "Heating_Zone_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Zone_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Heat,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Effective_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Effective,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Occupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Standby_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Standby,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Unoccupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Occupied_Heating_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Heat,
-                                            TAG.Occupied,
-                                        ],
-                                        "subclasses": {
-                                            "Occupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Open_Heating_Valve_Outside_Air_Temperature_Setpoint": {
                                         "parents": [
-                                            BRICK.Heating_Temperature_Setpoint,
+                                            BRICK.Leaving_Water_Temperature_Setpoint,
                                         ],
                                         "tags": [
                                             TAG.Point,
-                                            TAG.Open,
-                                            TAG.Heat,
-                                            TAG.Valve,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Unoccupied_Heating_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Heat,
-                                            TAG.Unoccupied,
-                                        ],
-                                        "subclasses": {
-                                            "Unoccupied_Heating_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Heat,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                            "Humidification_Setpoint": {},
-                            "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
                                             TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Low_Outside_Air_Temperature_Enable_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Low,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Enable,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Outside_Air_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Outside_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Return_Air_Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Return_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Return,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Air_Flow_Low_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.Low,
-                                ],
-                            },
-                            "Supply_Air_Temperature_Low_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
-                                ],
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Supply_Air,
-                                "parents": [
-                                    BRICK.Temperature_Low_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.Low,
-                                ],
-                            },
-                            "Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
                                             TAG.Water,
-                                            TAG.Entering,
                                             TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
+                                            TAG.Deadband,
                                             TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Temperature,
-                                                    TAG.Low,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Temperature,
-                                                    TAG.Low,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Outside_Air_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Outside_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Return_Air_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_Low_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        "parents": [
-                                            BRICK.Temperature_Low_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.Low,
-                                        ],
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "Outside_Air_Lockout_Temperature_Setpoint": {
-                        "tags": [
-                            TAG.Point,
-                            TAG.Outside,
-                            TAG.Air,
-                            TAG.Lockout,
-                            TAG.Temperature,
-                            TAG.Setpoint,
-                        ],
-                    },
-                    "Reset_Setpoint": {
-                        BRICK.hasQuantity: QUDTQK.Dimensionless,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Supply_Air_Flow_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Flow_Reset_Setpoint,
-                                ],
-                                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                                BRICK.hasSubstance: BRICK.Discharge_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Supply_Air_Flow_High_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.High,
-                                        ],
-                                    },
-                                    "Supply_Air_Flow_Low_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Flow,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.Low,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Supply_Air_Temperature_Reset_Differential_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Temperature_Reset_Differential_Setpoint,
-                                ],
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                BRICK.hasSubstance: [
-                                    BRICK.Supply_Air,
-                                    BRICK.Discharge_Air,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Temperature_Differential_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Differential_Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Temperature_High_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Temperature,
-                                                    TAG.High,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Temperature,
-                                                    TAG.High,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Outside_Air_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Outside_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Return_Air_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_High_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        "parents": [
-                                            BRICK.Temperature_High_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.High,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Temperature_Low_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Low,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Temperature,
-                                                    TAG.Low,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Leaving_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Temperature,
-                                                    TAG.Low,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Outside_Air_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Outside_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Return_Air_Temperature_Low_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Low,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_Low_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Temperature_Low_Reset_Setpoint,
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        "parents": [
-                                            BRICK.Temperature_Low_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.Low,
-                                        ],
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    "Supply_Air_Flow_Reset_Setpoint": {
-                        "aliases": [
-                            BRICK.Discharge_Air_Flow_Reset_Setpoint,
-                        ],
-                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
-                        BRICK.hasSubstance: BRICK.Discharge_Air,
-                        "tags": [
-                            TAG.Point,
-                            TAG.Supply,
-                            TAG.Discharge,
-                            TAG.Air,
-                            TAG.Flow,
-                            TAG.Reset,
-                            TAG.Setpoint,
-                        ],
-                        "subclasses": {
-                            "Supply_Air_Flow_High_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.High,
-                                ],
-                            },
-                            "Supply_Air_Flow_Low_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Flow_Low_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.Low,
-                                ],
-                            },
-                        },
-                    },
-                    "Upper_Threshold_Setpoint": {
-                        "subclasses": {
-                            "CO2_Setpoint": {
-                                BRICK.hasQuantity: BRICK.CO2_Concentration,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.CO2,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Return_Air_CO2_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.CO2_Concentration,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.CO2,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Cooling_Temperature_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                    TAG.Cool,
-                                ],
-                                "subclasses": {
-                                    "Cooling_Zone_Air_Temperature_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Zone_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Cool,
-                                            TAG.Zone,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Effective_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Effective_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Effective,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Occupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Standby_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Standby,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                            "Unoccupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Occupied_Cooling_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Cool,
-                                            TAG.Occupied,
-                                        ],
-                                        "subclasses": {
-                                            "Occupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Occupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Occupied,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Supply_Air_Temperature_Cooling_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Temperature_Cooling_Setpoint,
-                                        ],
-                                        "parents": [
-                                            BRICK.Cooling_Temperature_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Cool,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Unoccupied_Cooling_Temperature_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Temperature,
-                                            TAG.Setpoint,
-                                            TAG.Cool,
-                                            TAG.Unoccupied,
-                                        ],
-                                        "subclasses": {
-                                            "Unoccupied_Cooling_Zone_Air_Temperature_Setpoint": {
-                                                "parents": [
-                                                    BRICK.Unoccupied_Air_Temperature_Setpoint,
-                                                ],
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Unoccupied,
-                                                    TAG.Cool,
-                                                    TAG.Zone,
-                                                    TAG.Air,
-                                                    TAG.Temperature,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                            "Dehumidification_Setpoint": {},
-                            "Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Disable,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.System,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Entering,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Medium,
-                                            TAG.Temperature,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                },
-                            },
-                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Medium,
-                                    TAG.Temperature,
-                                    TAG.Hot,
-                                    TAG.Water,
-                                    TAG.Leaving,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Outside_Air_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Outside_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Outside,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Return_Air_Temperature_High_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Return_Air,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Return,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                            },
-                            "Supply_Air_Flow_High_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Flow_High_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Flow,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.High,
-                                ],
-                            },
-                            "Supply_Air_Temperature_High_Reset_Setpoint": {
-                                "aliases": [
-                                    BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
-                                ],
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                BRICK.hasSubstance: BRICK.Supply_Air,
-                                "parents": [
-                                    BRICK.Temperature_High_Reset_Setpoint,
-                                ],
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Supply,
-                                    TAG.Discharge,
-                                    TAG.Air,
-                                    TAG.Temperature,
-                                    TAG.Differential,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                    TAG.High,
-                                ],
-                            },
-                            "Temperature_High_Reset_Setpoint": {
-                                BRICK.hasQuantity: BRICK.Temperature,
-                                "tags": [
-                                    TAG.Point,
-                                    TAG.Temperature,
-                                    TAG.High,
-                                    TAG.Reset,
-                                    TAG.Setpoint,
-                                ],
-                                "subclasses": {
-                                    "Entering_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Entering,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Entering,
-                                                    TAG.Temperature,
-                                                    TAG.High,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Leaving_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Hot,
-                                            TAG.Water,
-                                            TAG.Leaving,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                        "subclasses": {
-                                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Setpoint": {
-                                                "tags": [
-                                                    TAG.Point,
-                                                    TAG.Medium,
-                                                    TAG.Temperature,
-                                                    TAG.Hot,
-                                                    TAG.Water,
-                                                    TAG.Leaving,
-                                                    TAG.Temperature,
-                                                    TAG.High,
-                                                    TAG.Reset,
-                                                    TAG.Setpoint,
-                                                ],
-                                            },
-                                        },
-                                    },
-                                    "Outside_Air_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Outside_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Outside,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Return_Air_Temperature_High_Reset_Setpoint": {
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Return_Air,
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Return,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.High,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                        ],
-                                    },
-                                    "Supply_Air_Temperature_High_Reset_Setpoint": {
-                                        "aliases": [
-                                            BRICK.Discharge_Air_Temperature_High_Reset_Setpoint,
-                                        ],
-                                        BRICK.hasQuantity: BRICK.Temperature,
-                                        BRICK.hasSubstance: BRICK.Supply_Air,
-                                        "parents": [
-                                            BRICK.Temperature_High_Reset_Setpoint,
-                                        ],
-                                        "tags": [
-                                            TAG.Point,
-                                            TAG.Supply,
-                                            TAG.Discharge,
-                                            TAG.Air,
-                                            TAG.Temperature,
-                                            TAG.Differential,
-                                            TAG.Reset,
-                                            TAG.Setpoint,
-                                            TAG.High,
                                         ],
                                     },
                                 },

--- a/bricksrc/threshold.py
+++ b/bricksrc/threshold.py
@@ -1,4 +1,4 @@
-from namespaces import TAG, BRICK, RDFS, QUDTQK
+from .namespaces import TAG, BRICK, RDFS, QUDTQK
 
 
 threshold_definitions = {

--- a/bricksrc/threshold.py
+++ b/bricksrc/threshold.py
@@ -822,7 +822,7 @@ threshold_definitions = {
                     },
                 },
             },
-            "Upper_Threshold_Threshold": {
+            "Upper_Threshold": {
                 "subclasses": {
                     "CO2_Threshold": {
                         BRICK.hasQuantity: BRICK.CO2_Concentration,

--- a/bricksrc/threshold.py
+++ b/bricksrc/threshold.py
@@ -1,0 +1,1275 @@
+from namespaces import TAG, BRICK, RDFS, QUDTQK
+
+
+threshold_definitions = {
+    "Threshold": {
+        "subclasses": {
+            "Lockout_Threshold": {},
+            "Lower_Threshold": {
+                "subclasses": {
+                    "Enable_Hot_Water_System_Outside_Air_Temperature_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Enable,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.System,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Entering_Hot_Water_Temperature_Low_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                        },
+                    },
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Heating_Temperature_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Threshold,
+                            TAG.Heat,
+                        ],
+                        "subclasses": {
+                            "Heating_Zone_Air_Temperature_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Zone_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Heat,
+                                    TAG.Zone,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Effective_Heating_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Effective,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Occupied_Heating_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Standby_Heating_Zone_Air_Temperature_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Standby,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Unoccupied_Heating_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Occupied_Heating_Temperature_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                    TAG.Heat,
+                                    TAG.Occupied,
+                                ],
+                                "subclasses": {
+                                    "Occupied_Heating_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Open_Heating_Valve_Outside_Air_Temperature_Threshold": {
+                                "parents": [
+                                    BRICK.Heating_Temperature_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Open,
+                                    TAG.Heat,
+                                    TAG.Valve,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Unoccupied_Heating_Temperature_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                    TAG.Heat,
+                                    TAG.Unoccupied,
+                                ],
+                                "subclasses": {
+                                    "Unoccupied_Heating_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Heat,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "Humidification_Threshold": {},
+                    "Leaving_Hot_Water_Temperature_Low_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                        },
+                    },
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Low_Outside_Air_Temperature_Enable_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Low,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Enable,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Outside_Air_Temperature_Low_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Outside_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Return_Air_Temperature_Low_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Return_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Return,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Supply_Air_Flow_Low_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_Low_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.Low,
+                        ],
+                    },
+                    "Supply_Air_Temperature_Low_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Temperature_Low_Reset_Threshold,
+                        ],
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Supply_Air,
+                        "parents": [
+                            BRICK.Temperature_Low_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.Low,
+                        ],
+                    },
+                    "Temperature_Low_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Outside_Air_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Return_Air_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Supply_Air_Temperature_Low_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Low_Reset_Threshold,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_Low_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.Low,
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+            "Outside_Air_Lockout_Temperature_Threshold": {
+                "tags": [
+                    TAG.Point,
+                    TAG.Outside,
+                    TAG.Air,
+                    TAG.Lockout,
+                    TAG.Temperature,
+                    TAG.Threshold,
+                ],
+            },
+            "Reset_Threshold": {
+                BRICK.hasQuantity: QUDTQK.Dimensionless,
+                "tags": [
+                    TAG.Point,
+                    TAG.Reset,
+                    TAG.Threshold,
+                ],
+                "subclasses": {
+                    "Supply_Air_Flow_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_Reset_Threshold,
+                        ],
+                        BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                        BRICK.hasSubstance: BRICK.Discharge_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Supply_Air_Flow_High_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_High_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.High,
+                                ],
+                            },
+                            "Supply_Air_Flow_Low_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Flow_Low_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Flow,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.Low,
+                                ],
+                            },
+                        },
+                    },
+                    "Supply_Air_Temperature_Reset_Differential_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Temperature_Reset_Differential_Threshold,
+                        ],
+                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                        BRICK.hasSubstance: [
+                            BRICK.Supply_Air,
+                            BRICK.Discharge_Air,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Temperature_Differential_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Differential_Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Temperature_High_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Hot_Water_Temperature_High_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Hot_Water_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Outside_Air_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Return_Air_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Supply_Air_Temperature_High_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_High_Reset_Threshold,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_High_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.High,
+                                ],
+                            },
+                        },
+                    },
+                    "Temperature_Low_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Low,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Entering_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_Low_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.Low,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Outside_Air_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Return_Air_Temperature_Low_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Low,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Supply_Air_Temperature_Low_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Low_Reset_Threshold,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_Low_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.Low,
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+            "Supply_Air_Flow_Reset_Threshold": {
+                "aliases": [
+                    BRICK.Discharge_Air_Flow_Reset_Threshold,
+                ],
+                BRICK.hasQuantity: QUDTQK.VolumeFlowRate,
+                BRICK.hasSubstance: BRICK.Discharge_Air,
+                "tags": [
+                    TAG.Point,
+                    TAG.Supply,
+                    TAG.Discharge,
+                    TAG.Air,
+                    TAG.Flow,
+                    TAG.Reset,
+                    TAG.Threshold,
+                ],
+                "subclasses": {
+                    "Supply_Air_Flow_High_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_High_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.High,
+                        ],
+                    },
+                    "Supply_Air_Flow_Low_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_Low_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.Low,
+                        ],
+                    },
+                },
+            },
+            "Upper_Threshold_Threshold": {
+                "subclasses": {
+                    "CO2_Threshold": {
+                        BRICK.hasQuantity: BRICK.CO2_Concentration,
+                        "tags": [
+                            TAG.Point,
+                            TAG.CO2,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Return_Air_CO2_Threshold": {
+                                BRICK.hasQuantity: BRICK.CO2_Concentration,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.CO2,
+                                    TAG.Threshold,
+                                ],
+                            },
+                        },
+                    },
+                    "Cooling_Temperature_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.Threshold,
+                            TAG.Cool,
+                        ],
+                        "subclasses": {
+                            "Cooling_Zone_Air_Temperature_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Zone_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Cool,
+                                    TAG.Zone,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Effective_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Effective_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Effective,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Occupied_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Standby_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Standby,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                    "Unoccupied_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Occupied_Cooling_Temperature_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                    TAG.Cool,
+                                    TAG.Occupied,
+                                ],
+                                "subclasses": {
+                                    "Occupied_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Occupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Occupied,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Supply_Air_Temperature_Cooling_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_Cooling_Threshold,
+                                ],
+                                "parents": [
+                                    BRICK.Cooling_Temperature_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Cool,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Unoccupied_Cooling_Temperature_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Temperature,
+                                    TAG.Threshold,
+                                    TAG.Cool,
+                                    TAG.Unoccupied,
+                                ],
+                                "subclasses": {
+                                    "Unoccupied_Cooling_Zone_Air_Temperature_Threshold": {
+                                        "parents": [
+                                            BRICK.Unoccupied_Air_Temperature_Threshold,
+                                        ],
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Unoccupied,
+                                            TAG.Cool,
+                                            TAG.Zone,
+                                            TAG.Air,
+                                            TAG.Temperature,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    "Dehumidification_Threshold": {},
+                    "Disable_Hot_Water_System_Outside_Air_Temperature_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Disable,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.System,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Entering_Hot_Water_Temperature_High_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                        },
+                    },
+                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Entering,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Leaving_Hot_Water_Temperature_High_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Medium,
+                                    TAG.Temperature,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                        },
+                    },
+                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                        "tags": [
+                            TAG.Point,
+                            TAG.Medium,
+                            TAG.Temperature,
+                            TAG.Hot,
+                            TAG.Water,
+                            TAG.Leaving,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Outside_Air_Temperature_High_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Outside_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Outside,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Return_Air_Temperature_High_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Return_Air,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Return,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                    },
+                    "Supply_Air_Flow_High_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Flow_High_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Flow,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.High,
+                        ],
+                    },
+                    "Supply_Air_Temperature_High_Reset_Threshold": {
+                        "aliases": [
+                            BRICK.Discharge_Air_Temperature_High_Reset_Threshold,
+                        ],
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        BRICK.hasSubstance: BRICK.Supply_Air,
+                        "parents": [
+                            BRICK.Temperature_High_Reset_Threshold,
+                        ],
+                        "tags": [
+                            TAG.Point,
+                            TAG.Supply,
+                            TAG.Discharge,
+                            TAG.Air,
+                            TAG.Temperature,
+                            TAG.Differential,
+                            TAG.Reset,
+                            TAG.Threshold,
+                            TAG.High,
+                        ],
+                    },
+                    "Temperature_High_Reset_Threshold": {
+                        BRICK.hasQuantity: BRICK.Temperature,
+                        "tags": [
+                            TAG.Point,
+                            TAG.Temperature,
+                            TAG.High,
+                            TAG.Reset,
+                            TAG.Threshold,
+                        ],
+                        "subclasses": {
+                            "Entering_Hot_Water_Temperature_High_Reset_Threshold": {
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Entering,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Entering_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Entering,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Leaving_Hot_Water_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Leaving_Hot_Water,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Hot,
+                                    TAG.Water,
+                                    TAG.Leaving,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                                "subclasses": {
+                                    "Leaving_Medium_Temperature_Hot_Water_Temperature_High_Reset_Threshold": {
+                                        "tags": [
+                                            TAG.Point,
+                                            TAG.Medium,
+                                            TAG.Temperature,
+                                            TAG.Hot,
+                                            TAG.Water,
+                                            TAG.Leaving,
+                                            TAG.Temperature,
+                                            TAG.High,
+                                            TAG.Reset,
+                                            TAG.Threshold,
+                                        ],
+                                    },
+                                },
+                            },
+                            "Outside_Air_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Outside_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Outside,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Return_Air_Temperature_High_Reset_Threshold": {
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Return_Air,
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Return,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.High,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                ],
+                            },
+                            "Supply_Air_Temperature_High_Reset_Threshold": {
+                                "aliases": [
+                                    BRICK.Discharge_Air_Temperature_High_Reset_Threshold,
+                                ],
+                                BRICK.hasQuantity: BRICK.Temperature,
+                                BRICK.hasSubstance: BRICK.Supply_Air,
+                                "parents": [
+                                    BRICK.Temperature_High_Reset_Threshold,
+                                ],
+                                "tags": [
+                                    TAG.Point,
+                                    TAG.Supply,
+                                    TAG.Discharge,
+                                    TAG.Air,
+                                    TAG.Temperature,
+                                    TAG.Differential,
+                                    TAG.Reset,
+                                    TAG.Threshold,
+                                    TAG.High,
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The current Setpoint class mixes "Targets", "Thresholds", and "Parameters". We propose restructuring classes to clearly represent the semantic differences between these fundamental concepts:

1. Redefine Setpoint to represent only "Target" setpoints:
   > The desired or target value for an essential variable, or process value (PV) of a control system which may differ from the actual measured value of the variable.

2. Introduce a new Threshold class for concepts initiating actions when a process variable crosses a limit:
   - Examples: Cooling, Heating, Humidification, Lockout, Enable Setpoints

3. Create two Threshold subclasses:
   - Upper Threshold: Action when PV exceeds value
   - Lower Threshold: Action when PV falls below value

4. Move (and rename) several Setpoints to Parameter:
    - Deadband Setpoint: Represents the distance between two thresholds, typically between heating and cooling "thresholds".
    - Time setpoint: Specifies durations or intervals for various control actions.

This separation clarifies the distinct concepts and improves class organization.

## Proposed Class Reorganization (Draft)
#### Reclassified as Parameters
- Deadband Setpoint → Deadband
- Time Setpoint → Time Parameter

#### Reclassified as Thresholds
- Cooling Setpoint → Cooling Threshold
- Heating Setpoint → Heating Threshold
- Reset Setpoint → Reset Threshold
- Lockout Setpoint → Lockout Threshold

#### Deprecated Classes
- Max_Air_Temperature_Setpoint
- Max_Water_Temperature_Setpoint
- Min_Air_Temperature_Setpoint
- Min_Water_Temperature_Setpoint
- Load_Setpoint
- Outside_Air_Temperature_Setpoint

#### New Additions
Setpoint:
- Position_Setpoint
- Valve_Position_Setpoint

Threshold:
- Dehumidification_Threshold
- Humidification_Threshold
- Lockout_Threshold

#### Under Consideration
Potential reclassification as Parameters:
- Demand Setpoint
- Voltage Ratio Setpoint
- Current Ratio Setpoint

#### Open Discussion Topics
- Discuss the naming convention for threshold setpoints as I mentioned. We want to encourage "an action" for threshold - setpoints. E.g., "CO2_Setpoint" by the name implies it's a target setpoint like temperature setpoint. We could make an exception but need to discuss the overall direction
