### PR TITLE
SHACL rule preventing brick:hasSubstance and brick:hasQuantity on all point instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ format:
 	black tools/
 
 test: Brick.ttl
-	pytest -s -vvvv  -n auto tests
+	pytest -s -vvvv -n auto tests
 
 quantity-test: Brick.ttl
 	pytest -s -vvvv tests/test_quantities.py

--- a/bricksrc/collections.py
+++ b/bricksrc/collections.py
@@ -62,7 +62,9 @@ system_subclasses = {
                     },
                 },
             },
-            "VRF_System": {"tags": [TAG.Variable, TAG.Refrigerant, TAG.Flow, TAG.System]},
+            "VRF_System": {
+                "tags": [TAG.Variable, TAG.Refrigerant, TAG.Flow, TAG.System]
+            },
             "Refrigeration_System": {"tags": [TAG.Refrigeration, TAG.System]},
             "Steam_System": {"tags": [TAG.Steam, TAG.System]},
             "Water_System": {

--- a/bricksrc/deprecations.py
+++ b/bricksrc/deprecations.py
@@ -629,7 +629,6 @@ deprecations = {
             BRICK.Discharge_Water_Temperature_Sensor,
         ],
     },
-
     BRICK.Electric_Current: {
         "version": "1.4.4",
         "mitigation_message": "Brick-defined quantity 'Electric_Current' is deprecated. Use the equivalent QUDT quantity 'qudt:QuantityKind/ElectricCurrent' directly.",
@@ -670,7 +669,7 @@ deprecations = {
         "mitigation_message": "Brick-defined quantity 'Atmospheric_Pressure' is deprecated. Use the equivalent QUDT quantity 'qudt:QuantityKind/AtmosphericPressure' directly.",
         "replace_with": QUDTQK.AtmosphericPressure,
     },
-     BRICK.Gauge_Pressure: {
+    BRICK.Gauge_Pressure: {
         "version": "1.4.4",
         "mitigation_message": "Brick-defined quantity 'Gauge_Pressure' is deprecated. Use the QUDT quantity 'qudt:QuantityKind/Pressure' and indicate contextually that it is gauge pressure if necessary.",
         "replace_with": QUDTQK.Pressure,
@@ -725,7 +724,6 @@ deprecations = {
         "mitigation_message": "Brick-defined quantity 'Radioactivity_Concentration_Sensor' is deprecated. Use Air_Quality_Sensor instead, or the provided sensor class for the specific kind or source of radioactivity (e.g. Radon gas)",
         "replace_with": BRICK.Air_Quality_Sensor,
     },
-
     BRICK.Phasor: {
         "version": "1.4.4",
         "mitigation_message": "Brick-defined quantity 'Phasor' is deprecated.",

--- a/bricksrc/deprecations.ttl
+++ b/bricksrc/deprecations.ttl
@@ -18,7 +18,7 @@
 
 # deprecations.ttl is reserved for non-class deprecations, e.g. entity properties
 
-brick:powerComplexity owl:deprecated true ; brick:deprecation [    
+brick:powerComplexity owl:deprecated true ; brick:deprecation [
     brick:deprecatedInVersion "1.3.1" ;
     brick:deprecationMitigationMessage "powerComplexity is deprecated in favor of electricalComplexPower because the latter is more clear";
     brick:deprecationMitigationRule [

--- a/bricksrc/entity_properties.py
+++ b/bricksrc/entity_properties.py
@@ -1,6 +1,7 @@
 """
 Entity property definitions
 """
+
 from collections import defaultdict
 from rdflib import Literal
 from .namespaces import BRICK, RDFS, SKOS, UNIT, XSD, SH, BSH, REF, QUDTQK
@@ -79,7 +80,7 @@ entity_properties = {
     BRICK.resolution: {
         SKOS.definition: Literal(
             "The resolution of the entity specifing the smallest measurable or controllable increment"
-            ),
+        ),
         SH.node: BSH.ResolutionShape,
         RDFS.label: Literal("Resolution", lang="en"),
         "property_of": BRICK.Point,
@@ -572,9 +573,7 @@ shape_properties = {
             },
         },
     },
-    BSH.ElectricVehicleChargingTypeShape: {
-        "values": ["Level 1", "Level 2", "Level 3"]
-    },
+    BSH.ElectricVehicleChargingTypeShape: {"values": ["Level 1", "Level 2", "Level 3"]},
     BSH.ElectricVehicleChargingDirectionalityShape: {
         "values": ["unidirectional", "bidirectional"]
     },

--- a/bricksrc/env.py
+++ b/bricksrc/env.py
@@ -1,3 +1,8 @@
 from ontoenv import OntoEnv, Config
-cfg = Config(["support/", "extensions/", "rec/Source/SHACL/RealEstateCore"], strict=False, offline=True)
+
+cfg = Config(
+    ["support/", "extensions/", "rec/Source/SHACL/RealEstateCore"],
+    strict=False,
+    offline=True,
+)
 env = OntoEnv(cfg, recreate=True)

--- a/bricksrc/equipment.py
+++ b/bricksrc/equipment.py
@@ -1504,7 +1504,7 @@ hvac_valve_subclasses = {
     },
     "Cooling_Valve": {
         "parents": [BRICK.Valve],
-        "tags": [TAG.Valve, TAG.Cool, TAG.Equipment]
+        "tags": [TAG.Valve, TAG.Cool, TAG.Equipment],
     },
     "Isolation_Valve": {
         "tags": [TAG.Isolation, TAG.Valve, TAG.Equipment],
@@ -1589,7 +1589,7 @@ security_subclasses = {
                     TAG.Surveillance,
                     TAG.Camera,
                 ],
-                "parents": [BRICK.Camera]
+                "parents": [BRICK.Camera],
                 # TODO: subclass of PTZ (Pan/Tilt/Zoom) cameras?
             },
             "Network_Video_Recorder": {

--- a/bricksrc/quantities.py
+++ b/bricksrc/quantities.py
@@ -320,7 +320,7 @@ quantity_definitions = {
                 SKOS.definition: Literal("Direction of wind relative to North"),
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
             }
-        }
+        },
     },
     "Electric_Energy": {
         QUDT.applicableUnit: [
@@ -439,7 +439,7 @@ quantity_definitions = {
                 RDFS.isDefinedBy: URIRef(str(BRICK).strip("#")),
                 SKOS.broader: QUDTQK.Dimensionless,
             },
-        }
+        },
     },
     "Position": {
         QUDT.applicableUnit: [UNIT["PERCENT"]],

--- a/bricksrc/recpatches.ttl
+++ b/bricksrc/recpatches.ttl
@@ -1641,7 +1641,7 @@ brick:ICT_Equipment sh:property [ a sh:PropertyShape ;
             sh:name "Standard"^^xsd:string ;
             sh:path rec:standard ] .
 
-brick:Ethernet_Port sh:property 
+brick:Ethernet_Port sh:property
         [ a sh:PropertyShape ;
             sh:datatype xsd:float ;
             sh:description "The data rate of the port in Mib/s, i.e. mebibit (2^20 bit) per second."^^xsd:string ;
@@ -1655,7 +1655,7 @@ brick:Ethernet_Port sh:property
             sh:name "PoE Type"^^xsd:string ;
             sh:path rec:poeType ] .
 
-brick:Wireless_Access_Point sh:property [ 
+brick:Wireless_Access_Point sh:property [
             a sh:PropertyShape ;
             sh:datatype xsd:string ;
             sh:in ( "WiFi4"^^xsd:string "WiFi5"^^xsd:string "WiFi6"^^xsd:string "WiFi6E"^^xsd:string "WiFi7"^^xsd:string ) ;
@@ -1663,7 +1663,7 @@ brick:Wireless_Access_Point sh:property [
             sh:name "Generation"^^xsd:string ;
             sh:path rec:generation ] .
 
-brick:Sensor_Equipment sh:property 
+brick:Sensor_Equipment sh:property
         [ a sh:PropertyShape ;
             sh:datatype xsd:double ;
             sh:name "Battery Percentage"^^xsd:string ;

--- a/bricksrc/relationships.py
+++ b/bricksrc/relationships.py
@@ -238,4 +238,8 @@ for row in rec.query(query):
     if row["datatype"]:
         relationships[row["path"]][A] = [OWL.DatatypeProperty]
     if row["nodeKind"]:
-        relationships[row["path"]][A] = [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty]
+        relationships[row["path"]][A] = [
+            OWL.ObjectProperty,
+            OWL.AsymmetricProperty,
+            OWL.IrreflexiveProperty,
+        ]

--- a/bricksrc/rules.ttl
+++ b/bricksrc/rules.ttl
@@ -556,3 +556,40 @@ bsh:InheritEVSEChargerDirection a sh:NodeShape ;
         """ ;
     ] ;
 .
+
+bsh:NoSubstanceOrQuantityOnPointInstances
+    a sh:NodeShape ;
+
+    sh:target [
+        a sh:SPARQLTarget ;
+        sh:prefixes (
+            <https://brickschema.org/schema/1.4/Brick>
+            <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            <http://www.w3.org/2000/01/rdf-schema#>
+        ) ;
+        sh:select """
+          SELECT ?this
+          WHERE {
+            ?this rdf:type/rdfs:subClassOf* brick:Point .
+          }
+        """ ;
+    ] ;
+
+    sh:property [
+        sh:path brick:hasSubstance ;
+        sh:maxCount 0 ;
+        sh:message """
+          Point instances must NOT directly assert brick:hasSubstance;
+          this should only be inferred via class definitions.
+        """ ;
+    ] ;
+
+    sh:property [
+        sh:path brick:hasQuantity ;
+        sh:maxCount 0 ;
+        sh:message """
+          Point instances must NOT directly assert qudt:hasQuantityKind;
+          this should only be inferred via class definitions.
+        """ ;
+    ] ;
+.

--- a/bricksrc/sensor.py
+++ b/bricksrc/sensor.py
@@ -1924,7 +1924,7 @@ sensor_definitions = {
                                             TAG.Sensor,
                                         ],
                                     },
-                                }
+                                },
                             },
                             "Domestic_Hot_Water_Temperature_Sensor": {
                                 "tags": [

--- a/bricksrc/tag_exclusion.py
+++ b/bricksrc/tag_exclusion.py
@@ -1,5 +1,6 @@
 """
 """
+
 from bricksrc.namespaces import TAG, A, OWL, BRICK
 from bricksrc.setpoint import setpoint_definitions
 from bricksrc.sensor import sensor_definitions

--- a/examples/connections/rvav.ttl
+++ b/examples/connections/rvav.ttl
@@ -74,4 +74,3 @@
     rdfs:label "Pipe 2" ;
     s223:hasMedium s223:Medium-Water ;
     s223:cnx  :coil_water_outlet, :boiler_water_return .
-

--- a/examples/no_substance_quantity/no_substance_quantity.ttl
+++ b/examples/no_substance_quantity/no_substance_quantity.ttl
@@ -1,0 +1,53 @@
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix ns1: <http://buildsys.org/ontologies/bldg1#> .
+
+<http://buildsys.org/ontologies/bldg1> a owl:Ontology ;
+    owl:imports <https://brickschema.org/schema/1.4/Brick> .
+
+ns1:Flow_Sensor_1 a brick:Flow_Sensor ;
+    brick:hasQuantity brick:Humidity ;
+    brick:hasSubstance brick:Natural_Gas .
+
+ns1:Flow_Sensor_2 a brick:Flow_Sensor ;
+    brick:hasQuantity brick:Humidity ;
+    brick:hasSubstance brick:Natural_Gas .
+
+ns1:Flow_Sensor_3 a brick:Flow_Sensor ;
+    brick:hasQuantity brick:Humidity ;
+    brick:hasSubstance brick:Natural_Gas .
+
+ns1:Pressure_Sensor_1 a brick:Pressure_Sensor ;
+    brick:hasQuantity brick:Pressure ;
+    brick:hasSubstance brick:Water .
+
+ns1:Pressure_Sensor_2 a brick:Pressure_Sensor ;
+    brick:hasQuantity brick:Pressure ;
+    brick:hasSubstance brick:Water .
+
+ns1:Pressure_Sensor_3 a brick:Pressure_Sensor ;
+    brick:hasQuantity brick:Pressure ;
+    brick:hasSubstance brick:Water .
+
+ns1:Supply_Air_Temperature_Setpoint_1 a brick:Supply_Air_Temperature_Setpoint ;
+    brick:hasQuantity brick:Flow ;
+    brick:hasSubstance brick:Supply_Air .
+
+ns1:Supply_Air_Temperature_Setpoint_2 a brick:Supply_Air_Temperature_Setpoint ;
+    brick:hasQuantity brick:Flow ;
+    brick:hasSubstance brick:Supply_Air .
+
+ns1:Supply_Air_Temperature_Setpoint_3 a brick:Supply_Air_Temperature_Setpoint ;
+    brick:hasQuantity brick:Flow ;
+    brick:hasSubstance brick:Supply_Air .
+
+ns1:Temperature_Sensor_1 a brick:Temperature_Sensor ;
+    brick:hasQuantity brick:Temperature ;
+    brick:hasSubstance brick:Air .
+
+ns1:Temperature_Sensor_2 a brick:Temperature_Sensor ;
+    brick:hasQuantity brick:Temperature ;
+    brick:hasSubstance brick:Air .
+
+ns1:Temperature_Sensor_3 a brick:Temperature_Sensor ;
+    brick:hasQuantity brick:Temperature ;
+    brick:hasSubstance brick:Air .

--- a/generate_brick.py
+++ b/generate_brick.py
@@ -347,7 +347,9 @@ def define_classes(definitions, parent, pun_classes=False, graph=G):
             graph.add((alias, A, SH.NodeShape))
             graph.add((alias, OWL.equivalentClass, classname))
             # find parent class of what the alias is equivalent to, add the RDFS subClassOf properties
-            parent_classes = list(graph.objects(subject=classname, predicate=RDFS.subClassOf))
+            parent_classes = list(
+                graph.objects(subject=classname, predicate=RDFS.subClassOf)
+            )
             for pc in parent_classes:
                 graph.add((alias, RDFS.subClassOf, pc))
             graph.add((alias, BRICK.aliasOf, classname))
@@ -436,7 +438,13 @@ def define_entity_properties(definitions, superprop=None, graph=G):
                 val = defn.pop(annotation)
                 graph.add((pshape, annotation, val))
         if not has_label(pshape):
-            graph.add((pshape, RDFS.label, Literal(f"has {defn.get(RDFS.label)} property", lang="en")))
+            graph.add(
+                (
+                    pshape,
+                    RDFS.label,
+                    Literal(f"has {defn.get(RDFS.label)} property", lang="en"),
+                )
+            )
 
         # add the entity property as a sh:property on all of the
         # other Nodeshapes indicated by "property_of"
@@ -831,21 +839,22 @@ def handle_concept_labels():
     If there are two or more labels for a concept, choose one and raise a Warning
     """
     concepts = chain(
-            G.transitive_subjects(RDFS.subClassOf, BRICK.Entity),
-            G.subjects(A, BRICK.Entity),
-            G.subjects(A, OWL.ObjectProperty),
-            G.subjects(A, OWL.DatatypeProperty),
-            )
+        G.transitive_subjects(RDFS.subClassOf, BRICK.Entity),
+        G.subjects(A, BRICK.Entity),
+        G.subjects(A, OWL.ObjectProperty),
+        G.subjects(A, OWL.DatatypeProperty),
+    )
     for s in concepts:
         labels = list(G.objects(s, RDFS.label))
         if len(labels) == 0:
-            G.add((s, RDFS.label, Literal(s.split("#")[-1].replace("_", " "), lang="en")))
+            G.add(
+                (s, RDFS.label, Literal(s.split("#")[-1].replace("_", " "), lang="en"))
+            )
         elif len(labels) > 1:
             logging.warning(f"Multiple labels for {s}: {labels}")
             # choose one and remove the others
             for to_remove in labels[1:]:
                 G.remove((s, RDFS.label, to_remove))
-
 
 
 logger.info("Beginning BRICK Ontology compilation")
@@ -1027,7 +1036,9 @@ G.add((BRICK.EntityProperty, A, RDF.Property))
 G.add((BRICK.EntityProperty, RDFS.subClassOf, BRICK.Relationship))
 G.add((BRICK.EntityPropertyValue, A, OWL.Class))
 G.add((BRICK.EntityPropertyValue, A, SH.NodeShape))
-G.add((BRICK.EntityPropertyValue, RDFS.label, Literal("EntityPropertyValue", lang="en")))
+G.add(
+    (BRICK.EntityPropertyValue, RDFS.label, Literal("EntityPropertyValue", lang="en"))
+)
 G.add((BRICK.EntityPropertyValue, RDFS.subClassOf, BRICK.Entity))
 G.add((BSH.ValueShape, A, OWL.Class))
 define_entity_properties(entity_properties)

--- a/support/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
+++ b/support/VOCAB_QUDT-QUANTITY-KINDS-ALL.ttl
@@ -41,13 +41,13 @@ quantitykind:AbsoluteActivity
 quantitykind:AbsoluteHumidity
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Absolute Humidity}$ is an amount of water vapor, usually discussed per unit volume. 
-  Absolute humidity in air ranges from zero to roughly 30 grams per cubic meter when the air is saturated at $30 ^\\circ C$. 
-  The absolute humidity changes as air temperature or pressure changes. 
+  $\\textit{Absolute Humidity}$ is an amount of water vapor, usually discussed per unit volume.
+  Absolute humidity in air ranges from zero to roughly 30 grams per cubic meter when the air is saturated at $30 ^\\circ C$.
+  The absolute humidity changes as air temperature or pressure changes.
   $$$$
-  This is very inconvenient for chemical engineering calculations, e.g. for clothes dryers, where temperature can vary considerably. 
+  This is very inconvenient for chemical engineering calculations, e.g. for clothes dryers, where temperature can vary considerably.
   As a result, absolute humidity is generally defined in chemical engineering as mass of water vapor per unit mass of dry air,
-   also known as the mass mixing ratio, which is much more rigorous for heat and mass balance calculations. 
+   also known as the mass mixing ratio, which is much more rigorous for heat and mass balance calculations.
   $$$$
   Mass of water per unit volume as in the equation above would then be defined as volumetric humidity, because of the potential confusion.
   """^^qudt:LatexString ;
@@ -263,13 +263,13 @@ quantitykind:Absorptance
 quantitykind:Acceleration
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Acceleration}$ is the (instantaneous) rate of change of velocity. 
-  Acceleration may be either linear acceleration, or angular acceleration. 
+  $\\textit{Acceleration}$ is the (instantaneous) rate of change of velocity.
+  Acceleration may be either linear acceleration, or angular acceleration.
   It is a vector quantity with dimension $length/time^{2}$ for linear acceleration,
-   or in the case of angular acceleration, with dimension $angle/time^{2}$. 
+   or in the case of angular acceleration, with dimension $angle/time^{2}$.
   $$$$
   In SI units, linear acceleration is measured in $meters/second^{2}$ ($m \\cdot s^{-2}$),
-   and angular acceleration is measured in $radians/second^{2}$. 
+   and angular acceleration is measured in $radians/second^{2}$.
   $$$$
   In physics, any increase or decrease in speed is referred to as acceleration and similarly,
    motion in a circle at constant speed is also an acceleration, since the direction component of the velocity is changing.
@@ -465,14 +465,14 @@ quantitykind:AcousticImpedance
 quantitykind:Action
   a qudt:QuantityKind ;
   dcterms:description """
-  An action is usually an integral over time. 
-  But for action pertaining to fields, it may be integrated over spatial variables as well. 
-  In some cases, the action is integrated along the path followed by the physical system.  
+  An action is usually an integral over time.
+  But for action pertaining to fields, it may be integrated over spatial variables as well.
+  In some cases, the action is integrated along the path followed by the physical system.
   $$$$
-  The evolution of a physical system between two states is determined by requiring the action be minimized or, more generally, 
+  The evolution of a physical system between two states is determined by requiring the action be minimized or, more generally,
    be stationary for small perturbations about the true evolution.
-  This requirement leads to differential equations that describe the true evolution. 
-  Conversely, an action principle is a method for reformulating differential equations of motion for a physical system as an equivalent integral equation. 
+  This requirement leads to differential equations that describe the true evolution.
+  Conversely, an action principle is a method for reformulating differential equations of motion for a physical system as an equivalent integral equation.
   Although several variants have been defined (see below), the most commonly used action principle is Hamilton's principle.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:AttoJ-SEC ;
@@ -610,7 +610,7 @@ quantitykind:ActiveEnergy
 quantitykind:ActivePower
   a qudt:QuantityKind ;
   dcterms:description """
-  An $Active Power$ is, under periodic conditions, the mean value, taken over one period $T$, of the instantaneous power $p$. 
+  An $Active Power$ is, under periodic conditions, the mean value, taken over one period $T$, of the instantaneous power $p$.
   In complex notation, $P = \\mathbf{Re} \\; \\underline{S}$, where $\\underline{S}$ is $\\textit{complex power}$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:ExaW ;
@@ -650,7 +650,7 @@ quantitykind:Activity
   a qudt:QuantityKind ;
   dcterms:description """
   $\\textit{Activity}$ is the number of decays per unit time of a radioactive sample,
-   the term used to characterise the number of nuclei which disintegrate in a radioactive substance per unit time. 
+   the term used to characterise the number of nuclei which disintegrate in a radioactive substance per unit time.
   Activity is usually measured in Becquerels ($Bq$), where 1 $Bq$ is 1 disintegration per second,
    in honor of the scientist Henri Becquerel.
   """^^qudt:LatexString ;
@@ -675,8 +675,8 @@ quantitykind:Activity
   qudt:isoNormativeReference "http://www.iso.org/iso/catalogue_detail?csnumber=31895"^^xsd:anyURI ;
   qudt:latexDefinition """
   $A = Z + N$, where $Z$ is the atomic number and $N$ is the neutron number.
-  Variation $dN$ of spontaneous number of nuclei $N$ in a particular energy state, 
-   in a sample of radionuclide, due to spontaneous nuclear transitions from this state during an infinitesimal time interval, 
+  Variation $dN$ of spontaneous number of nuclei $N$ in a particular energy state,
+   in a sample of radionuclide, due to spontaneous nuclear transitions from this state during an infinitesimal time interval,
    divided by its duration $dt$, thus $A = -\\frac{dN}{dt}$.
   """^^qudt:LatexString ;
   qudt:siExactMatch si-quantity:ARRN ;
@@ -721,7 +721,7 @@ quantitykind:ActivityConcentration
 quantitykind:ActivityRelatedByMass
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Activity Related By Mass}$ is quantitative data of the radioactivity of the amount of a radionuclide in a particular state of energy at a defined point in time, 
+  $\\textit{Activity Related By Mass}$ is quantitative data of the radioactivity of the amount of a radionuclide in a particular state of energy at a defined point in time,
    divided by the related mass of this quantity.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:BQ-PER-KiloGM ;
@@ -1032,18 +1032,18 @@ quantitykind:AmountOfSubstance
   a qudt:QuantityKind ;
   dcterms:description """
   $\\textit{Amount of Substance}$ is a standards-defined quantity that measures the size of an ensemble of elementary entities,
-   such as atoms, molecules, electrons, and other particles. 
+   such as atoms, molecules, electrons, and other particles.
   It is sometimes referred to as chemical amount.
 
-  The International System of Units (SI) defines the amount of substance to be proportional to the number of elementary entities present. 
-  The SI unit for amount of substance is mole. 
+  The International System of Units (SI) defines the amount of substance to be proportional to the number of elementary entities present.
+  The SI unit for amount of substance is mole.
   It has the unit symbol $mol$.
 
-  The mole is defined as the amount of substance that contains an equal number of elementary entities as there are atoms in 0.012kg of the isotope carbon-12. 
-  This number is called Avogadro's number and has the value $6.02214179(30) \\times 10^{23}$. 
-  
+  The mole is defined as the amount of substance that contains an equal number of elementary entities as there are atoms in 0.012kg of the isotope carbon-12.
+  This number is called Avogadro's number and has the value $6.02214179(30) \\times 10^{23}$.
+
   The only other unit of amount of substance in current use is the $pound-mole$ with the symbol $lb-mol$,
-   which is sometimes used in chemical engineering in the United States. 
+   which is sometimes used in chemical engineering in the United States.
   One $pound-mole$ is exactly $453.59237 mol$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:CentiMOL ;
@@ -1448,8 +1448,8 @@ quantitykind:AngularMomentum
   a qudt:QuantityKind ;
   dcterms:description """
   $\\textit{Angular Momentum}$, $\\textit{Moment of Momentum}$, or $\\textit{Rotational Momentum}$, is a vector quantity that represents the product of a body's rotational inertia and rotational velocity about a particular axis.
-  The $\\textit{Angular Momentum}$ of an object rotating about some reference point is the measure of the extent to which the object will continue to rotate about that point unless acted upon by an external torque. 
-  In particular, if a point mass rotates about an axis, then the angular momentum with respect to a point on the axis is related to the mass of the object, the velocity and the distance of the mass to the axis. 
+  The $\\textit{Angular Momentum}$ of an object rotating about some reference point is the measure of the extent to which the object will continue to rotate about that point unless acted upon by an external torque.
+  In particular, if a point mass rotates about an axis, then the angular momentum with respect to a point on the axis is related to the mass of the object, the velocity and the distance of the mass to the axis.
   While the motion associated with linear momentum has no absolute frame of reference, the rotation associated with angular momentum is sometimes spoken of as being measured relative to the fixed stars.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:ERG-SEC ;
@@ -2624,7 +2624,7 @@ quantitykind:AverageVacuumThrust
 
 quantitykind:Azimuth
   a qudt:QuantityKind ;
-  dcterms:description """The horizontal angle between an object's orientation frame and a cardinal direction, generally north. 
+  dcterms:description """The horizontal angle between an object's orientation frame and a cardinal direction, generally north.
   In the context of architecture, this would refer to the direction a structure faces relative to the direction north.""" ;
   qudt:applicableUnit unit:2PiRAD ;
   qudt:applicableUnit unit:ARCMIN ;
@@ -2640,7 +2640,7 @@ quantitykind:Azimuth
   qudt:applicableUnit unit:RAD ;
   qudt:applicableUnit unit:REV ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:plainTextDescription """The horizontal angle between an object and a cardinal direction, generally north. 
+  qudt:plainTextDescription """The horizontal angle between an object and a cardinal direction, generally north.
   In the context of architecture, this would refer to the direction a structure faces relative to the direction north.""" ;
   rdfs:comment "Applicable units are those of quantitykind:Angle" ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/quantitykind> ;
@@ -2895,23 +2895,23 @@ quantitykind:BitTransmissionRate
 quantitykind:BloodGlucoseLevel
   a qudt:QuantityKind ;
   dcterms:description """
-  Blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and animals. 
-  Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times.  
+  Blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and animals.
+  Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times.
   Stored in skeletal muscle and liver cells in the form of glycogen, the body tightly regulates blood glucose levels as a part of metabolic homeostasis.
-  During fasting blood glucose is maintained at a constant level at the expense of the glycogen stores in the liver and skeletal muscle. 
-  There are two main methods of describing concentrations: by weight, and by molecular count. 
-  Weights are in grams and molecular counts in moles. 
+  During fasting blood glucose is maintained at a constant level at the expense of the glycogen stores in the liver and skeletal muscle.
+  There are two main methods of describing concentrations: by weight, and by molecular count.
+  Weights are in grams and molecular counts in moles.
   A mole is $6.022\\times 10^{23}$ molecules.
   In both cases, the unit is usually modified by $milli-$ or $micro-$ or other prefix,
-   and is always $per$ some volume, often a litre. 
-  Conversion factors depend on the molecular weight of the substance in question. 
-  $mmol/L$ is millimoles/liter, and is the world standard unit for measuring glucose in blood. 
-  Specifically, it is the designated SI (Systeme International) unit. 
-  Some countries use $mg/dl$. 
+   and is always $per$ some volume, often a litre.
+  Conversion factors depend on the molecular weight of the substance in question.
+  $mmol/L$ is millimoles/liter, and is the world standard unit for measuring glucose in blood.
+  Specifically, it is the designated SI (Systeme International) unit.
+  Some countries use $mg/dl$.
   A mole is about $6\\times 10^{23}$ molecules.
-  $mg/dL$ (milligrams/deciliter) is the traditional unit for measuring $bG$ (blood glucose). 
-  There is a trend toward using $mmol/L$ however $mg/dL$ is much in practice. 
-  Some use is made of $mmol/L$ as the primary unit with $mg/dL$ quoted in parentheses. 
+  $mg/dL$ (milligrams/deciliter) is the traditional unit for measuring $bG$ (blood glucose).
+  There is a trend toward using $mmol/L$ however $mg/dL$ is much in practice.
+  Some use is made of $mmol/L$ as the primary unit with $mg/dL$ quoted in parentheses.
   This acknowledges the large base of health care providers, researchers and patients who are already familiar with $mg/dL$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:MilliMOL-PER-L ;
@@ -2926,23 +2926,23 @@ quantitykind:BloodGlucoseLevel
 quantitykind:BloodGlucoseLevel_Mass
   a qudt:QuantityKind ;
   dcterms:description """
-  Blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and animals. 
-  Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times.  
+  Blood sugar level, blood sugar concentration, or blood glucose level is the amount of glucose present in the blood of humans and animals.
+  Glucose is a simple sugar and approximately 4 grams of glucose are present in the blood of humans at all times.
   Stored in skeletal muscle and liver cells in the form of glycogen, the body tightly regulates blood glucose levels as a part of metabolic homeostasis.
-  During fasting blood glucose is maintained at a constant level at the expense of the glycogen stores in the liver and skeletal muscle. 
-  There are two main methods of describing concentrations: by weight, and by molecular count. 
-  Weights are in grams and molecular counts in moles. 
+  During fasting blood glucose is maintained at a constant level at the expense of the glycogen stores in the liver and skeletal muscle.
+  There are two main methods of describing concentrations: by weight, and by molecular count.
+  Weights are in grams and molecular counts in moles.
   A mole is $6.022\\times 10^{23}$ molecules.
   In both cases, the unit is usually modified by $milli-$ or $micro-$ or other prefix,
-   and is always $per$ some volume, often a litre. 
-  Conversion factors depend on the molecular weight of the substance in question. 
-  $mmol/L$ is millimoles/liter, and is the world standard unit for measuring glucose in blood. 
-  Specifically, it is the designated SI (Systeme International) unit. 
-  Some countries use $mg/dl$. 
+   and is always $per$ some volume, often a litre.
+  Conversion factors depend on the molecular weight of the substance in question.
+  $mmol/L$ is millimoles/liter, and is the world standard unit for measuring glucose in blood.
+  Specifically, it is the designated SI (Systeme International) unit.
+  Some countries use $mg/dl$.
   A mole is about $6\\times 10^{23}$ molecules.
-  $mg/dL$ (milligrams/deciliter) is the traditional unit for measuring $bG$ (blood glucose). 
-  There is a trend toward using $mmol/L$ however $mg/dL$ is much in practice. 
-  Some use is made of $mmol/L$ as the primary unit with $mg/dL$ quoted in parentheses. 
+  $mg/dL$ (milligrams/deciliter) is the traditional unit for measuring $bG$ (blood glucose).
+  There is a trend toward using $mmol/L$ however $mg/dL$ is much in practice.
+  Some use is made of $mmol/L$ as the primary unit with $mg/dL$ quoted in parentheses.
   This acknowledges the large base of health care providers, researchers and patients who are already familiar with $mg/dL$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:MilliGM-PER-DeciL ;
@@ -3521,8 +3521,8 @@ quantitykind:CENTER-OF-MASS
 
 quantitykind:CO2Equivalent
   a qudt:QuantityKind ;
-  dcterms:description """The CO2 equivalent is a measure used to compare the emissions from various greenhouse gases 
-  on the basis of their global-warming potential (GWP), by converting amounts of other gases to the equivalent amount 
+  dcterms:description """The CO2 equivalent is a measure used to compare the emissions from various greenhouse gases
+  on the basis of their global-warming potential (GWP), by converting amounts of other gases to the equivalent amount
   of carbon dioxide with the same global warming potential."""^^rdf:HTML ;
   qudt:applicableUnit unit:KiloGM ;
   qudt:applicableUnit unit:TONNE ;
@@ -4823,7 +4823,7 @@ quantitykind:ConductiveHeatTransferRate
 quantitykind:Conductivity
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Conductivity}$ is a scalar or tensor quantity the product of which by the electric field strength in a medium is equal to the electric current density. 
+  $\\textit{Conductivity}$ is a scalar or tensor quantity the product of which by the electric field strength in a medium is equal to the electric current density.
   For an isotropic medium the conductivity is a scalar quantity; for an anisotropic medium it is a tensor quantity.
   $$\\mathbf{J} = \\sigma \\mathbf{E}$$
   Where $\\mathbf{J}$ is electric current density, and $\\mathbf{E}$ is electric field strength.
@@ -5728,10 +5728,10 @@ quantitykind:DegreeOfDissociation
 quantitykind:Density
   a qudt:QuantityKind ;
   dcterms:description """
-  The mass density or density of a material is defined as its mass per unit volume. 
-  The symbol most often used for density is $\\rho$. 
+  The mass density or density of a material is defined as its mass per unit volume.
+  The symbol most often used for density is $\\rho$.
    Mathematically, density is defined as mass divided by volume: $\\rho = m/V$,
-    where $\\rho$ is the density, $m$ is the mass, and $V$ is the volume. 
+    where $\\rho$ is the density, $m$ is the mass, and $V$ is the volume.
     In some cases, density is also defined as its weight per unit volume, although this quantity is more properly called specific weight.
     """^^qudt:LatexString ;
   qudt:applicableUnit unit:DEGREE_BALLING ;
@@ -6460,8 +6460,8 @@ quantitykind:DisplacementCurrent
 quantitykind:DisplacementCurrentDensity
   a qudt:QuantityKind ;
   dcterms:description """
-$\\text{Displacement Current Density}$ is the time rate of change of the $\\textit{Electric Flux Density}$. 
-  This is a measure of how quickly the electric field changes if we observe it as a function of time. 
+$\\text{Displacement Current Density}$ is the time rate of change of the $\\textit{Electric Flux Density}$.
+  This is a measure of how quickly the electric field changes if we observe it as a function of time.
   This is different than if we look at how the electric field changes spatially, that is, over a region of space for a fixed amount of time.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:A-PER-M2 ;
@@ -7520,9 +7520,9 @@ quantitykind:ElectricChargeVolumeDensity
 quantitykind:ElectricConductivity
   a qudt:QuantityKind ;
   dcterms:description """
-  The quantity kind $\\textit{Electric Conductivity}$ or $\\textit{Specific Conductance}$ is a measure of a material's ability to conduct an electric current. 
-  When an electrical potential difference is placed across a conductor, its movable charges flow, giving rise to an electric current. 
-  The conductivity $\\sigma$ is defined as the ratio of the electric current density $J$ to the electric field, $E$: $J = \\sigma E$. 
+  The quantity kind $\\textit{Electric Conductivity}$ or $\\textit{Specific Conductance}$ is a measure of a material's ability to conduct an electric current.
+  When an electrical potential difference is placed across a conductor, its movable charges flow, giving rise to an electric current.
+  The conductivity $\\sigma$ is defined as the ratio of the electric current density $J$ to the electric field, $E$: $J = \\sigma E$.
   In isotropic materials, conductivity is scalar-valued, however in general, conductivity is a tensor-valued quantity.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:MHO_Stat ;
@@ -7547,10 +7547,10 @@ quantitykind:ElectricConductivity
 quantitykind:ElectricCurrent
   a qudt:QuantityKind ;
   dcterms:description """
-  The quantity kind $\\textit{Electric Current}$ is the flow (movement) of electric charge. 
+  The quantity kind $\\textit{Electric Current}$ is the flow (movement) of electric charge.
   The amount of electric current through some surface, for example, a section through a copper conductor,
-   is defined as the amount of electric charge flowing through that surface over time. 
-  Current is a scalar-valued quantity. 
+   is defined as the amount of electric charge flowing through that surface over time.
+  Current is a scalar-valued quantity.
   Electric current is one of the base quantities in the International System of Quantities, ISQ,
    on which the International System of Units, SI, is based.
   """^^rdf:HTML ;
@@ -8411,14 +8411,14 @@ $\\textit{Electromagnetic Energy Density}$, also known as the $\\color{indigo} {
 quantitykind:ElectromagneticPermeability
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Permeability}$ is the degree of magnetization of a material that responds linearly to an applied magnetic field. 
-  In general permeability is a tensor-valued quantity. 
-  The definition given applies to an isotropic medium. 
-  For an anisotropic medium permeability is a second order tensor. 
-  In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself. 
-  In other words, it is the degree of magnetization that a material obtains in response to an applied magnetic field. 
-  Magnetic permeability is typically represented by the Greek letter $\\mu$. 
-  The term was coined in September, 1885 by Oliver Heaviside. 
+  $\\textit{Permeability}$ is the degree of magnetization of a material that responds linearly to an applied magnetic field.
+  In general permeability is a tensor-valued quantity.
+  The definition given applies to an isotropic medium.
+  For an anisotropic medium permeability is a second order tensor.
+  In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself.
+  In other words, it is the degree of magnetization that a material obtains in response to an applied magnetic field.
+  Magnetic permeability is typically represented by the Greek letter $\\mu$.
+  The term was coined in September, 1885 by Oliver Heaviside.
   The reciprocal of magnetic permeability is $\\textit{Magnetic Reluctivity}$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:H-PER-M ;
@@ -8480,7 +8480,7 @@ quantitykind:ElectromagneticWavePhaseSpeed
 quantitykind:ElectromotiveForce
   a qudt:QuantityKind ;
   dcterms:description """
-  In physics, $\\textit{Electromotive Force}$, or most commonly $emf$ (seldom capitalized), or (occasionally) electromotance is that which tends to cause current (actual electrons and ions) to flow. 
+  In physics, $\\textit{Electromotive Force}$, or most commonly $emf$ (seldom capitalized), or (occasionally) electromotance is that which tends to cause current (actual electrons and ions) to flow.
   More formally, $emf$ is the external work expended per unit of charge to produce an electric potential difference across two open-circuited terminals.
   $\\textit{Electromotive Force}$ is deprecated in the ISO System of Quantities.
   """^^qudt:LatexString ;
@@ -8527,7 +8527,7 @@ quantitykind:ElectromotiveForce
 quantitykind:ElectronAffinity
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Electron Affinity}$ is the energy difference between an electron at rest at infinity and an electron at the lowest level of the conduction band in an insulator or semiconductor. 
+  $\\textit{Electron Affinity}$ is the energy difference between an electron at rest at infinity and an electron at the lowest level of the conduction band in an insulator or semiconductor.
   The amount of energy released when an electron is added to a neutral atom or molecule to form a negative ion.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:AttoJ ;
@@ -8593,7 +8593,7 @@ quantitykind:ElectronAffinity
 quantitykind:ElectronDensity
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Electron Density}$ is the number of electrons per volume in conduction bands. 
+  $\\textit{Electron Density}$ is the number of electrons per volume in conduction bands.
   It is the measure of the probability of an electron being present at a specific location.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:NUM-PER-L ;
@@ -9015,7 +9015,7 @@ quantitykind:EnergyContent
 quantitykind:EnergyDensity
   a qudt:QuantityKind ;
   dcterms:description """
-  Energy density is defined as energy per unit volume. 
+  Energy density is defined as energy per unit volume.
   The SI unit for energy density is the joule per cubic meter.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:BTU_IT-PER-FT3 ;
@@ -9798,7 +9798,7 @@ quantitykind:EquivalentAbsorptionArea
 
 quantitykind:EquivalentConcentration
   a qudt:QuantityKind ;
-  dcterms:description """"Equivalent Concentration" is the amount of a substance that reacts with (or is equivalent to) an arbitrary amount (typically one mole) of 
+  dcterms:description """"Equivalent Concentration" is the amount of a substance that reacts with (or is equivalent to) an arbitrary amount (typically one mole) of
 another substance in a given chemical reaction, per volume."""^^rdf:HTML ;
   qudt:applicableUnit unit:CentiMOL-PER-L ;
   qudt:applicableUnit unit:FemtoMOL-PER-L ;
@@ -9822,7 +9822,7 @@ another substance in a given chemical reaction, per volume."""^^rdf:HTML ;
 
 quantitykind:EquivalentDensity
   a qudt:QuantityKind ;
-  dcterms:description """"Equivalent Density" is the mass of a substance that reacts with (or is equivalent to) an arbitrary mass of 
+  dcterms:description """"Equivalent Density" is the mass of a substance that reacts with (or is equivalent to) an arbitrary mass of
 another substance in a given chemical reaction, per volume."""^^rdf:HTML ;
   qudt:applicableUnit unit:DEGREE_BALLING ;
   qudt:applicableUnit unit:DEGREE_BAUME ;
@@ -9890,7 +9890,7 @@ another substance in a given chemical reaction, per volume."""^^rdf:HTML ;
 
 quantitykind:Equivalent_Mass
   a qudt:QuantityKind ;
-  dcterms:description """"Mass Equivalent" is the mass of a substance that reacts with (or is equivalent to) an arbitrary mass of 
+  dcterms:description """"Mass Equivalent" is the mass of a substance that reacts with (or is equivalent to) an arbitrary mass of
 another substance in a given chemical reaction."""^^rdf:HTML ;
   qudt:applicableUnit unit:AMU ;
   qudt:applicableUnit unit:CARAT ;
@@ -9955,7 +9955,7 @@ another substance in a given chemical reaction."""^^rdf:HTML ;
 
 quantitykind:Equivalent_Molar
   a qudt:QuantityKind ;
-  dcterms:description """"Molar Equivalent" is the amount of a substance that reacts with (or is equivalent to) an arbitrary amount (typically one mole) of 
+  dcterms:description """"Molar Equivalent" is the amount of a substance that reacts with (or is equivalent to) an arbitrary amount (typically one mole) of
 another substance in a given chemical reaction."""^^rdf:HTML ;
   qudt:applicableUnit unit:CentiMOL ;
   qudt:applicableUnit unit:FemtoMOL ;
@@ -11550,8 +11550,8 @@ quantitykind:GasLeakRate
 
 quantitykind:GaugePressure
   a qudt:QuantityKind ;
-  dcterms:description """Gauge Pressure is the pressure of a system relative to the pressure of the surrounding atmosphere. 
-It is the difference between the absolute pressure and the atmospheric pressure. Gauge pressure is positive for pressures 
+  dcterms:description """Gauge Pressure is the pressure of a system relative to the pressure of the surrounding atmosphere.
+It is the difference between the absolute pressure and the atmospheric pressure. Gauge pressure is positive for pressures
 above atmospheric pressure and negative for pressures below it. A Quantity in QUDT having a QuantityKind of GaugePressure
 would typically also assert the value of qudt:isDeltaQuantity to be true, indicating that the value is a difference between
 two pressures."""^^qudt:LatexString ;
@@ -11696,10 +11696,10 @@ quantitykind:GeneralizedVelocity
 quantitykind:GibbsEnergy
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Internal Energy}$ is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state. 
-  The potential used depends on the constraints of the system, such as constant temperature or pressure. 
+  $\\textit{Internal Energy}$ is one of the potentials are used to measure energy changes in systems as they evolve from an initial state to a final state.
+  The potential used depends on the constraints of the system, such as constant temperature or pressure.
   $\\textit{Internal Energy}$ is the internal energy of the system, $\\textit{Enthalpy}$ is the internal energy of the system plus the energy related to pressure-volume work,
-   and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively. 
+   and Helmholtz and Gibbs free energy are the energies available in a system to do useful work when the temperature and volume or the pressure and temperature are fixed, respectively.
   The name $\\textit{Gibbs Free Energy}$ is also used.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:AttoJ ;
@@ -11924,7 +11924,7 @@ quantitykind:GyromagneticRatio
   dcterms:description """
   $\\textit{Gyromagnetic Ratio}$, also sometimes known as the magnetogyric ratio in other disciplines,
    of a particle or system is the ratio of its magnetic dipole moment to its angular momentum,
-  and it is often denoted by the symbol, $\\gamma$. 
+  and it is often denoted by the symbol, $\\gamma$.
   Its SI units are radian per second per tesla ($rad s^{-1} \\cdot T^{1}$) or, equivalently,
    coulomb per kilogram ($C \\cdot kg^{-1}$).
   """^^qudt:LatexString ;
@@ -13332,15 +13332,15 @@ quantitykind:InitialVelocity
 quantitykind:InstantaneousPower
   a qudt:QuantityKind ;
   dcterms:description """
-  For a two-terminal element or a two-terminal circuit with terminals A and B, 
-   $\\textit{Instantaneous Power}$ is the product of the voltage $u_{AB}$ between the terminals and the electric current i in the element or circuit: 
+  For a two-terminal element or a two-terminal circuit with terminals A and B,
+   $\\textit{Instantaneous Power}$ is the product of the voltage $u_{AB}$ between the terminals and the electric current i in the element or circuit:
   $$p = u_{AB} \\cdot i$$
   Where $u_{AB}$ is the line integral of the electric field strength from A to B,
-    and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case. 
+    and where the electric current in the element or circuit is taken positive if its direction is from A to B and negative in the opposite case.
   $$$$
-  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs. 
+  For an n-terminal circuit, it is the sum of the instantaneous powers relative to the n - 1 pairs of terminals when one of the terminals is chosen as a common terminal for the pairs.
   $$$$
-  For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element.  
+  For a polyphase element, it is the sum of the instantaneous powers in all phase elements of a polyphase element.
   $$$$
   For a polyphase line consisting of m line conductors and one neutral conductor, it is the sum of the m instantaneous powers expressed for each line conductor by the product of the polyphase line-to-neutral voltage and the corresponding line current.
    """^^qudt:LatexString ;
@@ -13956,7 +13956,7 @@ quantitykind:IsentropicCompressibility
 quantitykind:IsentropicExponent
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Isentropic Exponent}$ is a variant of $\\textit{Specific Heat Ratio Capacities}$. 
+  $\\textit{Isentropic Exponent}$ is a variant of $\\textit{Specific Heat Ratio Capacities}$.
   For an ideal gas $\\textit{Isentropic Exponent}$, $\\varkappa$. is equal to $\\gamma$,
    the ratio of its specific heat capacities $c_p$ and $c_v$ under steady pressure and volume.
   """^^qudt:LatexString ;
@@ -15759,7 +15759,7 @@ quantitykind:LuminousExposure
 quantitykind:LuminousFlux
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Luminous Flux}$, or $\\textit{Luminous Power}$, is the measure of the perceived power of light. 
+  $\\textit{Luminous Flux}$, or $\\textit{Luminous Power}$, is the measure of the perceived power of light.
   It differs from radiant flux, the measure of the total power of light emitted,
    in that luminous flux is adjusted to reflect the varying sensitivity of the human eye to different wavelengths of light.
   """^^qudt:LatexString ;
@@ -16737,11 +16737,11 @@ quantitykind:MagnetizationField
 quantitykind:MagnetomotiveForce
   a qudt:QuantityKind ;
   dcterms:description """
-$\\text{Magnetomotive Force}$, also referred to as ($mmf$), is the ability of an electric circuit to produce magnetic flux. 
-  Just as the ability of a battery to produce electric current is called its electromotive force 
-  or emf, mmf is taken as the work required to move a unit magnet pole from any point through any path 
-  which links the electric circuit back the same point in the presence of the magnetic force produced 
-  by the electric current in the circuit. 
+$\\text{Magnetomotive Force}$, also referred to as ($mmf$), is the ability of an electric circuit to produce magnetic flux.
+  Just as the ability of a battery to produce electric current is called its electromotive force
+  or emf, mmf is taken as the work required to move a unit magnet pole from any point through any path
+  which links the electric circuit back the same point in the presence of the magnetic force produced
+  by the electric current in the circuit.
 $\\text{Magnetomotive Force}$ is the scalar line integral of the magnetic field strength along a closed path.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:A ;
@@ -20437,13 +20437,13 @@ quantitykind:OlfactoryThreshold
 
 quantitykind:OpeningRatio
   a qudt:QuantityKind ;
-  dcterms:description """In the context of mechanical systems, "opening ratio" might refer to the proportion of time 
+  dcterms:description """In the context of mechanical systems, "opening ratio" might refer to the proportion of time
   or the extent to which a valve or gate is open relative to its maximum capacity.""" ;
   qudt:applicableUnit unit:FRACTION ;
   qudt:applicableUnit unit:NUM ;
   qudt:applicableUnit unit:PERCENT ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:plainTextDescription """In the context of mechanical systems, "opening ratio" might refer to the proportion of time 
+  qudt:plainTextDescription """In the context of mechanical systems, "opening ratio" might refer to the proportion of time
   or the extent to which a valve or gate is open relative to its maximum capacity.""" ;
   rdfs:comment "Applicable units are those of quantitykind:OpeningRatio" ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/quantitykind> ;
@@ -20769,7 +20769,7 @@ quantitykind:PRODUCT-OF-INERTIA
   a qudt:QuantityKind ;
   dcterms:description """
   The quantity kind $\\textit{Product of Inertia}$ is a measure of a body's dynamic
-   (or coupled) imbalance resulting in a precession when rotating about an axis 
+   (or coupled) imbalance resulting in a precession when rotating about an axis
    other than the body's principal axis.
   """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
@@ -20799,7 +20799,7 @@ quantitykind:PRODUCT-OF-INERTIA_Y
   """^^qudt:LatexString ;
   qudt:hasDimensionVector qkdv:A0E0L2I0M1H0T0D0 ;
   qudt:plainTextDescription """
-  The quantity kind 'Product of Inertia in the Y axis' is a measure of a body's 
+  The quantity kind 'Product of Inertia in the Y axis' is a measure of a body's
   dynamic (or coupled) imbalance resulting in a precession when rotating about an axis
   other than the body's principal axis.
   """ ;
@@ -22267,9 +22267,9 @@ quantitykind:PoyntingVector
   a qudt:QuantityKind ;
   dcterms:description """
   A $\\textit{Poynting Vector}$ is the vector product of the electric field strength $\\mathbf{E}$
-   and the magnetic field strength $\\mathbf{H}$ of the electromagnetic field at a given point. 
+   and the magnetic field strength $\\mathbf{H}$ of the electromagnetic field at a given point.
   The flux of the Poynting vector through a closed surface is equal to the electromagnetic power passing
-   through this surface. 
+   through this surface.
   For a periodic electromagnetic field, the time average of the Poynting vector is a vector of which,
    with certain reservations, the direction may be considered as being the direction of propagation
    of electromagnetic energy and the magnitude considered as being the average electromagnetic power
@@ -23068,8 +23068,8 @@ quantitykind:RadiantEmmitance
 quantitykind:RadiantEnergy
   a qudt:QuantityKind ;
   dcterms:description """
-  In radiometry, $\\textit{Radiant Energy}$ is the energy of electromagnetic waves. 
-  The quantity of radiant energy may be calculated by integrating radiant flux (or power) with respect to time. 
+  In radiometry, $\\textit{Radiant Energy}$ is the energy of electromagnetic waves.
+  The quantity of radiant energy may be calculated by integrating radiant flux (or power) with respect to time.
   In nuclear physics, $\\textit{Radiant Energy}$ is energy, excluding rest energy, of the particles that are emitted, transferred, or received.
   """^^qudt:LatexString ;
   qudt:abbreviation "M-L2-PER-T2" ;
@@ -23586,7 +23586,7 @@ quantitykind:RatioOfSpecificHeatCapacities
   a qudt:QuantityKind ;
   dcterms:description """
   The specific heat ratio of a gas is the ratio of the specific heat at constant pressure,
-   $c_p$, to the specific heat at constant volume, $c_V$. 
+   $c_p$, to the specific heat at constant volume, $c_V$.
   It is sometimes referred to as the $\\textit{adiabatic index}$,
    or the $\\textit{heat capacity ratio}$,
    or the $\\textit{isentropic expansion factor}$,
@@ -23609,10 +23609,10 @@ quantitykind:Reactance
   a qudt:QuantityKind ;
   dcterms:description """
   $\\textit{Reactance}$ is the opposition of a circuit element to a change of electric current or voltage,
-   due to that element's inductance or capacitance. 
+   due to that element's inductance or capacitance.
   A built-up electric field resists the change of voltage on the element,
-   while a magnetic field resists the change of current. 
-  The notion of reactance is similar to electrical resistance, but they differ in several respects. 
+   while a magnetic field resists the change of current.
+  The notion of reactance is similar to electrical resistance, but they differ in several respects.
   Capacitance and inductance are inherent properties of an element, just like resistance.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:OHM ;
@@ -23957,10 +23957,10 @@ quantitykind:RelativeAtomicMass
 quantitykind:RelativeHumidity
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Relative Humidity}$ is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature. 
-  The relative humidity of air depends not only on temperature but also on the pressure of the system of interest. 
+  $\\textit{Relative Humidity}$ is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature.
+  The relative humidity of air depends not only on temperature but also on the pressure of the system of interest.
   $$$$
