### PR TITLE
Descriptions of canonical and alias classes

### DIFF
--- a/bricksrc/definitions.csv
+++ b/bricksrc/definitions.csv
@@ -1143,7 +1143,7 @@ https://brickschema.org/schema/Brick#Unoccupied_Load_Shed_Command,,
 https://brickschema.org/schema/Brick#Unoccupied_Target_Zone_Air_Temperature_Setpoint,Target Setpoint (also known as Common Setpoint) is a reference point representing the desired unoccupied air temperature in a specific zone of a building. This setpoint acts as a baseline from which deadband setpoints are established by adding or subtracting a deadband width.,
 https://brickschema.org/schema/Brick#Usage_Sensor,"Measures the amount of some substance that is consumed or used, over some period of time",
 https://brickschema.org/schema/Brick#VAV,,
-https://brickschema.org/schema/Brick#VFD,,https://xp20.ashrae.org/terminology/index.php?term=vfd&submit=Search
+https://brickschema.org/schema/Brick#VFD,,
 https://brickschema.org/schema/Brick#VFD_Enable_Command,Enables operation of a variable frequency drive,
 https://brickschema.org/schema/Brick#Valve,"A device that regulates, directs or controls the flow of a fluid by opening, closing or partially obstructing various passageways",https://en.wikipedia.org/wiki/Valve
 https://brickschema.org/schema/Brick#Valve_Command,Controls or reports the openness of a valve (typically as a proportion of its full range of motion),


### PR DESCRIPTION
Pull Request to Fix #699

This PR addresses missing and inconsistent class descriptions in the definitions.csv file:

Changes Made
- Removed all descriptions from "Non-canonical" classes.

- Added 8 "canonical" classes that were missing from the definitions.csv file, each with a corresponding definition.

- Populated descriptions for "canonical" classes that were previously missing them but have equivalent classes with valid descriptions.

Important Note:
- 116 "canonical" classes still lack descriptions in the CSV file. These classes either have no equivalent classes or their equivalents also lack descriptions.

- 274 "canonical" classes are still missing entirely from the CSV file.

Note: This fix only considers subclasses of brick:Entity, as outlined in [this document](https://docs.brickschema.org/brick/aliases.html).