### PR TITLE
fix: remove duplicate shapes for isPointOf

### DIFF
--- a/bricksrc/relationships.py
+++ b/bricksrc/relationships.py
@@ -102,14 +102,14 @@ relationships = {
         A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         OWL.inverseOf: BRICK["isPointOf"],
         "range": BRICK.Point,
-        "domain": [BRICK.Equipment, BRICK.Location, REC.Architecture],
+        "domain": [BRICK.Equipment, BRICK.Location, REC.Space],
         RDFS.label: Literal("Has point", lang="en"),
     },
     "isPointOf": {
         A: [OWL.ObjectProperty, OWL.AsymmetricProperty, OWL.IrreflexiveProperty],
         OWL.inverseOf: BRICK["hasPoint"],
         "domain": BRICK.Point,
-        "range": [BRICK.Equipment, BRICK.Location, REC.Architecture],
+        "range": [BRICK.Equipment, BRICK.Location, REC.Space],
         RDFS.label: Literal("Is point of", lang="en"),
     },
     "hasPart": {

--- a/bricksrc/root_class_shapes.ttl
+++ b/bricksrc/root_class_shapes.ttl
@@ -158,14 +158,6 @@ bsh:hasHotColdDeck
     ] ;
 .
 
-bsh:isPointOfShape a sh:PropertyShape ;
-    sh:targetClass brick:Point ;
-    sh:path brick:isPointOf ;
-    sh:or ( [ sh:class brick:Equipment ] [ sh:class brick:Location ] [ sh:class rec:Space ] );
-    sh:message "A Point can be a Point of Equipment, Location or Space."
-.
-
-
 # sensors inherit hasQuantity from their parent class
 bsh:SensorInheritQuantityKind a sh:NodeShape ;
     sh:target [


### PR DESCRIPTION
The two definitions coming from relationships.py and root_class_shapes.ttl cause multiple lists behind the sh:or predicate.

This is the current definition in [Brick 1.4.4](https://brickschema.org/schema/1.4.4/Brick.ttl):

```ttl
bsh:isPointOfShape a sh:PropertyShape ;
    sh:message "A Point can be a Point of Equipment, Location or Space." ;
    sh:or ( [ sh:class brick:Equipment ] [ sh:class brick:Location ] ),
        ( [ sh:class brick:Equipment ] [ sh:class brick:Location ] [ sh:class rec:Space ] ) ;
    sh:path brick:isPointOf ;
    sh:targetClass brick:Point .
```

This effectively restricts isPointOf's range to rec:Architecture, but there can also be points on spaces, not only on architectures, like an outside air temperature.

Here I cleaned it up to have a single definition, and allow it to be a Space, not just an Architecture.

Example: <https://s.zazuko.com/2wf1yio>

@gtfierro @ektrah 