-  $\\textit{Relative Humidity}$ is also referred to as $\\textit{Relative Partial Pressure}$. 
+  $\\textit{Relative Humidity}$ is also referred to as $\\textit{Relative Partial Pressure}$.
   $$$$
   Relative partial pressure is often referred to as $RH$ and expressed in percent.
   """^^qudt:LatexString ;
@@ -25892,7 +25892,7 @@ quantitykind:SourceVoltage
   a qudt:QuantityKind ;
   dcterms:description """
   The quantity kind $\\textit{Source Voltage}$, also referred to as $\\textit{Source Tension}$
-   is the voltage between the two terminals of a voltage source when there is no electric current through the source. 
+   is the voltage between the two terminals of a voltage source when there is no electric current through the source.
   The name $\\text{electromotive force}$ with the abbreviation $\\textit{EMF}$ and the symbol $E$ is deprecated.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:ExaV ;
@@ -26047,16 +26047,16 @@ quantitykind:SpecificElectricCurrent
 quantitykind:SpecificEnergy
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Specific Energy}$ is defined as the energy per unit mass. 
-  Common metric units are $J/kg$. 
-  It is an intensive property. 
-  Contrast this with energy, which is an extensive property. 
-  There are two main types of specific energy: potential energy and specific kinetic energy. 
-  Others are the $\\textit{gray}$ and $\\textit{sievert}$, which are measures for the absorption of radiation. 
+  $\\textit{Specific Energy}$ is defined as the energy per unit mass.
+  Common metric units are $J/kg$.
+  It is an intensive property.
+  Contrast this with energy, which is an extensive property.
+  There are two main types of specific energy: potential energy and specific kinetic energy.
+  Others are the $\\textit{gray}$ and $\\textit{sievert}$, which are measures for the absorption of radiation.
   $$$$
