### PR TITLE
Do do not duplicate literals if all enumeration values are strings

### DIFF
--- a/generate_brick.py
+++ b/generate_brick.py
@@ -562,26 +562,7 @@ def define_shape_properties(definitions, graph=G):
             graph.add((brick_value_shape, SH["in"], enumeration))
             graph.add((brick_value_shape, SH.minCount, Literal(1)))
             vals = defn.pop("values")
-            if all(map(lambda v: isinstance(v, str), vals)):
-                Collection(
-                    graph,
-                    enumeration,
-                    map(lambda x: Literal(x, datatype=XSD.string), vals),
-                )
-            if all(map(lambda v: isinstance(v, int), vals)):
-                Collection(
-                    graph,
-                    enumeration,
-                    map(lambda x: Literal(x, datatype=XSD.integer), vals),
-                )
-            if all(map(lambda v: isinstance(v, float), vals)):
-                Collection(
-                    graph,
-                    enumeration,
-                    map(lambda x: Literal(x, datatype=XSD.decimal), vals),
-                )
-            else:
-                Collection(graph, enumeration, map(Literal, vals))
+            Collection(graph, enumeration, map(Literal, vals))
         if "units" in defn:
             v = BNode()
             enumeration = BNode()


### PR DESCRIPTION
This fixes a portion of #705.

There are no enumerations where all the values are either `int`s or `float`s, so the only branches taken in the original code are `if all(map(lambda v: isinstance(v, str), vals)):` and `elif:`, which causes the enumeration values to be added twice if all of them are strings.

There is actually only one enumeration where not all values are strings: `[1, 2, 3, "Total"]`. `map(Literal, vals)` does the right thing here, so there doesn't seem to be a need for handling data types differently.
