### PR TITLE
Remove circular Brick import

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -1103,6 +1103,8 @@ with open("Brick-only.ttl", "w", encoding="utf-8") as fp:
 
 # add rec stuff
 env.import_graph(G, "https://w3id.org/rec")
+# remove the REC import
+G.remove((None, OWL.imports, URIRef("https://w3id.org/rec")))
 
 # add inferred information to Brick
 # logger.info("Adding inferred information to Brick")


### PR DESCRIPTION
Brick imports REC which imports Brick. This can cause issues with duplicate definitions involving blank nodes (https://github.com/BrickSchema/Brick/issues/656)

- remove REC import after adding in the REC graph