-  The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context. 
+  The concept of specific energy applies to a particular or theoretical way of extracting useful energy from the material considered that is usually implied by context.
   These intensive properties are each symbolized by using the lower case letter of the symbol for the corresponding extensive property,
-   which is symbolized by a capital letter. 
+   which is symbolized by a capital letter.
   For example, the extensive thermodynamic property enthalpy is symbolized by $H$; specific enthalpy is symbolized by $h$.
   """^^qudt:LatexString ;
   qudt:applicableUnit unit:BTU_IT-PER-LB ;
@@ -26186,8 +26186,8 @@ quantitykind:SpecificGibbsEnergy
   a qudt:QuantityKind ;
   dcterms:description """
   $\\textit{Specific Gibbs Energy}$ is a "corresponding intensive property",
-   which is $\\textit{Gibbs Energy}$ per mass of substance involved. 
-  Energy has corresponding intensive (size-independent) properties for pure materials. 
+   which is $\\textit{Gibbs Energy}$ per mass of substance involved.
+  Energy has corresponding intensive (size-independent) properties for pure materials.
   $\\textit{Specific Gibbs Energy}$ is denoted by a lower case $g$,
    with dimension of energy per mass (SI unit: $joule/kg$).
   """^^qudt:LatexString ;
@@ -26378,7 +26378,7 @@ quantitykind:SpecificHelmholtzEnergy
   dcterms:description """
   $\\textit{Specific Helmholtz Energy}$ is a "corresponding intensive property",
     which is $\\textit{Helmholz Energy}$ per mass of substance involved.
