### PR TITLE
feat: introduce specific relationships for Controller: controls, concerns and hosts

### DIFF
--- a/bricksrc/relationships.py
+++ b/bricksrc/relationships.py
@@ -162,6 +162,48 @@ relationships = {
         "domain": BRICK.Point,
         RDFS.label: Literal("Has unit", lang="en"),
     },
+    "controls": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["isControlledBy"],
+        "range": BRICK.Equipment,
+        "domain": BRICK.Controller,
+        RDFS.label: Literal("Controls", lang="en"),
+    },
+    "isControlledBy": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["controls"],
+        "range": BRICK.Controller,
+        "domain": BRICK.Equipment,
+        RDFS.label: Literal("Is controlled by", lang="en"),
+    },
+    "hosts": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["isHostedBy"],
+        "range": REC.Collection,
+        "domain": BRICK.Controller,
+        RDFS.label: Literal("Hosts", lang="en"),
+    },
+    "isHostedBy": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["hosts"],
+        "range": BRICK.Controller,
+        "domain": REC.Collection,
+        RDFS.label: Literal("Is hosted by", lang="en"),
+    },
+    "concerns": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["isConcernedBy"],
+        "range": REC.Zone,
+        "domain": BRICK.Controller,
+        RDFS.label: Literal("Concerns", lang="en"),
+    },
+    "isConcernedBy": {
+        A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
+        OWL.inverseOf: BRICK["concerns"],
+        "range": BRICK.Controller,
+        "domain": REC.Zone,
+        RDFS.label: Literal("Is concerned by", lang="en"),
+    },
     "meters": {
         A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         OWL.inverseOf: BRICK.isMeteredBy,
@@ -238,4 +280,8 @@ for row in rec.query(query):
     if row["datatype"]:
         relationships[row["path"]][A] = [OWL.DatatypeProperty]
     if row["nodeKind"]:
-        relationships[row["path"]][A] = [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty]
+        relationships[row["path"]][A] = [
+            OWL.ObjectProperty,
+            OWL.AsymmetricProperty,
+            OWL.IrreflexiveProperty,
+        ]


### PR DESCRIPTION
Currently [brick:Controller](https://ontology.brickschema.org/brick/Controller.html) doesn't have any specific relationships defined, it just inherits its relationships from brick:Equipment.

I propose introducing some Controller-specific relationships that a Building Automation Controller would have, because of the control logic it contains:

- controls: A controller can reside outside of the equipment (e.g. control cabinet). Even when it is part of an equipment, it is not straightforward to come to the conclusion which part of the equipment it is controlling. So a controls relationship from brick:Controller to brick:Equipment would be useful.
- concerns: A controller controls an equipment that influences (feeds) a rec:Space (we will use rec:Zone specifically). It would be useful to shorten this path and introduce a concerns relationship from brick:Controller to rec:Space (alternatively rec:Zone).
- hosts: A collection of entities can be hosted on a Controller (e.g. sensors, zones, light groups etc.), the hosts relationship from brick:Controller to brick:Collection would allow this. This is also a preparation for future introduction of functions.

I am already providing this draft-PR to demonstrate the idea concretely. I'm open for any other proposals.

/cc @ektrah 
