### PR TITLE
Mark brick:powerFlow and brick:powerFlow explicitly as deprecated

### DIFF
--- a/bricksrc/deprecations.ttl
+++ b/bricksrc/deprecations.ttl
@@ -18,7 +18,7 @@
 
 # deprecations.ttl is reserved for non-class deprecations, e.g. entity properties
 
-brick:powerComplexity brick:deprecation [
+brick:powerComplexity owl:deprecated true ; brick:deprecation [    
     brick:deprecatedInVersion "1.3.1" ;
     brick:deprecationMitigationMessage "powerComplexity is deprecated in favor of electricalComplexPower because the latter is more clear";
     brick:deprecationMitigationRule [
@@ -37,7 +37,7 @@ brick:powerComplexity brick:deprecation [
     ] ;
 ] .
 
-brick:powerFlow brick:deprecation [
+brick:powerFlow owl:deprecated true ; brick:deprecation [
     brick:deprecatedInVersion "1.3.1" ;
     brick:deprecationMitigationMessage "powerFlow is deprecated in favor of electricalFlow as the latter is more clear";
     brick:deprecationMitigationRule [


### PR DESCRIPTION
This should fix the SHACL violations in #689. I'm not sure yet what causes the duplicated output.