-  Energy has corresponding intensive (size-independent) properties for pure materials. 
+  Energy has corresponding intensive (size-independent) properties for pure materials.
   $\\textit{Specific Helmholz Energy}$ is denoted by a lower case $u$,
    with dimension of energy per mass (SI unit: $joule/kg$).
   """^^qudt:LatexString ;
@@ -29022,7 +29022,7 @@ quantitykind:ThrusterPowerToThrustEfficiency
 
 quantitykind:Tilt
   a qudt:QuantityKind ;
-  dcterms:description """The angle between an object's orientation vector relative to a reference frame.  
+  dcterms:description """The angle between an object's orientation vector relative to a reference frame.
   In the context of architecture, this would refer to the angle between the ground and the face of a surface.""" ;
   qudt:applicableUnit unit:2PiRAD ;
   qudt:applicableUnit unit:ARCMIN ;
@@ -29038,7 +29038,7 @@ quantitykind:Tilt
   qudt:applicableUnit unit:RAD ;
   qudt:applicableUnit unit:REV ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:plainTextDescription """The angle between an object's orientation vector relative to a reference frame.  
+  qudt:plainTextDescription """The angle between an object's orientation vector relative to a reference frame.
   In the context of architecture, this would refer to the angle between the ground and the face of a surface.""" ;
   rdfs:comment "Applicable units are those of quantitykind:Angle" ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/quantitykind> ;
@@ -30905,8 +30905,8 @@ quantitykind:VolumeFlowRate_SurfaceRelated
 
 quantitykind:VolumeFlowRatio
   a qudt:QuantityKind ;
-  dcterms:description """Volume flow ratio is commonly used in fluid dynamics and engineering, 
-  referring to the ratio of the flow rates of two or more fluid streams within a system. In HVAC systems, 
+  dcterms:description """Volume flow ratio is commonly used in fluid dynamics and engineering,
+  referring to the ratio of the flow rates of two or more fluid streams within a system. In HVAC systems,
   the flow ratio could compare the amount of fresh air introduced to the amount of recirculated air.""" ;
   qudt:applicableUnit unit:FRACTION ;
   qudt:applicableUnit unit:GR ;
@@ -30922,8 +30922,8 @@ quantitykind:VolumeFlowRatio
   qudt:applicableUnit unit:PSU ;
   qudt:applicableUnit unit:UNITLESS ;
   qudt:hasDimensionVector qkdv:A0E0L0I0M0H0T0D1 ;
-  qudt:plainTextDescription """Volume flow ratio is commonly used in fluid dynamics and engineering, 
-  referring to the ratio of the flow rates of two or more fluid streams within a system. In HVAC systems, 
+  qudt:plainTextDescription """Volume flow ratio is commonly used in fluid dynamics and engineering,
+  referring to the ratio of the flow rates of two or more fluid streams within a system. In HVAC systems,
   the flow ratio could compare the amount of fresh air introduced to the amount of recirculated air.""" ;
   qudt:qkdvDenominator qkdv:A0E0L3I0M0H0T-1D0 ;
   qudt:qkdvNumerator qkdv:A0E0L3I0M0H0T-1D0 ;
@@ -31800,12 +31800,12 @@ quantitykind:Width
 quantitykind:Work
   a qudt:QuantityKind ;
   dcterms:description """
-  $\\textit{Work}$ or $net\\ work$ is equal to the change in kinetic energy. 
-  This relationship is called the work-energy theorem: 
+  $\\textit{Work}$ or $net\\ work$ is equal to the change in kinetic energy.
+  This relationship is called the work-energy theorem:
   $$Wnet = K. E._f  K. E._o $$
-   where $K. E._f$ is the final kinetic energy and $K. E._o$ is the original kinetic energy. 
-  Potential energy, also referred to as stored energy, is the ability of a system to do work due to its position or internal structure. 
-  Change in potential energy is equal to work. 
+   where $K. E._f$ is the final kinetic energy and $K. E._o$ is the original kinetic energy.
+  Potential energy, also referred to as stored energy, is the ability of a system to do work due to its position or internal structure.
+  Change in potential energy is equal to work.
   The potential energy equations can also be derived from the integral form of work:
   $$\\Delta P. E. = W = \\int  F \\cdot dx$$.
   """^^qudt:LatexString ;
@@ -32005,5 +32005,3 @@ voag:QUDT-QUANTITY-KINDS-VocabCatalogEntry_v1.2
   a vaem:CatalogEntry ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/quantitykind> ;
   rdfs:label "QUDT Quantity Kinds Vocabulary Catalog Entry v1.2" .
-
-

--- a/support/VOCAB_QUDT-UNITS-ALL.ttl
+++ b/support/VOCAB_QUDT-UNITS-ALL.ttl
@@ -36,11 +36,11 @@ unit:2PiRAD
 
 unit:A
   a qudt:Unit ;
-  dcterms:description """$\\textit{Ampere}$, often shortened to $\\text{amp}$, 
+  dcterms:description """$\\textit{Ampere}$, often shortened to $\\text{amp}$,
 is the SI unit of electric current and is one of the seven SI base units defined as:
 
-$$\\text{A} \\equiv \\frac{\\textit{C}}{\\textit{s}} 
-\\equiv \\frac{\\textit{coulomb}}{\\textit{second}} 
+$$\\text{A} \\equiv \\frac{\\textit{C}}{\\textit{s}}
+\\equiv \\frac{\\textit{coulomb}}{\\textit{second}}
 \\equiv \\frac{\\text{joule}}{\\text{weber}}$$
 
 Note that SI supports only the use of symbols and deprecates the use of any abbreviations for units.
@@ -98,13 +98,13 @@ Note that SI supports only the use of symbols and deprecates the use of any abbr
 unit:A-HR
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """$\\textit{Ampere Hour}$ is a practical unit of electric charge equal to the charge flowing
-   in one hour through a conductor passing one ampere. 
+   in one hour through a conductor passing one ampere.
    An ampere-hour or amp-hour (symbol $Ah,\\,AHr,\\, A \\cdot h, A h$) is a unit of electric
     charge, with sub-units milliampere-hour ($mAh$) and milliampere second ($mAs$).
     One ampere-hour is equal to 3600 coulombs (ampere-seconds), the electric charge transferred
-     by a steady current of one ampere for one hour. 
+     by a steady current of one ampere for one hour.
     The ampere-hour is frequently used in measurements of electrochemical systems such as
-     electroplating and electrical batteries. 
+     electroplating and electrical batteries.
     The commonly seen milliampere-hour ($mAh$ or $mA \\cdot h$) is one-thousandth of an
      ampere-hour ($3.6 \\,coulombs$).
   """^^qudt:LatexString ;
@@ -478,7 +478,7 @@ unit:A-PER-DEG_C
 
 unit:A-PER-GM
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{Ampere per gram}$ is a practical unit to describe an (applied) current relative to the involved amount of material. 
+  dcterms:description """$\\textit{Ampere per gram}$ is a practical unit to describe an (applied) current relative to the involved amount of material.
   This unit is often found in electrochemistry to standardize test conditions and compare various scales of investigated materials.
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 1000.0 ;
@@ -503,7 +503,7 @@ unit:A-PER-GM
 
 unit:A-PER-J
   a qudt:Unit ;
-  dcterms:description """$\\textit{Ampere per Joule}$ is the inverse measure of $joule-per-ampere$ or $weber$. 
+  dcterms:description """$\\textit{Ampere per Joule}$ is the inverse measure of $joule-per-ampere$ or $weber$.
   The measure for the reciprical of magnetic flux.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -628,7 +628,7 @@ unit:A-PER-M
 
 unit:A-PER-M2
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{Ampere Per Square Meter}$ is a unit in the category of electric current density. 
+  dcterms:description """$\\textit{Ampere Per Square Meter}$ is a unit in the category of electric current density.
 This unit is commonly used in the SI unit system.
 """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -1133,8 +1133,8 @@ unit:AT-PER-IN
 unit:AT-PER-M
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The  $\\textit{Ampere Turn per Metre}$ is the SI unit of magnetic field strength. 
-  One ampere per meter is equal to $\\pi/250$ oersteds (12.566 371 millioersteds) in CGS units. 
+  The  $\\textit{Ampere Turn per Metre}$ is the SI unit of magnetic field strength.
+  One ampere per meter is equal to $\\pi/250$ oersteds (12.566 371 millioersteds) in CGS units.
   The ampere per meter is also the SI unit of "magnetization" in the sense of magnetic dipole moment per unit volume;
    in this context $1 A/m = 0.001 emu per cubic centimeter$.
   """^^qudt:LatexString ;
@@ -1163,7 +1163,7 @@ unit:ATM
   a qudt:Unit ;
   dcterms:description """
   The unit for $\\textit{Standard Atmosphere}$, symbol: $atm$, is an international reference pressure defined as $101.325 \\,kPa$ and formerly used as unit of pressure.
