### PR TITLE
Update REC patches

### DIFF
--- a/bricksrc/recpatches.ttl
+++ b/bricksrc/recpatches.ttl
@@ -542,7 +542,6 @@ brick:Entrance
     brick:isReplacedBy rec:Entrance ;
 .
 brick:Equipment
-  rdfs:subClassOf rec:Asset ;
   sh:property [
       rdf:type sh:PropertyShape ;
       sh:path rec:feeds ;
@@ -1435,9 +1434,6 @@ rec:AngularVelocityObservation
 rec:AreaObservation
   rdf:type <dtmi:dtdl:class:Component> ;
 .
-rec:Asset
-  rdf:type sh:NodeShape ;
-.
 rec:AssetCollection
   rdf:type sh:NodeShape ;
 .
@@ -1446,9 +1442,6 @@ rec:BooleanValueObservation
 .
 rec:CapacitanceObservation
   rdf:type <dtmi:dtdl:class:Component> ;
-.
-rec:Collection
-  rdf:type sh:NodeShape ;
 .
 rec:DataRateObservation
   rdf:type <dtmi:dtdl:class:Component> ;
@@ -1470,12 +1463,6 @@ rec:ElectricChargeObservation
 .
 rec:ElectricCurrentObservation
   rdf:type <dtmi:dtdl:class:Component> ;
-.
-rec:EnergyObservation
-  rdf:type <dtmi:dtdl:class:Component> ;
-.
-rec:EquipmentCollection
-  rdf:type sh:NodeShape ;
 .
 rec:ExceptionEvent
   rdf:type <dtmi:dtdl:class:Component> ;
@@ -1554,53 +1541,6 @@ rec:VolumeFlowRateObservation
 .
 rec:VolumeObservation
   rdf:type <dtmi:dtdl:class:Component> ;
-.
-rec:substance
-  rdf:type owl:AnnotationProperty ;
-  rdfs:domain rec:feeds ;
-  rdfs:domain rec:isFedBy ;
-  rdfs:label "substance" ;
-  rdfs:range [
-      rdf:type rdfs:Datatype ;
-      owl:oneOf (
-          "ACElec"
-          "Air"
-          "BlowdownWater"
-          "ChilledWater"
-          "ColdDomesticWater"
-          "Condensate"
-          "CondenserWater"
-          "DCElec"
-          "Diesel"
-          "DriveElec"
-          "Ethernet"
-          "ExhaustAir"
-          "Freight"
-          "FuelOil"
-          "Gasoline"
-          "GreaseExhaustAir"
-          "HotDomesticWater"
-          "HotWater"
-          "IrrigationWater"
-          "Light"
-          "MakeupWater"
-          "NaturalGas"
-          "NonPotableDomesticWater"
-          "OutsideAir"
-          "People"
-          "Propane"
-          "RecircHotDomesticWater"
-          "Refrig"
-          "ReturnAir"
-          "SprinklerWater"
-          "Steam"
-          "StormDrainage"
-          "SupplyAir"
-          "TransferAir"
-          "WasteVentDrainage"
-          "Water"
-        ) ;
-    ] ;
 .
 <https://w3id.org/rec/brickpatches>
   rdf:type owl:Ontology ;


### PR DESCRIPTION
This fixes another portion of https://github.com/BrickSchema/Brick/issues/705 by removing all the statements from [bricksrc/recpatches.ttl](https://github.com/BrickSchema/Brick/blob/a56d5e2fae1d7e39aba531f96d3c8a0922e1014e/bricksrc/recpatches.ttl) that are already present in [`rec @ 352187a`/Source/SHACL/RealEstateCore/rec.ttl](https://github.com/RealEstateCore/rec/blob/352187a7dea0a73a40893ead8ba5cda6f7e181e3/Source/SHACL/RealEstateCore/rec.ttl) (at least those that I could find).