### PR TITLE
Cleaning up gh actions

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   # the python version to release the ontology with.
   # Must be a version in the matrix.python-version list
@@ -29,18 +33,15 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
+        enable-cache: true
         python-version: ${{ matrix.python-version }}
-    - name: Set up AllegroGraph (Docker)
-      run: |
-        docker version
-        docker pull franzinc/agraph:v7.1.0
     - name: Install the project
       run: uv sync --all-extras --dev --pre
     - name: Generate new Brick ontology
       # generate new Brick ontology (in case this hasn't been run)
       run: |
         uv run make
-        cat Brick.ttl
+        ls -lh Brick*.ttl
     - name: zip imports and extensions
       run: |
         zip -r imports.zip imports

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -4,21 +4,29 @@ on:
     - cron: '0 2 * * *' # run at 2 AM UTC
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Nightly Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
+          enable-cache: true
           python-version: '3.11'
       - name: Install the project
         run: uv sync --all-extras --dev --pre
@@ -26,7 +34,7 @@ jobs:
         # generate new Brick ontology (in case this hasn't been run)
         run: |
           uv run make
-          cat Brick.ttl
+          ls -lh Brick*.ttl
       - name: zip imports and extensions
         run: |
           zip -r imports.zip imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pytest>=8.3.2",
     "tqdm>=4.66.5",
     "pyshacl>=0.30",
-    "docker>=7.1.0",
     "black>=24.8.0",
     "pre-commit>=3.8.0",
     "flake8>=7.1.1",


### PR DESCRIPTION
- Removed the unused AllegroGraph Docker setup step from `.github/workflows/builds.yml`.
- Removed the unused `docker` Python dependency from `pyproject.toml`.
- Kept artifact upload before tests in `.github/workflows/builds.yml` so failed CI runs still publish downloadable ontology artifacts for local debugging.
- Added explicit GitHub Actions permissions to `.github/workflows/builds.yml`:
  - `contents: read`
  - `pull-requests: write`
- Added explicit GitHub Actions permissions to `.github/workflows/nightly-builds.yml`:
  - `contents: write`
- Enabled `astral-sh/setup-uv` cache support in both workflows with `enable-cache: true`.
- Replaced noisy `cat Brick.ttl` log output with `ls -lh Brick*.ttl` in both workflows.
- Added `concurrency` controls to `.github/workflows/nightly-builds.yml` to avoid overlapping runs.
- Upgraded `.github/workflows/nightly-builds.yml` from `actions/checkout@v3` to `actions/checkout@v4`.
- Replaced deprecated `::set-output` usage in `.github/workflows/nightly-builds.yml` with `$GITHUB_OUTPUT`.