-  For practical purposes it has been replaced by the bar which is $100 kPa$. 
+  For practical purposes it has been replaced by the bar which is $100 kPa$.
   The difference of about 1% is not significant for many applications, and is within the error range of common pressure gauges.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -1240,11 +1240,11 @@ unit:ATM-PER-M
 unit:ATM_T
   a qudt:Unit ;
   dcterms:description """
-  The unit for $\\textit{Technical Atmosphere}$, symbol: $at$, is a non-SI unit of pressure equal to one kilogram-force per square centimeter. 
-  The symbol $at$ clashes with that of the katal (symbol: $kat$), the SI unit of catalytic activity; a kilotechnical atmosphere would have the symbol $kat$, indistinguishable from the symbol for katal. 
-  It also clashes with that of the non-SI unit, the $attotonne$, but that unit would be more likely be rendered as the equivalent SI unit. 
+  The unit for $\\textit{Technical Atmosphere}$, symbol: $at$, is a non-SI unit of pressure equal to one kilogram-force per square centimeter.
+  The symbol $at$ clashes with that of the katal (symbol: $kat$), the SI unit of catalytic activity; a kilotechnical atmosphere would have the symbol $kat$, indistinguishable from the symbol for katal.
+  It also clashes with that of the non-SI unit, the $attotonne$, but that unit would be more likely be rendered as the equivalent SI unit.
   Assay ton (abbreviation $AT$) is not a unit of measurement, but a standard quantity used in assaying ores of precious metals; it is $29 1D6 \\,grams$ (short assay ton) or $32 2D3 \\,grams$ (long assay ton),
-   the amount which bears the same ratio to a milligram as a short or long ton bears to a troy ounce. 
+   the amount which bears the same ratio to a milligram as a short or long ton bears to a troy ounce.
   In other words, the number of milligrams of a particular metal found in a sample of this size gives the number of troy ounces contained in a short or long ton of ore.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -1324,8 +1324,8 @@ unit:AU
 unit:A_Ab
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{Abampere (aA)}$, also called the $biot$ after Jean-Baptiste Biot, is the basic electromagnetic unit of electric current in the emu-cgs system of units (electromagnetic cgs). 
-  One $abampere$ is equal to ten amperes in the SI system of units. 
+  The $\\textit{Abampere (aA)}$, also called the $biot$ after Jean-Baptiste Biot, is the basic electromagnetic unit of electric current in the emu-cgs system of units (electromagnetic cgs).
+  One $abampere$ is equal to ten amperes in the SI system of units.
   An $abampere$ is the constant current that produces, when maintained in two parallel conductors of negligible circular section and of infinite length placed 1 centimetre apart,
    a force of 2 dynes per centimetre between the two conductors.
   """^^qudt:LatexString ;
@@ -1383,11 +1383,11 @@ unit:A_Ab-CentiM2
 unit:A_Ab-PER-CentiM2
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Abampere Per Square Centimeter}$, symbol $aA/cm^2$, is a unit in the category of Electric current density. 
+  The unit $\\textit{Abampere Per Square Centimeter}$, symbol $aA/cm^2$, is a unit in the category of Electric current density.
   It is also known as $\\textit{abamperes per square centimeter}$, $\\textit{abampere/square centimeter}$,
-   and $\\textit{abampere per square centimetre}$. 
+   and $\\textit{abampere per square centimetre}$.
    This unit is commonly used in the cgs unit system.
-  $\\textit{Abampere Per Square Centimeter}$ has a dimension of $L^{-2}I$ where $L$ is length, and $I$ is electric current. 
+  $\\textit{Abampere Per Square Centimeter}$ has a dimension of $L^{-2}I$ where $L$ is length, and $I$ is electric current.
   It can be converted to the corresponding standard SI unit $A/m^{2}$ by multiplying its value by a factor of 100000.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -1418,10 +1418,10 @@ unit:A_Ab-PER-CentiM2
 unit:A_Stat
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Statampere}$, symbol $statA$ is a unit in the category of Electric current. 
-  It is also known as statamperes. 
-  This unit is commonly used in the cgs unit system. 
-  $\\textit{Statampere (statA)}$ has a dimension of $I$ where $I$ is electric current. 
+  The unit $\\textit{Statampere}$, symbol $statA$ is a unit in the category of Electric current.
+  It is also known as statamperes.
+  This unit is commonly used in the cgs unit system.
+  $\\textit{Statampere (statA)}$ has a dimension of $I$ where $I$ is electric current.
   It can be converted to the corresponding standard SI unit $A$ by multiplying its value by a factor of 3.355641E-010.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -1614,7 +1614,7 @@ unit:AttoSEC
 unit:B
   a qudt:DimensionlessUnit, qudt:LogarithmicUnit, qudt:Unit ;
   dcterms:description """
-  The $\\textit{Bel}$ is a logarithmic unit of sound pressure equal to 10 decibels (dB). 
+  The $\\textit{Bel}$ is a logarithmic unit of sound pressure equal to 10 decibels (dB).
   It is defined as: $1 B = (1/2) \\log_{10}(Np)$
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
@@ -1691,7 +1691,7 @@ unit:BAN
   dcterms:description """
   A $\\textit{ban}$ is a logarithmic unit which measures information or entropy,
    based on base 10 logarithms and powers of 10, rather than the powers of 2
-   and base 2 logarithms which define the bit. 
+   and base 2 logarithms which define the bit.
   One $\\textit{ban}$ is approximately $3.32 (log_2 10) bits$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:ASU ;
@@ -1717,12 +1717,12 @@ unit:BAR
   a qudt:Unit ;
   dcterms:description """
   The $\\textit{bar}$ is a non-SI unit of pressure, defined by the IUPAC as exactly equal
-   to $100,000\\,Pa$. 
+   to $100,000\\,Pa$.
   It is about equal to the atmospheric pressure on Earth at sea level, and since 1982
    the IUPAC has recommended that the standard for atmospheric pressure should be
-   harmonized to $100,000\\,Pa = 1 \\,bar \\approx 750.0616827\\, Torr$. 
+   harmonized to $100,000\\,Pa = 1 \\,bar \\approx 750.0616827\\, Torr$.
   Units derived from the bar are the megabar (symbol: $Mbar$), kilobar (symbol: $kbar$),
-   decibar (symbol: $dbar$), centibar (symbol: $cbar$), and millibar (symbol: $mbar$ or $mb$). 
+   decibar (symbol: $dbar$), centibar (symbol: $cbar$), and millibar (symbol: $mbar$ or $mb$).
   They are not SI or cgs units, but they are accepted for use with the SI.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -2528,15 +2528,15 @@ unit:BQ
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   The $\\textit{Becquerel}$ is the SI derived unit of activity, usually meaning radioactivity.
-  Radioactivity is caused when atoms disintegrate, ejecting energetic particles. 
-  One becquerel is the radiation caused by one disintegration per second; 
-  this is equivalent to about $27.0270 \\text{picocuries (pCi)}$. 
-  The unit is named for a French physicist, Antoine-Henri Becquerel (1852-1908), 
-  the discoverer of radioactivity. 
-  Note: both the becquerel and the hertz are basically defined as one event per second, 
-  yet they measure different things. 
-  The hertz is used to measure the rates of events that happen periodically in a fixed and definite cycle. 
-  The becquerel is used to measure the rates of events that happen sporadically and unpredictably, 
+  Radioactivity is caused when atoms disintegrate, ejecting energetic particles.
+  One becquerel is the radiation caused by one disintegration per second;
+  this is equivalent to about $27.0270 \\text{picocuries (pCi)}$.
+  The unit is named for a French physicist, Antoine-Henri Becquerel (1852-1908),
+  the discoverer of radioactivity.
+  Note: both the becquerel and the hertz are basically defined as one event per second,
+  yet they measure different things.
+  The hertz is used to measure the rates of events that happen periodically in a fixed and definite cycle.
+  The becquerel is used to measure the rates of events that happen sporadically and unpredictably,
   not in a definite cycle.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -2809,10 +2809,10 @@ unit:BTU_60DEG_F
 
 unit:BTU_IT
   a qudt:Unit ;
-  dcterms:description """$\\textit{British Thermal Unit}$ (BTU or Btu) is a traditional unit of energy equal to about $1.0550558526 \\textit{ kilojoule}$. 
-  It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from $39^{\\circ}{F}$ to $40^{\\circ}{F}$ . 
-  The unit is most often used in the power, steam generation, heating and air conditioning industries. 
-  In scientific contexts the BTU has largely been replaced by the SI unit of energy, the $joule$, though it may be used as a measure of agricultural energy production (BTU/kg). 
+  dcterms:description """$\\textit{British Thermal Unit}$ (BTU or Btu) is a traditional unit of energy equal to about $1.0550558526 \\textit{ kilojoule}$.
+  It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from $39^{\\circ}{F}$ to $40^{\\circ}{F}$ .
+  The unit is most often used in the power, steam generation, heating and air conditioning industries.
+  In scientific contexts the BTU has largely been replaced by the SI unit of energy, the $joule$, though it may be used as a measure of agricultural energy production (BTU/kg).
   It is still used unofficially in metric English-speaking countries (such as Canada), and remains the standard unit of classification for air conditioning units manufactured and sold in many non-English-speaking metric countries.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -2937,7 +2937,7 @@ unit:BTU_IT-IN-PER-FT2-HR-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   $BTU_{th}$ Inch per Square Foot Hour Degree Fahrenheit is an Imperial unit for 'Thermal Conductivity' expressed as $Btu_{it}-in/(h-ft^{2}-degF)$.
-  An International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units. 
+  An International British thermal unit inch per second per square foot per degree Fahrenheit is a unit of thermal conductivity in the US Customary Units and British Imperial Units.
   $1\\,Btu_{it} \\cdot in/(h \\cdot ft^{2} \\cdot degF)$ shows that one thermochemical BTU of heat per one hour moves through one square foot of material, which is one foot thick due to a temperature difference of one degree Fahrenheit.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -3105,7 +3105,7 @@ unit:BTU_IT-IN-PER-SEC-FT2-DEG_F
 
 unit:BTU_IT-PER-DEG_F
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{British Thermal Unit (IT) Per Fahrenheit Degree}$ ($Btu (IT)/^\\circ F$) is a measure of heat capacity. 
+  dcterms:description """$\\textit{British Thermal Unit (IT) Per Fahrenheit Degree}$ ($Btu (IT)/^\\circ F$) is a measure of heat capacity.
   It can be converted to the corresponding standard SI unit $J/K$ by multiplying its value by a factor of $1899.10534$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -3322,10 +3322,10 @@ unit:BTU_IT-PER-FT2-SEC-DEG_F
 
 unit:BTU_IT-PER-FT3
   a qudt:Unit ;
-  dcterms:description """$\\textit{British Thermal Unit (IT) Per Cubic Foot}$ ($Btu (IT)/ft^3$) is a unit in the category of Energy density. 
-  It is also known as Btu per cubic foot, Btu/cubic foot. 
-  This unit is commonly used in the UK, US unit systems. 
-  It has a dimension of $ML^{-1}T^{-2}$ where $M$ is mass, $L$ is length, and $T$ is time. 
+  dcterms:description """$\\textit{British Thermal Unit (IT) Per Cubic Foot}$ ($Btu (IT)/ft^3$) is a unit in the category of Energy density.
+  It is also known as Btu per cubic foot, Btu/cubic foot.
+  This unit is commonly used in the UK, US unit systems.
+  It has a dimension of $ML^{-1}T^{-2}$ where $M$ is mass, $L$ is length, and $T$ is time.
   It can be converted to the corresponding standard SI unit $J/m^3$ by multiplying its value by a factor of 37258.94579.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -3358,7 +3358,7 @@ unit:BTU_IT-PER-FT3
 unit:BTU_IT-PER-HR
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The $\\text{BTU per Hour}$ is the amount of energy that is being produced or consumed per hour. 
+  The $\\text{BTU per Hour}$ is the amount of energy that is being produced or consumed per hour.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
   qudt:applicableSystem sou:USCS ;
@@ -3957,9 +3957,9 @@ unit:BTU_MEAN
 unit:BTU_TH
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{British Thermal Unit (thermochemical definition)}$ ($BTU_{th}$), is a traditional unit of energy equal to about $1.0543502645 kilojoule$. 
-  It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from $39^{\\circ}\\text{F}$ ($3.9^{\\circ}\\text{C}$) to $40^{\\circ}\\text{F}$ ($4.4^{\\circ}\\text{C}$). 
-  The unit is most often used in the power, steam generation, heating and air conditioning industries. 
+  The $\\textit{British Thermal Unit (thermochemical definition)}$ ($BTU_{th}$), is a traditional unit of energy equal to about $1.0543502645 kilojoule$.
+  It is approximately the amount of energy needed to heat 1 pound (0.454 kg) of water from $39^{\\circ}\\text{F}$ ($3.9^{\\circ}\\text{C}$) to $40^{\\circ}\\text{F}$ ($4.4^{\\circ}\\text{C}$).
+  The unit is most often used in the power, steam generation, heating and air conditioning industries.
   In scientific contexts the BTU has largely been replaced by the SI unit of energy, the $joule$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -4952,10 +4952,10 @@ unit:C
 unit:C-M
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The $\\text{Coulomb Meter (C-m)}$ is a unit in the category of Electric dipole moment. 
-  It is also known as atomic unit, u.a., au, ua. 
-  This unit is commonly used in the SI unit system. 
-  Coulomb Meter (C-m) has a dimension of LTI where $L$ is length, $T$ is time, and $I$ is electric current. 
+  The $\\text{Coulomb Meter (C-m)}$ is a unit in the category of Electric dipole moment.
+  It is also known as atomic unit, u.a., au, ua.
+  This unit is commonly used in the SI unit system.
+  Coulomb Meter (C-m) has a dimension of LTI where $L$ is length, $T$ is time, and $I$ is electric current.
   This unit is the standard SI unit in this category.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -9167,7 +9167,7 @@ unit:C_Stat
 
 unit:C_Stat-PER-CentiM2
   a qudt:Unit ;
-  dcterms:description """$\\textit{Statcoulomb per Square Centimeter}$ is a unit of measure for electric flux density and electric polarization. 
+  dcterms:description """$\\textit{Statcoulomb per Square Centimeter}$ is a unit of measure for electric flux density and electric polarization.
   One Statcoulomb per Square Centimeter is $2.15\\times 10^9 \\, coulomb\\,per\\,square\\,inch$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -11274,12 +11274,12 @@ unit:DEGREE_TWADDELL
 unit:DEG_C
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Celsius}$, also known as centigrade, is a scale and unit of measurement for temperature. 
-  It can refer to a specific temperature on the Celsius scale as well as a unit to indicate a temperature interval, 
-  a difference between two temperatures or an uncertainty. 
-  This definition fixes the magnitude of both the degree Celsius and the kelvin as precisely 1 part 
-  in 273.16 (approximately 0.00366) of the difference between absolute zero and the triple point of water. 
-  Thus, it sets the magnitude of one degree Celsius and that of one kelvin as exactly the same. 
+  The unit $\\textit{Celsius}$, also known as centigrade, is a scale and unit of measurement for temperature.
+  It can refer to a specific temperature on the Celsius scale as well as a unit to indicate a temperature interval,
+  a difference between two temperatures or an uncertainty.
+  This definition fixes the magnitude of both the degree Celsius and the kelvin as precisely 1 part
+  in 273.16 (approximately 0.00366) of the difference between absolute zero and the triple point of water.
+  Thus, it sets the magnitude of one degree Celsius and that of one kelvin as exactly the same.
   Additionally, it establishes the difference between the two scales' null points as being precisely $273.15^{\\circ}\\text{C}$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -11653,7 +11653,7 @@ unit:DEG_C_GROWING_CEREAL-DAY
 unit:DEG_F
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Degree Fahrenheit}$ is an Imperial unit for 'Thermodynamic Temperature' expressed as 
+  The unit $\\textit{Degree Fahrenheit}$ is an Imperial unit for 'Thermodynamic Temperature' expressed as
   $\\circ\\text{F}$
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -12144,10 +12144,10 @@ unit:DEG_F-SEC-PER-BTU_TH
 unit:DEG_R
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Degree Rankine}$ is a thermodynamic (absolute) temperature scale. 
-  The symbol for degrees Rankine is $^\\circ R$ or $^\\circ Ra$ if necessary to distinguish it from the Rømer and Réaumur scales). 
+  The unit $\\textit{Degree Rankine}$ is a thermodynamic (absolute) temperature scale.
+  The symbol for degrees Rankine is $^\\circ R$ or $^\\circ Ra$ if necessary to distinguish it from the Rømer and Réaumur scales).
   Zero on both the Kelvin and Rankine scales is absolute zero, but the Rankine degree is defined as equal
