### PR TITLE
Fix missing labels

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -823,6 +823,7 @@ def handle_concept_labels():
     If there are two or more labels for a concept, choose one and raise a Warning
     """
     concepts = chain(
+            G.transitive_subjects(RDFS.subClassOf, BRICK.Entity),
             G.subjects(A, BRICK.Entity),
             G.subjects(A, OWL.ObjectProperty),
             G.subjects(A, OWL.DatatypeProperty),


### PR DESCRIPTION
There is a regression in Brick 1.4.1 where many concepts do not have labels. This PR reverts that regression and fixes the broken test that didn't notify us the labels were missing