-   to one degree Fahrenheit, rather than the one degree Celsius used by the Kelvin scale. 
+   to one degree Fahrenheit, rather than the one degree Celsius used by the Kelvin scale.
   A temperature of $-459.67 ^\\circ F$ is exactly equal to $0 ^\\circ R$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -12277,10 +12277,10 @@ unit:DIOPTER
   a qudt:Unit ;
   dcterms:description """
   The unit $\\textit{Dioptre}$, or $\\textit{Diopter}$, is a unit of measurement for the optical power of a lens or curved mirror,
-   which is equal to the reciprocal of the focal length measured in metres (that is, $1/metre$). 
-  For example, a $3 \\; dioptre$ lens brings parallel rays of light to focus at $1/3\\,metre$. 
+   which is equal to the reciprocal of the focal length measured in metres (that is, $1/metre$).
+  For example, a $3 \\; dioptre$ lens brings parallel rays of light to focus at $1/3\\,metre$.
   The same unit is also sometimes used for other reciprocals of distance, particularly radii of curvature
-   and the vergence of optical beams. 
+   and the vergence of optical beams.
   Though the diopter is based on the SI-metric system it has not been included in the standard so that there is
    no international name or abbreviation for this unit of measurement within the international system of units
     this unit for optical power would need to be specified explicitly as the inverse metre.
@@ -12387,10 +12387,10 @@ unit:DWT
 unit:DYN
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  In physics, the $dyne$ is a unit of force specified in the centimetre-gram-second (CGS) system of units. 
-  The $dyne$ is a unit of force specified in the centimetre-gram-second (CGS) system of units. 
-  One $dyne$ is equal to $\\SI{10}{\\micro\\newton}$. 
-  Equivalently, the $dyne$ is defined as 'the force required to accelerate a mass of one gram at a rate of one centimetre per square second'. 
+  In physics, the $dyne$ is a unit of force specified in the centimetre-gram-second (CGS) system of units.
+  The $dyne$ is a unit of force specified in the centimetre-gram-second (CGS) system of units.
+  One $dyne$ is equal to $\\SI{10}{\\micro\\newton}$.
+  Equivalently, the $dyne$ is defined as 'the force required to accelerate a mass of one gram at a rate of one centimetre per square second'.
   A $\\textit{dyne per centimetre}$ is the unit traditionally used to measure surface tension.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -13663,10 +13663,10 @@ unit:Denier
 
 unit:E
   a qudt:Unit ;
-  dcterms:description """$\\textit{Elementary Charge}$, usually denoted as $e$, is the electric charge carried by a single proton, 
-  or equivalently, the negation (opposite) of the electric charge carried by a single electron. 
-  This elementary charge is a fundamental physical constant. 
-  To avoid confusion over its sign, e is sometimes called the elementary positive charge. 
+  dcterms:description """$\\textit{Elementary Charge}$, usually denoted as $e$, is the electric charge carried by a single proton,
+  or equivalently, the negation (opposite) of the electric charge carried by a single electron.
+  This elementary charge is a fundamental physical constant.
+  To avoid confusion over its sign, e is sometimes called the elementary positive charge.
   This charge has a measured value of approximately $1.602176634 \\times 10^{-19} coulombs$.
   In the cgs system, $e$ is $4.80320471257026372 \\times 10^{-10} statcoulombs$.
   """^^qudt:LatexString ;
@@ -14829,10 +14829,10 @@ unit:FARAD_Ab-PER-CentiM
 unit:FARAD_Stat
   a qudt:Unit ;
   dcterms:description """
-  The $\\text{Statfarad (statF)}$ is a unit in the category of Electric capacitance. 
-  It is also known as $statfarads$. 
-  This unit is commonly used in the cgs unit system. 
-  $Statfarad$ has a dimension of $M^{-1}L^{-2}T^4I^2$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current. 
+  The $\\text{Statfarad (statF)}$ is a unit in the category of Electric capacitance.
+  It is also known as $statfarads$.
+  This unit is commonly used in the cgs unit system.
+  $Statfarad$ has a dimension of $M^{-1}L^{-2}T^4I^2$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current.
   It can be converted to the corresponding standard SI unit F by multiplying its value by a factor of 1.11265E-012.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -15944,8 +15944,8 @@ unit:FT2-SEC-DEG_F
 unit:FT3
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The cubic foot is an Imperial and US customary unit of volume, used in the United States and the United Kingdom. 
-  It is defined as the volume of a cube with sides of one foot (0.3048 m) in length. 
+  The cubic foot is an Imperial and US customary unit of volume, used in the United States and the United Kingdom.
+  It is defined as the volume of a cube with sides of one foot (0.3048 m) in length.
   To calculate cubic feet multiply length X width X height.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:IMPERIAL ;
@@ -20780,13 +20780,13 @@ unit:GigaW-HR
 unit:Gs
   a qudt:Unit ;
   dcterms:description """
-  The $gauss$, abbreviated as $G$, is the cgs unit of measurement of a magnetic field $B$, 
+  The $gauss$, abbreviated as $G$, is the cgs unit of measurement of a magnetic field $B$,
   which is also known as the "magnetic flux density" or the "magnetic induction".
-  One gauss is defined as one maxwell per square centimeter; it equals $10^{-4} tesla$ (or $100 micro T$). 
-  The Gauss is identical to maxwells per square centimetre; technically defined in a three-dimensional system, 
-  it corresponds in the SI, with its extra base unit the ampere. 
-  The gauss is quite small by earthly standards, 1 Gs being only about four times Earth's flux density, 
-  but it is subdivided, with $1 gauss = 105 gamma$. 
+  One gauss is defined as one maxwell per square centimeter; it equals $10^{-4} tesla$ (or $100 micro T$).
+  The Gauss is identical to maxwells per square centimetre; technically defined in a three-dimensional system,
+  it corresponds in the SI, with its extra base unit the ampere.
+  The gauss is quite small by earthly standards, 1 Gs being only about four times Earth's flux density,
+  but it is subdivided, with $1 gauss = 105 gamma$.
   This unit of magnetic induction is also known as the $\\textit{abtesla}$.
   """^^qudt:LatexString ;
   dcterms:isReplacedBy unit:GAUSS ;
@@ -20812,14 +20812,14 @@ unit:Gs
 unit:H
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Henry}$ is the SI unit of electric inductance. 
-  A changing magnetic field induces an electric current in a loop of wire (or in a coil of many loops) located in the field. 
-  Although the induced voltage depends only on the rate at which the magnetic flux changes, measured in webers per second, the amount of the current depends also on the physical properties of the coil. 
-  A coil with an inductance of one henry requires a flux of one weber for each ampere of induced current. 
-  If, on the other hand, it is the current which changes, then the induced field will generate a potential difference within the coil: 
-  if the inductance is one henry a current change of one ampere per second generates a potential difference of one volt. 
-  The henry is a large unit; inductances in practical circuits are measured in millihenrys (mH) or microhenrys (u03bc H). 
-  The unit is named for the American physicist Joseph Henry (1797-1878), one of several scientists who discovered independently how magnetic fields can be used to generate alternating currents. 
+  The unit $\\textit{Henry}$ is the SI unit of electric inductance.
+  A changing magnetic field induces an electric current in a loop of wire (or in a coil of many loops) located in the field.
+  Although the induced voltage depends only on the rate at which the magnetic flux changes, measured in webers per second, the amount of the current depends also on the physical properties of the coil.
+  A coil with an inductance of one henry requires a flux of one weber for each ampere of induced current.
+  If, on the other hand, it is the current which changes, then the induced field will generate a potential difference within the coil:
+  if the inductance is one henry a current change of one ampere per second generates a potential difference of one volt.
+  The henry is a large unit; inductances in practical circuits are measured in millihenrys (mH) or microhenrys (u03bc H).
+  The unit is named for the American physicist Joseph Henry (1797-1878), one of several scientists who discovered independently how magnetic fields can be used to generate alternating currents.
 
   A $\\textit{Henry}$ is defined as:
 
@@ -21274,8 +21274,8 @@ unit:HR_Sidereal
 unit:HZ
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  $\\textit{Hertz}$ (symbol $Hz$) is the SI unit of frequency defined as the number of cycles per second of a periodic phenomenon. 
-  One of its most common uses is the description of the sine wave, particularly those used in radio and audio applications, such as the frequency of musical tones. 
+  $\\textit{Hertz}$ (symbol $Hz$) is the SI unit of frequency defined as the number of cycles per second of a periodic phenomenon.
+  One of its most common uses is the description of the sine wave, particularly those used in radio and audio applications, such as the frequency of musical tones.
   The word $\\bf{hertz}$ is named for Heinrich Rudolf Hertz, who was the first to conclusively prove the existence of electromagnetic waves.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -21475,10 +21475,10 @@ unit:H_Ab
 unit:H_Stat
   a qudt:Unit ;
   dcterms:description """
-  The $\\text{Stathenry (statH)}$ is a unit in the category of Electric inductance. 
-  It is also known as $tathenries$. 
-  This unit is commonly used in the cgs unit system. 
-  $Stathenry$ has a dimension of $ML^2T^{-2}I^{-2}$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current. 
+  The $\\text{Stathenry (statH)}$ is a unit in the category of Electric inductance.
+  It is also known as $tathenries$.
+  This unit is commonly used in the cgs unit system.
+  $Stathenry$ has a dimension of $ML^2T^{-2}I^{-2}$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current.
   It can be converted to the corresponding standard SI unit H by multiplying its value by a factor of $8.987552 \\times 10^{11}$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -22565,7 +22565,7 @@ The magnitude of one $IU/L$ depends on the material, so there is no single conve
 
 unit:J
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{Joule}$ is the SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied. 
+  dcterms:description """$\\textit{Joule}$ is the SI unit of work or energy, defined to be the work done by a force of one newton acting to move an object through a distance of one meter in the direction in which the force is applied.
   Equivalently, since kinetic energy is one half the mass times the square of the velocity, one joule is the kinetic energy of a mass of two kilograms moving at a velocity of $1 m/s$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -22994,9 +22994,9 @@ unit:J-PER-K
 unit:J-PER-KiloGM
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  A $\\textit{Joule Per Kilogram}$, ($J/kg$), is a unit in the category of Thermal heat capacity. 
-  It is also known as $\\textit{joules per kilogram}$.  
-  The unit has a dimension of $L2T^{-2}$ where $L$ is length, and $T$ is time. 
+  A $\\textit{Joule Per Kilogram}$, ($J/kg$), is a unit in the category of Thermal heat capacity.
+  It is also known as $\\textit{joules per kilogram}$.
+  The unit has a dimension of $L2T^{-2}$ where $L$ is length, and $T$ is time.
   This unit is the standard SI unit in this category.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -23072,7 +23072,7 @@ unit:J-PER-KiloGM-K
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   Specific heat capacity - The heat required to raise unit mass of a substance by unit temperature interval under specified conditions,
-   such as constant pressure: usually measured in joules per kelvin per kilogram. 
+   such as constant pressure: usually measured in joules per kelvin per kilogram.
   Symbol $c_p$ (for constant pressure).
   Also called specific heat.
   """^^qudt:LatexString ;
@@ -23306,7 +23306,7 @@ unit:J-PER-M3-K
 unit:J-PER-M4
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Joule Per Quartic Meter}$ ($J/m^4$) is a unit for the spectral concentration of radiant energy density (in terms of wavelength), or the spectral radiant energy density (in terms of wave length). 
+  The unit $\\textit{Joule Per Quartic Meter}$ ($J/m^4$) is a unit for the spectral concentration of radiant energy density (in terms of wavelength), or the spectral radiant energy density (in terms of wave length).
   This unit is commonly used in the SI unit system.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -23540,7 +23540,7 @@ unit:J-PER-T2
 unit:J-SEC
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The $\\textit{joule-second}$ is a unit equal to a $joule$ multiplied by a second, used to measure action or angular momentum. 
+  The $\\textit{joule-second}$ is a unit equal to a $joule$ multiplied by a second, used to measure action or angular momentum.
   The joule-second is the unit used for Planck's constant.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -23619,12 +23619,12 @@ unit:J-SEC-PER-MOL
 unit:K
   a qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Kelvin}$ is the SI base unit of temperature, previously called the degree Kelvin. 
-  One kelvin represents the same temperature difference as one degree Celsius. 
+  The unit $\\textit{Kelvin}$ is the SI base unit of temperature, previously called the degree Kelvin.
+  One kelvin represents the same temperature difference as one degree Celsius.
   In 1967 the General Conference on Weights and Measures defined the temperature of the triple point of water
-   (the temperature at which water exists simultaneously in the gaseous, liquid, and solid states) to be exactly 273.16 kelvins. 
-  Since this temperature is also equal to 0.01 u00b0C, the temperature in kelvins is always equal to 273.15 plus the temperature in degrees Celsius. 
-  The kelvin equals exactly 1.8 degrees Fahrenheit. 
+   (the temperature at which water exists simultaneously in the gaseous, liquid, and solid states) to be exactly 273.16 kelvins.
+  Since this temperature is also equal to 0.01 u00b0C, the temperature in kelvins is always equal to 273.15 plus the temperature in degrees Celsius.
+  The kelvin equals exactly 1.8 degrees Fahrenheit.
   The unit is named for the British mathematician and physicist William Thomson (1824-1907),
    later known as Lord Kelvin after he was named Baron Kelvin of Largs.
   """^^qudt:LatexString ;
@@ -27270,9 +27270,9 @@ unit:KiloGM-PER-MOL
   a qudt:Unit ;
   dcterms:description """
   The unit $\\textit{}$, symbol $kg/mol$, is the base SI unit for molar mass.
-  In chemistry, the molar mass $M$ is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance. 
-  It is a physical property of a given substance.  
-  However, for historical reasons, molar masses are almost always expressed in $g/mol$. 
+  In chemistry, the molar mass $M$ is defined as the mass of a given substance (chemical element or chemical compound) divided by its amount of substance.
+  It is a physical property of a given substance.
+  However, for historical reasons, molar masses are almost always expressed in $g/mol$.
   As an example, the molar mass of water is approximately: $18.01528(33) \\; g/mol$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:SI ;
@@ -30027,7 +30027,7 @@ unit:KiloVAR-PER-K
 unit:KiloW
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Kilowatt}$ is a derived unit of power in the International System of Units (SI). 
+  The unit $\\textit{Kilowatt}$ is a derived unit of power in the International System of Units (SI).
   The unit, defined as 1,000 joule per second, measures the rate of energy conversion or transfer.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -35909,11 +35909,11 @@ unit:M2-PER-K
 unit:M2-PER-KiloGM
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  Square Meter Per Kilogram (m2/kg) is a unit in the category of Specific Area. 
+  Square Meter Per Kilogram (m2/kg) is a unit in the category of Specific Area.
   It is also known as square meters per kilogram, square metre per kilogram, square metres per kilogram,
-   square meter/kilogram, square metre/kilogram. 
+   square meter/kilogram, square metre/kilogram.
    This unit is commonly used in the SI unit system.
-  Square Meter Per Kilogram (m2/kg) has a dimension of M-1L2 where $M$ is mass, and $L$ is length. 
+  Square Meter Per Kilogram (m2/kg) has a dimension of M-1L2 where $M$ is mass, and $L$ is length.
   This unit is the standard SI unit in this category.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -36093,8 +36093,8 @@ unit:M2-PER-SEC
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
   The unit $\\textit{Square Metres per Second}$ is the SI derived unit of angular momentum, defined by distance
-   or displacement in metres multiplied by distance again in metres and divided by time in seconds. 
-  The unit is written in symbols as $m^2/s$ or $m^22s^{-1}$. 
+   or displacement in metres multiplied by distance again in metres and divided by time in seconds.
+  The unit is written in symbols as $m^2/s$ or $m^22s^{-1}$.
   It may be better understood when phrased as $\\textit{metres per second times metres}$, i.e. the momentum
    of an object with respect to a position.
   """^^qudt:LatexString ;
@@ -36152,7 +36152,7 @@ unit:M2-PER-SEC-BAR
   dcterms:description """
   The unit $\\textit{Square Metre per Second Bar}$ typically refers to a measure of fluid permeability in the
    context of materials science or engineering.
-  It is the volume of fluid (in square metres) that can pass through a material in one second under a pressure difference of one bar. 
+  It is the volume of fluid (in square metres) that can pass through a material in one second under a pressure difference of one bar.
   This unit is particularly important in fields such as petrophysics, hydrogeology, and materials engineering,
    where understanding the flow of fluids through porous media is crucial.
   A $Bar$ is not an SI unit but is a unit of pressure that is widely used in various scientific and engineering contexts.
@@ -36186,7 +36186,7 @@ unit:M2-PER-SEC-K
   a qudt:Unit ;
   dcterms:description """
   The unit $\\textit{Square Metre per Second Kelvin}$ is a heat transfer coefficient that is area-dependent
-   and varies with time and temperature difference. 
+   and varies with time and temperature difference.
   Heat transfer is typically defined in terms of watts per square meter per kelvin ($W/m^{2}K$),
    representing the rate of heat transfer across a surface per unit area per unit temperature difference.
   """^^qudt:LatexString ;
@@ -36218,7 +36218,7 @@ unit:M2-PER-SEC-PA
   a qudt:Unit ;
   dcterms:description """
   The unit $\\textit{Square Metre per Second Pascal}$, symbol $m^{2}/s\\cdot Pa$, is a measure of permeability, which describes the ability
-   of a material to allow fluids to pass through it under a pressure gradient. 
+   of a material to allow fluids to pass through it under a pressure gradient.
   It's particularly relevant in fields like hydrogeology, petroleum engineering, and civil engineering,
    where understanding fluid flow through porous materials is essential.
   """^^qudt:LatexString ;
@@ -37954,7 +37954,7 @@ unit:MO
 unit:MOHM
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{Mohm}$ is a unit of mechanical mobility for sound waves, being the reciprocal of the mechanical $ohm$ unit of impedance, i.e., for an acoustic medium, the ratio of the flux or volumic speed (area times particle speed) of the resulting waves through it to the effective sound pressure (i.e. force) causing them, the unit being qualified, according to the units used, as m.k.s. or c.g.s. 
+  The $\\textit{Mohm}$ is a unit of mechanical mobility for sound waves, being the reciprocal of the mechanical $ohm$ unit of impedance, i.e., for an acoustic medium, the ratio of the flux or volumic speed (area times particle speed) of the resulting waves through it to the effective sound pressure (i.e. force) causing them, the unit being qualified, according to the units used, as m.k.s. or c.g.s.
   The mechanical ohm is defined as:
   $$Mohm \\equiv 1\\,dyn\\cdot\\,s\\cdot cm^{-1} \\text{ or } 10^{-3} N\\cdot s\\cdot m^{-1}$$.
   """^^qudt:LatexString ;
@@ -37974,12 +37974,12 @@ unit:MOHM
 unit:MOL
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{mole}$ is a unit of measurement used in chemistry to express amounts of a chemical substance. 
+  The $\\textit{mole}$ is a unit of measurement used in chemistry to express amounts of a chemical substance.
   The official definition, adopted as part of the SI system in 1971, is that one mole of a substance contains just as many elementary entities (atoms, molecules, ions, or other kinds of particles) as there are atoms in 12 grams of carbon-12 (carbon-12 is the most common atomic form of carbon, consisting of atoms having 6 protons and 6 neutrons).
-  This corresponds to a value of $6.02214179(30) \\times 10^{23}$ elementary entities of the substance. 
-  It is one of the base units in the International System of Units, and has the unit symbol $mol$. 
-  A Mole is the SI base unit of the amount of a substance (as distinct from its mass or weight). 
-  Moles measure the actual number of atoms or molecules in an object. 
+  This corresponds to a value of $6.02214179(30) \\times 10^{23}$ elementary entities of the substance.
+  It is one of the base units in the International System of Units, and has the unit symbol $mol$.
+  A Mole is the SI base unit of the amount of a substance (as distinct from its mass or weight).
+  Moles measure the actual number of atoms or molecules in an object.
   An earlier name is gram molecular weight, because one mole of a chemical compound is the same number of grams as the molecular weight of a molecule of that compound measured in atomic mass units.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:SI ;
@@ -43745,8 +43745,8 @@ unit:MilliA-HR
 
 unit:MilliA-HR-PER-GM
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{Milliampere hour per gram}$ is a practical unit of electric charge relative to the mass of the (active) parts. 
-  1mAh/g describes the capability of a material to store charge equivalent to 1h charge with 1mA per gram. 
+  dcterms:description """$\\textit{Milliampere hour per gram}$ is a practical unit of electric charge relative to the mass of the (active) parts.
+  1mAh/g describes the capability of a material to store charge equivalent to 1h charge with 1mA per gram.
   The unit is often used in electrochemistry to describe the properties of active components like electrodes.
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 3600.0 ;
@@ -44387,10 +44387,10 @@ unit:MilliCi
 unit:MilliDARCY
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The $\\textit{Millidarcy}$ ($md$) is a unit of permeability named after Henry Darcy. 
-  It is not an SI unit, but it is widely used in petroleum engineering and geology. 
-  The unit has also been used in biophysics and biomechanics, where the flow of fluids such as 
-  blood through capillary beds and cerebrospinal fluid through the brain interstitial space is being examined. 
+  The $\\textit{Millidarcy}$ ($md$) is a unit of permeability named after Henry Darcy.
+  It is not an SI unit, but it is widely used in petroleum engineering and geology.
+  The unit has also been used in biophysics and biomechanics, where the flow of fluids such as
+  blood through capillary beds and cerebrospinal fluid through the brain interstitial space is being examined.
   A millidarcy has dimensional units of $length^2$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -50527,9 +50527,9 @@ unit:N-SEC-PER-M2
 unit:N-SEC-PER-M3
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The SI unit of specific acoustic impedance. 
-  When sound waves pass through any physical substance the pressure of the waves causes the particles of the substance to move. 
-  The sound specific impedance is the ratio between the sound pressure and the particle velocity it produces. 
+  The SI unit of specific acoustic impedance.
+  When sound waves pass through any physical substance the pressure of the waves causes the particles of the substance to move.
+  The sound specific impedance is the ratio between the sound pressure and the particle velocity it produces.
   The specific impedance is $1 N \\cdot s \\cdot m^{-3}$ if unit pressure produces unit velocity.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -50693,10 +50693,10 @@ unit:NT
   qudt:hasDimensionVector qkdv:A0E0L3I0M0H0T0D0 ;
   qudt:hasQuantityKind quantitykind:Volume ;
   qudt:informativeReference "http://en.wikipedia.org/wiki/Net_tonnage"^^xsd:anyURI ;
-  qudt:plainTextDescription """Net tonnage is used in the United States to determine eligibility for registering boats with 
- the federal government. It is a nonlinear unit derived from the total volume of a ship's cargo space as well as some 
- dimensionless factors. Net tonnage is not a measure of the weight of the ship or its cargo, and should not be confused 
- with terms such as deadweight tonnage or displacement. Net tonnage is also used to determine the amount of money that 
+  qudt:plainTextDescription """Net tonnage is used in the United States to determine eligibility for registering boats with
+ the federal government. It is a nonlinear unit derived from the total volume of a ship's cargo space as well as some
+ dimensionless factors. Net tonnage is not a measure of the weight of the ship or its cargo, and should not be confused
+ with terms such as deadweight tonnage or displacement. Net tonnage is also used to determine the amount of money that
  can be charged to a ship for using a port's facilities.""" ;
   qudt:symbol "NT" ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/unit> ;
@@ -52927,12 +52927,12 @@ unit:OERSTED-CentiM
 unit:OHM
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The $\\textit{ohm}$ is the SI derived unit of electrical resistance, named after German physicist Georg Simon Ohm. 
-  
+  The $\\textit{ohm}$ is the SI derived unit of electrical resistance, named after German physicist Georg Simon Ohm.
+
   It is defined as:
-  
+
   $$\\Omega \\equiv\\ \\frac{\\text{V}}{\\text{A}}\\ \\equiv\\ \\frac{\\text{volt}}{\\text{amp}}\\ \\equiv\\ \\frac{\\text{W}}{\\text {A}^{2}}\\ \\equiv\\ \\frac{\\text{watt}}{\\text{amp}^{2}}\\ \\equiv\\ \\frac{\\text{H}}{\\text {s}}\\ \\equiv\\ \\frac{\\text{henry}}{\\text{second}}$$
-  
+
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
   qudt:applicableSystem sou:CGS-GAUSS ;
@@ -55510,11 +55510,11 @@ unit:PDL-IN
 unit:PDL-PER-FT2
   a qudt:Unit ;
   dcterms:description """
-  A $\\textit{Poundal Per Square Foot}$, ($pdl/ft^2$), is a unit in the category of Pressure. 
-  It is also known as poundals per square foot, poundal/square foot. 
-  This unit is commonly used in the UK, US unit systems. 
+  A $\\textit{Poundal Per Square Foot}$, ($pdl/ft^2$), is a unit in the category of Pressure.
+  It is also known as poundals per square foot, poundal/square foot.
+  This unit is commonly used in the UK, US unit systems.
   A $\\textit{Poundal Per Square Foot}$ has a dimension of $ML^{-1}T^{-2}$,
-   where $M$ is mass, $L$ is length, and $T$ is time. 
+   where $M$ is mass, $L$ is length, and $T$ is time.
    It can be converted to the corresponding standard SI unit $\\textit{Pa}$ by multiplying its value
     by a factor of 1.488163944.
   """^^qudt:LatexString ;
@@ -59238,11 +59238,11 @@ unit:PERMEABILITY_REL
 unit:PERMITTIVITY_REL
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{relative permittivity}$ of a material under given conditions reflects the extent to which it concentrates electrostatic lines of flux. 
-  In technical terms, it is the ratio of the amount of electrical energy stored in a material by an applied voltage, 
-  relative to that stored in a vacuum. 
-  Likewise, it is also the ratio of the capacitance of a capacitor using that material as a dielectric, compared to a similar capacitor that has a vacuum as its dielectric. 
-  Relative permittivity is a dimensionless number that is in general complex. 
+  The $\\textit{relative permittivity}$ of a material under given conditions reflects the extent to which it concentrates electrostatic lines of flux.
+  In technical terms, it is the ratio of the amount of electrical energy stored in a material by an applied voltage,
+  relative to that stored in a vacuum.
+  Likewise, it is also the ratio of the capacitance of a capacitor using that material as a dielectric, compared to a similar capacitor that has a vacuum as its dielectric.
+  Relative permittivity is a dimensionless number that is in general complex.
   The imaginary portion of the permittivity corresponds to a phase shift of the polarization $P$ relative to $E$ and leads to the attenuation of electromagnetic waves passing through the medium.
   $$\\epsilon_r(w) = \\frac{\\epsilon(w)}{\\epsilon_O}$$,
    where $\\epsilon_r(w)$ is the complex frequency-dependent absolute permittivity of the material,
@@ -59379,19 +59379,19 @@ unit:PH
   Where $a_{H^+}$ is the equilibrium molar concentration of $H^+$ in the solution, the activity of
    the hydrogen ion in the solution.
   $$$$
-  This definition is appropriate for concentrations equal to, or less than $1\\ mol/l$, 
+  This definition is appropriate for concentrations equal to, or less than $1\\ mol/l$,
    where $aH+ \\equiv [H+]$, that is, $1\\ mol/L\\ HCl$ has a $pH$ of zero.
   $$$$
-  To relate this to standard molality ($b^\\circ$), typically taken as $1 \\ mol/kg$, 
+  To relate this to standard molality ($b^\\circ$), typically taken as $1 \\ mol/kg$,
    consideration is given to the activity ($a_{H^+}$) of the hydrogen ions.
   $$$$
   The activity can be expressed as:
 
-  $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$ 
+  $$a_{H^+} = \\gamma_{H^+} \\times m_{H^+}$$
 
   Where, $\\gamma_{H^+}$ is the activity coefficient, which adjusts the molality to account for
    non-ideal behavior due to interactions between ions in the solution.
-  $m_{H^+}$ is the molality of hydrogen ions in the solution relative to the standard molality, 
+  $m_{H^+}$ is the molality of hydrogen ions in the solution relative to the standard molality,
    expressed in $mol/kg$.
   $$$$
   The expansion of $pH$ then becomes:
@@ -59399,7 +59399,7 @@ unit:PH
   $$\\text{pH} = -log_{10}\\left(m_{H+}\\times\\gamma_{H^+}\\right)$$
 
   $$$$
-  This definition is relevant in more concentrated solutions or when precise thermodynamic calculations are required. 
+  This definition is relevant in more concentrated solutions or when precise thermodynamic calculations are required.
   It reflects how the properties of the solution deviate from ideal behavior and provides a more accurate understanding of the $pH$ under various conditions.
   $$$$
   While $pH$ is a universally recognized scale for expressing hydrogen ion activity,
@@ -62222,16 +62222,16 @@ unit:PlanckTemperature
 unit:PlanckTime
   a qudt:Unit ;
   dcterms:description """
-  In physics, the Planck time, denoted by $t_P$, is the unit of time in the system of natural units known as Planck units. 
-  It is the time required for light to travel, in a vacuum, a distance of 1 Planck length. 
+  In physics, the Planck time, denoted by $t_P$, is the unit of time in the system of natural units known as Planck units.
+  It is the time required for light to travel, in a vacuum, a distance of 1 Planck length.
   The unit is named after Max Planck, who was the first to propose it.
-  
+
   The formula for $\\textit{PlankTime}$ is:
-  
+
   $$ \\\\ t_P \\equiv  \\sqrt{\\frac{\\hbar G}{c^5}} \\approx 5.39106(32) \\times 10^{-44} s$$
-  
+
    where, $c$ is the speed of light in a vacuum, $\\hbar$ is the reduced Planck's constant
-    (defined as $\\hbar = \\frac{h}{2 \\pi}$ and $G$ is the gravitational constant. 
+    (defined as $\\hbar = \\frac{h}{2 \\pi}$ and $G$ is the gravitational constant.
   The two digits between parentheses denote the standard error of the estimated value.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:PLANCK ;
@@ -62558,9 +62558,9 @@ unit:QUAD
   a qudt:Unit ;
   dcterms:description """
   A $\\textit{quad}$ is a unit of energy equal to $10 BTU$, or $1.055 \\times 10\\,\\text{joule}$,
-   which is $1.055 exajoule$ or $EJ$ in SI units. 
-  The unit is used by the U.S. Department of Energy in discussing world and national energy budgets. 
-  
+   which is $1.055 exajoule$ or $EJ$ in SI units.
+  The unit is used by the U.S. Department of Energy in discussing world and national energy budgets.
+
   Some common types of an energy carrier approximately equal 1 quad are:
 
   8,007,000,000 Gallons (US) of gasoline, 293,083,000,000 Kilowatt-hours (kWh), 36,000,000 Tonnes of coal,
@@ -63267,11 +63267,11 @@ unit:RichterMagnitude
 
 unit:S
   a qudt:DerivedUnit, qudt:Unit ;
-  dcterms:description """$\\textit{Siemens}$ is the SI unit of electric conductance, susceptance, and admittance. 
-The most important property of a conductor is the amount of current it will carry when a voltage is applied. 
-Current flow is opposed by resistance in all circuits, and by also by reactance and impedance in alternating current circuits. 
-Conductance, susceptance, and admittance are the inverses of resistance, reactance, and impedance, respectively. 
-To measure these properties, the siemens is the reciprocal of the ohm. In other words, the conductance, susceptance, or admittance, in siemens, is simply 1 divided by the resistance, reactance or impedance, respectively, in ohms. 
+  dcterms:description """$\\textit{Siemens}$ is the SI unit of electric conductance, susceptance, and admittance.
+The most important property of a conductor is the amount of current it will carry when a voltage is applied.
+Current flow is opposed by resistance in all circuits, and by also by reactance and impedance in alternating current circuits.
+Conductance, susceptance, and admittance are the inverses of resistance, reactance, and impedance, respectively.
+To measure these properties, the siemens is the reciprocal of the ohm. In other words, the conductance, susceptance, or admittance, in siemens, is simply 1 divided by the resistance, reactance or impedance, respectively, in ohms.
 The unit is named for the German electrical engineer Werner von Siemens (1816-1892).
 $$\\  \\text{Siemens}\\equiv\\frac{\\text{A}}{\\text{V}}\\equiv\\frac{\\text{amp}}{\\text{volt}}\\equiv\\frac{\\text{F}}{\\text {s}}\\equiv\\frac{\\text{farad}}{\\text{second}}$$
   """^^qudt:LatexString ;
@@ -63464,7 +63464,7 @@ unit:SAMPLE-PER-SEC
 unit:SCF
   a qudt:Unit ;
   dcterms:description """
-The $\\textit{standard cubic foot}$ (scf) is a unit representing the amount of gas (such as natural gas) 
+The $\\textit{standard cubic foot}$ (scf) is a unit representing the amount of gas (such as natural gas)
 contained in a volume of one cubic foot at reference temperature and pressure conditions. As such, it is a measure of the actual amount of gas,
 not the volume of the gas. The reference conditions for standard cubic foot are 60 degrees Fahrenheit and 14.7 pounds per square inch (psi) of pressure.
   """^^qudt:LatexString ;
@@ -63482,7 +63482,7 @@ unit:SCF-PER-HR
   dcterms:description """
 The $\\textit{standard cubic foot per hour}$ (scfm) is the molar flow rate of a gas (such as natural gas)
 contained in a volume of one cubic foot at reference temperature and pressure conditions. As such, it is a measure of the actual amount of gas,
-not the volume of the gas. The reference conditions for standard cubic foot per minute are 60 degrees Fahrenheit and 14.7 pounds per 
+not the volume of the gas. The reference conditions for standard cubic foot per minute are 60 degrees Fahrenheit and 14.7 pounds per
 square inch (psi) of pressure.
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 0.0003328 ;
@@ -63507,7 +63507,7 @@ unit:SCF-PER-MIN
   dcterms:description """
 The $\\textit{standard cubic foot per minute}$ (scfm) is the molar flow rate of a gas (such as natural gas)
 contained in a volume of one cubic foot at reference temperature and pressure conditions. As such, it is a measure of the actual amount of gas,
-not the volume of the gas. The reference conditions for standard cubic foot per minute are 60 degrees Fahrenheit and 14.7 pounds per 
+not the volume of the gas. The reference conditions for standard cubic foot per minute are 60 degrees Fahrenheit and 14.7 pounds per
 square inch (psi) of pressure.
   """^^qudt:LatexString ;
   qudt:conversionMultiplier 0.0199683 ;
@@ -64339,12 +64339,12 @@ unit:STANDARD
 unit:STILB
   a qudt:Unit ;
   dcterms:description """
-  The $\\textit{stilb (sb)}$ is the CGS unit of luminance for objects that are not self-luminous. 
-  It is equal to one candela per square centimeter or 10 nits (candelas per square meter). 
-  The name was coined by the French physicist A. Blondel around 1920. 
-  It comes from the Greek word stilbein meaning 'to glitter'. 
-  It was in common use in Europe up to World War I. 
-  In North America self-explanatory terms such as candle per square inch and candle per square meter were more common. 
+  The $\\textit{stilb (sb)}$ is the CGS unit of luminance for objects that are not self-luminous.
+  It is equal to one candela per square centimeter or 10 nits (candelas per square meter).
+  The name was coined by the French physicist A. Blondel around 1920.
+  It comes from the Greek word stilbein meaning 'to glitter'.
+  It was in common use in Europe up to World War I.
+  In North America self-explanatory terms such as candle per square inch and candle per square meter were more common.
   The unit has since largely been replaced by the SI unit: $\\textit{candela per square meter}$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -64843,10 +64843,10 @@ unit:THM_EEC
 unit:THM_US
   a qudt:Unit ;
   dcterms:description """
-  $\\textit{Therm}$ (symbol $thm$) is a non-SI unit of heat energy. 
-  It was defined in the United States in 1968 as the energy equivalent of burning 100 cubic feet of 
-  natural gas at standard temperature and pressure. 
-  In the US gas industry its SI equivalent is defined as exactly $100,000 BTU59^{\\circ}{F}$ or $105.4804 megajoules$. 
+  $\\textit{Therm}$ (symbol $thm$) is a non-SI unit of heat energy.
+  It was defined in the United States in 1968 as the energy equivalent of burning 100 cubic feet of
+  natural gas at standard temperature and pressure.
+  In the US gas industry its SI equivalent is defined as exactly $100,000 BTU59^{\\circ}{F}$ or $105.4804 megajoules$.
   Public utilities in the U.S. use the therm unit for measuring customer usage of gas and calculating the monthly bills.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:USCS ;
@@ -67321,12 +67321,12 @@ unit:UnitPole
 
 unit:V
   a qudt:Unit ;
-  dcterms:description """$\\textit{Volt}$ is the SI unit of electric potential. 
-  Separating electric charges creates potential energy, which can be measured in energy units such as joules. 
-  Electric potential is defined as the amount of potential energy present per unit of charge. 
-  Electric potential is measured in volts, with one volt representing a potential of one joule per coulomb of charge. 
+  dcterms:description """$\\textit{Volt}$ is the SI unit of electric potential.
+  Separating electric charges creates potential energy, which can be measured in energy units such as joules.
+  Electric potential is defined as the amount of potential energy present per unit of charge.
+  Electric potential is measured in volts, with one volt representing a potential of one joule per coulomb of charge.
   The name of the unit honors the Italian scientist Count Alessandro Volta (1745-1827), the inventor of the first battery.
-  The volt also may be expressed with a variety of other units. 
+  The volt also may be expressed with a variety of other units.
   For example, a volt is also equal to one watt per ampere ($W/A$) and one joule per ampere per second ($J/A/s$).
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -67744,10 +67744,10 @@ unit:V-PER-L-MIN
 unit:V-PER-M
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\{Volt Per Meter (V/m)}$ is a unit in the category of Electric field strength. 
-  It is also known as volts per meter, volt/meter, volt/metre, volt per metre, volts per metre. 
-  This unit is commonly used in the SI unit system. 
-  $\\{Volt Per Meter}$ has a dimension of $MLT^{-3}I^{-1}$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current. 
+  The unit $\\{Volt Per Meter (V/m)}$ is a unit in the category of Electric field strength.
+  It is also known as volts per meter, volt/meter, volt/metre, volt per metre, volts per metre.
+  This unit is commonly used in the SI unit system.
+  $\\{Volt Per Meter}$ has a dimension of $MLT^{-3}I^{-1}$ where $M$ is mass, $L$ is length, $T$ is time, and $I$ is electric current.
   This unit is the standard SI unit in this category.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -67800,8 +67800,8 @@ unit:V-PER-M
 unit:V-PER-M2
   a qudt:Unit ;
   dcterms:description """
-  $\\textit{Volt per Square Metre}$ is the divergence at a particular point in a vector field is (roughly) how much the vector field 'spreads out' from that point. 
-  Operationally, we take the partial derivative of each of the field with respect to each of its space variables and add all the derivatives together to get the divergence. 
+  $\\textit{Volt per Square Metre}$ is the divergence at a particular point in a vector field is (roughly) how much the vector field 'spreads out' from that point.
+  Operationally, we take the partial derivative of each of the field with respect to each of its space variables and add all the derivatives together to get the divergence.
   $\\textit{Electric field}$ ($V/m$) differentiated with respect to distance ($m$) yields $V/(m^2)$.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS-EMU ;
@@ -68887,10 +68887,10 @@ unit:W-PER-M2
 unit:W-PER-M2-K
   a qudt:DerivedUnit, qudt:Unit ;
   dcterms:description """
-  The unit $\\textit{Watt Per Square Meter Kelvin }$ ($W m^{-2} K^{-1}$) is a unit in the category of Thermal heat transfer coefficient. 
-  It is also known as $\\textit{watt/square meter-kelvin}$. 
-  This unit is commonly used in the SI unit system. 
-  $\\textit{Watt Per Square Meter Kelvin }$ has a dimension of $MT^{-1}Q^{-1}$ where $M$ is mass, $T$ is time, and $Q$ is temperature. 
+  The unit $\\textit{Watt Per Square Meter Kelvin }$ ($W m^{-2} K^{-1}$) is a unit in the category of Thermal heat transfer coefficient.
+  It is also known as $\\textit{watt/square meter-kelvin}$.
+  This unit is commonly used in the SI unit system.
+  $\\textit{Watt Per Square Meter Kelvin }$ has a dimension of $MT^{-1}Q^{-1}$ where $M$ is mass, $T$ is time, and $Q$ is temperature.
   This unit is the standard SI unit in this category.
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:SI ;
@@ -69107,8 +69107,8 @@ unit:W-PER-M2-SR
   while that of spectral radiance in frequency is the watt per steradian per square metre
   per hertz ($W·sr^{-1}·m^{-2}·Hz^{-1}$) and that of spectral radiance in wavelength is
   the watt per steradian per square metre, per metre ($W·sr^{-1}·m^{-3}$),
-  commonly the watt per steradian per square metre per nanometre ($W·sr^{-1}·m^{-2}·nm^{-1}$). 
-  It has a dimension of $ML^{-4}T^{-3}$ where $M$ is mass, $L$ is length, and $T$ is time. 
+  commonly the watt per steradian per square metre per nanometre ($W·sr^{-1}·m^{-2}·nm^{-1}$).
+  It has a dimension of $ML^{-4}T^{-3}$ where $M$ is mass, $L$ is length, and $T$ is time.
   This unit is the standard SI unit in this category."
   """^^qudt:LatexString ;
   qudt:applicableSystem sou:CGS ;
@@ -70061,10 +70061,10 @@ vaem:GMD_QUDT-UNITS-ALL
   dcterms:modified "2025-03-20T15:47:09Z"^^xsd:dateTime ;
   dcterms:rights """
   This product includes all or a portion of the UCUM table, UCUM codes, and UCUM definitions
-   or is derived from it, subject to a license from Regenstrief Institute, Inc. and The UCUM Organization. 
+   or is derived from it, subject to a license from Regenstrief Institute, Inc. and The UCUM Organization.
   Your use of the UCUM table, UCUM codes, UCUM definitions also is subject to this license,
-   a copy of which is available at ​http://unitsofmeasure.org. 
-  The current complete UCUM table, UCUM Specification are available for download at ​http://unitsofmeasure.org. 
+   a copy of which is available at ​http://unitsofmeasure.org.
+  The current complete UCUM table, UCUM Specification are available for download at ​http://unitsofmeasure.org.
   The UCUM table and UCUM codes are copyright © 1995-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization.
   All rights reserved.
   THE UCUM TABLE (IN ALL FORMATS), UCUM DEFINITIONS, AND SPECIFICATION ARE PROVIDED 'AS IS.' ANY EXPRESS OR IMPLIED WARRANTIES ARE DISCLAIMED,
@@ -70100,5 +70100,3 @@ voag:QUDT-UNITS-VocabCatalogEntry
   a vaem:CatalogEntry ;
   rdfs:isDefinedBy <http://qudt.org/3.1.0/vocab/unit> ;
   rdfs:label "QUDT UNITS Vocab Catalog Entry" .
-
-

--- a/support/bacnet.ttl
+++ b/support/bacnet.ttl
@@ -29411,4 +29411,3 @@ bacnet:TimeStamp a sh:NodeShape ;
                         sh:maxCount 1 ;
                         sh:minCount 1 ;
                         sh:path bacnet:datetime ] ] ) .
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Generates tests automatically
 """
+
 import pytest
 from rdflib import Namespace
 import ontoenv
@@ -32,6 +33,7 @@ def pytest_configure(config):
         "markers", "slow: mark tests as slow (deselect w/ '-m \"not slow\"')"
     )
 
+
 @pytest.fixture()
 def brick():
     g = brickschema.Graph()
@@ -43,9 +45,15 @@ def brick():
     g.remove((None, OWL.imports, None))
     return g
 
+
 @pytest.fixture()
 def brick_with_imports():
-    cfg = Config(["Brick.ttl", "support/", "extensions/", "rec/Source/SHACL/RealEstateCore"], strict=False, offline=True, temporary=True)
+    cfg = Config(
+        ["Brick.ttl", "support/", "extensions/", "rec/Source/SHACL/RealEstateCore"],
+        strict=False,
+        offline=True,
+        temporary=True,
+    )
     env = OntoEnv(cfg)
     g = brickschema.Graph()
     g.load_file("Brick.ttl")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,11 +1,24 @@
 """
 Tests all example files. See tests/conftest.py for the fixture that generates each of the individual test cases
 """
+
 import ontoenv
 from rdflib import OWL, RDF
 from brickschema import Graph
 
-cfg = ontoenv.Config(["Brick.ttl", "examples/", "support/", "extensions/", "rec/Source/SHACL/RealEstateCore"], strict=False, offline=True, temporary=True, excludes=[".venv/*"])
+cfg = ontoenv.Config(
+    [
+        "Brick.ttl",
+        "examples/",
+        "support/",
+        "extensions/",
+        "rec/Source/SHACL/RealEstateCore",
+    ],
+    strict=False,
+    offline=True,
+    temporary=True,
+    excludes=[".venv/*"],
+)
 env = ontoenv.OntoEnv(cfg)
 
 

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -18,7 +18,9 @@ base_data = (
 def test_no_relations(brick_with_imports):
     data = base_data
     data_g = brickschema.Graph().parse(data=data, format="turtle")
-    conforms, _, report_str = data_g.validate([brick_with_imports], engine="topquadrant")
+    conforms, _, report_str = data_g.validate(
+        [brick_with_imports], engine="topquadrant"
+    )
     assert conforms, report_str
 
 
@@ -30,7 +32,9 @@ def test_equip(brick_with_imports):
 """
     )
     valid_g = brickschema.Graph().parse(data=valid_data, format="turtle")
-    conforms, _, report_str = valid_g.validate([brick_with_imports], engine="topquadrant")
+    conforms, _, report_str = valid_g.validate(
+        [brick_with_imports], engine="topquadrant"
+    )
     assert conforms, report_str
 
     invalid_data = (
@@ -103,7 +107,9 @@ def test_meter_shapes(brick_with_imports):
 """
     )
     valid_g = brickschema.Graph().parse(data=valid_data, format="turtle")
-    conforms, _, report_str = valid_g.validate([brick_with_imports], engine="topquadrant")
+    conforms, _, report_str = valid_g.validate(
+        [brick_with_imports], engine="topquadrant"
+    )
     assert conforms, report_str
 
     invalid_data = (
@@ -139,5 +145,7 @@ def test_meter_shapes(brick_with_imports):
 """
     )
     valid_g = brickschema.Graph().parse(data=valid_data, format="turtle")
-    conforms, _, report_str = valid_g.validate([brick_with_imports], engine="topquadrant")
+    conforms, _, report_str = valid_g.validate(
+        [brick_with_imports], engine="topquadrant"
+    )
     assert conforms, report_str

--- a/tools/compare_versions/README.md
+++ b/tools/compare_versions/README.md
@@ -7,4 +7,3 @@ python tools/compare_versions/compare_versions.py --oldbrick 1.3.0 https://githu
 ```
 
 This will produce the comparison results inside `./history/{old_version}-{new_version}`.
-


### PR DESCRIPTION
- Added SHACL rule in rules.ttl (EOF) to prevent brick:hasSubstance and brick:hasQuantity
- Added new file for testing added rule under examples/no_substance_quantity/no_substance_quantity.ttl